### PR TITLE
perf(build): parse each render's config.yml once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,17 +90,22 @@ env:
 
 jobs:
   test:
-    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }} (${{ matrix.shard }})
     runs-on: ${{ matrix.os }}
     # Without a bound, a single wedged xdist worker holds the lane at 99% for
     # the 6-hour default.
     #
-    # 60 rather than 45, because the healthy run grew. Through August a cell
-    # finished in ~15-18 min; by 2026-09-01 the suite had grown to the point
-    # where every cell needs ~35-41 min (ubuntu and macOS alike, coverage cell
-    # included: it measures through PEP 669, see COVERAGE_CORE below, which
-    # costs near enough nothing, so no cell is an outlier). What forces the
-    # headroom on top of that is a known intermittent tail worth ~12 minutes:
+    # 60 rather than 45 (#838, #841). The healthy runtime of one cell is not
+    # a number but a band: on main between 2026-08-28 and 2026-09-03 the four
+    # cells took anywhere from 24 to 46 minutes, with the same commit landing
+    # at 33 and 45 minutes on the same day. The per-test event logs in the
+    # ci-diag artifact show why — every test, the 24,000 sub-10 ms ones
+    # included, runs 1.5-1.7x slower on some runners than on others, so the
+    # spread is the runner pool, not the suite (the coverage cell is no
+    # outlier either: it measures through PEP 669, see COVERAGE_CORE below,
+    # which costs near enough nothing). The shard axis below halves what one
+    # job runs, which is what keeps a slow runner clear of this cap. What
+    # forces the headroom on top is a known intermittent tail worth ~12 minutes:
     # a worker wedges mid-test and its share has to be redistributed to a
     # replacement, or the session hangs after the last test on non-daemon
     # threads that outlive it. Both are visible in this lane's uploaded
@@ -115,6 +120,17 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12']
         os: [ubuntu-latest, macos-latest]
+        # Each cell runs as two jobs. `cli` is tests/cli alone; `rest` is
+        # everything else. Measured on the per-test event logs of a full run,
+        # tests/cli is 49% of the suite's test time on both OSes (its ~120
+        # tests that run a real `osprey build` are most of that), so the two
+        # halves finish together and a job takes half the wall clock of a
+        # whole-suite cell on the same runner. A shard is a directory, not a
+        # duration file or a hash: nothing to regenerate, and the balance is
+        # re-checked by reading `--durations` when tests/cli drifts far from
+        # half. Runner-minutes are unchanged; the macOS concurrency ceiling
+        # discussed below sees twice the jobs at half the length each.
+        shard: [cli, rest]
         # Pull requests drop the 3.11/macOS cell; every other event runs the
         # full product.
         #
@@ -184,9 +200,11 @@ jobs:
       # minute intermittent tail described on the job cap above. A cap set just
       # above the healthy runtime kills the runs that hit that tail and would
       # have passed anyway; the value is deliberately loose for that reason, and
-      # tightening it is how this lane starts flaking. 55 = the ~41 min the
-      # slowest healthy cell now takes + the ~12 min tail; the previous 40 was
-      # sized for a ~18 min cell and became the healthy runtime itself.
+      # tightening it is how this lane starts flaking. 55 was sized when a cell
+      # ran the whole suite and the slowest healthy one took ~41 min; a shard
+      # runs half of it, so the same cap now leaves room for the slowest runner
+      # in the pool AND the tail. The previous 40 was sized for a ~18 min cell
+      # and became the healthy runtime itself.
       timeout-minutes: 55
       env:
         # Switches on tests/ci_diagnostics.py: a continuously flushed event log
@@ -326,7 +344,14 @@ jobs:
         # which is after tee has to open its file.
         mkdir -p ci-diag
         set -o pipefail
-        uv run pytest tests/ --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short --durations=50 --timeout=600 --timeout-method=signal -n 4 --dist loadgroup $COV_ARGS 2>&1 | tee ci-diag/pytest.log
+        # The shard: `cli` narrows the path to tests/cli, `rest` keeps tests/
+        # and ignores tests/cli. Spelled as two variables on the one pytest
+        # line so the invocation test_ci_workflow_wiring.py pins stays one line.
+        case "${{ matrix.shard }}" in
+          cli)  SHARD_PATH="cli"; SHARD_IGNORE="" ;;
+          rest) SHARD_PATH="";    SHARD_IGNORE="--ignore=tests/cli" ;;
+        esac
+        uv run pytest tests/$SHARD_PATH $SHARD_IGNORE --ignore=tests/e2e --ignore=tests/va/test_record_factory.py --ignore=tests/va/test_apply_fault.py -m "not pty" -v --tb=short --durations=50 --timeout=600 --timeout-method=signal -n 4 --dist loadgroup $COV_ARGS 2>&1 | tee ci-diag/pytest.log
 
     # The two steps below are the reason the step above has its own timeout.
     # They run on success too: on a green lane the summary is the slow-test
@@ -349,7 +374,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: ci-diag-unit-${{ matrix.python-version }}-${{ matrix.os }}
+        name: ci-diag-unit-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.shard }}
         path: ci-diag/
         retention-days: 14
         if-no-files-found: warn
@@ -363,8 +388,10 @@ jobs:
       # contended ones, so they would be where this suite starts flaking. What
       # it covers is not OS-specific either: it is how OSPREY's own renderer
       # drives a terminal. Both Linux Python cells run it, so it is not
-      # single-interpreter, and a developer on macOS runs it locally.
-      if: matrix.os == 'ubuntu-latest'
+      # single-interpreter, and a developer on macOS runs it locally. One shard
+      # per cell: the suite is not part of either half and would otherwise run
+      # twice.
+      if: matrix.os == 'ubuntu-latest' && matrix.shard == 'rest'
       # Serial by construction, and no xdist flags. Each scenario allocates a
       # pty, starts a real verb on it in its own session, and asserts on what
       # the terminal showed, including that a spinner ADVANCED between two
@@ -402,17 +429,20 @@ jobs:
       # seam test actually executes. The gate fails unless every module exits
       # 0 with zero skips and at least one pass, which closes the gap the
       # in-sweep venue guard cannot: a skipped live suite fails THIS step even
-      # if a future marker or fixture skip slips past the import guard.
-      if: matrix.os == 'ubuntu-latest'
+      # if a future marker or fixture skip slips past the import guard. One
+      # shard per cell, as for the pty suite above.
+      if: matrix.os == 'ubuntu-latest' && matrix.shard == 'rest'
       run: uv run python scripts/va/live_ca/gate.py --pva
 
     - name: Upload coverage reports to Codecov
+      # Both shards of the coverage cell upload; Codecov merges reports for
+      # one commit, so the two halves add up to the whole suite's coverage.
       uses: codecov/codecov-action@v7
       if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
       with:
         files: ./coverage.xml
         flags: unittests
-        name: codecov-umbrella
+        name: codecov-umbrella-${{ matrix.shard }}
         fail_ci_if_error: false
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/changelog.d/841-batching.changed.md
+++ b/changelog.d/841-batching.changed.md
@@ -1,0 +1,5 @@
+`osprey build` edits each rendered `config.yml` in memory across every step of
+the render instead of re-reading and rewriting the file in each one, which
+roughly halves the build time. The rendered file now keeps the template's
+quoting and list indentation all the way through the build; previously the last
+step to touch it rewrote lists at column zero and dropped the quotes.

--- a/changelog.d/841.changed.md
+++ b/changelog.d/841.changed.md
@@ -1,3 +1,6 @@
 `osprey build` is faster: a deployment's YAML is parsed on the libyaml scanner
-when it is installed, and the rendered `config.yml` is parsed once per change
-instead of on every check.
+when it is installed, and each rendered `config.yml` is parsed once and edited
+in memory by every step of the render instead of being re-read and rewritten by
+each one. The rendered `config.yml` now keeps the template's quoting and list
+indentation all the way through the build; previously the last step to touch it
+rewrote lists at column zero and dropped the quotes.

--- a/changelog.d/841.changed.md
+++ b/changelog.d/841.changed.md
@@ -1,6 +1,3 @@
 `osprey build` is faster: a deployment's YAML is parsed on the libyaml scanner
