### PR TITLE
fix(control-system): publish target endpoints under the session's posture

### DIFF
--- a/changelog.d/target-display-posture.fixed.md
+++ b/changelog.d/target-display-posture.fixed.md
@@ -1,0 +1,4 @@
+After a session narrows a control target to read-only, the approval prompt's
+`Target:` line, refusal messages, and the header chip's dialogs name the
+gateway the session actually uses, not the write gateway's host:port. The
+turn-writes-on dialog no longer prints an endpoint.

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -10,6 +10,7 @@ import os
 import re
 import tempfile
 import uuid
+from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -2655,20 +2656,42 @@ def _row_availability(
     return bool(verdict.available_now), verdict.reason, detail
 
 
-def _target_display(config: Any, record: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+def _target_display(
+    config: Any,
+    record: dict[str, Any] | None,
+    effective_writes: Mapping[str, bool],
+) -> dict[str, dict[str, Any]]:
     """Per-target ``label`` / ``endpoint`` / ``real_machine``, published first.
 
     The controls server mints these once, for the target it is actually running,
     and every reader renders what it was handed. So a live record wins wherever
     it carries a label: it describes the process that owns the connector, while
     the render describes what a *new* server would do with the config as it
-    stands now.
+    stands now. A labelled row therefore names the gateway that server last
+    published, which after a narrowing is the gateway the previous posture
+    selected until the reconciler's next pass republishes the record.
 
     The render is the fallback, through the same
     :func:`~osprey.mcp_server.control_system.connector_host_manager.target_display_metadata`
     the writer uses — a card whose session has not started a controls server yet
     still has to name its targets, and naming them with a second derivation of
     this module's own is how a badge comes to disagree with a prompt.
+
+    That fallback is rendered under THIS session's effective posture, which is
+    what *effective_writes* carries. The renderer's own default resolves the
+    posture from ``OSPREY_POSTURE_SESSION``, a stamp the web server does not
+    carry, so an uninjected render would find no narrowing at all and name the
+    write gateway of a target the operator has already given up writes on. The
+    caller resolves the column once and hands it over, so the endpoint on a row
+    and the ``effective`` flag beside it are one answer rather than two.
+
+    Args:
+        config: The rendered config mapping, or ``_UNREADABLE_SECTION`` when
+            ``config.yml`` could not be read.
+        record: The session's published controls-server record, if it has one.
+        effective_writes: Per-target effective write posture for this session,
+            keyed by target name. A target the mapping does not answer for is
+            rendered from the deployment ceiling and this run's mode.
     """
     published = record.get("targets") if isinstance(record, dict) else None
     derived: dict[str, Any] = {}
@@ -2678,7 +2701,7 @@ def _target_display(config: Any, record: dict[str, Any] | None) -> dict[str, dic
                 target_display_metadata,
             )
 
-            derived = dict(target_display_metadata(config))
+            derived = dict(target_display_metadata(config, effective_writes=effective_writes))
         except Exception:  # noqa: BLE001 — the roster must render, not 500
             logger.warning("Could not derive the control targets' display metadata")
 
@@ -2743,29 +2766,39 @@ def _posture_view(app: Any, session_key: str, config_path: Path | None) -> dict[
     store_key = _posture_lookup_key(app, session_key)
     entry = _posture_entry(app, session_key)
     ceilings = _session_ceilings(section)
-    display = _target_display(config, record)
+    configured = list(_configured_target_names(section))
+    # Resolved BEFORE the render, and exactly once. The display metadata names
+    # one gateway per target, and WHICH gateway depends on the same effective
+    # answer the rows below publish — the renderer's own default would resolve
+    # it from a posture stamp this process does not carry, and name the write
+    # gateway of a target this session has narrowed.
+    #
+    # ONE ceiling per row. ``ceiling_writes`` reports ``session_posture``'s
+    # per-target map; ``effective`` runs through the store, whose own ceiling is
+    # ``target_writes_enabled`` for every configured target. On a NON-switch-
+    # capable render those two disagree — ``session_posture`` answers for the
+    # baseline alone, while ``configured_targets`` still lists the others — so
+    # an unarmed row would render ceiling-off beside effective-on: a filled dot
+    # for a target no connector here is ever built for. Gating on the ceiling
+    # the route already holds keeps the row internally consistent; where the two
+    # agree (every switch-capable deployment) this changes nothing.
+    effective_by_target = {
+        target: bool(ceilings.get(target, False)) and _effective_writes(section, store_key, target)
+        for target in configured
+    }
+    display = _target_display(config, record, effective_by_target)
     threshold_s = _probe_staleness_threshold_s(config)
     reachability = (record or {}).get("reachability")
     probed = reachability.get("targets") if isinstance(reachability, dict) else {}
 
     rows: list[dict[str, Any]] = []
-    for target in _configured_target_names(section):
+    for target in configured:
         meta = display.get(target) or {}
         real_machine = bool(meta.get("real_machine"))
         label = str(meta.get("label") or "") or target
         short_label, kind = _short_label_and_kind(label, real_machine)
-        # ONE ceiling per row. ``ceiling_writes`` reports ``session_posture``'s
-        # per-target map; ``effective`` runs through the store, whose own
-        # ceiling is ``target_writes_enabled`` for every configured target. On a
-        # NON-switch-capable render those two disagree — ``session_posture``
-        # answers for the baseline alone, while ``configured_targets`` still
-        # lists the others — so an unarmed row would render ceiling-off beside
-        # effective-on: a filled dot for a target no connector here is ever
-        # built for. Gating on the ceiling the route already holds keeps the row
-        # internally consistent; where the two agree (every switch-capable
-        # deployment) this changes nothing.
         ceiling_writes = bool(ceilings.get(target, False))
-        effective = ceiling_writes and _effective_writes(section, store_key, target)
+        effective = effective_by_target[target]
         posture = entry.get(target, POSTURE_WRITES)
         # Only for a row a narrowing would actually CHANGE, mirroring the POST's
         # "targets the request would touch" rule: a target already narrowed

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
@@ -309,9 +309,9 @@ export function identTitle(row) {
 /**
  * Everything the turn-writes-on confirm says. Only this direction asks —
  * turning off removes reach and is undone by a click; turning on is the
- * gesture after which a write the agent makes can land. The title names the
- * machine, so the body does not name it again: one line for the scope and
- * the endpoint, one for when it takes hold.
+ * gesture after which a write the agent makes can land. The body names no
+ * endpoint: the one the roster carries is where reads go under the session's
+ * current posture, not where the write this dialog allows would land.
  * @param {any} row
  * @param {string} kind
  * @returns {{title: string, body: ConfirmRun[][], live: string|null, confirmLabel: string}}
@@ -320,7 +320,7 @@ export function turnOnConfirm(row, kind) {
   return {
     title: `Turn writes on for ${displayName(row, kind)}?`,
     body: [
-      ['For ', { em: 'your session' }, row.endpoint ? ` · ${row.endpoint}.` : '.'],
+      ['For ', { em: 'your session' }, '.'],
       ['Takes effect at the next write — nothing restarts.'],
     ],
     live: hardwareNote(kind),
@@ -330,10 +330,11 @@ export function turnOnConfirm(row, kind) {
 
 /**
  * Everything the switch confirm says. The first line states the consequence —
- * where every control read and write goes next. The second names the write
- * state the session will ARRIVE in, because writes on/off is per machine and
- * does not travel; the word is stateWord's own, so the dialog and the chip a
- * moment later can never disagree.
+ * where control goes next, naming writes only when the session arrives able to
+ * make them. The second names the write state the session will ARRIVE in,
+ * because writes on/off is per machine and does not travel; the word is
+ * stateWord's own, so the dialog and the chip a moment later can never
+ * disagree.
  * @param {any} row
  * @param {string} kind
  * @param {'writes'|'sandbox'|'read-only'} word  stateWord's answer for the row
@@ -353,7 +354,11 @@ export function switchConfirm(row, kind, word) {
   return {
     title: `Switch to ${displayName(row, kind)}?`,
     body: [
-      ['All control reads and writes go to ', { em: String(row.endpoint || row.target) }, '.'],
+      [
+        word === 'writes' ? 'All control reads and writes go to ' : 'All control reads go to ',
+        { em: String(row.endpoint || row.target) },
+        '.',
+      ],
       arrival,
     ],
     live: word === 'writes' ? hardwareNote(kind) : null,

--- a/src/osprey/mcp_server/control_system/connector_host_manager.py
+++ b/src/osprey/mcp_server/control_system/connector_host_manager.py
@@ -69,6 +69,7 @@ import signal
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -80,6 +81,7 @@ from osprey.mcp_server.control_system.target_eligibility import (
     REASON_TARGET_UNRESOLVABLE,
     ROLE_READ_ONLY,
     ROLE_WRITE_ACCESS,
+    Endpoint,
     TargetDerivation,
     Verification,
     connector_block,
@@ -390,6 +392,17 @@ class _Child:
     def is_alive(self) -> bool:
         return self.process.returncode is None
 
+    def reported_role(self) -> str | None:
+        """The gateway role the child said it connected on, or ``None``.
+
+        A connector with no gateways to select between reports no role, and a
+        report is trusted here because it was verified against the parent's
+        derivation before the child was adopted. Anything but a non-empty
+        string is "no role", never a role spelled oddly.
+        """
+        reported = self.report.get("selected_role")
+        return reported if isinstance(reported, str) and reported else None
+
 
 # ---------------------------------------------------------------------------
 # Config-derived facts
@@ -440,28 +453,96 @@ def _connector_block(config: Any, connector_type: str) -> dict[str, Any]:
     return block if isinstance(block, dict) else {}
 
 
-def target_display_metadata(config: Any) -> dict[str, dict[str, Any]]:
+def _endpoint_text(endpoint: Endpoint | None) -> str:
+    """The ``host:port`` string the state file's ``endpoint`` slot carries.
+
+    Empty when there is no row to name: the slot is always written, so a
+    target whose gateway cannot be derived is described as ``""`` rather
+    than omitted.
+    """
+    return f"{endpoint.host}:{endpoint.port}" if endpoint is not None else ""
+
+
+def _display_writes(config: Any, target: str, effective_writes: Mapping[str, bool] | None) -> bool:
+    """Whether the endpoint rendered for *target* should be the write one.
+
+    The injected mapping wins where it holds an answer for *target*; a miss, a
+    ``None`` value or no mapping at all falls back to this process's own
+    posture through
+    :func:`~osprey.mcp_server.control_system.target_eligibility.effective_writes_for_target`,
+    which takes the ``control_system:`` section rather than the whole config.
+
+    Injection exists because the one caller that already knows the session's
+    posture computes it before it renders, and a second store read there could
+    answer a question the caller has already answered differently. A process
+    that carries no ``OSPREY_POSTURE_SESSION`` stamp has no narrowing to find,
+    so the fallback returns the deployment ceiling ANDed with this run's mode.
+
+    Args:
+        config: The full rendered config mapping.
+        target: The session control target being described.
+        effective_writes: Per-target effective posture, or ``None``.
+
+    Returns:
+        ``True`` when writes are armed for *target* under the posture that
+        applies to this rendering.
+    """
+    if effective_writes is not None:
+        override = effective_writes.get(target)
+        if override is not None:
+            return bool(override)
+    return effective_writes_for_target(_control_system_section(config), target)
+
+
+def target_display_metadata(
+    config: Any, *, effective_writes: Mapping[str, bool] | None = None
+) -> dict[str, dict[str, Any]]:
     """Per-target display metadata for the state file's single writer.
 
-    Rendered once, here, from config: readers (the prompt hook, the roster)
+    Rendered once, here, by the writer, under the session's effective posture:
+    readers (the prompt hook, the roster, the approval banner, the web badge)
     render the identity line straight from the state file and never re-derive
     it, so this is the only place the three targets get described.
 
     Each entry carries ``label``, ``display_name``, ``endpoint``,
-    ``real_machine`` and ``probe_channel`` — the destination's probe channel
-    travels with the metadata so a describer can name it without opening
-    ``config.yml``.
+    ``selected_role``, ``real_machine`` and ``probe_channel`` — the
+    destination's probe channel travels with the metadata so a describer can
+    name it without opening ``config.yml``.
+
+    Identity and posture are derived separately, and only the endpoint moves.
+    ``label``, ``display_name``, ``real_machine`` and the ``(stand-in)``
+    parenthesis come from the deployment ceiling, so narrowing a session never
+    renames the machine an operator is standing in front of. ``endpoint`` and
+    ``selected_role`` come from a second derivation under the effective
+    posture, so a session that has given up writes is told the read gateway it
+    is actually talking to rather than the write gateway the deployment would
+    permit. A process with no ``OSPREY_POSTURE_SESSION`` stamp has no narrowing
+    to answer for and is rendered from the ceiling and this run's mode.
 
     One entry per name in :data:`~osprey.mcp_server.control_system.target_state.TARGET_NAMES`,
     walked from that tuple rather than from a list spelled again here: the
     state file has a slot per target, this is its single writer, and a target
     described in one place and missing from the other is a reader rendering an
     empty identity line for a target an operator can select.
+
+    Args:
+        config: The full rendered config mapping (``config.yml`` as loaded).
+        effective_writes: Per-target effective write posture to render under.
+            A caller that has already resolved the session's posture passes it
+            so the rendering and the enforcement cannot disagree; a target the
+            mapping does not answer for falls back to this process's own
+            posture.
+
+    Returns:
+        One entry per target name. Every entry carries every key: a target
+        whose endpoints cannot be derived is described with an empty
+        ``endpoint`` and an empty ``selected_role`` rather than omitted.
     """
     metadata: dict[str, dict[str, Any]] = {}
     for target in target_state.TARGET_NAMES:
         try:
-            derivation = derive_endpoints(config, target)
+            # The ceiling derivation, and the only one identity is read from.
+            ceiling = derive_endpoints(config, target)
         except ValueError:
             # A deployment that has never named its real machine still needs a
             # slot: "unknown" is a truthful rendering, an absent key is not.
@@ -469,25 +550,31 @@ def target_display_metadata(config: Any) -> dict[str, dict[str, Any]]:
                 "label": _label(target, None),
                 "display_name": _display_name(config, target, None),
                 "endpoint": "",
+                "selected_role": "",
                 "real_machine": False,
                 "probe_channel": "",
             }
             continue
-        endpoint = derivation.selected_endpoint()
-        block = _connector_block(config, derivation.connector_type)
-        standin = _is_live_standin(config, target, endpoint)
+        block = _connector_block(config, ceiling.connector_type)
+        # Asked of the ceiling endpoint, so the parenthesis cannot move under a
+        # narrowing: a deployment whose two gateway rows sit on different ports
+        # would otherwise be a stand-in with writes armed and the real machine
+        # without them.
+        standin = _is_live_standin(config, target, ceiling.selected_endpoint())
+        selected = derive_endpoints(
+            config, target, writes_enabled=_display_writes(config, target, effective_writes)
+        )
         metadata[target] = {
-            "label": _label(target, derivation.connector_type, standin=standin),
-            "display_name": _display_name(
-                config, target, derivation.connector_type, standin=standin
-            ),
-            "endpoint": f"{endpoint.host}:{endpoint.port}" if endpoint else "",
+            "label": _label(target, ceiling.connector_type, standin=standin),
+            "display_name": _display_name(config, target, ceiling.connector_type, standin=standin),
+            "endpoint": _endpoint_text(selected.selected_endpoint()),
+            "selected_role": selected.selected_role,
             # True for the stand-in as well as the facility's machine, and the
             # question is the connector type alone rather than which target
             # asked: a stand-in is a real-machine posture, so every strict
             # limit, approval prompt and banner hardware gets, it gets. Only
             # the name on the label moves.
-            "real_machine": derivation.connector_type not in _SIMULATED_TYPES,
+            "real_machine": ceiling.connector_type not in _SIMULATED_TYPES,
             "probe_channel": str(block.get(PROBE_CHANNEL_KEY) or ""),
         }
     return metadata
@@ -512,6 +599,12 @@ def _is_live_standin(config: Any, target: str, endpoint: Any) -> bool:
     nothing more, so the port conjunct fails and the label stays
     ``LIVE MACHINE`` — which is the truth, because the operator is one hop from
     hardware.
+
+    Asked of the CEILING endpoint rather than of the one a narrowed session
+    lands on. The parenthesis is an identity fact, and identity does not move
+    when a session gives up writes: a deployment whose two gateway rows sit on
+    different ports would otherwise be a stand-in while writes are armed and
+    the facility's own machine once they are not.
 
     Asked of the live family — ``live`` and ``standin``, the two targets that
     dial a Channel Access gateway. ``va`` is not asked at all: the simulator is
@@ -712,6 +805,11 @@ class ConnectorHostManager:
         self._target = self._baseline
         self._generation = 0
         self._started = False
+        #: The targets block as last rendered, or ``None`` before the first
+        #: render. Identity depends on a posture that moves under a running
+        #: session, so this is a cache of the last answer rather than a
+        #: constant computed at start.
+        self._display: dict[str, dict[str, Any]] | None = None
         self._drain_override = drain_timeout_s
         self._probe_timeout_s = probe_timeout_s
         self._spawn_timeout_s = spawn_timeout_s
@@ -801,6 +899,106 @@ class ConnectorHostManager:
             return None
         return child
 
+    # -- display metadata --------------------------------------------------
+
+    def _render_display(self) -> dict[str, dict[str, Any]]:
+        """The targets block as this session would have it described right now.
+
+        :func:`target_display_metadata` renders every slot from config under
+        this process's own effective posture. The ACTIVE slot then takes a
+        second opinion it alone is entitled to: its target is being served by a
+        child that has already reported which gateway role it connected on, and
+        that report was verified against the parent's derivation before the
+        child was adopted. Rendering the active slot from the report rather
+        than from a fresh derivation is what stops the block from leading or
+        lagging the process an operator's reads actually go through — a landing
+        that fell back to the read gateway is described as ``read_only`` while
+        a re-derivation would still say ``write_access``.
+
+        Nothing else is overridden. A child that reports no role at all (a
+        connector with no gateways to select between), a target whose endpoints
+        cannot be derived, and every non-active slot are left exactly as
+        rendered.
+
+        Returns:
+            One entry per target name, in the shape
+            :func:`~osprey.mcp_server.control_system.target_state.publish_targets`
+            takes.
+        """
+        metadata = target_display_metadata(self._config.raw)
+        child = self._live_child()
+        if child is None:
+            return metadata
+        reported = child.reported_role()
+        slot = metadata.get(self._target)
+        if slot is None or reported is None:
+            return metadata
+        try:
+            endpoints = derive_endpoints(self._config.raw, self._target).endpoints
+        except ValueError:
+            # The slot is already the "not configured" rendering; a role
+            # without an endpoint to put beside it would say less, not more.
+            return metadata
+        slot["selected_role"] = reported
+        slot["endpoint"] = _endpoint_text(endpoints.get(reported))
+        return metadata
+
+    def display_metadata(self) -> dict[str, dict[str, Any]]:
+        """The targets block this server last rendered, rendering it if needed.
+
+        Reads only. The refusal describers reach identity through here while
+        building an error, and writing the state file as a side effect of
+        explaining a failure would make a bad moment worse. :meth:`reset_state`
+        seeds the cache at start and :meth:`publish_display` replaces it; a
+        caller that somehow arrives before either gets a fresh render rather
+        than an empty identity line.
+        """
+        if self._display is None:
+            self._display = self._render_display()
+        return self._display
+
+    def publish_display(self) -> bool:
+        """Re-render the targets block and republish it. Never raises.
+
+        The block is where every reader outside this process gets target
+        identity, and identity depends on a posture that moves under a running
+        session: an operator narrows the session to read-only, the child is
+        replaced by one on the read gateway, and readers rendering the block
+        verbatim would go on naming the write gateway. Readers are not what
+        fixes that — by contract they render what they are handed — so the
+        single writer restates its own opinion here.
+
+        Fail-soft in both halves, for the reason :meth:`_publish` is: the swap
+        has already happened by the time this runs. A render that raises and a
+        file that cannot be written are both logged and left, and neither turns
+        a switch that succeeded into an exception saying it failed.
+
+        Returns:
+            ``True`` when the record was updated; ``False`` when it was not —
+            no record to update, an unwritable file, or a render that raised.
+        """
+        try:
+            rendered = self._render_display()
+            self._display = rendered
+            if target_state.publish_targets(rendered):
+                return True
+            logger.warning(
+                "No target-state record to republish the display metadata for target %r "
+                "(generation %s) into; the server did not reset its state file at start",
+                self._target,
+                self._generation,
+            )
+        except Exception as exc:
+            logger.error(
+                "The display metadata for target %r (generation %s) could not be "
+                "republished: %s. Readers outside this server keep rendering the endpoint "
+                "the last successful publication named",
+                self._target,
+                self._generation,
+                exc,
+            )
+        return False
+
     # -- lifecycle ---------------------------------------------------------
 
     def reset_state(self, *, grace_s: float | None = None) -> list[int]:
@@ -808,10 +1006,17 @@ class ConnectorHostManager:
 
         Synchronous on purpose: it runs during server start, before the event
         loop that will own the children exists.
+
+        The targets block written here is rendered through
+        :meth:`display_metadata`, so the copy on disk and the copy this manager
+        will hand a describer are the same one from the first moment. Rendering
+        it twice — once for the file, once on the first refusal — is how the
+        two would drift apart.
         """
         return reset_target_state(
             self._config.raw,
             baseline=self._baseline,
+            targets_meta=self.display_metadata(),
             grace_s=self._terminate_grace_s if grace_s is None else grace_s,
         )
 
@@ -1070,9 +1275,7 @@ class ConnectorHostManager:
             self._generation,
             child.pid,
         )
-        reported = child.report.get("selected_role")
-        has_role = isinstance(reported, str) and bool(reported)
-        selected_role = reported if has_role else derivation.selected_role
+        selected_role = child.reported_role() or derivation.selected_role
         endpoint = derivation.endpoints.get(selected_role)
         return {
             "target": target,
@@ -1099,16 +1302,26 @@ class ConnectorHostManager:
         old target while every tool call went to the new one. The in-memory
         truth is authoritative and is what the accessors report; the file is
         the copy readers outside this process get, and its failure to update is
-        logged loudly and left stale rather than pretended away.
+        logged loudly and left stale rather than pretended away. The same is
+        true of the display metadata republished after it, which is why
+        :meth:`publish_display` is fail-soft as well.
+
+        Returns:
+            ``True`` when the switch record was updated. The display
+            republication is reported only in the log: a switch is not less
+            complete for having left one stale identity line behind.
         """
+        published = False
         try:
-            if target_state.publish_switch(self._target, self._generation, children=[child_pid]):
-                return True
-            logger.warning(
-                "No target-state record to publish the switch to %r into; "
-                "the server did not reset its state file at start",
-                target,
+            published = target_state.publish_switch(
+                self._target, self._generation, children=[child_pid]
             )
+            if not published:
+                logger.warning(
+                    "No target-state record to publish the switch to %r into; "
+                    "the server did not reset its state file at start",
+                    target,
+                )
         except OSError as exc:
             logger.error(
                 "The switch to %r (generation %s) succeeded, but its state file could not be "
@@ -1118,7 +1331,11 @@ class ConnectorHostManager:
                 self._generation,
                 exc,
             )
-        return False
+        # The identity readers render moved with the switch: a different target
+        # is active, served through a role this session's posture chose. It is
+        # republished here rather than left at what start-up rendered.
+        self.publish_display()
+        return published
 
     def _derive(self, target: str) -> TargetDerivation:
         """The destination's derivation, or a refusal naming what is missing.

--- a/src/osprey/mcp_server/control_system/error_handling.py
+++ b/src/osprey/mcp_server/control_system/error_handling.py
@@ -34,8 +34,11 @@ def describe_active_target() -> dict[str, str] | None:
     materially different situation on the live machine than on the simulator,
     and the operator should not have to reconstruct which one it was from
     session memory. This resolves ``{name, label, endpoint}`` for the active
-    target from the same authorities the roster uses: the supervisor's target
-    of record and the per-target display metadata rendered from config.
+    target from the supervisor alone: its target of record, and the endpoint
+    the writer last rendered for that target. Re-deriving that endpoint from
+    config here would name the write gateway no matter which one the session
+    is actually talking through, so the envelope reads the writer's rendering
+    instead of forming a second opinion beside it.
 
     Fail-soft by construction: an envelope that raises while describing a
     failure is worse than one that omits the target, so every problem here —
@@ -43,14 +46,11 @@ def describe_active_target() -> dict[str, str] | None:
     to ``None`` and the envelope renders exactly as it did before this existed.
     """
     try:
-        from osprey.mcp_server.control_system.connector_host_manager import (
-            target_display_metadata,
-        )
         from osprey.mcp_server.control_system.server_context import get_server_context
 
         context = get_server_context()
         target = context.connector_hosts.active_target()
-        meta = target_display_metadata(context.config.raw).get(target) or {}
+        meta = context.connector_hosts.display_metadata().get(target) or {}
         identity = {"name": target, "label": str(meta.get("label") or target)}
         endpoint = str(meta.get("endpoint") or "")
         if endpoint:

--- a/src/osprey/mcp_server/control_system/session_control.py
+++ b/src/osprey/mcp_server/control_system/session_control.py
@@ -31,6 +31,10 @@ may no longer use. Realignment is a rebuild of that child through
 :meth:`~osprey.mcp_server.control_system.server_context.ControlSystemContext.invalidate_connector`,
 which owns its own lock — this task takes none, deliberately, because a second
 lock around the same operation is how two things that must agree stop agreeing.
+A store that moved also republishes the ``targets`` block through
+:meth:`~osprey.mcp_server.control_system.connector_host_manager.ConnectorHostManager.publish_display`:
+display metadata names the gateway a posture chose, and a narrowing that lands
+without a switch to carry it has no other writer to restate that name.
 
 The rebuild waits for any execution in flight. A python execution is stamped
 with the target and generation it launched under, and retiring its child
@@ -301,7 +305,14 @@ class SessionControlReconciler:
     # -- the posture store -------------------------------------------------
 
     async def _reconcile_posture(self, context: Any) -> None:
-        """Realign the connector when the ACTIVE target's posture moved."""
+        """Republish on any move of the store; realign on the ACTIVE target's.
+
+        The two halves answer different questions. Display metadata names the
+        gateway a posture chose, so it is stale the moment the store moves for
+        ANY target, and it is republished on every move. The connector is only
+        wrong when the entry for the target the session is ON moved, so that is
+        the only case that rebuilds a child.
+        """
         signature = _signature(session_store.store_path())
         try:
             target = context.connector_hosts.active_target()
@@ -309,7 +320,12 @@ class SessionControlReconciler:
             logger.debug("No connector-host supervisor to read the session target from")
             return
 
-        if signature != self._store_signature or target != self._active_target:
+        store_moved = signature != self._store_signature
+        if store_moved:
+            # Only on a move of the store. A change of TARGET republished
+            # already, inside the switch that made it.
+            self._publish_display(context)
+        if store_moved or target != self._active_target:
             self._store_signature = signature
             self._observe(target)
 
@@ -384,6 +400,25 @@ class SessionControlReconciler:
             return
         self._realign_pending = False
         self._publish_realign(REALIGN_DONE)
+
+    def _publish_display(self, context: Any) -> None:
+        """Restate the target display metadata. Never costs the pass that ran it.
+
+        The writer renders identity from the posture it is actually in, so a
+        narrowing recorded for ANY target moves what the block should say —
+        including one the session is not on, where no switch runs and nothing
+        else would republish. A republication that fails is logged and left:
+        readers keep rendering the endpoint the last successful one named,
+        which is a stale identity line rather than a reconcile pass that
+        stopped before the realignment it was really there for.
+
+        Args:
+            context: The server context whose supervisor owns the block.
+        """
+        try:
+            context.connector_hosts.publish_display()
+        except Exception:
+            logger.warning("Could not republish the target display metadata", exc_info=True)
 
     def _publish_realign(self, state: str) -> None:
         """Publish a realignment note. Never costs the reconcile that made it."""

--- a/src/osprey/mcp_server/control_system/target_state.py
+++ b/src/osprey/mcp_server/control_system/target_state.py
@@ -52,13 +52,14 @@ Record shape
       "server_pid": 4321,          # os.getpid() of the controls server
       "owner_ppid": 4200,          # os.getppid() at write-on-start: the Claude
                                    # Code process that spawned the server
-      "targets": {
+      "targets": {                 # probe_channel and selected_role are both
+                                   # optional; each is omitted when unresolved
         "live":    {"label": str, "endpoint": str, "real_machine": bool,
-                    "probe_channel": str},  # optional; omitted when unconfigured
+                    "probe_channel": str, "selected_role": str},
         "va":      {"label": str, "endpoint": str, "real_machine": bool,
-                    "probe_channel": str},
+                    "probe_channel": str, "selected_role": str},
         "standin": {"label": str, "endpoint": str, "real_machine": bool,
-                    "probe_channel": str}
+                    "probe_channel": str, "selected_role": str}
       },
       "children": [5001, 5002],    # connector-host child PIDs, may be empty
       "last_switch": {             # last switch terminus, or null
@@ -90,6 +91,13 @@ YAML to answer "which target am I on" would be a second opinion about identity.
 describer names the channel a switch would probe, and it names it from here. It
 is optional and never fabricated: a target with no configured probe channel
 carries no key, so a reader can tell "not configured" from "configured as".
+``selected_role`` names the role whose gateway the ``endpoint`` beside it is,
+and is optional on the same terms.
+
+Rendered once does not mean rendered forever. Identity depends on the session's
+posture, and a session can narrow itself after start, so :func:`publish_targets`
+lets the same single writer re-render the block and republish it. That is still
+one opinion — the writer's, restated — and readers keep rendering verbatim.
 
 ``children`` records the connector-host children a server owns so that
 :func:`sweep_stale` can hand a starting server the orphan PIDs left behind by a
@@ -339,14 +347,22 @@ def is_process_alive(pid: int) -> bool:
 # -- record normalization --------------------------------------------------
 
 
+#: Display keys written only when the caller supplied a non-empty string.
+#: ``probe_channel`` is the channel a switch would probe; ``selected_role`` is
+#: the role whose gateway the ``endpoint`` beside it belongs to. Neither is ever
+#: fabricated, so a reader can tell "not resolved" from "resolved as".
+_OPTIONAL_TARGET_KEYS = ("probe_channel", "selected_role")
+
+
 def _normalize_target_meta(value: Any) -> dict[str, Any]:
     """Coerce one target's display metadata to the shape readers expect.
 
     ``label`` / ``endpoint`` / ``real_machine`` are always present — a reader
-    branching on a missing key is a reader that can crash a hook. ``probe_channel``
-    is OPTIONAL and passes through only when the caller supplied a real one: the
-    approval describer renders it exclusively from this file, so an invented
-    placeholder would show an operator a channel nobody probes.
+    branching on a missing key is a reader that can crash a hook. The keys in
+    :data:`_OPTIONAL_TARGET_KEYS` pass through only when the caller supplied a
+    real one: the approval describer renders them exclusively from this file,
+    so an invented placeholder would show an operator a channel nobody probes
+    or a role nobody selected.
     """
     meta = value if isinstance(value, dict) else {}
     normalized: dict[str, Any] = {
@@ -354,9 +370,10 @@ def _normalize_target_meta(value: Any) -> dict[str, Any]:
         "endpoint": str(meta.get("endpoint") or ""),
         "real_machine": bool(meta.get("real_machine", False)),
     }
-    probe_channel = meta.get("probe_channel")
-    if isinstance(probe_channel, str) and probe_channel:
-        normalized["probe_channel"] = probe_channel
+    for key in _OPTIONAL_TARGET_KEYS:
+        optional = meta.get(key)
+        if isinstance(optional, str) and optional:
+            normalized[key] = optional
     return normalized
 
 
@@ -502,7 +519,8 @@ def publish_switch(
     Writes what it is told. Whether a generation is bumped — a same-target
     respawn does not bump — is the switch lifecycle's rule, not this module's:
     this file records the outcome so readers agree on it, and does not arbitrate
-    it. Display metadata written at start is preserved.
+    it. Display metadata written at start is preserved; :func:`publish_targets`
+    is the one publisher that moves it.
 
     Returns:
         ``True`` when the record was updated, ``False`` when no record exists
@@ -512,6 +530,38 @@ def publish_switch(
     if children is not None:
         changes["children"] = _normalize_children(children)
     return _update(server_pid, changes)
+
+
+def publish_targets(
+    targets_meta: dict[str, Any],
+    *,
+    server_pid: int | None = None,
+) -> bool:
+    """Replace the per-target display metadata with a freshly rendered mapping.
+
+    :func:`write_on_start` renders the ``targets`` block once from the deployment
+    config, which is the right answer only while the session's posture matches
+    the config ceiling. A session that narrows itself to read-only afterwards is
+    served by a gateway the start-time render never named, and every reader of
+    this file renders verbatim by contract — so the writer, not the readers, is
+    what has to say the new thing. This publisher is that move: the single writer
+    re-renders identity from the session it is actually in and republishes it.
+
+    Normalized exactly as at start (:func:`_normalize_targets`), so a slot the
+    caller omits is written empty rather than dropped, and the whole block is
+    REPLACED rather than merged — a half-updated ``targets`` would let one target
+    name its old gateway beside another naming its new one.
+
+    Args:
+        targets_meta: Prepared per-target display metadata, the same shape
+            :func:`write_on_start` takes.
+        server_pid: Owning PID; defaults to this process.
+
+    Returns:
+        ``True`` when the record was updated, ``False`` when no record exists
+        (nothing was written, and the caller has a start-ordering bug).
+    """
+    return _update(server_pid, {"targets": _normalize_targets(targets_meta)})
 
 
 # -- publication blocks ----------------------------------------------------

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -757,10 +757,10 @@ def _target_identity_phrase(record, target):
     if claim is None:
         return None
     if claim:
-        # The endpoint is the selected-role one the writer chose (write_access
-        # when writes are enabled, read_only otherwise). Rendered verbatim:
-        # picking a role here would be a second opinion about which gateway
-        # this session actually holds.
+        # The endpoint is the role the writer selected under the session's
+        # effective posture, republished whenever that posture changes.
+        # Rendered verbatim: picking a role here would be a second opinion
+        # about which gateway this session actually holds.
         endpoint = _sanitize_label(meta.get("endpoint") or "endpoint not recorded")
         # The label is the writer's too, for the same reason the destination
         # line below reads it rather than re-deriving one: a deployment may put

--- a/tests/hooks/test_approval_target_identity.py
+++ b/tests/hooks/test_approval_target_identity.py
@@ -199,9 +199,10 @@ def test_live_target_names_the_machine_and_its_endpoint(
 ):
     """A real-machine target renders LOUD, with the endpoint the writer selected.
 
-    The endpoint is whichever role the writer chose — write_access when writes
-    are enabled, read_only otherwise — and reaches the prompt verbatim: picking
-    a role here would be a second opinion about which gateway the session holds.
+    The endpoint is whichever role the writer selects under the session's
+    effective posture, republished whenever that posture changes, and reaches
+    the prompt verbatim: picking a role here would be a second opinion about
+    which gateway the session holds.
     """
     write_state(state_dir, target="live")
 

--- a/tests/interfaces/web_terminal/control-target-popover.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-popover.test.mjs
@@ -700,18 +700,20 @@ describe('turning writes off and on', () => {
     expect(confirmBtn()?.textContent).toBe('Turn writes on');
   });
 
-  test('the confirm body states scope and endpoint, and claims nothing about process', async () => {
+  test('the confirm body states scope and claims nothing about process or endpoint', async () => {
     // Whether a write prompts for approval, and what limits apply, are
     // deployment configuration the browser cannot see — the dialog must not
-    // state either as fact.
+    // state either as fact. The roster's endpoint is where reads go under the
+    // current posture, so it is not where this write will land: it stays out.
     await bootOpen();
     toggleEl('live')?.click();
     await flush();
 
     const body = inConfirm('.posture-modal-body').textContent ?? '';
-    expect(body).toContain('For your session · als-gw.lbl.gov:5064.');
+    expect(body).toContain('For your session.');
     expect(body).toContain('Takes effect at the next write — nothing restarts.');
     expect(body).not.toMatch(/approval|asks you|limits/i);
+    expect(body).not.toMatch(/[\w.-]+:\d+/);
     // The title names the machine; the body's own sentences do not repeat it.
     // (The hardware notice below them is the one deliberate exception.)
     const paragraphs = [...(confirmEl()?.querySelectorAll('.posture-modal-body p') ?? [])]
@@ -890,6 +892,24 @@ describe('switching', () => {
     );
     // Off means off: no hardware notice until writes are actually on there.
     expect(confirmEl()?.querySelector('.posture-modal-live')).toBeNull();
+  });
+
+  test('a machine arrived at with writes off promises reads only', async () => {
+    await bootOpen(viewOf({ targets: [rowOf(KINDS.va, { ...STATES.sandbox })] }));
+    switchEl('va')?.click();
+    await flush();
+    const body = inConfirm('.posture-modal-body').textContent ?? '';
+    expect(body).toContain('All control reads go to 127.0.0.1:10064.');
+    expect(body).not.toContain('reads and writes');
+  });
+
+  test('a locked machine promises reads only too', async () => {
+    await bootOpen(viewOf({ targets: [rowOf(KINDS.va, { ...STATES['read-only'] })] }));
+    switchEl('va')?.click();
+    await flush();
+    const body = inConfirm('.posture-modal-body').textContent ?? '';
+    expect(body).toContain('All control reads go to 127.0.0.1:10064.');
+    expect(body).toContain('Writes are locked read-only there by the deployment.');
   });
 
   test('switching onto the live machine with writes on carries the hardware notice', async () => {

--- a/tests/interfaces/web_terminal/test_posture_get_contract.py
+++ b/tests/interfaces/web_terminal/test_posture_get_contract.py
@@ -160,6 +160,7 @@ def render(
     va_writes=None,
     standin_roles=("read_only", "write_access"),
     display_names=None,
+    live_write_port=None,
     name="config.yml",
     tmp_path=None,
 ):
@@ -178,6 +179,12 @@ def render(
     ``display_names`` is written verbatim as
     ``control_system.target_display_names``, the deployment's renaming of the
     chip's per-target words.
+
+    ``live_write_port`` puts the facility machine's write gateway on a port of
+    its own. It is what makes a posture observable in an endpoint at all: with
+    one gateway row serving both roles the selected role moves under a narrowing
+    and the host:port the row reports does not, so a render that named the wrong
+    gateway would look identical to one that named the right one.
     """
     gateway = {"address": "gw", "port": 5064, "use_name_server": True}
     standin_gateway = {"address": "localhost", "port": STANDIN_PORT, "use_name_server": True}
@@ -204,7 +211,8 @@ def render(
                     "probe_channel": "SR:PROBE",
                     "gateways": {
                         "read_only": dict(gateway),
-                        "write_access": dict(gateway),
+                        "write_access": dict(gateway)
+                        | ({} if live_write_port is None else {"port": live_write_port}),
                     },
                 },
                 "live_standin": {
@@ -351,6 +359,25 @@ def write_target_state(
         encoding="utf-8",
     )
     return path
+
+
+@contextmanager
+def chat_session(client, chat_id=CHAT_A):
+    """Make the operator registry answer to *chat_id* as a chat pool key.
+
+    A chat has no PTY, so ``_posture_view`` resolves no controls-server record
+    for it and every identity on its rows comes from the render alone.
+    """
+
+    async def _cleanup_all():  # the lifespan's shutdown calls this
+        return None
+
+    client.app.state.operator_registry = SimpleNamespace(
+        has_chat_key=lambda key: key == chat_id,
+        get_chat_session=lambda key: SimpleNamespace() if key == chat_id else None,
+        cleanup_all=_cleanup_all,
+    )
+    yield
 
 
 @contextmanager
@@ -501,6 +528,90 @@ class TestIdentity:
         # An empty override is no name at all: the default answers.
         assert row_for(payload, "va")["display_name"] == "Simulator"
         assert row_for(payload, "live")["display_name"] == "Real machine"
+
+    def test_an_armed_session_is_rendered_through_its_write_gateway(self, make_client, tmp_path):
+        """The baseline the narrowing tests below move away from."""
+        with make_client(
+            render(tmp_path=tmp_path, global_writes=True, live_write_port=6064)
+        ) as client:
+            payload = get_posture(client)
+
+        assert row_for(payload, "live")["effective"] is True
+        assert row_for(payload, "live")["endpoint"] == "gw:6064"
+
+    def test_a_narrowing_moves_the_rendered_endpoint_to_the_read_gateway(
+        self, make_client, tmp_path, agent_data_root
+    ):
+        """The render answers for THIS session, not for the deployment.
+
+        Nothing is published here, so the fallback render is the whole of the
+        row's identity — and the renderer resolves its own posture from
+        ``OSPREY_POSTURE_SESSION``, a stamp this server does not carry. Left to
+        that default it would find no narrowing at all and name the write
+        gateway of a machine the operator has just given up writes on, beside an
+        ``effective`` of ``False`` on the same row.
+        """
+        narrow(agent_data_root, SESSION_A, {"live": "sandbox"})
+        with make_client(
+            render(tmp_path=tmp_path, global_writes=True, live_write_port=6064)
+        ) as client:
+            payload = get_posture(client)
+
+        live = row_for(payload, "live")
+        assert live["effective"] is False
+        assert live["endpoint"] == "gw:5064"
+        # Per-target, so the machine the operator did not narrow is untouched.
+        assert row_for(payload, "standin")["effective"] is True
+        # Identity is read from the ceiling: only the gateway moves.
+        assert live["label"] == "LIVE MACHINE"
+        assert live["real_machine"] is True
+
+    def test_a_labelled_record_still_names_the_endpoint_under_a_narrowing(
+        self, make_client, tmp_path, agent_data_root
+    ):
+        """A published row describes the process that owns the connector.
+
+        The reconciler republishes that record when it realigns the narrowed
+        session, so the row can name the previous posture's gateway until the
+        next pass lands. Letting the render win instead would put this server's
+        guess about a *new* server on a row about a running child.
+        """
+        narrow(agent_data_root, SESSION_A, {"live": "sandbox"})
+        with make_client(
+            render(tmp_path=tmp_path, global_writes=True, live_write_port=6064)
+        ) as client:
+            with live_session(
+                client,
+                targets={
+                    "live": {
+                        "label": "LIVE MACHINE",
+                        "endpoint": "gw:6064",
+                        "real_machine": True,
+                    }
+                },
+            ):
+                payload = get_posture(client)
+
+        live = row_for(payload, "live")
+        assert live["endpoint"] == "gw:6064"
+        assert live["effective"] is False
+
+    def test_a_chat_session_renders_its_targets_under_its_own_posture(
+        self, make_client, tmp_path, agent_data_root
+    ):
+        """No PTY means no record, so the injected render is the whole answer."""
+        narrow(agent_data_root, CHAT_A, {"live": "sandbox"})
+        with make_client(
+            render(tmp_path=tmp_path, global_writes=True, live_write_port=6064)
+        ) as client:
+            with chat_session(client):
+                payload = get_posture(client, CHAT_A)
+
+        live = row_for(payload, "live")
+        assert live["label"] == "LIVE MACHINE"
+        assert live["effective"] is False
+        assert live["endpoint"] == "gw:5064"
+        assert row_for(payload, "standin")["endpoint"] == f"localhost:{STANDIN_PORT}"
 
     def test_active_follows_the_published_target_and_baseline_does_not(self, client):
         with live_session(client, target="va"):
@@ -868,20 +979,8 @@ class TestAvailability:
 class TestChatSessions:
     """A chat has no controls server, and says so without losing its toggles."""
 
-    @contextmanager
-    def _chat(self, client, chat_id=CHAT_A):
-        async def _cleanup_all():  # the lifespan's shutdown calls this
-            return None
-
-        client.app.state.operator_registry = SimpleNamespace(
-            has_chat_key=lambda key: key == chat_id,
-            get_chat_session=lambda key: SimpleNamespace() if key == chat_id else None,
-            cleanup_all=_cleanup_all,
-        )
-        yield
-
     def test_no_switch_is_offered_and_the_reason_says_why(self, client):
-        with self._chat(client):
+        with chat_session(client):
             payload = get_posture(client, CHAT_A)
 
         for row in payload["targets"]:
@@ -890,14 +989,14 @@ class TestChatSessions:
 
     def test_reachability_is_unknown(self, client):
         """No PTY, so no record, so nothing has been probed on its behalf."""
-        with self._chat(client):
+        with chat_session(client):
             payload = get_posture(client, CHAT_A)
 
         for row in payload["targets"]:
             assert row["reachability"]["state"] == "unknown", row["target"]
 
     def test_nothing_is_active_beyond_the_baseline(self, client):
-        with self._chat(client):
+        with chat_session(client):
             payload = get_posture(client, CHAT_A)
 
         assert payload["session_target"] == "standin"
@@ -906,7 +1005,7 @@ class TestChatSessions:
     def test_the_toggles_stay_live(self, make_client, tmp_path):
         """The store is keyed on the session, not on the topology."""
         with make_client(render(tmp_path=tmp_path, global_writes=True)) as client:
-            with self._chat(client):
+            with chat_session(client):
                 payload = get_posture(client, CHAT_A)
 
         for row in payload["targets"]:
@@ -915,7 +1014,7 @@ class TestChatSessions:
 
     def test_a_chat_session_is_enforceable(self, client):
         """Its spawn seam stamps the store key, which is the whole question."""
-        with self._chat(client):
+        with chat_session(client):
             payload = get_posture(client, CHAT_A)
 
         assert payload["enforceable"] is True

--- a/tests/interfaces/web_terminal/test_posture_toggle_browser.py
+++ b/tests/interfaces/web_terminal/test_posture_toggle_browser.py
@@ -23,6 +23,9 @@ Coverage (one test each):
   (c) turning writes back on is the direction that confirms: the dialog names
       the machine, Cancel is a true no-op on the row *and* in the store, and
       only a confirmed dialog widens.
+  (c2) a narrowing moves the endpoint the row's tooltip names off the write
+      gateway and onto the read one, and the confirm that would widen again
+      names no endpoint at all.
   (d) Switch confirms, is accepted as ``202``, and puts the chip and the row
       into ``switching…`` with a request file addressed to the controls server
       — this route only *asks*; the reconciler that would answer is not running
@@ -74,6 +77,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
@@ -134,6 +138,23 @@ _LONG_LIVED_SHELL = [sys.executable, "-c", "import time; time.sleep(3600)"]
 #: The Channel Access port the co-deployed stand-in serves on.
 STANDIN_PORT = 5074
 
+#: The facility machine's two gateway ports, deliberately distinct. Which of
+#: them a row names is the whole observable of the posture-aware render: under
+#: writes the row is talking to :data:`WRITE_PORT`, and a session that has given
+#: up writes is talking to :data:`READ_PORT`.
+READ_PORT = 5064
+WRITE_PORT = 5065
+
+#: The endpoints those two ports spell on the row, on the host both roles share.
+READ_ENDPOINT = f"gw:{READ_PORT}"
+WRITE_ENDPOINT = f"gw:{WRITE_PORT}"
+
+#: Anything shaped like a gateway address. Used to assert an ABSENCE: the
+#: turn-writes-on confirm names no endpoint at all, because the one the roster
+#: carries is where reads go under the current posture and not where the write
+#: this dialog allows would land.
+_HOST_PORT = re.compile(r"\b\S+:\d{2,5}\b")
+
 #: The target the published record puts the session on. Chosen so the roster
 #: carries all three interesting rows at once: ``va`` is active (no Switch),
 #: ``live`` is switchable, and ``standin`` is a real machine that is not.
@@ -147,6 +168,11 @@ POSTURE_TARGET = "standin"
 
 #: The row Switch is exercised on — the only one this render offers it for.
 SWITCH_TARGET = "live"
+
+#: The row the endpoint case is made on. The facility's own machine is the only
+#: target here whose two gateway roles sit on different ports, so it is the only
+#: row whose named endpoint can be seen to move when a session gives up writes.
+ENDPOINT_TARGET = "live"
 
 #: The server's own labels. The controls server mints these once, and this
 #: render keeps them where the machine vocabulary now lives: on tooltips.
@@ -183,8 +209,17 @@ def _write_config(path: Path, *, writes_enabled: bool = True) -> Path:
     channel to probe, strict limits (required toward the live family) and the
     operator's acknowledgement of the live gateway. Without them every row
     would carry an eligibility refusal and no Switch would be offered anywhere.
+
+    The ``epics`` block is the one target here whose two roles sit on DIFFERENT
+    ports, which is what makes a narrowing observable at all: a block whose
+    ``read_only`` and ``write_access`` name one gateway renders the same
+    endpoint under either posture, so a test asserting the endpoint moved would
+    pass on a render that never consulted the posture. The host stays ``gw`` in
+    both roles — a loopback address is the stand-in predicate's own signal, and
+    moving the write role off it would rename the machine mid-test.
     """
-    gateway = {"address": "gw", "port": 5064, "use_name_server": True}
+    gateway = {"address": "gw", "port": READ_PORT, "use_name_server": True}
+    write_gateway = {"address": "gw", "port": WRITE_PORT, "use_name_server": True}
     standin_gateway = {"address": "localhost", "port": STANDIN_PORT, "use_name_server": True}
     path.write_text(
         yaml.safe_dump(
@@ -199,7 +234,7 @@ def _write_config(path: Path, *, writes_enabled: bool = True) -> Path:
                             "probe_channel": "SR:PROBE",
                             "gateways": {
                                 "read_only": dict(gateway),
-                                "write_access": dict(gateway),
+                                "write_access": dict(write_gateway),
                             },
                         },
                         "live_standin": {
@@ -637,6 +672,63 @@ def test_arming_confirms_and_cancel_changes_nothing(tmp_path, monkeypatch, chrom
             # only ever records what was taken away.
             stored = _stored_postures()
             assert POSTURE_TARGET not in stored.get(session_id, {}), stored
+        finally:
+            page.close()
+
+
+def test_narrowing_moves_the_tooltip_onto_the_read_gateway(tmp_path, monkeypatch, chromium_browser):
+    """A narrowed row names the gateway it is actually talking to.
+
+    The endpoint on a row is where control *reads* go under this session's
+    posture. Armed, that is the write gateway; give the writes up and it is the
+    read gateway — and the tooltip an operator hovers has to say so, because the
+    render answering from the deployment ceiling would keep naming a gateway
+    this session can no longer reach.
+
+    The narrowing is made the way an operator makes it, through the popover's
+    own toggle and therefore through the real POST: a store written from the
+    test instead would prove the renderer reads a file, not that the round trip
+    an operator drives ends on screen. The row is re-read from the page after
+    the gesture — the popover subtree is replaced wholesale on every refetch.
+
+    The confirm that would widen again is checked for the opposite: it names no
+    endpoint whatsoever. The one the roster carries describes reads under the
+    posture the dialog is about to leave, so quoting it in the question would
+    name the wrong gateway at the one moment an operator is deciding about
+    writes.
+    """
+    known_ids: set[str] = set()
+
+    with _chip_hub(tmp_path, monkeypatch, known_ids=known_ids) as (base_url, app):
+        page, _session_id, _pid = _settled_chip(chromium_browser, base_url, app, known_ids)
+        try:
+            _open_popover(page)
+
+            # Armed: the write gateway, and only it.
+            ident = _row(page, ENDPOINT_TARGET).locator(".ctc-tip-ident")
+            expect(ident).to_contain_text(WRITE_ENDPOINT, timeout=TIMEOUT)
+            assert READ_ENDPOINT not in (ident.text_content() or "")
+
+            _narrow(page, ENDPOINT_TARGET)
+
+            # Narrowed: the read gateway. Re-resolved from the page, since the
+            # refetch that carried the new posture replaced the node above.
+            ident = _row(page, ENDPOINT_TARGET).locator(".ctc-tip-ident")
+            expect(ident).to_contain_text(READ_ENDPOINT, timeout=TIMEOUT)
+            tip = ident.text_content() or ""
+            assert WRITE_ENDPOINT not in tip
+            # Identity is derived from the ceiling and does not move with the
+            # posture: the operator is standing in front of the same machine.
+            assert LABELS[ENDPOINT_TARGET] in tip
+
+            # The confirm that widens again names no gateway at all.
+            _toggle(page, ENDPOINT_TARGET).click()
+            expect(page.locator(MODAL_TITLE)).to_have_text(
+                f"Turn writes on for {NAMES[ENDPOINT_TARGET]}?", timeout=TIMEOUT
+            )
+            body = page.locator(f"{OPEN_MODAL} .posture-modal-body").text_content() or ""
+            assert body.strip(), "the confirm rendered an empty body"
+            assert not _HOST_PORT.search(body), body
         finally:
             page.close()
 

--- a/tests/mcp_server/test_control_target_roster.py
+++ b/tests/mcp_server/test_control_target_roster.py
@@ -36,6 +36,7 @@ from osprey.mcp_server.control_system.target_eligibility import (
     target_availability,
 )
 from osprey.mcp_server.control_system.tools import control_target
+from osprey_connectors import session_store
 from osprey_connectors.standin import ARCHIVER_RECORDER_SERVICE
 from tests.mcp_server import test_switch_lifecycle as switch_suite
 from tests.mcp_server.conftest import assert_raises_error, extract_response_dict, get_tool_fn
@@ -52,6 +53,10 @@ child_environment = switch_suite.child_environment
 fixture_dir = switch_suite.fixture_dir
 make_manager = switch_suite.make_manager
 state_root = switch_suite.state_root
+# The posture store the endpoint cases narrow, stamped and cleared the same way
+# the lifecycle suite's republication cases need it.
+posture_store = switch_suite.posture_store
+narrow = switch_suite.narrow
 
 ROSTER = get_tool_fn(control_target.control_target)
 
@@ -97,6 +102,9 @@ TUNNELLED_PORT = 5064
 VA_GATEWAY_PORT = 5065
 REAL_GATEWAY_HOST = "gw.example.org"
 STANDIN_PROBE = "STANDIN:BEAM:CURRENT"
+#: The stand-in's write-capable gateway, on its own port, for the cases where
+#: which role was selected has to be visible in the rendered endpoint.
+STANDIN_WRITE_PORT = 5075
 
 #: A real archiver, so the honesty rule has no invented past to object to. The
 #: stand-in's connector type is one of the two whose history is invented, so a
@@ -110,6 +118,7 @@ def standin_config(
     standin_port=STANDIN_PORT,
     gateway_host="localhost",
     gateway_port=STANDIN_PORT,
+    write_port=None,
     live_host=REAL_GATEWAY_HOST,
     live_port=TUNNELLED_PORT,
     deployed=True,
@@ -137,6 +146,12 @@ def standin_config(
     gateway, which is how a case can ask what ``live`` is called when its
     endpoint happens to look exactly like the stand-in's.
 
+    *write_port* splits the stand-in's two gateway rows onto different ports.
+    The default puts both roles on the same one, where which role was selected
+    is unobservable in the endpoint; a case about the *posture* the endpoint
+    was rendered under has to split them, or it would pass whatever the
+    selection did.
+
     The display cases below need nothing more than that. The roster cases need
     the rest of a deployment an operator could actually switch on, and take it
     from the same builder rather than a second copy of these three blocks:
@@ -148,6 +163,9 @@ def standin_config(
     and whether an ``archiver_recorder`` makes the store the stand-in's).
     """
     gateway = {"address": gateway_host, "port": gateway_port, "use_name_server": True}
+    write_gateway = dict(gateway)
+    if write_port is not None:
+        write_gateway["port"] = write_port
     live_gateway = {"address": live_host, "port": live_port, "use_name_server": True}
     va_block = {"probe_channel": VA_PROBE}
     if va_gateways:
@@ -171,7 +189,7 @@ def standin_config(
                 "probe_channel": STANDIN_PROBE,
                 "gateways": {
                     "read_only": dict(gateway),
-                    "write_access": dict(gateway),
+                    "write_access": dict(write_gateway),
                 },
             },
             "virtual_accelerator": va_block,
@@ -189,6 +207,19 @@ def standin_config(
     if recorder:
         raw.setdefault("deployed_services", []).append(ARCHIVER_RECORDER_SERVICE)
     return raw
+
+
+def split_gateway_config(**kwargs):
+    """A stand-in whose read and write gateways sit on different ports.
+
+    The stand-in container is the *write* row's port, so the ceiling
+    derivation — the one identity is read from — still recognises the endpoint
+    as this deployment's own stand-in when the deployment arms writes. A
+    session that has given up writes selects the read row on the other port,
+    which is the only thing a posture is allowed to move.
+    """
+    kwargs.setdefault("writes_enabled", True)
+    return standin_config(write_port=STANDIN_WRITE_PORT, standin_port=STANDIN_WRITE_PORT, **kwargs)
 
 
 def without_a_standin(**kwargs):
@@ -887,13 +918,23 @@ class TestLiveStandinLabel:
         assert metadata["standin"]["label"] == "LIVE MACHINE (stand-in)"
         assert metadata["standin"]["real_machine"] is True
 
-    def test_an_armed_deployment_names_the_standin_through_its_write_gateway(self):
-        """Arming writes selects the other gateway row, and both point at it."""
-        metadata = target_display_metadata(standin_config(writes_enabled=True))
+    def test_an_armed_deployment_names_the_standin_through_its_write_gateway(self, monkeypatch):
+        """Arming writes selects the other gateway row, and the endpoint says so.
+
+        The two rows are split onto different ports, so the selection is
+        visible rather than implied, and the stamp is deleted explicitly: a
+        process with no ``OSPREY_POSTURE_SESSION`` has no session narrowing to
+        find, so the rendering is the deployment's ceiling — what every reader
+        saw before postures could move an endpoint at all.
+        """
+        monkeypatch.delenv("OSPREY_POSTURE_SESSION", raising=False)
+
+        metadata = target_display_metadata(split_gateway_config())
 
         assert metadata["standin"]["label"] == "LIVE MACHINE (stand-in)"
         assert metadata["standin"]["real_machine"] is True
-        assert metadata["standin"]["endpoint"] == f"localhost:{STANDIN_PORT}"
+        assert metadata["standin"]["endpoint"] == f"localhost:{STANDIN_WRITE_PORT}"
+        assert metadata["standin"]["selected_role"] == "write_access"
 
     def test_the_simulator_is_described_by_its_own_branch(self):
         """``va`` is untouched by the stand-in, in every case above and here."""
@@ -1001,6 +1042,121 @@ class TestDisplayName:
         assert metadata["standin"]["display_name"] == "Shadow ring"
         assert metadata["standin"]["label"] == "LIVE MACHINE (stand-in)"
         assert metadata["standin"]["real_machine"] is True
+
+
+# ------------------------------------------------- display: the endpoint
+
+
+class TestEndpointFollowsThePosture:
+    """Which gateway the rendered ``endpoint`` names, and what it may not move.
+
+    A session can narrow itself from write-capable to read-only after the
+    state file was written. Enforcement already follows that; the rendered
+    string is what nine readers print verbatim, so it has to follow it too —
+    otherwise an operator who gave up writes is still told the name of the
+    write gateway, which is the one endpoint their session can no longer reach.
+
+    Identity is the half that must *not* move. The label, the display name,
+    the ``real_machine`` flag and the ``(stand-in)`` parenthesis all come from
+    the deployment ceiling, so narrowing a session never renames the machine
+    in front of the operator. Every case here runs on a split-port stand-in,
+    where the two halves are told apart by the port in the string.
+    """
+
+    def test_a_narrowed_session_is_named_through_the_read_gateway(self, posture_store):
+        narrow(posture_store, "standin")
+
+        metadata = target_display_metadata(split_gateway_config())
+
+        assert metadata["standin"]["endpoint"] == f"localhost:{STANDIN_PORT}"
+        assert metadata["standin"]["selected_role"] == "read_only"
+
+    def test_a_narrowing_never_renames_the_machine(self, posture_store):
+        """The parenthesis is read from the ceiling, so it cannot follow a port."""
+        narrow(posture_store, "standin")
+
+        metadata = target_display_metadata(split_gateway_config())
+
+        assert metadata["standin"]["label"] == "LIVE MACHINE (stand-in)"
+        assert metadata["standin"]["display_name"] == "Rehearsal"
+        assert metadata["standin"]["real_machine"] is True
+        assert metadata["standin"]["probe_channel"] == STANDIN_PROBE
+
+    def test_a_narrowing_reaches_only_the_target_it_names(self, posture_store):
+        """Per-target, the way the store is keyed: ``live`` keeps its own answer."""
+        narrow(posture_store, "standin")
+
+        metadata = target_display_metadata(split_gateway_config())
+
+        assert metadata["standin"]["selected_role"] == "read_only"
+        assert metadata["live"]["selected_role"] == "write_access"
+
+    def test_an_unnarrowed_session_still_names_the_write_gateway(self, posture_store):
+        """Stamped, with nothing in the store: the ceiling answers unchanged."""
+        metadata = target_display_metadata(split_gateway_config())
+
+        assert metadata["standin"]["endpoint"] == f"localhost:{STANDIN_WRITE_PORT}"
+        assert metadata["standin"]["selected_role"] == "write_access"
+
+    def test_the_store_never_widens_a_deployment_that_arms_nothing(self, posture_store):
+        """Nothing a session holds can arm a target the deployment left unarmed."""
+        metadata = target_display_metadata(split_gateway_config(writes_enabled=False))
+
+        assert metadata["standin"]["endpoint"] == f"localhost:{STANDIN_PORT}"
+        assert metadata["standin"]["selected_role"] == "read_only"
+
+    def test_an_injected_mapping_overrides_the_session(self, posture_store):
+        """The caller that already resolved the posture is answered verbatim.
+
+        Both directions, because a mapping that only ever agreed with the
+        store would not prove it was consulted: it widens a narrowed session
+        back to the ceiling, and narrows an unnarrowed one.
+        """
+        narrow(posture_store, "standin")
+        config = split_gateway_config()
+
+        widened = target_display_metadata(config, effective_writes={"standin": True})
+        assert widened["standin"]["endpoint"] == f"localhost:{STANDIN_WRITE_PORT}"
+        assert widened["standin"]["selected_role"] == "write_access"
+
+        session_store.invalidate_cache()
+        narrowed = target_display_metadata(config, effective_writes={"standin": False})
+        assert narrowed["standin"]["endpoint"] == f"localhost:{STANDIN_PORT}"
+        assert narrowed["standin"]["selected_role"] == "read_only"
+
+    def test_a_target_the_mapping_skips_falls_back_to_the_session(self, posture_store):
+        """A miss is not an answer of ``False``: the store still decides."""
+        narrow(posture_store, "standin")
+
+        metadata = target_display_metadata(split_gateway_config(), effective_writes={"live": True})
+
+        assert metadata["standin"]["selected_role"] == "read_only"
+        assert metadata["live"]["selected_role"] == "write_access"
+
+    def test_the_label_is_unchanged_by_either_route(self, posture_store):
+        """One identity, whichever posture the endpoint was rendered under."""
+        config = split_gateway_config()
+        narrow(posture_store, "standin")
+
+        from_store = target_display_metadata(config)
+        injected = target_display_metadata(config, effective_writes={"standin": True})
+
+        assert from_store["standin"]["label"] == "LIVE MACHINE (stand-in)"
+        assert injected["standin"]["label"] == "LIVE MACHINE (stand-in)"
+        assert from_store["standin"]["endpoint"] != injected["standin"]["endpoint"]
+
+    def test_every_slot_carries_a_selected_role(self, posture_store):
+        """In-memory slots always carry the key, ``""`` where it is underivable."""
+        metadata = target_display_metadata(split_gateway_config())
+
+        assert all("selected_role" in meta for meta in metadata.values())
+
+    def test_an_underivable_target_carries_an_empty_role_and_endpoint(self):
+        """The slot survives; the two posture facts degrade rather than lie."""
+        metadata = target_display_metadata({"control_system": {"type": "virtual_accelerator"}})
+
+        assert metadata["live"]["selected_role"] == ""
+        assert metadata["live"]["endpoint"] == ""
 
 
 # ------------------------------------------------------ the limits posture

--- a/tests/mcp_server/test_error_envelope_target_identity.py
+++ b/tests/mcp_server/test_error_envelope_target_identity.py
@@ -8,8 +8,9 @@ human ``(active target: ...)`` clause into every control-system envelope.
 
 Two layers are pinned separately:
 
-* the resolver (``describe_active_target``) against a real config, including
-  its fail-soft collapse to ``None``;
+* the resolver (``describe_active_target``), which reads the supervisor's
+  display cache rather than re-deriving identity from config, including its
+  fail-soft collapse to ``None``;
 * the wiring — every branch of the handler carries the identity, the archiver
   (which has no live/VA axis) carries none, and an unresolvable identity
   leaves each envelope byte-identical to what it was before #697.
@@ -25,6 +26,7 @@ import pytest
 
 from osprey.errors import ChannelLimitsViolationError, ChannelWriteBlockedError
 from osprey.mcp_server.control_system import error_handling, server_context
+from osprey.mcp_server.control_system.connector_host_manager import ConnectorHostManager
 from osprey.mcp_server.control_system.error_handling import (
     connector_error_handler,
     describe_active_target,
@@ -39,17 +41,43 @@ CLAUSE = "(active target: LIVE MACHINE at localhost:5064)"
 # ------------------------------------------------------------- the resolver
 
 
+def _slot(endpoint: str = "localhost:5064", role: str = "write_access") -> dict:
+    """One target slot in the shape the supervisor's display cache holds."""
+    return {
+        "label": "LIVE MACHINE",
+        "display_name": "the live machine",
+        "endpoint": endpoint,
+        "selected_role": role,
+        "real_machine": True,
+        "probe_channel": "",
+    }
+
+
 class _FakeManager:
+    """The two supervisor reads: the target of record and the display cache."""
+
+    def __init__(self, slot: dict | None = None) -> None:
+        self._display = {"live": slot if slot is not None else _slot()}
+
     def active_target(self) -> str:
         return "live"
 
+    def display_metadata(self) -> dict[str, dict]:
+        return self._display
+
 
 class _FakeContext:
-    """Just the two attributes the resolver reads, nothing else."""
+    """Just the one attribute the resolver reads, nothing else."""
+
+    def __init__(self, slot: dict | None = None) -> None:
+        self.connector_hosts = _FakeManager(slot)
+
+
+class _RealManagerContext:
+    """A real supervisor that has never spawned a child, and nothing else."""
 
     def __init__(self, raw: dict) -> None:
-        self.connector_hosts = _FakeManager()
-        self.config = MCPServerConfig(raw=raw)
+        self.connector_hosts = ConnectorHostManager(MCPServerConfig(raw=raw))
 
 
 def _epics_raw(port: int = 5064) -> dict:
@@ -71,7 +99,35 @@ def _epics_raw(port: int = 5064) -> dict:
 
 
 def test_the_resolver_names_target_label_and_endpoint(monkeypatch):
-    monkeypatch.setattr(server_context, "get_server_context", lambda: _FakeContext(_epics_raw()))
+    monkeypatch.setattr(server_context, "get_server_context", lambda: _FakeContext())
+    assert describe_active_target() == IDENTITY
+
+
+def test_the_resolver_prints_the_read_gateway_the_writer_rendered(monkeypatch):
+    """The whole point of reading the cache instead of re-deriving.
+
+    A session that has given up writes is served through the read gateway,
+    and the writer rendered that. Re-deriving from config here would name
+    the write gateway and tell the operator the wrong port.
+    """
+    slot = _slot(endpoint="localhost:5065", role="read_only")
+    monkeypatch.setattr(server_context, "get_server_context", lambda: _FakeContext(slot))
+    assert describe_active_target() == {
+        "name": "live",
+        "label": "LIVE MACHINE",
+        "endpoint": "localhost:5065",
+    }
+
+
+def test_the_resolver_names_the_target_before_any_child_exists(monkeypatch):
+    """A real supervisor with no child still answers with label and endpoint.
+
+    The first child is spawned lazily, so the earliest failures happen while
+    the manager has nothing running. The cache renders on demand, which is
+    what keeps those envelopes from carrying an empty identity line.
+    """
+    context = _RealManagerContext(_epics_raw())
+    monkeypatch.setattr(server_context, "get_server_context", lambda: context)
     assert describe_active_target() == IDENTITY
 
 

--- a/tests/mcp_server/test_session_control_reconciler.py
+++ b/tests/mcp_server/test_session_control_reconciler.py
@@ -79,9 +79,19 @@ class FakeManager:
         #: put one caller *inside* the critical section and start the other.
         self.entered_switch = asyncio.Event()
         self.release_switch: asyncio.Event | None = None
+        #: How often the reconciler asked for the targets block to be restated.
+        self.display_publishes = 0
+        self.display_fails_with: Exception | None = None
 
     def active_target(self) -> str:
         return self._target
+
+    def publish_display(self) -> bool:
+        """Stand in for the real republication, which is fail-soft itself."""
+        self.display_publishes += 1
+        if self.display_fails_with is not None:
+            raise self.display_fails_with
+        return True
 
     def active_generation(self) -> int:
         return self._generation
@@ -649,6 +659,90 @@ class TestPostureRealignment:
         await reconciler.poll_once()
         assert manager.respawns == 0
         assert realign() is None
+
+
+# ------------------------------------------------------- display metadata
+
+
+class TestDisplayRepublication:
+    """The targets block follows the store, not just the switches.
+
+    Display metadata names the gateway a posture chose, and a narrowing can
+    land on a target no switch is about — where the writer would otherwise go
+    on naming a gateway the session may no longer use. So a move of the store
+    republishes the block on its own, and a store that has not moved buys
+    nothing: the steady state must cost no publication and no write at all,
+    or the reconciler would rewrite the state file once a second forever.
+    """
+
+    async def test_a_narrowing_on_another_target_republishes_without_realigning(self, monkeypatch):
+        """No switch runs for that machine, so nothing else would restate it."""
+        manager = FakeManager(target="live")
+        install_context(manager, monkeypatch)
+        reconciler = session_control.SessionControlReconciler()
+
+        await reconciler.poll_once()  # baseline: there is no store file yet
+        assert manager.display_publishes == 0
+
+        write_store({"va": "sandbox"})
+        await reconciler.poll_once()
+
+        assert manager.display_publishes == 1
+        assert manager.respawns == 0
+        assert realign() is None
+
+    async def test_a_narrowing_on_the_active_target_republishes_and_realigns(self, monkeypatch):
+        manager = FakeManager(target="live")
+        install_context(manager, monkeypatch)
+        reconciler = session_control.SessionControlReconciler()
+        await reconciler.poll_once()
+
+        write_store({"live": "sandbox"})
+        await reconciler.poll_once()
+
+        assert manager.display_publishes == 1
+        assert manager.respawns == 1
+        assert realign()["state"] == session_control.REALIGN_DONE
+
+    async def test_a_settled_store_republishes_nothing_and_writes_nothing(self, monkeypatch):
+        """Counted after the baseline pass, which legitimately does both."""
+        manager = FakeManager(target="live")
+        install_context(manager, monkeypatch)
+        reconciler = session_control.SessionControlReconciler()
+        write_store({"live": "sandbox"})
+        await reconciler.poll_once()
+
+        writes = 0
+        real_write = target_state._atomic_write_json
+
+        def counted(path, record):
+            nonlocal writes
+            writes += 1
+            real_write(path, record)
+
+        monkeypatch.setattr(target_state, "_atomic_write_json", counted)
+        manager.display_publishes = 0
+
+        for _ in range(10):
+            await reconciler.poll_once()
+
+        assert manager.display_publishes == 0
+        assert writes == 0
+
+    async def test_a_republication_that_raises_does_not_cost_the_realignment(self, monkeypatch):
+        """The rebuild is what the operator asked for; the block is a copy."""
+        manager = FakeManager(target="live")
+        manager.display_fails_with = OSError("the state file could not be written")
+        install_context(manager, monkeypatch)
+        reconciler = session_control.SessionControlReconciler()
+        await reconciler.poll_once()
+
+        write_store({"live": "sandbox"})
+        await reconciler.poll_once()
+
+        assert manager.display_publishes == 1
+        assert manager.respawns == 1
+        assert realign()["state"] == session_control.REALIGN_DONE
 
 
 # --------------------------------------------------------------------- races

--- a/tests/mcp_server/test_switch_lifecycle.py
+++ b/tests/mcp_server/test_switch_lifecycle.py
@@ -67,6 +67,7 @@ from osprey.mcp_server.control_system.target_eligibility import (
     Endpoint,
     TargetDerivation,
 )
+from osprey_connectors import session_store
 from osprey_connectors.control_system.base import ChannelValue
 from osprey_connectors.factory import ConnectorFactory, isolated_connector_registries
 from osprey_connectors.ipc.proxy import ConnectorHostProxy
@@ -101,6 +102,9 @@ DEAD_WRITE_PORT = 5555
 #: gateway it selects, or there would be nothing to verify.
 VA_READ_GATEWAY_PORT = 5065
 VA_WRITE_GATEWAY_PORT = 5066
+
+#: The posture-store key the narrowing tests stamp this process with.
+POSTURE_SESSION = "switch-lifecycle-session"
 
 FIXTURE_MODULE = '''\
 """A mock variant with the channels and the gateway selection the tests need.
@@ -352,6 +356,21 @@ async def started_on(factory, target, **overrides):
     return manager
 
 
+async def mixed_session(factory, va_armed_project):
+    """A started session whose 'va' block arms writes and whose 'live' does not.
+
+    The two targets then select different gateway roles, which is what lets a
+    case tell a per-target reading of the posture from a deployment-wide one.
+    """
+    manager = factory(
+        raw=gateway_config(writes_enabled=False, va_writes_enabled=True, va_gateways=True),
+        config_path=va_armed_project,
+    )
+    await manager.ensure_started()
+    assert manager.active_target() == "live"
+    return manager
+
+
 class _NeverBuilt:
     """Registered under the deployment's own connector type as a tripwire.
 
@@ -416,8 +435,12 @@ class TestSuccessfulSwitch:
         assert record["target"] == "va"
         assert record["generation"] == 1
         assert record["children"] == [result["child_pid"]]
-        # Display metadata written at start survives the switch.
+        # The display block is republished by the switch rather than merely
+        # surviving it, and it still describes every target. Neither connector
+        # here selects a gateway, so identity is the config rendering and the
+        # republication changes nothing an operator would read.
         assert record["targets"]["va"]["label"] == "virtual accelerator (simulation)"
+        assert record["targets"]["live"]["label"] == "LIVE MACHINE"
 
     async def test_the_previous_child_process_actually_exits(self, make_manager):
         manager = await started_on(make_manager, "live")
@@ -763,6 +786,25 @@ class TestDeadWriteGatewayFallback:
             await manager.active_proxy().read_channel(LIVE_PROBE, timeout=10.0), ChannelValue
         )
 
+    async def test_the_fallback_landing_is_published_as_the_read_gateway(
+        self, make_manager, write_armed_project
+    ):
+        """The state file names the gateway the session reached, not the armed one.
+
+        This deployment arms writes and configures a ``write_access`` row, so
+        re-deriving identity from config alone would tell every reader — the
+        approval banner, the refusal envelope, the header chip — that the
+        session is talking to the dead write gateway. The child that actually
+        landed reports ``read_only``, and that is what is published.
+        """
+        manager = await self._stranded_session(make_manager, write_armed_project)
+
+        await manager.switch("live")
+
+        live = target_state.read()["targets"]["live"]
+        assert live["selected_role"] == "read_only"
+        assert live["endpoint"] == f"{GATEWAY_HOST}:{READ_GATEWAY_PORT}"
+
     async def test_a_deployment_without_write_arming_never_needs_the_fallback(self, make_manager):
         """Read-only selection is untouched: no dead gateway is ever probed."""
         manager = make_manager(raw=gateway_config(writes_enabled=False))
@@ -855,16 +897,6 @@ class TestPerTargetPosture:
     it is actually serving.
     """
 
-    async def _mixed_session(self, make_manager, va_armed_project):
-        """A session whose 'va' block arms writes and whose 'live' does not."""
-        manager = make_manager(
-            raw=gateway_config(writes_enabled=False, va_writes_enabled=True, va_gateways=True),
-            config_path=va_armed_project,
-        )
-        await manager.ensure_started()
-        assert manager.active_target() == "live"
-        return manager
-
     async def test_each_target_lands_on_the_gateway_its_own_block_arms(
         self, make_manager, va_armed_project
     ):
@@ -877,7 +909,7 @@ class TestPerTargetPosture:
         'live' inherits the deployment-wide off and stays read-only — so a
         posture read once for the whole deployment would fail one of them.
         """
-        manager = await self._mixed_session(make_manager, va_armed_project)
+        manager = await mixed_session(make_manager, va_armed_project)
 
         armed = await manager.switch("va")
         unarmed = await manager.switch("live")
@@ -895,7 +927,7 @@ class TestPerTargetPosture:
         type's own key rather than the deployment-wide one — because that is
         the posture the connector serving this target actually read.
         """
-        manager = await self._mixed_session(make_manager, va_armed_project)
+        manager = await mixed_session(make_manager, va_armed_project)
         await manager.switch("va")
 
         armed = await manager.active_proxy().write_channel("VA:CORR:1:SP", 0.5, timeout=10.0)
@@ -906,6 +938,134 @@ class TestPerTargetPosture:
         assert refused.outcome is WriteOutcome.REFUSED
         assert refused.refusal_reason == "WRITES_DISABLED"
         assert f"control_system.connector.{GATEWAY_TYPE}.writes_enabled" in refused.error_message
+
+
+# --------------------------------------------------- republished identity
+
+
+@pytest.fixture
+def posture_store(tmp_path, monkeypatch):
+    """A scratch posture store this process and its children are stamped for.
+
+    Both stamps together, never one without the other: a process that knows
+    the session key and not the agent-data root reads a store nobody writes.
+    They go into the real environment rather than a patched lookup because the
+    connector-host children have to read the same store the parent does.
+    """
+    root = tmp_path / "agent_data"
+    monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(root))
+    monkeypatch.setenv("OSPREY_POSTURE_SESSION", POSTURE_SESSION)
+    monkeypatch.delenv("OSPREY_EXECUTION_MODE", raising=False)
+    session_store.invalidate_cache()
+    yield root
+    session_store.invalidate_cache()
+
+
+def narrow(root, *targets, session=POSTURE_SESSION):
+    """Record the operator's narrowing of *targets* for *session*."""
+    path = root / session_store.STATE_DIR_NAME / session_store.STORE_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({session: dict.fromkeys(targets, session_store.POSTURE_SANDBOX)}),
+        encoding="utf-8",
+    )
+    session_store.invalidate_cache()
+
+
+class TestRepublishedDisplayMetadata:
+    """What readers are told about identity after the session has moved.
+
+    The ``targets`` block is rendered by this manager and rendered VERBATIM by
+    everyone else — the prompt hook, the approval banner, the refusal envelope,
+    the header chip. Rendering it once at start is right only while the session
+    still matches the deployment ceiling it was rendered from, so the writer
+    re-renders and republishes whenever the posture behind it moves.
+    """
+
+    async def test_a_switch_republishes_the_whole_block(self, make_manager, va_armed_project):
+        """Emptied on purpose first, so nothing found afterwards predates the switch.
+
+        Every slot comes back, not just the one that moved: a block written
+        one target at a time would let one reader name the new gateway while
+        another still named the old one.
+        """
+        manager = await mixed_session(make_manager, va_armed_project)
+        target_state.publish_targets({})
+        assert target_state.read()["targets"]["va"]["label"] == ""
+
+        await manager.switch("va")
+
+        targets = target_state.read()["targets"]
+        assert targets["va"]["selected_role"] == "write_access"
+        assert targets["va"]["endpoint"] == f"{GATEWAY_HOST}:{VA_WRITE_GATEWAY_PORT}"
+        assert targets["live"]["selected_role"] == "read_only"
+        assert targets["live"]["endpoint"] == f"{GATEWAY_HOST}:{READ_GATEWAY_PORT}"
+
+    async def test_a_narrowed_session_is_published_through_its_read_gateway(
+        self, make_manager, write_armed_project, posture_store
+    ):
+        """The operator narrows the session; the published identity follows.
+
+        The respawn is the realign path a narrowing takes: the child is
+        replaced by one on the read gateway, and the block readers render from
+        has to name that gateway rather than the write-capable one the
+        deployment still permits.
+        """
+        manager = make_manager(
+            raw=gateway_config(writes_enabled=True), config_path=write_armed_project
+        )
+        await manager.ensure_started()
+        armed = target_state.read()["targets"]["live"]
+        assert armed["selected_role"] == "write_access"
+        assert armed["endpoint"] == f"{GATEWAY_HOST}:{DEAD_WRITE_PORT}"
+
+        narrow(posture_store, "live")
+        await manager.respawn_same_target()
+
+        narrowed = target_state.read()["targets"]["live"]
+        assert narrowed["selected_role"] == "read_only"
+        assert narrowed["endpoint"] == f"{GATEWAY_HOST}:{READ_GATEWAY_PORT}"
+        # Identity did not move with the endpoint: this is the same machine.
+        assert narrowed["label"] == "LIVE MACHINE"
+
+    async def test_a_render_that_raises_leaves_the_switch_intact(self, make_manager, monkeypatch):
+        """The swap has already happened, so a failed render may not undo it.
+
+        The block is left at what the last successful publication wrote rather
+        than emptied: a stale identity line is worse than nothing only if
+        nobody is told, and the failure is logged.
+        """
+        manager = await started_on(make_manager, "live")
+
+        def unrenderable(*args, **kwargs):
+            raise RuntimeError("the config went out from under the render")
+
+        monkeypatch.setattr(connector_host_manager, "target_display_metadata", unrenderable)
+
+        result = await manager.switch("va")
+
+        assert result["target"] == "va"
+        assert result["generation"] == 1
+        assert manager.active_target() == "va"
+        record = target_state.read()
+        assert record["target"] == "va"
+        assert record["targets"]["va"]["label"] == "virtual accelerator (simulation)"
+
+    async def test_the_metadata_names_a_target_before_any_child_exists(self, make_manager):
+        """The first refusal can arrive before the first child does.
+
+        A describer asking for identity on a manager that has never started
+        gets the config rendering, which is the truthful answer for a session
+        that has not yet been served by anything.
+        """
+        manager = make_manager(raw=gateway_config(writes_enabled=False))
+
+        metadata = manager.display_metadata()
+
+        assert manager.has_child() is False
+        assert metadata["live"]["label"] == "LIVE MACHINE"
+        assert metadata["live"]["selected_role"] == "read_only"
+        assert metadata["live"]["endpoint"] == f"{GATEWAY_HOST}:{READ_GATEWAY_PORT}"
 
 
 # ----------------------------------------------------------------- draining
@@ -1453,6 +1613,7 @@ class TestConfigDerivedFacts:
             "label": "live machine (not configured)",
             "display_name": "Real machine",
             "endpoint": "",
+            "selected_role": "",
             "real_machine": False,
             "probe_channel": "",
         }

--- a/tests/mcp_server/test_target_state.py
+++ b/tests/mcp_server/test_target_state.py
@@ -3,7 +3,9 @@
 Covers:
   - the path contract a stdlib-only hook has to be able to restate
   - write_on_start: baseline reset, PID capture, display metadata
-  - publish_switch / record_child_pids merges
+  - publish_switch / publish_targets / record_child_pids merges
+  - the optional display keys (probe_channel, selected_role): preserved when
+    real, absent when the caller has none
   - fail-closed reads (absent, corrupt, non-object)
   - stale-PID sweep: deletion, orphan child PIDs, own file preserved
   - delete_on_shutdown idempotence
@@ -200,6 +202,137 @@ class TestProbeChannel:
         target_state.publish_switch("va", 1, server_pid=1234)
 
         assert target_state.read(1234)["targets"] == TARGETS_META
+
+
+# ---------------------------------------------------------------------------
+# selected_role round-tripping
+# ---------------------------------------------------------------------------
+
+
+class TestSelectedRole:
+    """The role whose gateway the endpoint belongs to travels with the endpoint."""
+
+    ROLED_META = {
+        "live": {
+            "label": "ALS storage ring",
+            "endpoint": "gateway.example.com:5064",
+            "real_machine": True,
+            "selected_role": "read_only",
+        },
+        "va": {
+            "label": "Virtual accelerator",
+            "endpoint": "localhost:5074",
+            "real_machine": False,
+            "selected_role": "writes",
+        },
+        "standin": {
+            "label": "Live stand-in",
+            "endpoint": "localhost:5084",
+            "real_machine": False,
+            "selected_role": "read_only",
+        },
+    }
+
+    def test_present_selected_role_is_preserved(self, state_root):
+        target_state.write_on_start("live", self.ROLED_META, server_pid=1234)
+
+        targets = target_state.read(1234)["targets"]
+        assert targets["live"]["selected_role"] == "read_only"
+        assert targets["va"]["selected_role"] == "writes"
+        assert targets["standin"]["selected_role"] == "read_only"
+
+    def test_absent_selected_role_stays_absent(self, state_root):
+        target_state.write_on_start("live", TARGETS_META, server_pid=1234)
+
+        targets = target_state.read(1234)["targets"]
+        assert "selected_role" not in targets["live"]
+        assert "selected_role" not in targets["va"]
+        assert "selected_role" not in targets["standin"]
+
+    @pytest.mark.parametrize("bogus", ["", None, 5064, ["read_only"]])
+    def test_unusable_selected_role_is_dropped_never_stringified(self, state_root, bogus):
+        meta = {"live": {"label": "Live", "selected_role": bogus}}
+        target_state.write_on_start("live", meta, server_pid=1234)
+
+        assert "selected_role" not in target_state.read(1234)["targets"]["live"]
+
+    def test_selected_role_survives_a_switch(self, state_root):
+        target_state.write_on_start("live", self.ROLED_META, server_pid=1234)
+        target_state.publish_switch("va", 1, server_pid=1234)
+
+        assert target_state.read(1234)["targets"] == self.ROLED_META
+
+    def test_selected_role_survives_a_republish(self, state_root):
+        target_state.write_on_start("live", TARGETS_META, server_pid=1234)
+
+        assert target_state.publish_targets(self.ROLED_META, server_pid=1234) is True
+
+        assert target_state.read(1234)["targets"] == self.ROLED_META
+
+    def test_an_empty_role_is_dropped_on_a_republish_too(self, state_root):
+        target_state.write_on_start("live", self.ROLED_META, server_pid=1234)
+
+        target_state.publish_targets(
+            {"live": {"label": "Live", "endpoint": "gw:5064", "selected_role": ""}},
+            server_pid=1234,
+        )
+
+        assert "selected_role" not in target_state.read(1234)["targets"]["live"]
+
+
+# ---------------------------------------------------------------------------
+# publish_targets
+# ---------------------------------------------------------------------------
+
+
+class TestPublishTargets:
+    """The one publisher that moves the display metadata written at start."""
+
+    NARROWED = {
+        "live": {
+            "label": "ALS storage ring",
+            "endpoint": "gateway.example.com:5065",
+            "real_machine": True,
+            "probe_channel": "SR:BeamCurrent",
+            "selected_role": "read_only",
+        },
+    }
+
+    def test_republishing_replaces_the_block(self, state_root):
+        target_state.write_on_start("live", TARGETS_META, server_pid=1234)
+
+        assert target_state.publish_targets(self.NARROWED, server_pid=1234) is True
+
+        targets = target_state.read(1234)["targets"]
+        assert targets["live"]["endpoint"] == "gateway.example.com:5065"
+        assert targets["live"]["selected_role"] == "read_only"
+
+    def test_an_omitted_slot_is_written_empty_not_dropped(self, state_root):
+        target_state.write_on_start("live", TARGETS_META, server_pid=1234)
+
+        target_state.publish_targets(self.NARROWED, server_pid=1234)
+
+        targets = target_state.read(1234)["targets"]
+        assert set(targets) == set(target_state.TARGET_NAMES)
+        assert targets["va"] == {"label": "", "endpoint": "", "real_machine": False}
+        assert targets["standin"] == {"label": "", "endpoint": "", "real_machine": False}
+
+    def test_identity_and_pids_are_untouched(self, state_root):
+        target_state.write_on_start("live", TARGETS_META, server_pid=1234, owner_ppid=99)
+        target_state.publish_switch("va", 2, children=[5001], server_pid=1234)
+
+        target_state.publish_targets(self.NARROWED, server_pid=1234)
+
+        record = target_state.read(1234)
+        assert record["target"] == "va"
+        assert record["generation"] == 2
+        assert record["children"] == [5001]
+        assert record["server_pid"] == 1234
+        assert record["owner_ppid"] == 99
+
+    def test_without_a_record_writes_nothing(self, state_root):
+        assert target_state.publish_targets(TARGETS_META, server_pid=1234) is False
+        assert target_state.read(1234) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/test_target_state_publishers.py
+++ b/tests/mcp_server/test_target_state_publishers.py
@@ -10,6 +10,8 @@ prompt line:
   - the three publishers (``last_switch``, ``reachability``,
     ``last_posture_realign``): each merges without clobbering a sibling block,
     each is synchronous, and ``write_on_start`` resets all three
+  - ``publish_targets``, which re-renders the display metadata a narrowed
+    session outgrew, on the same merge terms
   - the in-flight marker reader in its new home, still importable from
     ``tools/control_target.py`` under its old name
 
@@ -328,6 +330,7 @@ class TestPublishersAreSynchronous:
             "publish_reachability",
             "publish_posture_realign",
             "publish_switch",
+            "publish_targets",
         ],
     )
     def test_publisher_is_not_a_coroutine_function(self, name):
@@ -504,6 +507,61 @@ class TestPublishPostureRealign:
 
     def test_without_a_record_writes_nothing(self, state_root):
         assert target_state.publish_posture_realign({"state": "pending"}) is False
+
+
+class TestPublishTargets:
+    """Display metadata is re-rendered by the writer, never by a reader."""
+
+    NARROWED = {
+        "live": {
+            "label": "ALS storage ring",
+            "endpoint": "gw:5065",
+            "real_machine": True,
+            "selected_role": "read_only",
+        },
+        "va": {"label": "Virtual accelerator", "endpoint": "localhost:5074"},
+        "standin": {"label": "Live stand-in", "endpoint": "localhost:5084"},
+    }
+
+    def test_publishes_the_new_block(self, started):
+        assert target_state.publish_targets(self.NARROWED) is True
+
+        targets = target_state.read()["targets"]
+        assert targets["live"]["endpoint"] == "gw:5065"
+        assert targets["live"]["selected_role"] == "read_only"
+
+    def test_the_sibling_blocks_survive(self, started):
+        target_state.publish_last_switch({"request_id": "r", "status": "success"})
+        target_state.publish_reachability({"live": {"epics": {"state": "reached"}}})
+        target_state.publish_posture_realign({"state": "done"})
+        target_state.record_child_pids([901])
+
+        target_state.publish_targets(self.NARROWED)
+
+        record = target_state.read()
+        assert record["last_switch"]["request_id"] == "r"
+        assert record["reachability"]["targets"]["live"]["epics"]["state"] == "reached"
+        assert record["last_posture_realign"]["state"] == "done"
+        assert record["children"] == [901]
+
+    def test_the_selection_is_untouched(self, started):
+        """This publisher says what a target IS, never which one is active."""
+        target_state.publish_switch("live", 4)
+
+        target_state.publish_targets(self.NARROWED)
+
+        record = target_state.read()
+        assert record["target"] == "live"
+        assert record["generation"] == 4
+
+    def test_an_empty_selected_role_is_dropped(self, started):
+        target_state.publish_targets({"live": {"label": "Live", "selected_role": ""}})
+
+        assert "selected_role" not in target_state.read()["targets"]["live"]
+
+    def test_without_a_record_writes_nothing(self, state_root):
+        assert target_state.publish_targets(self.NARROWED) is False
+        assert target_state.read() is None
 
 
 class TestBlocksDoNotClobberOneAnother:

--- a/tests/va/e2e/test_per_target_posture.py
+++ b/tests/va/e2e/test_per_target_posture.py
@@ -147,7 +147,7 @@ BOOT_TIMEOUT_S = 180.0
 
 #: Floor for this module's own test count -- a guard against a refactor that
 #: leaves the file importable but empty, which would otherwise pass silently.
-MIN_COLLECTED_TESTS = 25
+MIN_COLLECTED_TESTS = 28
 
 # -- the namespace both containers serve ------------------------------------
 
@@ -825,6 +825,30 @@ def realign_note():
     return record.get("last_posture_realign")
 
 
+def published_targets():
+    """The per-target display metadata this server last published.
+
+    The same ``targets`` block the prompt hook, the approval banner and the
+    per-target GET all render verbatim, read straight off the state file rather
+    than re-derived here. Re-deriving it in a test would be a second opinion
+    about identity, which is the thing a single-writer block exists to prevent.
+    """
+    record = target_state.read() or {}
+    return record.get("targets") or {}
+
+
+def configured_endpoint(config_path: Path, connector_type: str, role: str) -> str:
+    """The ``host:port`` one gateway row of the staged deployment names.
+
+    Read back out of the file :func:`raw_config` wrote, so an assertion about
+    "the read gateway" is anchored to the deployment the containers are actually
+    behind rather than to a port number spelled a second time in a test.
+    """
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    row = raw["control_system"]["connector"][connector_type]["gateways"][role]
+    return f"{row['address']}:{row['port']}"
+
+
 @pytest.fixture(scope="module")
 async def session(config_path, web, module_environment):
     """Drive the whole scripted session once, recording what each step saw.
@@ -894,6 +918,7 @@ async def session(config_path, web, module_environment):
             await reconciler.poll_once()
 
             journal["child_before_toggle"] = manager.status()["child_pid"]
+            journal["targets_before_toggle"] = published_targets()
             narrow = post_posture(web, TARGET_STANDIN, "sandbox")
             journal["narrow_status"] = narrow.status_code
             journal["narrow_body"] = narrow.json()
@@ -916,18 +941,36 @@ async def session(config_path, web, module_environment):
 
             # -- 2. The realignment waits for a run, then moves the gateway --
             #
-            # Back on the narrowed target, with the child still connected on
-            # write_access: this is the state the reconciler owes a rebuild.
+            # Back on the narrowed target, on a child that already read the
+            # moved store and so came up on the read gateway, while the
+            # reconciler — which has not yet observed the move — still owes a
+            # rebuild.
             await manager.switch(TARGET_STANDIN)
             journal["child_before_realign"] = manager.status()["child_pid"]
             with host_executor._in_flight_marker(TARGET_STANDIN):
                 await reconciler.poll_once()
                 journal["realign_while_running"] = realign_note()
                 journal["child_while_running"] = manager.status()["child_pid"]
+                # Taken INSIDE the in-flight window, together with the role
+                # the child serving the session actually holds. The switch back
+                # to the narrowed target already derived its gateway from the
+                # moved store, so what is pending here is a rebuild rather than
+                # a change of role -- and the block is expected to be carrying
+                # the read role already, before the reconciler reports "done".
+                journal["role_while_running"] = manager.status()["selected_role"]
+                journal["targets_while_running"] = published_targets()
             await reconciler.poll_once()
             journal["realign_after_running"] = realign_note()
             journal["child_after_realign"] = manager.status()["child_pid"]
             journal["role_after_realign"] = manager.status()["selected_role"]
+            # Taken HERE, immediately after the realignment, rather than in a
+            # test: the fixture keeps switching below, and every switch
+            # republishes the block. A test reading the file afterwards would be
+            # reading the last switch's answer, not the realignment's.
+            journal["targets_after_realign"] = published_targets()
+            journal["get_after_realign"] = web.get(
+                "/api/terminal/posture", params={"session_id": SESSION_ID}
+            ).json()
             journal["rows_narrowed"] = control_target_module.target_rows(
                 context.config.raw,
                 session_target=manager.active_target(),
@@ -1193,6 +1236,102 @@ class TestTheGatewayRealignsOnceNothingIsRunning:
 
         assert landed["target"] == TARGET_STANDIN
         assert landed["selected_role"] == "read_only"
+
+
+class TestThePublishedIdentityFollowsTheGateway:
+    """What every reader outside this process is handed once the child moves.
+
+    The state file's ``targets`` block is where the prompt hook, the approval
+    banner, the refusal envelopes and the header chip all get the endpoint they
+    print — by contract they render it verbatim and never re-derive it. So a
+    block still naming the write gateway of a target the operator narrowed is
+    not a cosmetic lag: it is every one of those surfaces telling an operator
+    their session is talking to a machine it is not talking to.
+
+    One caveat about the endpoints, stated once here. This deployment gives each
+    target's two gateway roles the same address and port, because there is one
+    soft IOC behind each container and the roles are two ways of asking the same
+    instance. The endpoint assertions below therefore prove that identity stayed
+    on the stand-in's own gateway rather than sliding to another machine, and
+    ``selected_role`` is what carries which role was picked.
+    """
+
+    def test_the_published_gateway_moves_when_the_session_narrows(
+        self, session, config_path
+    ) -> None:
+        """One target, one file, two postures — and the selected role moves between them.
+
+        Before the operator's toggle the stand-in's slot carries the role a
+        child with writes armed connected on; after the realignment it carries
+        the read one. Both ends are asserted against the deployment's own
+        gateway rows and against the role the child reported at each moment, so
+        this cannot pass on a block that was simply never written. The endpoint
+        is asserted at both ends as an identity check rather than as movement —
+        it is one address and port for both roles here, per the class docstring.
+        """
+        before = session["targets_before_toggle"][TARGET_STANDIN]
+        after = session["targets_after_realign"][TARGET_STANDIN]
+
+        assert before["selected_role"] == session["standin_role_before"] == "write_access"
+        assert before["endpoint"] == configured_endpoint(
+            config_path, "live_standin", "write_access"
+        )
+        assert after["selected_role"] == "read_only"
+        assert after["endpoint"] == configured_endpoint(config_path, "live_standin", "read_only")
+
+    def test_the_block_carries_the_read_role_before_the_realignment_reports_done(
+        self, session, config_path
+    ) -> None:
+        """Republished at the switch, not held back until the reconciler finishes.
+
+        The switch that put the session back on the narrowed target derived its
+        gateway from the store the toggle had already moved, so the child
+        holding the session through the in-flight window was itself on the read
+        gateway: what the reconciler still owed was a rebuild, not a change of
+        role. The claim pinned here is about WHEN the file moves — the block
+        already names the read role while ``last_posture_realign`` is still
+        ``pending``, so a reader is never told the write gateway during the wait.
+
+        It does not pin WHERE the rendered role came from. The fallback
+        derivation and the serving child's report agree at this moment, so this
+        assertion cannot tell the writer's child-report override apart from a
+        fresh derivation; that distinction is the unit suite's.
+        """
+        slot = session["targets_while_running"][TARGET_STANDIN]
+
+        assert slot["selected_role"] == session["role_while_running"]
+        assert slot["endpoint"] == configured_endpoint(
+            config_path, "live_standin", slot["selected_role"]
+        )
+
+    def test_the_get_and_the_state_file_agree_about_the_narrowed_target(self, session) -> None:
+        """Two surfaces, two derivations, one answer — endpoint and gateway role.
+
+        Compared against the journalled slot rather than against the config row,
+        because a published record carrying a label wins verbatim over the
+        route's own render and the row is therefore only ever as fresh as the
+        last publication.
+
+        Deliberately NOT claimed: that the row's endpoint proves the GET
+        repeated the record. This deployment gives the stand-in's two gateway
+        roles one address and port, so that string is the same whichever way the
+        route arrived at it. What the two surfaces are held to here is naming
+        one ``host:port`` for the stand-in and agreeing about the gateway role
+        behind it — the writer's published ``selected_role`` against the role the
+        route derives for itself in ``reachability`` (``_row_selected_role``,
+        which never reads the block). Those are independent derivations of the
+        same question, which is what makes their agreement worth an assertion.
+        ``effective`` is the premise rather than the evidence: it comes from the
+        posture store alone, and it is asserted so a green here cannot mean the
+        narrowing had silently gone away.
+        """
+        slot = session["targets_after_realign"][TARGET_STANDIN]
+        rows = {row["target"]: row for row in session["get_after_realign"]["targets"]}
+        row = rows[TARGET_STANDIN]
+
+        assert row["effective"] is False
+        assert row["endpoint"] == slot["endpoint"]
+        assert row["reachability"]["role"] == slot["selected_role"] == "read_only"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A session can narrow a control target from write-capable to read-only. Enforcement is
correct: the connector-host child is rebuilt on the read-only gateway and every write is
refused. What the operator is told is wrong. The per-target `endpoint` in the target
state file was rendered once at start from the config ceiling and preserved by every
later publisher, so it kept naming the write gateway's host:port. Every reader printed
that string verbatim: the approval prompt's `Target:` line, the refusal envelope's
`(active target: … at host:port)` clause, the posture route's row, and through it the
header chip's tooltip and confirm dialogs. The label beside the endpoint was right; the
host:port was not.

## Approach

The writer renders posture facts and republishes them; readers keep rendering verbatim.

- `target_display_metadata(config, *, effective_writes=None)` runs two derivations per
  target. Label, display name, real-machine flag and the stand-in predicate come from the
  ceiling derivation, so a stand-in never changes its name under a narrowing. `endpoint`
  and a new `selected_role` come from the effective-posture derivation: the mapping wins
  where it answers, otherwise the process's own session stamp, and a process without a
  stamp gets today's ceiling rendering.
- `ConnectorHostManager` keeps a display cache, renders lazily, and `publish_display()`
  rewrites the state file's `targets` block after every verified switch. The active slot
  follows the live child's verified role, so a failed write probe that falls back is
  published as `read_only`. A publish failure never fails a switch.
- The reconciler republishes the block whenever the posture store moves, before it decides
  whether to realign, so a narrowing of a target the session is not on still reaches the
  file. An unchanged store makes zero writes.
- `target_state.publish_targets` is a synchronous single update; `selected_role` is written
  only when non-empty, like `probe_channel`, so existing pins stay green.
- Refusal envelopes read the writer's cache instead of deriving a second answer from
  config.
- The posture route resolves effective writes per target once and hands the mapping to the
  renderer; a published row with a label still wins verbatim and may lag one reconcile
  interval.
- The turn-writes-on dialog names no gateway, because the roster's endpoint is where reads
  go, not where the write it allows would land. The switch dialog says only "reads" when
  the session arrives unable to write.

Hook code is untouched; its comment now states the contract the writer honours.

## Tests

Unit tests at each seam (renderer, publisher, manager, reconciler, envelope, route),
vitest pins for both dialog bodies and the unchanged tooltip, a browser test that narrows a
row through the real POST and watches the tooltip move to the read port, and the VA
end-to-end posture suite now journals the published block and the route's answer across a
narrowing.

Two things a reviewer should know:

- The end-to-end fixture cannot observe an in-flight window in which the block still names
  `write_access`: the switch back onto the narrowed target already lands on the read
  gateway. The mechanism (active slot follows the child's verified role) is pinned by the
  fallback-landing unit test instead.
- The VA deployment gives both gateway roles one host:port, so the end-to-end endpoint
  assertions are identity checks; `selected_role` carries the role.