-when it is installed, and each rendered `config.yml` is parsed once and edited
-in memory by every step of the render instead of being re-read and rewritten by
-each one. The rendered `config.yml` now keeps the template's quoting and list
-indentation all the way through the build; previously the last step to touch it
-rewrote lists at column zero and dropped the quotes.
+when it is installed, and the rendered `config.yml` is parsed once per change
+instead of on every check.

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -34,6 +34,7 @@ from osprey.build.claude_code_telemetry import (
 from osprey.models.spend_attribution import apply_attribution_env, gateway_for
 from osprey.models.tiers import VALID_TIERS
 from osprey.utils.dotenv import chain_files
+from osprey_connectors import yaml_loader
 
 logger = logging.getLogger("osprey.build.claude_code_resolver")
 
@@ -493,12 +494,11 @@ def load_provider_spec(
         ``env_block['ANTHROPIC_BASE_URL']`` and ``upstream_base_url``, or
         ``None`` when no provider is configured.
     """
-    import yaml
 
     from osprey.utils.config import resolve_env_vars
 
     project_dir = Path(project_dir)
-    raw = yaml.safe_load((project_dir / "config.yml").read_text()) or {}
+    raw = yaml_loader.safe_load((project_dir / "config.yml").read_text()) or {}
 
     # Build an os.environ + .env overlay (.env wins) WITHOUT mutating os.environ.
     lookup: dict[str, str] = _env_lookup(Path(env_dir) if env_dir is not None else project_dir)

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -51,6 +51,12 @@ import click
 from osprey.deployment.compose_merge import MERGED_COMPOSE_FILENAME
 from osprey.errors import BuildProfileError
 from osprey.port_layout import resolve_port_base
+from osprey.utils.config_writer import (
+    config_edit_session,
+    flush_config_edits,
+    load_config_document,
+    save_config_document,
+)
 from osprey.utils.logger import get_logger
 from osprey.utils.workspace import (
     BUILD_DIR_NAME,
@@ -1250,7 +1256,9 @@ def _rendered_config(render_dir: Path) -> dict[str, Any]:
     file's bytes are read every time and the parse is cached under their
     digest: a rewrite changes the digest and is parsed afresh, an unchanged
     file is parsed once. Callers get their own copy, since some annotate the
-    mapping before handing it on.
+    mapping before handing it on. The render edits the file under one
+    :func:`~osprey.utils.config_writer.config_edit_session`, so the bytes are
+    only current once that session has flushed: this is the read that flushes.
     """
     import copy
     import hashlib
@@ -1258,6 +1266,7 @@ def _rendered_config(render_dir: Path) -> dict[str, Any]:
     from osprey_connectors import yaml_loader
 
     path = render_dir / "config.yml"
+    flush_config_edits(path)  # an open edit session may hold what we are about to read
     data = path.read_bytes()
     key = (str(path), hashlib.sha256(data).digest())
     parsed = _rendered_config_cache.get(key)
@@ -1298,16 +1307,11 @@ def _resolve_rendered_execution_method(render_dir: Path) -> list[str]:
     if written == method:
         return []
 
-    from ruamel.yaml import YAML
-
-    yaml = YAML()
-    with config_path.open("r", encoding="utf-8") as fh:
-        document = yaml.load(fh)
+    document = load_config_document(config_path)
     if not isinstance(document.get("execution"), Mapping):
         document["execution"] = {}
     document["execution"]["execution_method"] = method
-    with config_path.open("w", encoding="utf-8") as fh:
-        yaml.dump(document, fh)
+    save_config_document(config_path, document)
     return []
 
 
@@ -1350,14 +1354,9 @@ def _resolve_rendered_container_runtime(render_dir: Path, progress: Any) -> None
         logger.debug("Leaving container_runtime: auto in the render — %s", e)
         return
 
-    from ruamel.yaml import YAML
-
-    yaml = YAML()
-    with config_path.open("r", encoding="utf-8") as fh:
-        document = yaml.load(fh)
+    document = load_config_document(config_path)
     document["container_runtime"] = runtime
-    with config_path.open("w", encoding="utf-8") as fh:
-        yaml.dump(document, fh)
+    save_config_document(config_path, document)
     progress("  ✓ container_runtime: %s (resolved from auto; the runtime this build used)", runtime)
 
 
@@ -1755,221 +1754,239 @@ def _render_project(
         else derived_tier
     )
 
-    # The render. No `.env` is carried in from anywhere: the repo's own `.env`
-    # is the deployment's whole secret store, it is mounted from the repo root,
-    # and a build neither reads nor rewrites it — copying it into the disposable
-    # zone would put the facility's keys somewhere a `rm -rf build/` is
-    # documented to make safe. A persona render is inside that same zone and is
-    # a container build context on top of it, so it gets no `.env` either; its
-    # container is handed one at run time through compose.
-    manager.create_project(
-        project_name=project_name,
-        output_dir=output_dir,
-        data_bundle=build_profile.data_bundle,
-        context=context,
-        force=True,
-        artifacts=artifacts or None,
-        tier=pinned_tier,
-        data_root=build_profile.resolved_data_root(repo_root),
-    )
-    progress("  ✓ Base template rendered")
+    # Every edit of the render's config.yml — the template's own ownership
+    # registration, the overrides, the projections, the service injectors, the
+    # `auto` resolvers, the persisted servers — happens under one edit session:
+    # one comment-preserving load, one document. It is written when something
+    # reads the file's bytes (`_rendered_config`, the injectors and the limits
+    # reader flush it first) and at the session's end, which comes before the
+    # manifest and the Claude Code render read the file, so nothing below the
+    # block can see a stale file.
+    with config_edit_session(render_dir / "config.yml"):
+        # The render. No `.env` is carried in from anywhere: the repo's own `.env`
+        # is the deployment's whole secret store, it is mounted from the repo root,
+        # and a build neither reads nor rewrites it — copying it into the disposable
+        # zone would put the facility's keys somewhere a `rm -rf build/` is
+        # documented to make safe. A persona render is inside that same zone and is
+        # a container build context on top of it, so it gets no `.env` either; its
+        # container is handed one at run time through compose.
+        manager.create_project(
+            project_name=project_name,
+            output_dir=output_dir,
+            data_bundle=build_profile.data_bundle,
+            context=context,
+            force=True,
+            artifacts=artifacts or None,
+            tier=pinned_tier,
+            data_root=build_profile.resolved_data_root(repo_root),
+        )
+        progress("  ✓ Base template rendered")
 
-    # One fact, two homes: a profile that also spells a key the live stand-in
-    # derives is refused rather than silently overwritten below — the same rule
-    # the va_archiver block applies to the archive's coordinates, and here the
-    # duplicate is a real gateway address sitting in the profile while every
-    # session is on the stand-in.
-    standin_duplicates = live_standin_duplicate_key_errors(
-        build_profile.virtual_accelerator, build_profile.config
-    )
-    if standin_duplicates:
-        raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(standin_duplicates))
+        # One fact, two homes: a profile that also spells a key the live stand-in
+        # derives is refused rather than silently overwritten below — the same rule
+        # the va_archiver block applies to the archive's coordinates, and here the
+        # duplicate is a real gateway address sitting in the profile while every
+        # session is on the stand-in.
+        standin_duplicates = live_standin_duplicate_key_errors(
+            build_profile.virtual_accelerator, build_profile.config
+        )
+        if standin_duplicates:
+            raise BuildProfileError(
+                "Profile validation failed:\n  " + "\n  ".join(standin_duplicates)
+            )
 
-    # What the deploy, va_archiver and virtual_accelerator blocks contribute to
-    # the rendered config, applied with the profile's own `config:` entries in
-    # one pass. Derived keys the profile also spells are rejected at validation,
-    # so winning here can never silently overwrite a facility's own value.
-    derived_by_block = {
-        "deploy": deploy_config_overrides(build_profile.deploy, build_profile.config),
-        "va_archiver": va_archiver_config_overrides(build_profile.va_archiver),
-        # Reads the render because the stand-in's probe channel is the sandbox
-        # VA's: whatever the template put there is the fallback for a profile
-        # that named none of its own.
-        "virtual_accelerator": live_standin_config_overrides(
-            build_profile.virtual_accelerator, build_profile.config, _rendered_config(render_dir)
-        ),
-    }
-    derived = {key: value for block in derived_by_block.values() for key, value in block.items()}
-    config_overrides = {**build_profile.config, **derived}
-    if config_overrides:
-        _apply_config_overrides(render_dir, config_overrides)
-        progress("  ✓ Applied %d config override(s)", len(config_overrides))
-        for block, entries in derived_by_block.items():
-            for key, value in entries.items():
-                progress("      %s: %s (from the profile's %s block)", key, value, block)
+        # What the deploy, va_archiver and virtual_accelerator blocks contribute to
+        # the rendered config, applied with the profile's own `config:` entries in
+        # one pass. Derived keys the profile also spells are rejected at validation,
+        # so winning here can never silently overwrite a facility's own value.
+        derived_by_block = {
+            "deploy": deploy_config_overrides(build_profile.deploy, build_profile.config),
+            "va_archiver": va_archiver_config_overrides(build_profile.va_archiver),
+            # Reads the render because the stand-in's probe channel is the sandbox
+            # VA's: whatever the template put there is the fallback for a profile
+            # that named none of its own.
+            "virtual_accelerator": live_standin_config_overrides(
+                build_profile.virtual_accelerator,
+                build_profile.config,
+                _rendered_config(render_dir),
+            ),
+        }
+        derived = {
+            key: value for block in derived_by_block.values() for key, value in block.items()
+        }
+        config_overrides = {**build_profile.config, **derived}
+        if config_overrides:
+            _apply_config_overrides(render_dir, config_overrides)
+            progress("  ✓ Applied %d config override(s)", len(config_overrides))
+            for block, entries in derived_by_block.items():
+                for key, value in entries.items():
+                    progress("      %s: %s (from the profile's %s block)", key, value, block)
 
-    # What an attached render is told about the services its host deploys —
-    # the ports it publishes, the panel URLs its injectors derived — copied
-    # from the deployment's own render (the Reach Contract,
-    # osprey.deployment.reach). After the profile's overlay, because the
-    # projection is gated on what THIS render switches on; before the
-    # service injection and the Claude Code re-render, because a projected
-    # block is what makes a server render at all (`graphdb_configured`).
-    # A deploying project projects nothing: its injectors write the blocks.
-    if not build_profile.deploy_services:
-        if shared.host_config is not None:
-            host_config, told_by = shared.host_config, "the hosting deployment's render"
-        else:
-            # Built alone, with no deployment in this repo: the profile extends
-            # a deployment of the same app template, so that template rendered
-            # AS a deployment is what the host says at the shipped defaults —
-            # and the profile's own `config:` is where a host that differs is
-            # named, so it is laid over those defaults first.
-            host_config = _template_host_config(
+        # What an attached render is told about the services its host deploys —
+        # the ports it publishes, the panel URLs its injectors derived — copied
+        # from the deployment's own render (the Reach Contract,
+        # osprey.deployment.reach). After the profile's overlay, because the
+        # projection is gated on what THIS render switches on; before the
+        # service injection and the Claude Code re-render, because a projected
+        # block is what makes a server render at all (`graphdb_configured`).
+        # A deploying project projects nothing: its injectors write the blocks.
+        if not build_profile.deploy_services:
+            if shared.host_config is not None:
+                host_config, told_by = shared.host_config, "the hosting deployment's render"
+            else:
+                # Built alone, with no deployment in this repo: the profile extends
+                # a deployment of the same app template, so that template rendered
+                # AS a deployment is what the host says at the shipped defaults —
+                # and the profile's own `config:` is where a host that differs is
+                # named, so it is laid over those defaults first.
+                host_config = _template_host_config(
+                    shared,
+                    build_profile,
+                    project_name=project_name,
+                    render_dir=render_dir,
+                    profile_dir=repo_root,
+                    context=context,
+                    artifacts=artifacts or None,
+                )
+                told_by = "the app template's defaults"
+            projected = attached_render_overrides(
+                host_config,
+                _rendered_config(render_dir),
+                selected_panels=build_profile.web_panels or (),
+            )
+            # A `config:` spelling that contradicts the projection is refused;
+            # one that agrees (inherited from the hosting profile, or laid over
+            # the template's defaults when built alone) is the same fact.
+            duplicate_errors = reach_override_errors(build_profile.config, projected)
+            if duplicate_errors:
+                raise BuildProfileError(
+                    "Profile validation failed:\n  " + "\n  ".join(duplicate_errors)
+                )
+            if projected:
+                _apply_config_overrides(render_dir, projected)
+                progress(
+                    "  ✓ Told this attached render %d fact(s) about the host's services",
+                    len(projected),
+                )
+                for key, value in projected.items():
+                    progress("      %s: %s (from %s)", key, value, told_by)
+            # A tab this profile selects (`web_panels:`) that the projection gave
+            # no address — the host it was told about runs no such sidecar — would
+            # otherwise vanish from the render without a word.
+            tabless = selected_panel_errors(
+                build_profile.web_panels or (), _rendered_config(render_dir), told_by=told_by
+            )
+            if tabless:
+                raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(tabless))
+
+        injected = _inject_services(build_profile, repo_root, render_dir)
+        if injected_out is not None:
+            injected_out.extend(injected)
+
+        # The selection, projected. The tab strip is read from `web.panels` alone,
+        # and by now every block this render will carry is there: the template's
+        # own for a selected builtin, the profile's `config:` facts about a custom
+        # panel, the facts a persona inherits for a tab it excluded, the blocks the
+        # injectors just wrote for a tab only a persona selects. Each is told
+        # whether THIS render shows it — the facts stay (a persona cannot subtract
+        # `config:`, and the Reach Contract copies addresses from the host's
+        # render); only `enabled` moves, and it says one thing: selected here.
+        projected_tabs = panel_selection_overrides(
+            build_profile.web_panels or (), _rendered_config(render_dir)
+        )
+        if projected_tabs:
+            _apply_config_overrides(render_dir, projected_tabs)
+            off = sorted(key.split(".")[2] for key, shown in projected_tabs.items() if not shown)
+            if off:
+                progress(
+                    "  ✓ Switched off %d panel block(s) this profile does not select: %s",
+                    len(off),
+                    ", ".join(off),
+                )
+
+        # The ground truth every client loads is the rendered config, so this is
+        # where a consumer switched on with nothing to dial is refused — for a
+        # deployment that dropped a block its modules still use, and for an
+        # attached render that was told nothing (a host, or an app template, that
+        # deploys no such service) alike. AFTER the injectors: a deploying profile
+        # that pins only `web.panels.events.path` has its `url` written by the
+        # dispatch injector, and refusing before that would name a key the build
+        # was about to write. The execution backend is read here for the same
+        # reason: it is the render, not the profile, that a container loads.
+        unrunnable = [
+            *_resolve_rendered_execution_method(render_dir),
+            *reach_errors(_rendered_config(render_dir), repo_root=repo_root),
+            *_incomplete_limits_errors(render_dir),
+        ]
+        if unrunnable:
+            raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unrunnable))
+        # And the runtime, for the same reason once more: the verbs that stop,
+        # restart and preflight this deployment read the render, and must act on
+        # the runtime that owns the containers rather than re-detect one.
+        _resolve_rendered_container_runtime(render_dir, progress)
+
+        applied = _apply_conventions(
+            repo_root,
+            render_dir,
+            _resolve_context_roster(render_dir),
+            extra_known=[
+                *_profile_known_root_entries(build_profile, profile_path),
+                *extra_known,
+            ],
+            excluded=resolved.excluded_artifacts,
+        )
+        if applied.copied:
+            progress(
+                "  ✓ Applied %d profile artifact(s): %s",
+                applied.copied,
+                ", ".join(f"{count} {key}" for key, count in sorted(applied.by_category.items())),
+            )
+            reg_count = _register_convention_artifacts(render_dir, applied)
+            if reg_count:
+                progress("  ✓ Registered %d profile artifact(s) in config.yml", reg_count)
+
+        if va_graph_deferred:
+            # The deferred half of the manifest step above: the render is on disk,
+            # so the rendered config can resolve the corpus the roster reads --
+            # the same resolution every other roster consumer applies. The refusal
+            # (a virtual accelerator with an unreadable or empty corpus) fires
+            # here, still before anything is published outside the render zone.
+            rendered = _rendered_config(render_dir)
+            rendered["config_dir"] = str(render_dir)
+            prepared_va_manifest = prepare_project_manifest(
+                va_data_root, va_key[1], config=rendered
+            )
+            shared.va_manifests[va_key] = prepared_va_manifest
+            _report_va_manifest_outcome(
                 shared,
                 build_profile,
-                project_name=project_name,
-                render_dir=render_dir,
-                profile_dir=repo_root,
-                context=context,
-                artifacts=artifacts or None,
+                data_root=va_data_root,
+                tier=va_key[1],
+                prepared=prepared_va_manifest,
+                config=rendered,
             )
-            told_by = "the app template's defaults"
-        projected = attached_render_overrides(
-            host_config,
-            _rendered_config(render_dir),
-            selected_panels=build_profile.web_panels or (),
-        )
-        # A `config:` spelling that contradicts the projection is refused;
-        # one that agrees (inherited from the hosting profile, or laid over
-        # the template's defaults when built alone) is the same fact.
-        duplicate_errors = reach_override_errors(build_profile.config, projected)
-        if duplicate_errors:
-            raise BuildProfileError(
-                "Profile validation failed:\n  " + "\n  ".join(duplicate_errors)
-            )
-        if projected:
-            _apply_config_overrides(render_dir, projected)
+
+        if prepared_va_manifest is not None:
+            write_project_manifest(prepared_va_manifest, render_dir / "data")
             progress(
-                "  ✓ Told this attached render %d fact(s) about the host's services", len(projected)
-            )
-            for key, value in projected.items():
-                progress("      %s: %s (from %s)", key, value, told_by)
-        # A tab this profile selects (`web_panels:`) that the projection gave
-        # no address — the host it was told about runs no such sidecar — would
-        # otherwise vanish from the render without a word.
-        tabless = selected_panel_errors(
-            build_profile.web_panels or (), _rendered_config(render_dir), told_by=told_by
-        )
-        if tabless:
-            raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(tabless))
-
-    injected = _inject_services(build_profile, repo_root, render_dir)
-    if injected_out is not None:
-        injected_out.extend(injected)
-
-    # The selection, projected. The tab strip is read from `web.panels` alone,
-    # and by now every block this render will carry is there: the template's
-    # own for a selected builtin, the profile's `config:` facts about a custom
-    # panel, the facts a persona inherits for a tab it excluded, the blocks the
-    # injectors just wrote for a tab only a persona selects. Each is told
-    # whether THIS render shows it — the facts stay (a persona cannot subtract
-    # `config:`, and the Reach Contract copies addresses from the host's
-    # render); only `enabled` moves, and it says one thing: selected here.
-    projected_tabs = panel_selection_overrides(
-        build_profile.web_panels or (), _rendered_config(render_dir)
-    )
-    if projected_tabs:
-        _apply_config_overrides(render_dir, projected_tabs)
-        off = sorted(key.split(".")[2] for key, shown in projected_tabs.items() if not shown)
-        if off:
-            progress(
-                "  ✓ Switched off %d panel block(s) this profile does not select: %s",
-                len(off),
-                ", ".join(off),
+                "  ✓ Generated virtual-accelerator channel manifest (%d channels)",
+                prepared_va_manifest.manifest["_metadata"]["total_channels"],
             )
 
-    # The ground truth every client loads is the rendered config, so this is
-    # where a consumer switched on with nothing to dial is refused — for a
-    # deployment that dropped a block its modules still use, and for an
-    # attached render that was told nothing (a host, or an app template, that
-    # deploys no such service) alike. AFTER the injectors: a deploying profile
-    # that pins only `web.panels.events.path` has its `url` written by the
-    # dispatch injector, and refusing before that would name a key the build
-    # was about to write. The execution backend is read here for the same
-    # reason: it is the render, not the profile, that a container loads.
-    unrunnable = [
-        *_resolve_rendered_execution_method(render_dir),
-        *reach_errors(_rendered_config(render_dir), repo_root=repo_root),
-        *_incomplete_limits_errors(render_dir),
-    ]
-    if unrunnable:
-        raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(unrunnable))
-    # And the runtime, for the same reason once more: the verbs that stop,
-    # restart and preflight this deployment read the render, and must act on
-    # the runtime that owns the containers rather than re-detect one.
-    _resolve_rendered_container_runtime(render_dir, progress)
+        # The limits database is read here and not in the `unrunnable` gate above,
+        # because it arrives with the conventions: the profile's `data/` tree is
+        # copied into the render after that gate, and a relative `database_path`
+        # resolves to exactly that copy. Same refusal shape as the gate.
+        limits_errors = limits_database_errors(render_dir)
+        if limits_errors:
+            raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(limits_errors))
 
-    applied = _apply_conventions(
-        repo_root,
-        render_dir,
-        _resolve_context_roster(render_dir),
-        extra_known=[
-            *_profile_known_root_entries(build_profile, profile_path),
-            *extra_known,
-        ],
-        excluded=resolved.excluded_artifacts,
-    )
-    if applied.copied:
-        progress(
-            "  ✓ Applied %d profile artifact(s): %s",
-            applied.copied,
-            ", ".join(f"{count} {key}" for key, count in sorted(applied.by_category.items())),
-        )
-        reg_count = _register_convention_artifacts(render_dir, applied)
-        if reg_count:
-            progress("  ✓ Registered %d profile artifact(s) in config.yml", reg_count)
-
-    if va_graph_deferred:
-        # The deferred half of the manifest step above: the render is on disk,
-        # so the rendered config can resolve the corpus the roster reads --
-        # the same resolution every other roster consumer applies. The refusal
-        # (a virtual accelerator with an unreadable or empty corpus) fires
-        # here, still before anything is published outside the render zone.
-        rendered = _rendered_config(render_dir)
-        rendered["config_dir"] = str(render_dir)
-        prepared_va_manifest = prepare_project_manifest(va_data_root, va_key[1], config=rendered)
-        shared.va_manifests[va_key] = prepared_va_manifest
-        _report_va_manifest_outcome(
-            shared,
-            build_profile,
-            data_root=va_data_root,
-            tier=va_key[1],
-            prepared=prepared_va_manifest,
-            config=rendered,
-        )
-
-    if prepared_va_manifest is not None:
-        write_project_manifest(prepared_va_manifest, render_dir / "data")
-        progress(
-            "  ✓ Generated virtual-accelerator channel manifest (%d channels)",
-            prepared_va_manifest.manifest["_metadata"]["total_channels"],
-        )
-
-    # The limits database is read here and not in the `unrunnable` gate above,
-    # because it arrives with the conventions: the profile's `data/` tree is
-    # copied into the render after that gate, and a relative `database_path`
-    # resolves to exactly that copy. Same refusal shape as the gate.
-    limits_errors = limits_database_errors(render_dir)
-    if limits_errors:
-        raise BuildProfileError("Profile validation failed:\n  " + "\n  ".join(limits_errors))
-
-    if build_profile.mcp_servers:
-        _persist_mcp_servers(render_dir, build_profile.mcp_servers)
-        progress("  ✓ Persisted %d MCP server(s) to config.yml", len(build_profile.mcp_servers))
-    if build_profile.artifact_server:
-        _persist_artifact_server(render_dir, build_profile.artifact_server)
-        progress("  ✓ Merged artifact_server overrides into config.yml")
+        if build_profile.mcp_servers:
+            _persist_mcp_servers(render_dir, build_profile.mcp_servers)
+            progress("  ✓ Persisted %d MCP server(s) to config.yml", len(build_profile.mcp_servers))
+        if build_profile.artifact_server:
+            _persist_artifact_server(render_dir, build_profile.artifact_server)
+            progress("  ✓ Merged artifact_server overrides into config.yml")
 
     if deployment:
         report_provider_credentials(render_dir, build_profile.provider, profile_dir=repo_root)
@@ -3433,6 +3450,10 @@ def _inject_services(build_profile: Any, profile_dir: Path, project_path: Path) 
             "scaffolded (it connects to a shared OSPREY services stack)."
         )
         return []
+
+    # Every injector rewrites config.yml with a loader of its own, over the
+    # file's bytes: what the render's edit session still holds has to land first.
+    flush_config_edits(project_path / "config.yml")
 
     injected: list[str] = []
 

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -23,7 +23,12 @@ from typing import TYPE_CHECKING, Any
 
 from osprey.bluesky_bridge_connection import LANE_KEYS, SECOND_LANE_KEYS
 from osprey.errors import BuildProfileError
-from osprey.utils.config_writer import anchored_append, anchored_put
+from osprey.utils.config_writer import (
+    anchored_append,
+    anchored_put,
+    load_config_document,
+    save_config_document,
+)
 from osprey.utils.logger import get_logger
 from osprey_connectors import types as connector_types
 from osprey_connectors.standin import LIVE_STANDIN_PORT_KEY
@@ -134,14 +139,14 @@ def _user_owned_services(project_path: Path) -> set[str]:
     service keys.  Build must not refresh a claimed service template — that
     is the whole point of ``osprey scaffold claim services/<name>``.
     """
-    import yaml as _yaml
+    from osprey_connectors import yaml_loader
 
     config_path = project_path / "config.yml"
     if not config_path.exists():
         return set()
     try:
         with open(config_path, encoding="utf-8") as fh:
-            config = _yaml.safe_load(fh) or {}
+            config = yaml_loader.safe_load(fh) or {}
     except Exception:
         return set()
     owned = config.get("scaffold", {}).get("user_owned", []) or []
@@ -307,15 +312,11 @@ def _copy_service_templates(project_path: Path) -> int:
     Returns:
         Number of service template directories copied.
     """
-    from ruamel.yaml import YAML
-
     config_path = project_path / "config.yml"
     if not config_path.exists():
         return 0
 
-    yaml = YAML()
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # Locate the package's service templates directory
     pkg_services = _locate_pkg_services()
@@ -421,7 +422,6 @@ def _inject_profile_services(
     Returns:
         Number of profile services injected.
     """
-    from ruamel.yaml import YAML
 
     if not services:
         return 0
@@ -430,10 +430,7 @@ def _inject_profile_services(
     if not config_path.exists():
         return 0
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     dest_services_root = project_path / "services"
     dest_services_root.mkdir(exist_ok=True)
@@ -481,8 +478,7 @@ def _inject_profile_services(
 
         count += 1
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     return count
 
@@ -606,10 +602,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
         logger.warning("config.yml not found. Skipping the dispatch config registration.")
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # No ``image`` key on either service, so each falls to its compose default:
     # the event-dispatcher builds the project's <project>-dispatch:local image (its
@@ -700,8 +693,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
                 events_panel, events_url, "/dashboard", "EVENTS", health_endpoint="/health"
             )
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 4. Post-build hint.
     logger.debug(
@@ -1094,7 +1086,6 @@ def _inject_bluesky(
             if a ``standin`` lane has no ``virtual_accelerator.live_standin``
             port to dial.
     """
-    from ruamel.yaml import YAML
 
     # 1. Copy the bundled compose template (located the same way as service templates).
     pkg_services = _locate_pkg_services()
@@ -1119,10 +1110,7 @@ def _inject_bluesky(
         logger.warning("config.yml not found. Skipping the bluesky config registration.")
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     _refuse_unknown_lane_targets(config)
 
@@ -1239,8 +1227,7 @@ def _inject_bluesky(
             anchored_append(deployed, lane_key)
     config["deployed_services"] = deployed
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 3. Post-build hint.
     logger.debug("  ✓ Injected Bluesky bridge (port %d)", bluesky.port)
@@ -1396,7 +1383,6 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
         va: Validated Virtual Accelerator configuration from the build profile.
         project_path: Root of the built project.
     """
-    from ruamel.yaml import YAML
 
     # 1. Copy the bundled compose template (located the same way as service templates).
     pkg_services = _locate_pkg_services()
@@ -1422,10 +1408,7 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
         )
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # No scenario-state directory is created here. Pre-creating the compose bind
     # source — so the container runtime cannot materialize it root-owned — only
@@ -1471,8 +1454,7 @@ def _inject_va(va: VAConfig, project_path: Path) -> None:
     # able to point at it is what would otherwise need a hand edit.
     wrote_gateways = _ensure_va_connector_gateways(config)
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 4. Post-build hint.
     logger.debug("  ✓ Injected Virtual Accelerator soft-IOC (CA port %d)", va.port)
@@ -1562,7 +1544,6 @@ def _inject_bluesky_web(bluesky_web: BlueskyWebConfig, project_path: Path) -> No
         bluesky_web: Validated bluesky-web configuration from the build profile.
         project_path: Root of the built project.
     """
-    from ruamel.yaml import YAML
 
     # 1. Copy the bundled compose template (located the same way as service templates).
     pkg_services = _locate_pkg_services()
@@ -1584,10 +1565,7 @@ def _inject_bluesky_web(bluesky_web: BlueskyWebConfig, project_path: Path) -> No
         logger.warning("config.yml not found. Skipping the bluesky_web config registration.")
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # No ``image`` key: the service builds the local bluesky-web image on
     # first ``osprey up``. Override with OSPREY_BLUESKY_WEB_IMAGE, or
@@ -1634,8 +1612,7 @@ def _inject_bluesky_web(bluesky_web: BlueskyWebConfig, project_path: Path) -> No
             continue
         _fill_panel_defaults(panel_cfg, default_url, panel_path, label)
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 4. Post-build hint.
     logger.debug("  ✓ Injected bluesky-web sidecar (port %d)", bluesky_web.port)
@@ -1678,7 +1655,6 @@ def _inject_nextcloud_bridge(
             declared in the resolved triggers file.
         project_path: Root of the built project.
     """
-    from ruamel.yaml import YAML
 
     # 1. Copy the bundled compose template (located the same way as service templates).
     pkg_services = _locate_pkg_services()
@@ -1700,10 +1676,7 @@ def _inject_nextcloud_bridge(
         logger.warning("config.yml not found. Skipping the nextcloud_bridge config registration.")
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # ``trigger`` is the one key the compose template reads with NO ``| default``
     # — it renders DISPATCH_TRIGGER straight from here, so a missing key must
@@ -1731,8 +1704,7 @@ def _inject_nextcloud_bridge(
         anchored_append(deployed, "nextcloud_bridge")
     config["deployed_services"] = deployed
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 3. Post-build hint.
     logger.debug("  ✓ Injected Nextcloud Talk bridge (trigger %r)", nextcloud_bridge.trigger)
@@ -1781,7 +1753,6 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
             declared in the resolved triggers file.
         project_path: Root of the built project.
     """
-    from ruamel.yaml import YAML
 
     # 1. Copy the bundled compose template (located the same way as service templates).
     pkg_services = _locate_pkg_services()
@@ -1803,10 +1774,7 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
         logger.warning("config.yml not found. Skipping the gchat_bridge config registration.")
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # ``trigger`` is the one key the compose template reads with NO ``| default``
     # — it renders DISPATCH_TRIGGER straight from here, so a missing key must
@@ -1830,8 +1798,7 @@ def _inject_gchat_bridge(gchat_bridge: GChatBridgeProfileConfig, project_path: P
         deployed.append("gchat_bridge")
     config["deployed_services"] = deployed
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 3. Post-build hint.
     logger.debug("  ✓ Injected Google Chat bridge (trigger %r)", gchat_bridge.trigger)
@@ -1887,7 +1854,6 @@ def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> No
         va_archiver: Validated archiver configuration from the build profile.
         project_path: Root of the built project.
     """
-    from ruamel.yaml import YAML
 
     # 1. Copy the bundled compose templates (located the same way as service
     #    templates). The recorder ships no Dockerfile — it runs the VA's image
@@ -1919,10 +1885,7 @@ def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> No
         logger.warning("config.yml not found. Skipping the archiver config registration.")
         return
 
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    with open(config_path) as fh:
-        config = yaml.load(fh)
+    config = load_config_document(config_path)
 
     # Only the keys the compose templates read: how the store publishes itself,
     # who it creates, and how it compresses. They restate profile knobs the
@@ -1960,8 +1923,7 @@ def _inject_va_archiver(va_archiver: VAArchiverConfig, project_path: Path) -> No
             anchored_append(deployed, name)
     config["deployed_services"] = deployed
 
-    with open(config_path, "w") as fh:
-        yaml.dump(config, fh)
+    save_config_document(config_path, config)
 
     # 3. Post-build hint.
     logger.debug(

--- a/src/osprey/cli/build_limits_check.py
+++ b/src/osprey/cli/build_limits_check.py
@@ -30,8 +30,11 @@ LIMITS_DATABASE_KEY = "control_system.limits_checking.database_path"
 
 
 def _rendered_config(render_dir: Path) -> dict[str, Any]:
+    from osprey.utils.config_writer import flush_config_edits
     from osprey_connectors import yaml_loader
 
+    # The render edits config.yml under one session; read what it holds.
+    flush_config_edits(render_dir / "config.yml")
     with (render_dir / "config.yml").open("r", encoding="utf-8") as fh:
         return yaml_loader.safe_load(fh) or {}
 

--- a/src/osprey/cli/build_persistence.py
+++ b/src/osprey/cli/build_persistence.py
@@ -120,13 +120,13 @@ def _resolve_context_roster(project_path: Path) -> list[str]:
     slots this copy fills.
     """
     from osprey.deployment.web_terminals.personas import as_dict, roster_user_names
-    from osprey.utils.config_writer import _load
+    from osprey.utils.config_writer import load_config_document
 
     config_path = project_path / "config.yml"
     if not config_path.exists():
         return []
 
-    modules = as_dict(as_dict(_load(config_path)).get("modules"))
+    modules = as_dict(as_dict(load_config_document(config_path)).get("modules"))
     return roster_user_names(modules.get("web_terminals"))
 
 
@@ -426,12 +426,12 @@ def _persist_mcp_servers(project_path: Path, mcp_servers: dict[str, Any]) -> Non
     ``.mcp.json`` and ``settings.json``.  Placeholders like ``{project_root}``
     are preserved as-is — resolution happens during regen.
     """
-    from osprey.utils.config_writer import _load, _save, anchored_put
+    from osprey.utils.config_writer import anchored_put, load_config_document, save_config_document
 
     from .build_profile import McpServerDef
 
     config_path = project_path / "config.yml"
-    data = _load(config_path)
+    data = load_config_document(config_path)
 
     # Collect the server specs first, then register them via anchored_put:
     # writing an empty ``servers:`` map and filling it afterwards would leave
@@ -491,7 +491,7 @@ def _persist_mcp_servers(project_path: Path, mcp_servers: dict[str, Any]) -> Non
         else:
             anchored_put(cc, "servers", specs)
 
-    _save(config_path, data)
+    save_config_document(config_path, data)
 
 
 def _persist_artifact_server(project_path: Path, overrides: dict[str, Any]) -> None:
@@ -503,10 +503,10 @@ def _persist_artifact_server(project_path: Path, overrides: dict[str, Any]) -> N
     """
     from ruamel.yaml import CommentedMap
 
-    from osprey.utils.config_writer import _load, _save, anchored_put
+    from osprey.utils.config_writer import anchored_put, load_config_document, save_config_document
 
     config_path = project_path / "config.yml"
-    data = _load(config_path)
+    data = load_config_document(config_path)
 
     if "artifact_server" not in data:
         # Root-level append: new top-level sections land at the file tail
@@ -528,4 +528,4 @@ def _persist_artifact_server(project_path: Path, overrides: dict[str, Any]) -> N
         else:
             anchored_put(block, "categories", categories)
 
-    _save(config_path, data)
+    save_config_document(config_path, data)

--- a/src/osprey/cli/build_profile_resolve.py
+++ b/src/osprey/cli/build_profile_resolve.py
@@ -647,9 +647,9 @@ def _write_profile_values(profile_path: Path, updates: list[tuple[list[str], Any
     """
     from ruamel.yaml import CommentedMap
 
-    from osprey.utils.config_writer import _load, _yaml
+    from osprey.utils.config_writer import _yaml, load_config_document
 
-    data = _load(profile_path)
+    data = load_config_document(profile_path)
     for key_path, value in updates:
         node = data
         for segment in key_path[:-1]:

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -24,6 +24,7 @@ from osprey.errors import BuildProfileError
 from osprey.services.build_artifacts.catalog import BuildArtifactCatalog
 from osprey.utils.config import resolve_env_vars
 from osprey.utils.facility import resolve_facility_name
+from osprey_connectors import yaml_loader
 
 logger = logging.getLogger("osprey.cli.templates")
 
@@ -2028,7 +2029,7 @@ def regenerate_claude_code(
         )
 
     with open(config_file, encoding="utf-8") as f:
-        config = yaml.safe_load(f) or {}
+        config = yaml_loader.safe_load(f) or {}
 
     config = resolve_env_vars(config)
 

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -6,7 +6,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-import yaml
 from jinja2 import Environment, FileSystemLoader, TemplateRuntimeError, select_autoescape
 
 from osprey.build.build_tiers import (
@@ -22,6 +21,7 @@ from osprey.profiles.web_panels import BUILTIN_PANELS
 from osprey.utils.config import resolve_env_vars
 from osprey.utils.facility import resolve_facility_name
 from osprey.utils.workspace import repo_root_for_config
+from osprey_connectors import yaml_loader
 
 logger = logging.getLogger("osprey.cli.templates")
 
@@ -338,7 +338,7 @@ class TemplateManager:
         ctx.setdefault("facility_permissions", {})
         if config_file.exists():
             with open(config_file) as f:
-                rendered_config = yaml.safe_load(f) or {}
+                rendered_config = yaml_loader.safe_load(f) or {}
             rendered_config = resolve_env_vars(rendered_config)  # Match regen path
             # Claude Code explicit overrides
             cc_config = rendered_config.get("claude_code", {})

--- a/src/osprey/cli/users_cmd.py
+++ b/src/osprey/cli/users_cmd.py
@@ -204,9 +204,9 @@ def _drop_user_from_profile_roster(profile_path: Path, user: str) -> _RosterEdit
     """
     from ruamel.yaml.comments import CommentedMap
 
-    from osprey.utils.config_writer import _load, _save
+    from osprey.utils.config_writer import load_config_document, save_config_document
 
-    data = _load(profile_path)
+    data = load_config_document(profile_path)
     located = _locate_profile_roster(data.get("config") if isinstance(data, dict) else None)
     if located is None:
         return _RosterEdit(changed=False, expanded_bare_entries=False)
@@ -238,7 +238,7 @@ def _drop_user_from_profile_roster(profile_path: Path, user: str) -> _RosterEdit
         if isinstance(entry, dict) and entry.get("name") == user:
             del roster[position]
 
-    _save(profile_path, data)
+    save_config_document(profile_path, data)
     return _RosterEdit(changed=True, expanded_bare_entries=expanded)
 
 

--- a/src/osprey/deployment/web_terminals/personas.py
+++ b/src/osprey/deployment/web_terminals/personas.py
@@ -41,6 +41,7 @@ from osprey.deployment.graphdb_service import resolve_graphdb_service_config
 from osprey.profiles.web_panels import panel_spec_enabled
 from osprey.registry.mcp import FRAMEWORK_SERVERS
 from osprey.utils.workspace import BUILD_DIR_NAME
+from osprey_connectors import yaml_loader
 from osprey_connectors.types import (
     baseline_target,
     target_writes_enabled,
@@ -716,7 +717,7 @@ def _persona_configs(
             continue
         try:
             with config_yml.open("r", encoding="utf-8") as fh:
-                persona_config = yaml.safe_load(fh)
+                persona_config = yaml_loader.safe_load(fh)
         except (OSError, yaml.YAMLError):
             continue
         yield persona_name, persona_config

--- a/src/osprey/utils/config_writer.py
+++ b/src/osprey/utils/config_writer.py
@@ -21,12 +21,21 @@ Typical usage:
         "control_system.connector.virtual_accelerator.writes_enabled": True,
         "approval.tools.channel_write": "always",
     })
+
+    # A run of edits to one file: loaded once, written once at the end
+    with config_edit_session(Path("config.yml")):
+        config_update_fields(Path("config.yml"), {...})
+        config_add_to_list(Path("config.yml"), ["scaffold", "user_owned"], "rules/a")
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -416,7 +425,7 @@ def config_backup_path(config_path: Path) -> Path:
     from osprey.utils.workspace import agent_data_base_dir, anchored_path, repo_root_for_config
 
     try:
-        config = _load(config_path)
+        config = load_config_document(config_path)
     except Exception:  # noqa: BLE001 -- an unreadable config still deserves a backup
         # Falls back to the framework default rather than to the file's own
         # directory: a config too broken to name its own state zone is precisely
@@ -472,17 +481,192 @@ def write_config_backup(config_path: Path) -> Path:
     return backup_path
 
 
-def _load(path: Path) -> Any:
-    """Load a YAML file with comment preservation."""
+def load_config_document(path: Path) -> Any:
+    """Load a YAML file with comment preservation, for a writer to edit in place.
+
+    The pair with :func:`save_config_document` is what a writer uses when it
+    edits the document itself rather than through the dotted-key functions
+    below — the build's service injectors and ``auto`` resolvers. Using this
+    pair rather than a ``YAML()`` of its own is what makes such a writer join
+    a :func:`config_edit_session`: inside a session for *path* the session's
+    document is returned, loaded once and shared by every writer in the
+    session. It is the live document — a mutation made to it is what the
+    session writes, whether or not :func:`save_config_document` is called.
+
+    Outside a session this is one load from disk.
+    """
+    session = _sessions.get(_session_key(path))
+    if session is not None:
+        return session.document()
+    return _load_from_disk(path)
+
+
+def _load_from_disk(path: Path) -> Any:
     with open(path, encoding="utf-8") as f:
         data = _yaml.load(f)
     return data if data is not None else CommentedMap()
 
 
-def _save(path: Path, data: Any) -> None:
-    """Write data back to a YAML file, preserving comments."""
+def save_config_document(path: Path, data: Any) -> None:
+    """Write a document back to its YAML file, preserving comments.
+
+    Inside a :func:`config_edit_session` for *path* the write is deferred: the
+    document is held until the session flushes (see :func:`flush_config_edits`)
+    or ends. Outside a session this is one dump to disk, in the one style every
+    writer here uses (block sequences indented under their key, no wrapping).
+    """
+    session = _sessions.get(_session_key(path))
+    if session is not None:
+        session.stage(data)
+        return
+    _save_to_disk(path, data)
+
+
+def _save_to_disk(path: Path, data: Any) -> None:
     with open(path, "w", encoding="utf-8") as f:
         _yaml.dump(data, f)
+
+
+# =============================================================================
+# Edit Sessions
+# =============================================================================
+# Every writer below round-trips the whole document: load with the
+# comment-preserving loader, mutate, dump. That is the right unit for one
+# `osprey set`, and the wrong one for a build, which applies a few dozen such
+# edits to each rendered config.yml with the load costing several times the
+# dump. A session makes the run of edits one round trip: the first writer
+# loads the document, every writer edits that document in memory, and it is
+# dumped once — at the session's end, or earlier when something has to read
+# the file's bytes.
+#
+# Two things about disk are made explicit rather than left to luck:
+#
+# * A READER of the file's bytes sees pending edits only after a flush. The
+#   build's shared parse flushes before it reads; any other reader must call
+#   `flush_config_edits` first. Readers that go through `load_config_document` need nothing —
+#   they get the live document.
+# * A WRITER that bypasses the session (an injector with its own YAML
+#   instance) is detected by content digest. After a flush, its write is
+#   picked up by reloading; under pending edits, it is a conflict and the
+#   pending edits are dropped rather than written over it.
+
+
+class ConfigEditConflict(RuntimeError):
+    """The file changed on disk under a session's pending edits.
+
+    Something wrote the file without going through the session while it held
+    edits that had not been flushed. Neither side can be kept without losing
+    the other, so the session refuses and drops its own — the file is left as
+    the other writer left it. The fix is ordering: flush the session
+    (:func:`flush_config_edits`) before handing the file to a writer that
+    does not use it.
+    """
+
+
+@dataclass
+class _EditSession:
+    """The in-memory document of one file for the duration of a session."""
+
+    path: Path
+    doc: Any = None
+    #: SHA-256 of the file's bytes the document mirrors: as loaded, or as
+    #: last flushed. What tells an outside write from our own.
+    synced_digest: bytes | None = None
+    dirty: bool = False
+
+    def _disk_digest(self) -> bytes:
+        return hashlib.sha256(self.path.read_bytes()).digest()
+
+    def document(self) -> Any:
+        digest = self._disk_digest()
+        if self.doc is None or (digest != self.synced_digest and not self.dirty):
+            # First touch, or someone else wrote the file since we last synced
+            # and we hold nothing they could lose: take theirs.
+            self.doc = _load_from_disk(self.path)
+            self.synced_digest = digest
+            self.dirty = False
+        elif digest != self.synced_digest:
+            self._conflict()
+        return self.doc
+
+    def stage(self, data: Any) -> None:
+        self.doc = data
+        self.dirty = True
+
+    def flush(self) -> None:
+        if not self.dirty:
+            return
+        if self._disk_digest() != self.synced_digest:
+            self._conflict()
+        _save_to_disk(self.path, self.doc)
+        self.synced_digest = self._disk_digest()
+        self.dirty = False
+
+    def _conflict(self) -> None:
+        self.doc = None
+        self.dirty = False
+        raise ConfigEditConflict(
+            f"{self.path} was rewritten outside its edit session while the session "
+            "held unflushed edits; the pending edits were dropped. Flush the session "
+            "(flush_config_edits) before handing the file to a writer that bypasses it."
+        )
+
+
+_sessions: dict[Path, _EditSession] = {}
+
+
+def _session_key(path: Path) -> Path:
+    return Path(path).resolve()
+
+
+@contextmanager
+def config_edit_session(config_path: Path) -> Iterator[None]:
+    """Batch every config edit to *config_path* made inside the block.
+
+    Within the block the writers in this module (:func:`config_update_fields`,
+    :func:`config_add_to_list`, ... — anything built on :func:`load_config_document` and
+    :func:`save_config_document`) share one loaded document and write nothing; the document
+    is written once when the block ends, or earlier by
+    :func:`flush_config_edits`. Signatures, return values and the bytes
+    written are those of the same calls made one at a time.
+
+    Nested sessions on the same file join the outer one. Sessions on different
+    files are independent. The block ending on an exception still flushes,
+    matching what one-at-a-time writes would have left on disk — except a
+    :class:`ConfigEditConflict`, where the file is left to the other writer.
+
+    Args:
+        config_path: The YAML file whose edits to batch. Need not exist yet;
+            the first writer to touch it loads it.
+    """
+    key = _session_key(config_path)
+    if key in _sessions:
+        yield
+        return
+    session = _EditSession(path=key)
+    _sessions[key] = session
+    try:
+        yield
+    except ConfigEditConflict:
+        raise
+    except BaseException:
+        session.flush()
+        raise
+    else:
+        session.flush()
+    finally:
+        del _sessions[key]
+
+
+def flush_config_edits(config_path: Path) -> None:
+    """Write *config_path*'s pending session edits to disk, if there are any.
+
+    The call a reader of the file's *bytes* makes before reading, while a
+    session may be open. A no-op outside a session or with nothing pending.
+    """
+    session = _sessions.get(_session_key(config_path))
+    if session is not None:
+        session.flush()
 
 
 # =============================================================================
@@ -530,7 +714,7 @@ def config_add_to_list(
     Returns:
         True if the value was added, False if it was already present.
     """
-    data = _load(config_path)
+    data = load_config_document(config_path)
     node = _ensure_parent_node(data, key_path)
 
     leaf = key_path[-1]
@@ -542,7 +726,7 @@ def config_add_to_list(
         return False
 
     anchored_append(lst, value)
-    _save(config_path, data)
+    save_config_document(config_path, data)
     logger.debug("config_add_to_list: %s += %s in %s", ".".join(key_path), value, config_path)
     return True
 
@@ -565,7 +749,7 @@ def config_remove_from_list(
     Returns:
         True if the value was removed, False if it was not present.
     """
-    data = _load(config_path)
+    data = load_config_document(config_path)
 
     parents: list[tuple[Any, str]] = []
     node = data
@@ -593,7 +777,7 @@ def config_remove_from_list(
             if isinstance(child, dict) and not child:
                 del parent_node[parent_key]
 
-    _save(config_path, data)
+    save_config_document(config_path, data)
     logger.debug("config_remove_from_list: %s -= %s in %s", ".".join(key_path), value, config_path)
     return True
 
@@ -625,11 +809,11 @@ def config_replace_list(
             :func:`config_add_to_list`.
         new_list: The full replacement list (scalars, or nested dicts/lists).
     """
-    data = _load(config_path)
+    data = load_config_document(config_path)
     node = _ensure_parent_node(data, key_path)
 
     node[key_path[-1]] = new_list
-    _save(config_path, data)
+    save_config_document(config_path, data)
     logger.debug(
         "config_replace_list: %s = <%d item(s)> in %s",
         ".".join(key_path),
@@ -651,12 +835,12 @@ def config_update_fields(
         config_path: Path to the YAML file.
         updates: Mapping of ``"dot.separated.key"`` → new value.
     """
-    data = _load(config_path)
+    data = load_config_document(config_path)
 
     for dotted_key, value in updates.items():
         _set_dotted_anchored(data, data, dotted_key, value, create_only=True)
 
-    _save(config_path, data)
+    save_config_document(config_path, data)
     logger.debug("config_update_fields: updated %d field(s) in %s", len(updates), config_path)
 
 
@@ -673,7 +857,7 @@ def config_delete_field(config_path: Path, dotted_key: str) -> bool:
     Returns:
         Whether the key was present and removed.
     """
-    data = _load(config_path)
+    data = load_config_document(config_path)
     parts = dotted_key.split(".")
     node = data
     for part in parts[:-1]:
@@ -683,7 +867,7 @@ def config_delete_field(config_path: Path, dotted_key: str) -> bool:
     if not isinstance(node, dict) or parts[-1] not in node:
         return False
     del node[parts[-1]]
-    _save(config_path, data)
+    save_config_document(config_path, data)
     logger.debug("config_delete_field: removed %s from %s", dotted_key, config_path)
     return True
 
@@ -748,7 +932,7 @@ def config_read(config_path: Path) -> dict:
     import copy
     import json
 
-    data = _load(config_path)
+    data = load_config_document(config_path)
     return json.loads(json.dumps(copy.deepcopy(data), default=str))
 
 
@@ -794,7 +978,7 @@ def update_yaml_file(
         ...     }
         ... })
     """
-    data = _load(file_path)
+    data = load_config_document(file_path)
 
     # Create backup before modifying
     backup_path = None
@@ -820,7 +1004,7 @@ def update_yaml_file(
                 comment_text = f"\n{separator}\n{comment}\n{separator}"
                 data.yaml_set_comment_before_after_key(key, before=comment_text)
 
-    _save(file_path, data)
+    save_config_document(file_path, data)
 
     return backup_path
 
@@ -876,7 +1060,7 @@ def get_control_system_type(config_path: Path, key: str = "control_system.type")
         Type string or None if not found
     """
     try:
-        data = _load(config_path)
+        data = load_config_document(config_path)
 
         keys = key.split(".")
         value = data
@@ -1034,7 +1218,7 @@ def get_epics_gateway_config(config_path: Path) -> dict | None:
         Dict with gateway configuration or None if not found
     """
     try:
-        data = _load(config_path)
+        data = load_config_document(config_path)
 
         gateways = (
             data.get("control_system", {}).get("connector", {}).get("epics", {}).get("gateways")

--- a/tests/cli/test_build_config_edit_session.py
+++ b/tests/cli/test_build_config_edit_session.py
@@ -1,0 +1,179 @@
+"""The build edits each rendered ``config.yml`` in one session, and reads see the edits.
+
+``_render_project`` applies a few dozen comment-preserving edits to the config
+it just rendered — the profile's overrides, the ownership registrations, the
+MCP servers. Under :func:`~osprey.utils.config_writer.config_edit_session` they
+share one ruamel load and one dump. The price is an ordering rule: whatever
+reads the file's *bytes* while the session is open has to flush it first. These
+tests pin that rule at each seam the render has — the shared parse
+(``_rendered_config``), the limits reader, and the service injectors, which
+rewrite the file with their own YAML instance — and pin the render's output
+against the one-edit-at-a-time path, byte for byte.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import ruamel.yaml
+from click.testing import CliRunner
+
+from osprey.cli import build_cmd, build_limits_check
+from osprey.cli.build_cmd import build
+from osprey.utils.config_writer import config_edit_session, config_update_fields
+
+SAMPLE = """\
+control_system:
+  type: mock
+  limits_checking:
+    enabled: false
+container_runtime: docker
+"""
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache() -> None:
+    build_cmd._rendered_config_cache.clear()
+
+
+def _render(tmp_path: Path) -> Path:
+    render_dir = tmp_path / "render"
+    render_dir.mkdir()
+    (render_dir / "config.yml").write_text(SAMPLE, encoding="utf-8")
+    return render_dir
+
+
+def test_the_shared_parse_sees_pending_edits(tmp_path: Path) -> None:
+    render_dir = _render(tmp_path)
+    config_path = render_dir / "config.yml"
+
+    with config_edit_session(config_path):
+        config_update_fields(config_path, {"control_system.type": "epics"})
+        assert build_cmd._rendered_config(render_dir)["control_system"]["type"] == "epics"
+        # The read flushed: the file now carries the edit too.
+        assert "type: epics" in config_path.read_text(encoding="utf-8")
+
+
+def test_the_limits_reader_sees_pending_edits(tmp_path: Path) -> None:
+    render_dir = _render(tmp_path)
+    config_path = render_dir / "config.yml"
+
+    with config_edit_session(config_path):
+        config_update_fields(config_path, {"control_system.limits_checking.enabled": True})
+        parsed = build_limits_check._rendered_config(render_dir)
+
+    assert parsed["control_system"]["limits_checking"]["enabled"] is True
+
+
+def test_the_injectors_run_on_a_flushed_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Injectors rewrite config.yml with their own loader; they must see every edit."""
+    render_dir = _render(tmp_path)
+    config_path = render_dir / "config.yml"
+    seen: list[str] = []
+
+    def first_injector_step(project_path: Path) -> int:
+        seen.append((project_path / "config.yml").read_text(encoding="utf-8"))
+        return 0
+
+    monkeypatch.setattr(build_cmd, "_copy_service_templates", first_injector_step)
+    profile = SimpleNamespace(
+        deploy_services=True,
+        services=None,
+        dispatch=None,
+        nextcloud_bridge=None,
+        gchat_bridge=None,
+        bluesky=None,
+        bluesky_web=None,
+        virtual_accelerator=None,
+        va_archiver=None,
+    )
+
+    with config_edit_session(config_path):
+        config_update_fields(config_path, {"control_system.type": "epics"})
+        build_cmd._inject_services(profile, tmp_path, render_dir)
+
+    assert len(seen) == 1
+    assert "type: epics" in seen[0]
+
+
+class TestTheRenderedConfigIsUnchanged:
+    """Byte-identical output: the session changes when the file is written, not what."""
+
+    def test_exemplar_render_matches_the_one_edit_at_a_time_render(
+        self, lifecycle_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = CliRunner()
+
+        def build_here() -> bytes:
+            previous = Path.cwd()
+            os.chdir(lifecycle_repo)
+            try:
+                result = runner.invoke(build, ["--skip-deps", "--skip-lifecycle"])
+            finally:
+                os.chdir(previous)
+            assert result.exit_code == 0, result.output
+            return (lifecycle_repo / "build" / "config.yml").read_bytes()
+
+        batched = build_here()
+
+        # The same repo, rendered again with every edit written as it is made.
+        monkeypatch.setattr(build_cmd, "config_edit_session", contextlib.nullcontext)
+        one_at_a_time = build_here()
+
+        assert batched == one_at_a_time
+        assert b"deployed_services" in batched  # a real render, not two empty files
+
+
+def test_a_build_parses_each_renders_config_once(
+    lifecycle_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The contract this module exists for, measured on a real build.
+
+    Every writer that edits a rendered ``config.yml`` — the dotted-key writers,
+    the service injectors, the ``auto`` resolvers — shares the render's one
+    document, so the comment-preserving parse happens once per render. A
+    second parse of the same file would mean a writer went around the session
+    and the file had to be reloaded behind it. Dumps are not counted: a reader
+    of the file's bytes flushes pending edits first, and how many times that
+    happens is the readers' business, not the loader's.
+    """
+    loads: list[str] = []
+    real_load = ruamel.yaml.YAML.load
+
+    def counting_load(self: ruamel.yaml.YAML, stream: object) -> object:
+        name = getattr(stream, "name", None)
+        if isinstance(name, str) and name.endswith("config.yml"):
+            loads.append(name)
+        return real_load(self, stream)
+
+    monkeypatch.setattr(ruamel.yaml.YAML, "load", counting_load)
+
+    previous = Path.cwd()
+    os.chdir(lifecycle_repo)
+    try:
+        result = CliRunner().invoke(build, ["--skip-deps", "--skip-lifecycle"])
+    finally:
+        os.chdir(previous)
+    assert result.exit_code == 0, result.output
+
+    # The renders: every config.yml the build wrote that is a project's own —
+    # not a bundled service template's, which no writer here edits. The build
+    # renders into a staging directory and swaps it into place, so the parsed
+    # paths are compared by count, not by name: no file parsed twice, and as
+    # many files parsed as there are renders.
+    renders = [
+        p for p in (lifecycle_repo / "build").rglob("config.yml") if "services" not in p.parts
+    ]
+    assert renders, "the exemplar build rendered nothing"
+    render_loads = [name for name in loads if "/services/" not in name]
+    twice = sorted({name for name in render_loads if render_loads.count(name) > 1})
+    assert not twice, "a render's config.yml was parsed more than once:\n" + "\n".join(twice)
+    assert len(render_loads) == len(renders), (
+        f"{len(render_loads)} config.yml parse(s) for {len(renders)} render(s)"
+    )

--- a/tests/cli/test_dispatch_network_injection.py
+++ b/tests/cli/test_dispatch_network_injection.py
@@ -28,13 +28,15 @@ from osprey.cli.build_profile import DispatchConfig
 
 # The exact config.yml this injection renders for the profile built by
 # ``_dispatch()`` below, captured from the injector as it stood before the
-# network axis existed. Any byte of drift in the default (bridge) render is a
-# regression, not a refresh: the axis is opt-in and unset means unchanged.
+# network axis existed and re-pinned when the injector joined the shared config
+# writer, whose style indents block sequences under their key. Any byte of
+# drift in the default (bridge) render is a regression, not a refresh: the
+# axis is opt-in and unset means unchanged.
 PRE_AXIS_CONFIG_YML = """\
 deployed_services:
-- postgresql
-- event_dispatcher
-- dispatch_worker
+  - postgresql
+  - event_dispatcher
+  - dispatch_worker
 services:
   postgresql: {}
   event_dispatcher:
@@ -43,8 +45,8 @@ services:
     facility_name: ALS
     pv_strip_prefix: 'ALS:'
     additional_dirs:
-    - src: triggers.yml
-      dst: triggers.yml
+      - src: triggers.yml
+        dst: triggers.yml
   dispatch_worker:
     path: ./services/dispatch_worker
     worker_count: 1

--- a/tests/utils/test_config_writer_edit_session.py
+++ b/tests/utils/test_config_writer_edit_session.py
@@ -1,0 +1,444 @@
+"""``config_edit_session``: one ruamel load and one dump for a run of config edits.
+
+Every writer in :mod:`osprey.utils.config_writer` round-trips the whole document
+through ruamel's comment-preserving loader — load, mutate, dump. A build applies
+a few dozen of them to each rendered ``config.yml``, and the load is what costs.
+Inside a session the document is loaded once, every writer edits it in memory,
+and it is dumped once: at the session's end, or earlier when something has to
+read the file from disk.
+
+What these tests pin, in order of importance:
+
+* the bytes a session writes are the bytes the same edits wrote one at a time —
+  comments, key order, indentation, quoting, all of it;
+* the ordering contract with disk readers is explicit — ``flush_config_edits``
+  is what makes a pending edit visible to a reader of the file's bytes, and a
+  writer that bypasses the session is detected rather than overwritten.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osprey.utils import config_writer
+from osprey.utils.config_writer import (
+    ConfigEditConflict,
+    config_add_to_list,
+    config_delete_field,
+    config_edit_session,
+    config_remove_from_list,
+    config_replace_list,
+    config_update_fields,
+    flush_config_edits,
+    load_config_document,
+    save_config_document,
+    update_yaml_file,
+)
+
+SAMPLE = """\
+# ============================================================
+# CLAUDE CODE
+# ============================================================
+claude_code:
+  provider: 'anthropic'   # quoted on purpose
+  default_model: haiku
+  timeout: 300
+
+# ============================================================
+# WEB PANEL CONFIGURATION
+# ============================================================
+# Prose about panels.
+
+web:
+  panels:
+    ariel:
+      enabled: true
+      url: http://localhost:8082
+    # trailing panel docs
+
+services:
+  postgresql:
+    path: ./services/postgresql
+  openobserve:
+    path: ./services/openobserve
+    port: 5080          # Host port
+
+# Services to deploy with `osprey up`
+deployed_services:
+  - postgresql
+  - openobserve
+
+scaffold:
+  user_owned:
+    - rules/facility
+
+# ============================================================
+# SAFETY CONTROLS
+# ============================================================
+approval:
+  enabled: true
+  tools:
+    channel_write: always
+"""
+
+
+def _write(path: Path, text: str = SAMPLE) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _recorded_edits(path: Path) -> list[Any]:
+    """The operation sequence a build applies, in a build's shape.
+
+    Overrides first (existing keys, new nested keys, a new root section), then
+    a run of ownership registrations, a duplicate that must be a no-op, a
+    removal, a whole-list replacement, a delete and the legacy nested-update
+    writer. Returns what each call returned so the two paths can be compared
+    on their results as well as on their bytes.
+    """
+    results: list[Any] = []
+    results.append(
+        config_update_fields(
+            path,
+            {
+                "claude_code.default_model": "sonnet",
+                "web.panels.ariel.enabled": False,
+                "web.panels.events.url": "http://localhost:9091",
+                "web.panels.events.enabled": True,
+                "control_system.type": "mock",
+                "control_system.writes_enabled": False,
+                "approval.tools.channel_write": "never",
+            },
+        )
+    )
+    for name in ("rules/facility", "rules/facility-ops", "skills/orbit-check", "services/foo"):
+        results.append(config_add_to_list(path, ["scaffold", "user_owned"], name))
+    results.append(config_add_to_list(path, ["deployed_services"], "event_dispatcher"))
+    results.append(config_remove_from_list(path, ["deployed_services"], "openobserve"))
+    results.append(
+        config_replace_list(
+            path,
+            ["modules", "web_terminals", "users"],
+            [{"name": "alice", "index": 0}, {"name": "bob", "index": 1}],
+        )
+    )
+    results.append(config_delete_field(path, "services.openobserve.port"))
+    results.append(
+        update_yaml_file(
+            path,
+            {"execution": {"execution_method": "container"}},
+            create_backup=False,
+            section_comments={"execution": "Execution backend"},
+        )
+    )
+    return results
+
+
+@pytest.fixture
+def counters(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Count ruamel round-trip loads and dumps the shared writer performs."""
+    counts = {"load": 0, "dump": 0}
+    real_load = config_writer._yaml.load
+    real_dump = config_writer._yaml.dump
+
+    def counting_load(stream: Any) -> Any:
+        counts["load"] += 1
+        return real_load(stream)
+
+    def counting_dump(data: Any, stream: Any, **kwargs: Any) -> Any:
+        counts["dump"] += 1
+        return real_dump(data, stream, **kwargs)
+
+    monkeypatch.setattr(config_writer._yaml, "load", counting_load)
+    monkeypatch.setattr(config_writer._yaml, "dump", counting_dump)
+    return counts
+
+
+class TestByteIdentity:
+    def test_a_session_writes_what_the_same_edits_wrote_one_at_a_time(self, tmp_path: Path):
+        one_at_a_time = _write(tmp_path / "plain" / "config.yml")
+        batched = _write(tmp_path / "batched" / "config.yml")
+
+        plain_results = _recorded_edits(one_at_a_time)
+        with config_edit_session(batched):
+            batched_results = _recorded_edits(batched)
+
+        assert batched.read_bytes() == one_at_a_time.read_bytes()
+        assert batched_results == plain_results
+        # And the edits landed: this is not two untouched copies agreeing.
+        text = batched.read_text(encoding="utf-8")
+        assert "default_model: sonnet" in text
+        assert "# Host port" not in text  # deleted with its key
+        assert "Execution backend" in text
+        assert text != SAMPLE
+
+    def test_the_file_is_untouched_until_the_session_flushes(self, tmp_path: Path):
+        path = _write(tmp_path / "config.yml")
+
+        with config_edit_session(path):
+            config_update_fields(path, {"claude_code.timeout": 600})
+            assert path.read_text(encoding="utf-8") == SAMPLE
+
+        assert "timeout: 600" in path.read_text(encoding="utf-8")
+
+    def test_a_missing_file_is_the_callers_problem_as_before(self, tmp_path: Path):
+        path = tmp_path / "absent" / "config.yml"
+
+        with config_edit_session(path):
+            # Opening a session touches nothing: callers gate on `exists()`.
+            assert not path.exists()
+            with pytest.raises(FileNotFoundError):
+                config_update_fields(path, {"a": 1})
+
+        assert not path.exists()
+
+
+class TestRoundTripCount:
+    def test_one_at_a_time_round_trips_per_edit(self, tmp_path: Path, counters: dict[str, int]):
+        path = _write(tmp_path / "config.yml")
+
+        _recorded_edits(path)
+
+        # Ten writers, one of which (the duplicate append) returns before saving.
+        assert counters == {"load": 10, "dump": 9}
+
+    def test_a_session_loads_once_and_dumps_once(self, tmp_path: Path, counters: dict[str, int]):
+        path = _write(tmp_path / "config.yml")
+
+        with config_edit_session(path):
+            _recorded_edits(path)
+
+        assert counters == {"load": 1, "dump": 1}
+
+    def test_a_session_with_no_edits_writes_nothing(self, tmp_path: Path, counters: dict[str, int]):
+        path = _write(tmp_path / "config.yml")
+        before = path.stat().st_mtime_ns
+
+        with config_edit_session(path):
+            pass
+
+        assert counters == {"load": 0, "dump": 0}
+        assert path.stat().st_mtime_ns == before
+
+    def test_a_nested_session_on_the_same_file_joins_the_outer_one(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        path = _write(tmp_path / "config.yml")
+
+        with config_edit_session(path):
+            config_update_fields(path, {"claude_code.timeout": 1})
+            with config_edit_session(path):
+                config_update_fields(path, {"claude_code.timeout": 2})
+            # The inner block ending is not the end of the edit.
+            assert path.read_text(encoding="utf-8") == SAMPLE
+            config_update_fields(path, {"claude_code.timeout": 3})
+
+        assert "timeout: 3" in path.read_text(encoding="utf-8")
+        assert counters == {"load": 1, "dump": 1}
+
+    def test_sessions_on_different_files_are_independent(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        a = _write(tmp_path / "a" / "config.yml")
+        b = _write(tmp_path / "b" / "config.yml")
+
+        with config_edit_session(a):
+            config_update_fields(a, {"claude_code.timeout": 1})
+            config_update_fields(b, {"claude_code.timeout": 2})  # outside any session
+            assert "timeout: 2" in b.read_text(encoding="utf-8")
+            assert "timeout: 300" in a.read_text(encoding="utf-8")
+
+        assert "timeout: 1" in a.read_text(encoding="utf-8")
+        assert counters == {"load": 2, "dump": 2}
+
+    def test_the_session_is_keyed_on_the_file_not_its_spelling(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        path = _write(tmp_path / "render" / "config.yml")
+        spelled_differently = tmp_path / "render" / ".." / "render" / "config.yml"
+
+        with config_edit_session(spelled_differently):
+            config_update_fields(path, {"claude_code.timeout": 1})
+            config_add_to_list(spelled_differently, ["deployed_services"], "x")
+
+        assert counters == {"load": 1, "dump": 1}
+        text = path.read_text(encoding="utf-8")
+        assert "timeout: 1" in text
+        assert "  - x" in text
+
+
+class TestDiskReaders:
+    """The ordering contract with anything that reads the file's bytes."""
+
+    def test_flush_makes_pending_edits_visible_on_disk(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        path = _write(tmp_path / "config.yml")
+
+        with config_edit_session(path):
+            config_update_fields(path, {"claude_code.timeout": 600})
+            flush_config_edits(path)
+            assert "timeout: 600" in path.read_text(encoding="utf-8")
+            # Nothing pending: a second flush is not a second dump.
+            flush_config_edits(path)
+            assert counters["dump"] == 1
+            config_update_fields(path, {"claude_code.timeout": 900})
+
+        assert "timeout: 900" in path.read_text(encoding="utf-8")
+        assert counters == {"load": 1, "dump": 2}
+
+    def test_flush_outside_a_session_is_a_no_op(self, tmp_path: Path):
+        path = _write(tmp_path / "config.yml")
+        before = path.stat().st_mtime_ns
+
+        flush_config_edits(path)
+        flush_config_edits(tmp_path / "never-existed.yml")
+
+        assert path.stat().st_mtime_ns == before
+
+    def test_a_flushed_session_reloads_after_someone_else_writes_the_file(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        path = _write(tmp_path / "config.yml")
+
+        with config_edit_session(path):
+            config_update_fields(path, {"claude_code.timeout": 600})
+            flush_config_edits(path)
+            # An injector with its own YAML instance rewrites the file in place.
+            text = path.read_text(encoding="utf-8")
+            path.write_text(
+                text.replace("deployed_services:\n", "deployed_services:\n  - injected\n"),
+                encoding="utf-8",
+            )
+            config_add_to_list(path, ["scaffold", "user_owned"], "rules/new")
+
+        final = path.read_text(encoding="utf-8")
+        assert "  - injected" in final  # the outside write survived
+        assert "rules/new" in final  # and so did ours
+        assert "timeout: 600" in final
+        assert counters == {"load": 2, "dump": 2}
+
+    def test_an_outside_write_under_pending_edits_is_a_conflict_not_a_clobber(self, tmp_path: Path):
+        path = _write(tmp_path / "config.yml")
+        outside = SAMPLE.replace("timeout: 300", "timeout: 42")
+
+        with pytest.raises(ConfigEditConflict, match=str(path)):
+            with config_edit_session(path):
+                config_update_fields(path, {"claude_code.default_model": "sonnet"})
+                path.write_text(outside, encoding="utf-8")  # nobody flushed first
+                config_add_to_list(path, ["scaffold", "user_owned"], "rules/new")
+
+        # The file is whatever the outside writer left; the pending edit is
+        # dropped rather than written over it, at the failing call and at exit.
+        assert path.read_text(encoding="utf-8") == outside
+
+    def test_flushing_over_an_outside_write_is_the_same_conflict(self, tmp_path: Path):
+        path = _write(tmp_path / "config.yml")
+        outside = SAMPLE.replace("timeout: 300", "timeout: 42")
+
+        with pytest.raises(ConfigEditConflict):
+            with config_edit_session(path):
+                config_update_fields(path, {"claude_code.default_model": "sonnet"})
+                path.write_text(outside, encoding="utf-8")
+
+        assert path.read_text(encoding="utf-8") == outside
+
+
+class TestFailureInsideTheBlock:
+    def test_edits_before_an_exception_still_land(self, tmp_path: Path):
+        """Parity with one-at-a-time writes, where each call had already hit disk."""
+        path = _write(tmp_path / "config.yml")
+
+        with pytest.raises(RuntimeError, match="later step"):
+            with config_edit_session(path):
+                config_update_fields(path, {"claude_code.timeout": 600})
+                raise RuntimeError("later step failed")
+
+        assert "timeout: 600" in path.read_text(encoding="utf-8")
+
+    def test_a_session_is_closed_after_an_exception(self, tmp_path: Path, counters: dict[str, int]):
+        path = _write(tmp_path / "config.yml")
+
+        with pytest.raises(RuntimeError):
+            with config_edit_session(path):
+                raise RuntimeError
+
+        config_update_fields(path, {"claude_code.timeout": 1})
+        assert "timeout: 1" in path.read_text(encoding="utf-8")  # immediate, no session
+        assert counters == {"load": 1, "dump": 1}
+
+
+def test_a_session_survives_the_file_being_replaced_wholesale(tmp_path: Path):
+    """Copying a fresh render over the file is an outside write like any other."""
+    path = _write(tmp_path / "config.yml")
+    fresh = _write(tmp_path / "fresh.yml", SAMPLE.replace("haiku", "opus"))
+
+    with config_edit_session(path):
+        config_update_fields(path, {"claude_code.timeout": 1})
+        flush_config_edits(path)
+        shutil.copy2(fresh, path)
+        config_update_fields(path, {"claude_code.timeout": 2})
+
+    text = path.read_text(encoding="utf-8")
+    assert "default_model: opus" in text
+    assert "timeout: 2" in text
+
+
+class TestDocumentApi:
+    """``load_config_document`` / ``save_config_document``: the pair a writer that
+    edits the document itself (the service injectors, the ``auto`` resolvers)
+    uses instead of a loader of its own, so that it joins the session too."""
+
+    def test_outside_a_session_the_pair_is_one_round_trip(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        path = _write(tmp_path / "config.yml")
+
+        doc = load_config_document(path)
+        doc["claude_code"]["timeout"] = 7
+        save_config_document(path, doc)
+
+        text = path.read_text(encoding="utf-8")
+        assert "timeout: 7" in text
+        assert "# quoted on purpose" in text  # comments survive, as with every writer
+        assert counters == {"load": 1, "dump": 1}
+
+    def test_inside_a_session_the_document_is_shared_and_the_write_waits(
+        self, tmp_path: Path, counters: dict[str, int]
+    ):
+        path = _write(tmp_path / "config.yml")
+
+        with config_edit_session(path):
+            doc = load_config_document(path)
+            doc["claude_code"]["timeout"] = 7
+            save_config_document(path, doc)
+            assert path.read_text(encoding="utf-8") == SAMPLE  # nothing on disk yet
+            # The dotted-key writers edit the very same object.
+            config_update_fields(path, {"claude_code.default_model": "sonnet"})
+            assert load_config_document(path) is doc
+            assert doc["claude_code"]["default_model"] == "sonnet"
+
+        text = path.read_text(encoding="utf-8")
+        assert "timeout: 7" in text
+        assert "default_model: sonnet" in text
+        assert counters == {"load": 1, "dump": 1}
+
+    def test_the_pair_writes_in_the_same_style_as_every_other_writer(self, tmp_path: Path):
+        """Block sequences indented under their key, no line wrapping: one style
+        for the whole file, whichever writer touched it last."""
+        path = _write(tmp_path / "config.yml")
+        long_value = "x" * 200
+
+        doc = load_config_document(path)
+        doc["deployed_services"].append("added")
+        doc["claude_code"]["note"] = long_value
+        save_config_document(path, doc)
+
+        text = path.read_text(encoding="utf-8")
+        assert "\n  - added\n" in text
+        assert f"note: {long_value}\n" in text


### PR DESCRIPTION
Closes #841.

## What the issue turned out to be

The two runs the issue compares ran the same tests, and in the "slow" one every test was about 1.7x slower, the 24,000 sub-10 ms ones included. On the ubuntu 3.11 cell the same two commits ran the other way round. Main-branch history since Aug 28 scatters between 24 and 46 minutes per cell with no step at any commit; one sha ran 33 and 45 minutes on the same day. The doubling is the runner pool, not a merge. Evidence and numbers are in the issue comment.

What is true underneath: about half the suite's CPU is the ~120 tests that run a real `osprey build`, and one build spent about half its time re-parsing the same rendered `config.yml` and another sixth in the pure-Python YAML parser.

## Changes

**perf(build): edit each render's config.yml as one document.** `config_edit_session` now spans the whole render. `load_config_document` / `save_config_document` are the public pair a writer uses to edit the document in place; the nine service injectors, the two `auto` resolvers and the persistence helpers use it, so every writer joins the session and each render's `config.yml` is parsed exactly once (pinned by a test on a real build). Readers of the file's bytes flush first; a write that bypasses the session is detected by content digest and refused rather than clobbered.

The rendered `config.yml` keeps the template's quoting and list indentation. The last writer to touch a render used to be a default `YAML()` that stripped both. Parsed content and comments are identical across all 23 rendered files of the exemplar, verified against a build from the unmodified branch.

**perf(build): parse config.yml on the libyaml loader at the remaining hot sites.** Five reads still used `yaml.safe_load`.

**ci(test): run each unit-test cell as two shards.** `tests/cli` (49% of the suite's test time on both OSes) and everything else. Same runner-minutes, half the wall time on any runner. The serial pty and live-CA steps run on one shard per cell; both shards of the coverage cell upload and Codecov merges them. Caps unchanged.

## Measured

| | before | after |
|---|---|---|
| one exemplar build (12 renders), wall | 5.3 s | 2.4 s |
| `tests/cli/test_build_zero_arg.py` | 45 s | 20 s |
| ruamel parses of config.yml per build | 97 | 12 |

Gates: ruff, mypy (no new errors), tests/utils + tests/cli (7,011 passed), the rest of the CI unit selection (32,320 passed).
