### PR TITLE
feat(web-terminal): JupyterLab notebooks as a per-terminal sidecar panel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1029,6 +1029,7 @@ jobs:
           tests/interfaces/artifacts/test_plot_theme_browser.py \
           tests/interfaces/web_terminal/test_panels_browser.py \
           tests/interfaces/web_terminal/test_panels_collab_browser.py \
+          tests/interfaces/web_terminal/test_jupyter_panel_browser.py \
           tests/interfaces/web_terminal/test_agent_activity_browser.py \
           tests/interfaces/web_terminal/test_contract_params.py \
           tests/interfaces/web_terminal/test_logout_resume_browser.py \
@@ -1450,7 +1451,7 @@ jobs:
           # tiled-roundtrip-e2e, va-substrate-equivalence-e2e,
           # orm-roundtrip-e2e, bluesky-catalog-e2e,
           # bluesky-sandbox-escape-e2e,
-          # nextcloud-talk-bridge-e2e,
+          # nextcloud-talk-bridge-e2e, jupyter-panel-e2e,
           # multi-user-deploy-lifecycle-e2e, deploy-writeback-e2e), the
           # Dockerfile e2e (dockerfile-e2e) and the container privilege
           # split (privilege-split-e2e) each have their own job because they build
@@ -1525,6 +1526,7 @@ jobs:
             --ignore=tests/e2e/web_terminals/test_auth_perimeter.py \
             --ignore=tests/e2e/web_terminals/test_terminal_auth_multiuser_e2e.py \
             --ignore=tests/e2e/test_full_chain_auth.py \
+            --ignore=tests/e2e/test_jupyter_panel_lifecycle.py \
             --ignore=tests/e2e/claude_code/test_channel_finder_mcp_benchmarks.py
         fi
     # On failure only: container logs, exit codes, `OOMKilled`, and runner
@@ -3824,6 +3826,88 @@ jobs:
         docker rmi -f fullchain-operator-operator:local || true
         docker rmi -f fullchain-probe-probe:local || true
 
+  jupyter-panel-e2e:
+    name: Notebook Panel E2E (deployed persona + a kernel that follows the terminal)
+    runs-on: ubuntu-latest
+    # Same-repo PRs only — house policy for any extra Docker-build-and-deploy
+    # job. No secret is needed: the fixture writes a fake ANTHROPIC_API_KEY and
+    # nothing in the module contacts a model.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # One cold persona image build (the neighbouring single-build auth lanes
+    # measure 7-11 minutes for the same work), one `osprey up --dev`, then the
+    # notebook assertions and a second down/up in the last test — which reuses
+    # the images the first build produced. The module caps its own `up` at
+    # 40 minutes, so this ceiling is a backstop rather than a budget; record
+    # the first cold wall clock in the PR body and resize from that.
+    timeout-minutes: 75
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@v2
+
+    - name: Install osprey
+      run: uv sync --extra dev
+
+    - name: Assert a container runtime is present
+      # The module skips itself when docker is unavailable, which is right for
+      # a developer laptop and wrong here: pytest exits 0 on an all-skipped
+      # run, so a runner without docker would turn this lane green having
+      # tested nothing. Failing here instead makes that state loud, and fails
+      # it before the image build rather than after.
+      run: |
+        set -euo pipefail
+        docker info > /dev/null
+
+    # The fixture drives `osprey init`/`osprey build`/`osprey up --dev` itself;
+    # `--dev` stages this branch's locally-built wheel into the persona image,
+    # so the kernel launcher, the sidecar and the guard hook under test are all
+    # THIS branch's code rather than a published release.
+    - name: Run notebook panel E2E
+      # Step cap under the job cap so a wedged kernel fails THIS step, leaving
+      # the capture step below room to run. A job-level timeout is a hard
+      # cancel that takes the container logs with it.
+      timeout-minutes: 65
+      run: |
+        uv run pytest tests/e2e/test_jupyter_panel_lifecycle.py -v --tb=short
+
+    # On failure only: container logs, exit codes, `OOMKilled`, and runner
+    # disk/memory state, uploaded as the `ci-diag-<lane>` artifact.
+    - name: Capture failure diagnostics
+      if: failure()
+      uses: ./.github/actions/capture-ci-diagnostics
+      with:
+        name: jupyter-panel-e2e
+        engine: docker
+
+    # Belt-and-suspenders on top of the test's own try/finally teardown, and
+    # BEFORE the image cleanup below (a surviving container pins its image).
+    # Every resource named here is exact — never a prune, an -a/--all sweep or
+    # a wildcard removal — matching the module's own container-ops guardrail.
+    - name: Clean up any stranded notebook-panel resources
+      if: always()
+      run: |
+        docker rm -f jnb-web-alice || true
+        docker rm -f jnb-nginx || true
+        docker compose -p osprey-e2e-jnb down || true
+        docker volume ls -q --filter "name=^osprey-e2e-jnb_" \
+          | xargs -r docker volume rm -f || true
+        docker rmi -f osprey-e2e-jnb-operator:local || true
+        docker rmi -f osprey-e2e-jnb-va:local || true
+        docker rmi -f osprey-e2e-jnb-qmd:local || true
+
   multi-user-deploy-lifecycle-e2e-podman:
     name: Multi-User Deploy Lifecycle E2E (PRs into main, podman runtime)
     runs-on: ubuntu-latest
@@ -4940,7 +5024,7 @@ jobs:
 
   all-checks-passed:
     name: All CI Checks Passed
-    needs: [test, dependency-floor, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dispatch-overlay-e2e, bluesky-deploy-e2e, bluesky-web-deploy-e2e, va-substrate-equivalence-e2e, orm-roundtrip-e2e, bluesky-queue-e2e, scan-agentic-e2e, archiver-world-e2e, tiled-roundtrip-e2e, bluesky-catalog-e2e, bluesky-sandbox-escape-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e, dockerfile-e2e, privilege-split-e2e, execution-environment-parity-e2e, agentic-per-preset, deploy-writeback-e2e, multi-user-deploy-lifecycle-e2e, multi-user-deploy-lifecycle-e2e-podman, auth-perimeter-e2e, terminal-auth-multiuser-e2e, full-chain-auth-e2e, two-shape-boot-e2e, qmd-sidecar-e2e, target-switch-e2e, target-switch-agentic-e2e, plugin-smoke]
+    needs: [test, dependency-floor, lint, docs, package, static-checks, visual-theming, frontend-js, build-boot-smoke, e2e-tests, deploy-e2e, dispatch-deploy-e2e, dispatch-overlay-e2e, bluesky-deploy-e2e, bluesky-web-deploy-e2e, va-substrate-equivalence-e2e, orm-roundtrip-e2e, bluesky-queue-e2e, scan-agentic-e2e, archiver-world-e2e, tiled-roundtrip-e2e, bluesky-catalog-e2e, bluesky-sandbox-escape-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e, dockerfile-e2e, privilege-split-e2e, execution-environment-parity-e2e, agentic-per-preset, deploy-writeback-e2e, multi-user-deploy-lifecycle-e2e, multi-user-deploy-lifecycle-e2e-podman, auth-perimeter-e2e, terminal-auth-multiuser-e2e, full-chain-auth-e2e, two-shape-boot-e2e, qmd-sidecar-e2e, jupyter-panel-e2e, target-switch-e2e, target-switch-agentic-e2e, plugin-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: always()
@@ -5054,6 +5138,7 @@ jobs:
         check_pr_lane "Full-chain auth E2E"        "${{ needs.full-chain-auth-e2e.result }}"
         check_pr_lane "Two-shape boot E2E (podman-compose)" "${{ needs.two-shape-boot-e2e.result }}"
         check_pr_lane "qmd sidecar E2E"              "${{ needs.qmd-sidecar-e2e.result }}"
+        check_pr_lane "Notebook panel E2E"           "${{ needs.jupyter-panel-e2e.result }}"
         check_pr_lane "Control-target switch E2E"    "${{ needs.target-switch-e2e.result }}"
         check_pr_lane "Control-target switch agentic E2E" "${{ needs.target-switch-agentic-e2e.result }}"
         echo "✅ All CI checks passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3847,6 +3847,16 @@ jobs:
       with:
         fetch-depth: 0
 
+    # The workflow-level OSPREY_OPENOBSERVE_IMAGE points the compose template
+    # at the ghcr mirror; the pull needs this login, exactly as every other
+    # openobserve-deploying lane does.
+    - name: Log in to ghcr (openobserve mirror)
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/changelog.d/jupyter-notebook-panel.added.md
+++ b/changelog.d/jupyter-notebook-panel.added.md
@@ -1,4 +1,4 @@
-Web terminal: a **NOTEBOOKS** panel (`jupyter`) serving JupyterLab in a tab,
+Web terminal: a **JUPYTER** panel (`jupyter`) serving JupyterLab in a tab,
 with kernels that read and write the control system through `osprey.runtime`
 under the same write gates as the agent's own Python. A kernel follows the
 terminal session most recently attached. It keeps the target it started with

--- a/changelog.d/jupyter-notebook-panel.added.md
+++ b/changelog.d/jupyter-notebook-panel.added.md
@@ -1,0 +1,13 @@
+Web terminal: a **NOTEBOOKS** panel (`jupyter`) serving JupyterLab in a tab,
+with kernels that read and write the control system through `osprey.runtime`
+under the same write gates as the agent's own Python. A kernel follows the
+terminal session most recently attached. It keeps the target it started with
+and can never write more than it could at launch, so switching the control
+target or turning writes on needs a kernel restart; turning writes off takes
+effect on its next write. Notebooks live in `notebooks/` under the agent-data
+root, so they survive a redeploy and the OSPREY agent can edit them there. The
+file browser downloads and deletes files under `notebooks/` only, and a
+deleted notebook is gone rather than trashed. The
+panel is selected by default in the `control-assistant` preset family.
+JupyterLab, `jupyter-server` and `ipykernel` are now core dependencies, so
+images grow by roughly 50 MB whether or not the panel is selected.

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -277,7 +277,7 @@ OSPREY is installed and ready to use. Here's what to do next:
    **Container Runtime (Docker or Podman)**
 
    A container runtime is only required if you plan to deploy containerized services
-   (Jupyter, simulation IOCs, databases). The core agent workflow does not require
+   (simulation IOCs, databases, the observability stack). The core agent workflow does not require
    containers.
 
    .. tab-set::
@@ -310,8 +310,8 @@ OSPREY is installed and ready to use. Here's what to do next:
 
    **Deploying Services**
 
-   See :doc:`/how-to/deploy-project/index` for setting up containerized services like Jupyter
-   notebooks, databases, or simulation IOCs.
+   See :doc:`/how-to/deploy-project/index` for setting up containerized services like
+   databases, simulation IOCs, or the observability stack.
 
    **Detailed Configuration**
 

--- a/docs/source/getting-started/osprey-build-interview.rst
+++ b/docs/source/getting-started/osprey-build-interview.rst
@@ -28,7 +28,7 @@ and you can stop, build, and resume at any point.
 
    * **A container runtime (Docker or Podman)** — not needed for the interview
      itself, but your generated project will likely include containerized
-     services (Jupyter, simulation IOCs, databases). Without one, ``osprey build``
+     services (simulation IOCs, databases, the observability stack). Without one, ``osprey build``
      still works but ``osprey up`` won't. See the "Container Runtime"
      dropdown in :doc:`installation` for install instructions.
    * **A list or spreadsheet of EPICS PV names** for your subsystem, if you have

--- a/docs/source/how-to/web-terminal/index.rst
+++ b/docs/source/how-to/web-terminal/index.rst
@@ -50,6 +50,14 @@ created, and switch between companion tools without ever leaving the page.
 
       Add your own tools as themed side panels that sit beside the chat.
 
+   .. grid-item-card:: Notebooks
+      :link: notebooks
+      :link-type: doc
+      :shadow: md
+
+      Run JupyterLab in a tab, with kernels that read and write the control
+      system through the session you already have open.
+
    .. grid-item-card:: Multi-user
       :link: multi-user/index
       :link-type: doc
@@ -64,5 +72,6 @@ created, and switch between companion tools without ever leaving the page.
    operate
    theming
    panels
+   notebooks
    send-feedback
    multi-user/index

--- a/docs/source/how-to/web-terminal/notebooks.rst
+++ b/docs/source/how-to/web-terminal/notebooks.rst
@@ -1,7 +1,7 @@
 Notebooks
 =========
 
-The **NOTEBOOKS** tab is a JupyterLab served from inside the Web Terminal. Its
+The **JUPYTER** tab is a JupyterLab served from inside the Web Terminal. Its
 kernels import ``osprey.runtime``, so a cell reads and writes the control
 system through the same connector the agent's own Python uses, under the same
 write gates and with the same refusal text. Notebooks are ordinary files on a
@@ -21,7 +21,7 @@ Name it under ``web_panels`` to add it to a build profile of your own:
 .. code-block:: yaml
 
    web_panels:
-     - jupyter         # NOTEBOOKS tab
+     - jupyter         # JUPYTER tab
 
 In a hand-written ``config.yml`` it is enabled the way its peers are:
 
@@ -122,7 +122,7 @@ Notebooks the agent also edits
 
 The OSPREY agent may edit a notebook under ``notebooks/`` (and, as before,
 under ``artifacts/``); an edit anywhere else is refused by the memory guard.
-When it edits one, the rail's NOTEBOOKS entry badges and the history row reads
+When it edits one, the rail's JUPYTER entry badges and the history row reads
 *agent edited <notebook>*.
 
 What you see next depends on what the notebook was doing at the time:
@@ -159,7 +159,7 @@ stored on the durable volume, so it comes back after a sidecar restart.
 When the tab is grey
 --------------------
 
-A grey NOTEBOOKS entry means the sidecar did not start. The terminal log says
+A grey JUPYTER entry means the sidecar did not start. The terminal log says
 why, with the last lines of the sidecar's own error output. The rest of the
 terminal is unaffected — only that one tab is unavailable, and it stays grey
 until the terminal is restarted.

--- a/docs/source/how-to/web-terminal/notebooks.rst
+++ b/docs/source/how-to/web-terminal/notebooks.rst
@@ -57,8 +57,17 @@ trash to bring it back from.
 
 When the terminal starts the sidecar and ``notebooks/`` holds no notebook at
 all, it writes ``getting-started.ipynb``, a two-cell notebook holding one note
-and one import line. Any existing ``.ipynb`` suppresses it, and it is never
+and one code cell. Any existing ``.ipynb`` suppresses it, and it is never
 rewritten once written, so it is yours to edit or delete.
+
+The code cell reads a channel where the deployment already names one it can
+serve, so running it returns a value rather than only importing two names.
+The channel comes from the deployment's own configuration, in this order: the
+``archiver_freshness`` health check's channel, which a facility declares is
+still moving, then a control target's ``probe_channel``. A deployment that
+names neither — the ``hello-world`` preset runs a mock connector and declares
+no channel — gets the import line alone, because a cell naming a channel
+nothing serves would fail on its first run.
 
 Which session a kernel follows
 ------------------------------

--- a/docs/source/how-to/web-terminal/notebooks.rst
+++ b/docs/source/how-to/web-terminal/notebooks.rst
@@ -1,0 +1,194 @@
+Notebooks
+=========
+
+The **NOTEBOOKS** tab is a JupyterLab served from inside the Web Terminal. Its
+kernels import ``osprey.runtime``, so a cell reads and writes the control
+system through the same connector the agent's own Python uses, under the same
+write gates and with the same refusal text. Notebooks are ordinary files on a
+durable path, so they outlive the container, and the OSPREY agent can edit
+them alongside you.
+
+Turning the panel on
+--------------------
+
+The panel is a built-in with the id ``jupyter``. Every persona built from the
+``control-assistant`` preset family already selects it, so a standard build
+has the tab. The ``ariel-standalone``, ``channel-finder-standalone`` and
+``hello-world`` presets do not select it.
+
+Name it under ``web_panels`` to add it to a build profile of your own:
+
+.. code-block:: yaml
+
+   web_panels:
+     - jupyter         # NOTEBOOKS tab
+
+In a hand-written ``config.yml`` it is enabled the way its peers are:
+
+.. code-block:: yaml
+
+   web:
+     panels:
+       jupyter: true
+
+.. note::
+
+   JupyterLab, ``jupyter-server`` and ``ipykernel`` are core OSPREY
+   dependencies, so an image grows by roughly 50 MB whether or not the panel
+   is selected. Selecting it costs nothing beyond that. Leaving it out starts
+   no process and opens no port.
+
+Where notebooks live
+--------------------
+
+Notebooks live in ``notebooks/`` under the deployment's agent-data root —
+``var/agent_data/notebooks/`` in a container build. That directory is on the
+durable volume, so notebooks survive ``osprey down && osprey up``. Kernels do
+not: stopping the deployment stops every kernel.
+
+JupyterLab opens on that directory and cannot see above it. A path that
+resolves outside it is refused with a ``404``, symlinks included — the check
+is against the resolved path, not the text of it. *Download* and *Copy
+Download Link* in the file browser obey the same rule: they serve files from
+``notebooks/`` and nothing else.
+
+*Delete* in the file browser removes the notebook from the volume. There is no
+trash to bring it back from.
+
+When the terminal starts the sidecar and ``notebooks/`` holds no notebook at
+all, it writes ``getting-started.ipynb``, a two-cell notebook holding one note
+and one import line. Any existing ``.ipynb`` suppresses it, and it is never
+rewritten once written, so it is yours to edit or delete.
+
+Which session a kernel follows
+------------------------------
+
+A kernel has no control-system identity of its own. It follows a terminal
+session, and the rule is **the session most recently attached** in the
+browser. Open a chat session first, then start the kernel.
+
+At start the kernel stamps itself with that session's control target, the
+target's generation, and the write posture in force. A cell can read those
+back:
+
+.. code-block:: python
+
+   import os
+
+   os.environ["OSPREY_CONTROL_TARGET"]    # the target this kernel is pinned to
+   os.environ["OSPREY_LAUNCH_POSTURE"]    # what it was allowed to write at launch
+
+A running kernel keeps the target it started with and can never write more
+than it could at launch. Turning writes off takes effect on its next write.
+Switch the control target from the chip, or turn writes on, and the kernel
+does not follow — restart it. (The chip's own "nothing restarts" wording
+covers the agent's ``execute()`` runs, which are a fresh child process every
+time. A kernel is not.) The first write after the change says which case you
+are in:
+
+.. code-block:: text
+
+   The session's control target changed. Restart the kernel to follow it.
+   This kernel started with writes off. Turn writes on from the chip, then restart the kernel.
+
+Closing a session tile detaches the tile. It does not end the session, so the
+kernel keeps following that session — and can still write whatever it could
+write at launch — until the session itself ends. *+ New* in the tile ends the
+current session and starts another, and the running kernel's next write is
+refused:
+
+.. code-block:: text
+
+   The chat session this kernel followed has ended. Restart the kernel.
+
+A kernel started with no chat session open carries no target at all. Reads
+answer from the deployment's baseline target, and every write is refused:
+
+.. code-block:: text
+
+   No chat session was open when this kernel started. Open one, then restart the kernel.
+
+You meet that state in two places: before a terminal's first session exists,
+and after the session a kernel followed has ended.
+
+A refusal for any other reason — a write ceiling, a limits violation — carries
+no extra line, because no restart would change it.
+
+A page reload keeps the kernel running, but the notebook comes back as it was
+last saved. Output from cells that ran since that save is gone.
+
+Notebooks the agent also edits
+------------------------------
+
+The OSPREY agent may edit a notebook under ``notebooks/`` (and, as before,
+under ``artifacts/``); an edit anywhere else is refused by the memory guard.
+When it edits one, the rail's NOTEBOOKS entry badges and the history row reads
+*agent edited <notebook>*.
+
+What you see next depends on what the notebook was doing at the time:
+
+- **Not open** — it opens with the agent's change already in it.
+- **Open with no unsaved edits of yours** — pick *File → Reload Notebook from
+  Disk* to take the change.
+- **Open with unsaved edits of yours** — JupyterLab notices the file moved
+  under it and offers *Overwrite* or *Revert* when you save. Your work is
+  never silently replaced.
+
+Notebooks in a multi-user deployment
+------------------------------------
+
+The multi-user stack gives every user their own container and their own
+volumes, which a redeploy never touches (:doc:`multi-user/index`), so
+notebooks are per user. There is no shared notebook folder in this release.
+Sharing a notebook means handing over the file.
+
+.. _notebooks-theming:
+
+How the tab is themed
+---------------------
+
+JupyterLab starts in the deployment's pinned theme. A ``web.theme`` that names
+a dark or a light look (:doc:`theming`) starts the tab in JupyterLab's matching
+built-in theme; a family name on its own pins nothing.
+
+Unlike the other panels, this one does not follow the terminal's Appearance
+toggle. Switching the terminal between light and dark leaves JupyterLab as it
+is. Pick a theme inside the tab from *Settings → Theme* instead. That pick is
+stored on the durable volume, so it comes back after a sidecar restart.
+
+When the tab is grey
+--------------------
+
+A grey NOTEBOOKS entry means the sidecar did not start. The terminal log says
+why, with the last lines of the sidecar's own error output. The rest of the
+terminal is unaffected — only that one tab is unavailable, and it stays grey
+until the terminal is restarted.
+
+A sidecar that dies after it started shows itself differently. JupyterLab
+reads *Disconnected* and saves fail, and there is nowhere else to save to, so
+copy any unsaved cells out of the browser before you restart the terminal. The
+terminal log carries one ``notebook sidecar exited`` line with the sidecar's
+last error lines. The tab greys on the next page load.
+
+``osprey health`` does not probe the panel. It reports one row per enabled
+sidecar reading *not probed — served inside the web terminal*, so it never
+claims a panel is healthy on evidence it does not have.
+
+Not in this release
+-------------------
+
+- The agent cannot run cells. It edits notebook files; you run them.
+- No real-time collaborative editing. Two people in one notebook fall back to
+  the save-time dialog above.
+- No health probe of the sidecar, only the skip row.
+- No live theme following. The tab starts in the pinned theme and stays there
+  until you pick another one inside it.
+- No per-panel restart. Restart the terminal.
+
+.. seealso::
+
+   :doc:`panels`
+      The other tabs, and how the panel proxy treats credentials.
+
+   :doc:`operate`
+      Running the terminal that hosts them.

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -224,7 +224,11 @@ ones are skipped and logged, so one bad panel never breaks the others.
    in your config. The practical consequence: a backend that authenticates its
    own callers with a cookie or an ``Authorization`` header — Grafana, for
    example — cannot be driven as a custom panel, because the proxy will never
-   pass those credentials through to it.
+   pass those credentials through to it. A panel OSPREY starts itself is the
+   one exception, and it is served rather than granted: the notebook sidecar
+   (:doc:`notebooks`) mints a token per launch, and the proxy attaches it to
+   each request on the way to the loopback backend, so the token never reaches
+   the browser.
 
    The return direction is just as strict. A panel's response is served from
    the terminal's own address, so any header that would act on *that* address

--- a/docs/source/how-to/web-terminal/theming.rst
+++ b/docs/source/how-to/web-terminal/theming.rst
@@ -48,7 +48,9 @@ preference.
 Panels shown inside the terminal are a separate case. The terminal hands each
 one its theme and view in the page address, and an address outranks the
 remembered preference, so an embedded panel always matches the terminal
-around it.
+around it. The NOTEBOOKS panel is the exception: it starts on the deployment's
+pinned theme and then keeps whatever theme you pick inside JupyterLab
+(:ref:`notebooks-theming`).
 
 .. grid:: 1 1 2 2
    :gutter: 2

--- a/docs/source/how-to/web-terminal/theming.rst
+++ b/docs/source/how-to/web-terminal/theming.rst
@@ -48,7 +48,7 @@ preference.
 Panels shown inside the terminal are a separate case. The terminal hands each
 one its theme and view in the page address, and an address outranks the
 remembered preference, so an embedded panel always matches the terminal
-around it. The NOTEBOOKS panel is the exception: it starts on the deployment's
+around it. The JUPYTER panel is the exception: it starts on the deployment's
 pinned theme and then keeps whatever theme you pick inside JupyterLab
 (:ref:`notebooks-theming`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ dependencies = [
     "nbformat>=5.0.0",
     "nbclient",
     "nbconvert>=7.0.0",
+    # JupyterLab and the server it runs on, launched by the notebook sidecar via
+    # ServerApp traits and a ContentsManager subclass. Capped below the next major
+    # so adopting it is a reviewed change, not a lock-refresh surprise.
+    "jupyterlab>=4.6,<5",
+    "jupyter-server>=2.21,<3",
+    "ipykernel",
     # AI/ML provider integrations
     "litellm>=1.56.0",  # Unified LLM provider interface (100+ providers)
     # Capped below 3.x: the 3.0 major is a client rewrite (new httpx2 stack).

--- a/scripts/benchmark/matrix_e2e_config.json
+++ b/scripts/benchmark/matrix_e2e_config.json
@@ -187,6 +187,10 @@
       "reason": "Runs the claude CLI with a deliberately bogus API key and reads only the pre-model stream-json init record's skills list — no model is ever contacted."
     },
     {
+      "path": "tests/e2e/test_jupyter_panel_lifecycle.py",
+      "reason": "Builds the persona image and drives one real `osprey up --dev`, then exercises the notebook panel over HTTP and the kernel's websocket channels. No agent session runs and nothing here contacts a model: the fixture writes a fake ANTHROPIC_API_KEY, and the assertions are the kernel's stamps, its refusal text and the audit ledger. Also needs Docker, which the bench box lacks. Runs in its own CI job (jupyter-panel-e2e)."
+    },
+    {
       "path": "tests/e2e/test_target_switch_agentic.py",
       "reason": "Docker-bound two-container fixture, bespoke pinned init."
     }

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -537,7 +537,7 @@ def artifact_menu_catalog() -> dict[str, list[tuple[str, str]]]:
     Universal panels (always served) are excluded: they are not opt-ins.
     """
     from osprey.cli.templates.artifact_library import _TYPE_TO_SUBDIR, list_artifacts
-    from osprey.profiles.web_panels import BUILTIN_PANELS, UNIVERSAL_PANELS
+    from osprey.profiles.web_panels import BUILTIN_PANELS, SIDECAR_PANELS, UNIVERSAL_PANELS
     from osprey.registry.web import FRAMEWORK_WEB_SERVERS
     from osprey.services.build_artifacts import BuildArtifactCatalog
 
@@ -550,6 +550,7 @@ def artifact_menu_catalog() -> dict[str, list[tuple[str, str]]]:
             entries.append((name, _first_sentence(artifact.description) if artifact else ""))
         menu[artifact_type] = entries
     labels = {d.panel_id: d.name for d in FRAMEWORK_WEB_SERVERS.values()}
+    labels |= {panel_id: entry.name for panel_id, entry in SIDECAR_PANELS.items()}
     menu["web_panels"] = [
         (panel, labels.get(panel, "")) for panel in sorted(BUILTIN_PANELS - UNIVERSAL_PANELS)
     ]

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -2851,11 +2851,11 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False, person
             ...     'additional_dirs': ['docs', 'scripts'],
             ... }
             >>> compose_path = setup_build_dir(
-            ...     'services/osprey/jupyter/docker-compose.yml.j2',
+            ...     'services/openobserve/docker-compose.yml.j2',
             ...     config,
             ...     container_cfg
             ... )
-            >>> print(compose_path)  # 'build/services/osprey/jupyter/docker-compose.yml'
+            >>> print(compose_path)  # 'build/services/openobserve/docker-compose.yml'
 
         Advanced service with custom directory mapping::
 
@@ -2885,7 +2885,7 @@ def setup_build_dir(template_path, config, container_cfg, dev_mode=False, person
     source_dir = os.path.relpath(os.path.dirname(template_path), os.getcwd())
 
     # Extract service name from the path for container path resolution
-    # e.g., "services/jupyter" -> "jupyter", "src/osprey/templates/services/pipelines" -> "pipelines"
+    # e.g., "services/qmd" -> "qmd", "src/osprey/templates/services/pipelines" -> "pipelines"
     os.path.basename(source_dir)
 
     # Clear the directory if it exists
@@ -3215,9 +3215,9 @@ def find_existing_compose_files(config, deployed_services, quiet=False, base=Non
         is what every caller building a ``-f`` list passes it through.
 
     Example:
-        compose_files = find_existing_compose_files(config, ['osprey.jupyter'])
+        compose_files = find_existing_compose_files(config, ['openobserve'])
         # Returns: ['./build/services/docker-compose.yml',
-        #          './build/services/osprey/jupyter/docker-compose.yml']
+        #          './build/services/openobserve/docker-compose.yml']
     """
     compose_files = []
     base = Path(base) if base is not None else Path.cwd()

--- a/src/osprey/health/core/web_panels.py
+++ b/src/osprey/health/core/web_panels.py
@@ -10,11 +10,15 @@ The detailed readout lives here, where it sits beside the other core categories,
 is reachable from ``osprey health`` and the MCP surface, and works with no
 browser involved.
 
-Panels come from two places and are probed accordingly:
+Panels come from three places and are probed accordingly:
 
 * **Built-in panels** (``web.panels.<id>`` enabled, id in ``BUILTIN_PANELS``) —
   host/port resolved by ``registry.web.resolve_web_server_address``, the one
   resolver ``server_launcher`` itself is bound to, then ``GET /health``.
+* **Sidecar panels** (``web.panels.<id>`` enabled, id in ``SIDECAR_PANELS``) —
+  not probed at all. The web terminal starts them and they are reached only
+  through its panel proxy, so they have no address this category could fetch;
+  each enabled one gets a ``skip`` row naming where the answer lives.
 * **Custom panels** (any other ``web.panels.<id>`` with a ``url``) — ``GET
   url + health_endpoint`` when one is configured. When it isn't (the scan
   ``plan``/``results`` panels declare none), the panel's own entry ``path`` is
@@ -45,6 +49,7 @@ from osprey.health.models import CheckResult, Status
 from osprey.profiles.web_panels import (
     BUILTIN_PANEL_LABELS,
     BUILTIN_PANELS,
+    SIDECAR_PANELS,
     UNIVERSAL_PANELS,
     panel_spec_enabled,
 )
@@ -129,8 +134,8 @@ def _resolve_targets(cfg: Mapping[str, Any]) -> tuple[list[_Target], list[CheckR
 
     Returns:
         ``(targets, config_rows)`` — the panels to probe, plus ready-made rows
-        for panels whose own config section is malformed and therefore has no
-        probeable address at all.
+        for the panels with no probeable address at all: a sidecar, and a panel
+        whose own config section is malformed.
     """
     web_cfg = cfg.get("web")
     if not isinstance(web_cfg, dict):
@@ -156,6 +161,9 @@ def _resolve_targets(cfg: Mapping[str, Any]) -> tuple[list[_Target], list[CheckR
             targets.append(target)
 
     for panel_id in sorted(enabled_builtin):
+        if panel_id in SIDECAR_PANELS:
+            config_rows.append(_sidecar_row(panel_id))
+            continue
         try:
             target = _builtin_target(panel_id, cfg)
         except WebServerConfigDepthError as exc:
@@ -189,6 +197,26 @@ def _builtin_target(panel_id: str, cfg: Mapping[str, Any]) -> _Target | None:
     host, port = resolve_web_server_address(registry_key, cfg)
     label = BUILTIN_PANEL_LABELS.get(panel_id, panel_id.upper())
     return _Target(panel_id, label, f"http://{host}:{port}/health", contract=True)
+
+
+def _sidecar_row(panel_id: str) -> CheckResult:
+    """Report a sidecar panel as skipped rather than probing it.
+
+    A sidecar has no address of its own: the web terminal starts it and it is
+    reached only through the terminal's panel proxy, so there is nothing here to
+    fetch when the terminal is not running. An OK row would claim a liveness
+    this category never established, and a warning row would call every
+    terminal-less host broken. A skip says what is true and names the one place
+    the answer lives.
+    """
+    label = BUILTIN_PANEL_LABELS.get(panel_id, panel_id.upper())
+    return CheckResult(
+        f"{CATEGORY}.{panel_id.replace('-', '_')}",
+        CATEGORY,
+        Status.SKIP,
+        f"{label}: not probed — served inside the web terminal; a grey tab means "
+        "the sidecar did not start, see the terminal log",
+    )
 
 
 def _misconfigured_row(panel_id: str, exc: WebServerConfigDepthError) -> CheckResult:

--- a/src/osprey/health/probes/container.py
+++ b/src/osprey/health/probes/container.py
@@ -19,7 +19,8 @@ state — and its healthcheck status, when the runtime reports one — to a
 Container matching uses a fuzzy short-name rule: the target's last dotted
 segment, lower-cased, is matched
 against each container's ``Names`` with underscore/hyphen variants, so
-``osprey.jupyter`` matches a container named ``project-osprey_jupyter-1``.
+``services.archiver_recorder`` matches a container named
+``project-archiver-recorder-1``.
 
 Spec keys:
     container: The container/service name to look up (required; alias ``service``).

--- a/src/osprey/interfaces/_serving.py
+++ b/src/osprey/interfaces/_serving.py
@@ -13,6 +13,7 @@ importing it from shipped code drags nothing extra along.
 
 from __future__ import annotations
 
+import logging
 import socket
 import threading
 import time
@@ -25,6 +26,29 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+#: Seconds uvicorn may spend draining open connections once it is told to
+#: exit, before it cancels whatever is still running and moves on to the
+#: application's lifespan shutdown. Uvicorn's default is *no* bound: it waits
+#: for every connection and every in-flight handler to finish, and only then
+#: runs the lifespan shutdown. A proxied WebSocket still closing upstream, or a
+#: handler stuck behind a slow peer, therefore holds the lifespan shutdown open
+#: for as long as it likes — and everything that shutdown owns (the notebook
+#: sidecar and its kernels, the file watcher, PTY children) keeps running with
+#: it. The callers here have already closed their pages by the time they stop
+#: the server, so a connection that has not gone in this long is not going to.
+_DRAIN_TIMEOUT = 5.0
+
+#: Seconds to wait for the serving thread to finish after ``should_exit``.
+#: Covers the drain above plus a lifespan shutdown that terminates
+#: subprocesses with a grace period of its own (the notebook sidecar gives its
+#: server five seconds on ``SIGTERM`` before ``SIGKILL``, then reaps kernels).
+#: The earlier five-second join returned before such a shutdown could possibly
+#: have finished, so a test that checked for leaked processes afterwards was
+#: racing the shutdown it was meant to observe.
+_SHUTDOWN_JOIN = 30.0
 
 
 def free_port() -> int:
@@ -100,7 +124,13 @@ def run_app_server(app: FastAPI) -> Iterator[str]:
     sock.listen(128)
     port = int(sock.getsockname()[1])
 
-    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        timeout_graceful_shutdown=_DRAIN_TIMEOUT,
+    )
     server = uvicorn.Server(config)
     thread_error: list[BaseException] = []
 
@@ -116,7 +146,18 @@ def run_app_server(app: FastAPI) -> Iterator[str]:
 
     def _shutdown() -> None:
         server.should_exit = True
-        t.join(timeout=5)
+        t.join(timeout=_SHUTDOWN_JOIN)
+        if t.is_alive():
+            # Said out loud rather than raised: this runs in the caller's
+            # ``finally``, where an exception would replace the test's own.
+            # What it names is a lifespan shutdown that has not finished, which
+            # is what a process-leak check further down will report in detail.
+            logger.warning(
+                "Server on port %d still shutting down after %.0f s; "
+                "its lifespan shutdown has not completed",
+                port,
+                _SHUTDOWN_JOIN,
+            )
         with suppress(OSError):
             sock.close()
 

--- a/src/osprey/interfaces/web_terminal/__init__.py
+++ b/src/osprey/interfaces/web_terminal/__init__.py
@@ -2,8 +2,39 @@
 
 A browser-based split-pane interface with a real terminal (running Claude Code
 via PTY) on the left and a live workspace file viewer on the right.
+
+``run_web`` is exported lazily. Importing it eagerly meant that reaching *any*
+module in this package — the notebook sidecar and its kernel-side helpers among
+them — built the FastAPI application and pulled in uvicorn, in processes that
+serve no HTTP at all. The module ``__getattr__`` keeps ``from
+osprey.interfaces.web_terminal import run_web`` working unchanged while a
+sibling import stays a sibling import.
 """
 
-from osprey.interfaces.web_terminal.app import run_web
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from osprey.interfaces.web_terminal.app import run_web
 
 __all__ = ["run_web"]
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve ``run_web`` on first access, leaving every other name unbound.
+
+    Args:
+        name: Attribute requested from the package.
+
+    Returns:
+        The requested attribute.
+
+    Raises:
+        AttributeError: For any name this package does not export.
+    """
+    if name == "run_web":
+        from osprey.interfaces.web_terminal.app import run_web
+
+        return run_web
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -7,6 +7,7 @@ via PTY) on the left and a live workspace file viewer on the right.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import os
 from collections import deque
 from collections.abc import Callable
@@ -46,7 +47,12 @@ from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
 from osprey.interfaces.web_terminal.routes import router
 from osprey.interfaces.web_terminal.routes.agent_activity import ACTIVITY_RING_MAX
 from osprey.port_layout import default_port
-from osprey.profiles.web_panels import BUILTIN_PANELS, UNIVERSAL_PANELS, panel_spec_enabled
+from osprey.profiles.web_panels import (
+    BUILTIN_PANELS,
+    SIDECAR_PANELS,
+    UNIVERSAL_PANELS,
+    panel_spec_enabled,
+)
 from osprey.registry.web import PANEL_ID_TO_REGISTRY_KEY, panel_url_state_attr
 
 if TYPE_CHECKING:
@@ -90,14 +96,138 @@ def _launch_enabled_panel_servers(app: FastAPI, enabled_panels: set[str]) -> Non
     sync with :func:`_load_panel_config`, which already folds
     ``UNIVERSAL_PANELS`` into ``enabled_panels`` unconditionally.
 
+    Sidecar panel ids are diverted before the registry lookup: a sidecar is in
+    no companion registry and has no key to look up, so indexing
+    ``PANEL_ID_TO_REGISTRY_KEY`` with one raises. :func:`_launch_enabled_sidecars`
+    starts those, from the same ``enabled_panels`` set.
+
     Args:
         app: The web-terminal application whose ``state`` the URLs are published on.
         enabled_panels: Enabled panel ids from :func:`_load_panel_config`. Ids with
             no companion server behind them (URL-backed custom panels such as
             ``events``) are skipped — the framework serves nothing for those.
     """
-    for panel_id in sorted(enabled_panels & BUILTIN_PANELS):
+    for panel_id in sorted(enabled_panels & (BUILTIN_PANELS - set(SIDECAR_PANELS))):
         _launch_panel_server(app, PANEL_ID_TO_REGISTRY_KEY[panel_id])
+
+
+#: How long a sidecar gets to answer its own status endpoint after it is spawned.
+#: Generous: the first launch on a cold deployment builds the panel's assets.
+SIDECAR_READY_TIMEOUT = 60.0
+
+
+async def _launch_enabled_sidecars(app: FastAPI, enabled_panels: set[str]) -> None:
+    """Start every enabled sidecar panel and publish what the proxy needs.
+
+    The async peer of :func:`_launch_enabled_panel_servers`. Split from it
+    rather than folded in because a sidecar launch blocks — an interpreter
+    probe, then a server that has to come up — and the lifespan's loop is
+    already running by the time this is reached.
+
+    Args:
+        app: The web-terminal application whose ``state`` the URLs are published on.
+        enabled_panels: Enabled panel ids from :func:`_load_panel_config`.
+    """
+    for panel_id in sorted(enabled_panels & set(SIDECAR_PANELS)):
+        await _launch_sidecar(app, panel_id)
+
+
+async def _launch_sidecar(app: FastAPI, panel_id: str) -> None:
+    """Start the sidecar behind *panel_id* and publish its URL and credential.
+
+    The class comes from :data:`~osprey.profiles.web_panels.SIDECAR_PANELS` as a
+    dotted ``module:attribute`` path, resolved here the way
+    :func:`_launch_panel_server` resolves a registry key — so adding a sidecar
+    is an entry in that registry and nothing in this module.
+
+    Publishing is all-or-nothing, and it happens only once the sidecar answers:
+    the panel URL (``app.state.<id>_server_url``) is the sole input to panel
+    availability, and the credential (``app.state.panel_auth_headers[<id>]``) is
+    what the proxy re-issues on the operator's behalf. A launch that failed
+    anywhere leaves the URL unset, which is what a switched-off panel looks like.
+
+    The blocking halves run in a worker thread. ``spawn()`` blocks only for the
+    fork, so it stays on the loop.
+
+    A sidecar that dies later is retracted the same way it was published: its
+    ``on_exit`` hook, which the sidecar fires from its own watcher thread, hands
+    the loop a callback that clears the URL and drops the credential, so the
+    availability route answers unavailable at once and the next page load greys
+    the tab. The sidecar logs the exit itself, with its stderr tail. Nothing
+    restarts it; the object stays in ``app.state.sidecars`` so shutdown still
+    removes its per-launch tempdir.
+
+    Args:
+        app: The web-terminal application whose ``state`` the URL is published on.
+        panel_id: The sidecar's panel id, a key of ``SIDECAR_PANELS``.
+    """
+    attr = panel_url_state_attr(panel_id)
+    setattr(app.state, attr, None)
+    sidecar = None
+    try:
+        from osprey.interfaces.web_terminal.operator_session import resolve_agent_data_root
+
+        module_path, _, attribute = SIDECAR_PANELS[panel_id].factory_path.partition(":")
+        factory = getattr(importlib.import_module(module_path), attribute)
+        sidecar = factory(
+            Path(resolve_agent_data_root(app)),
+            compute_url_prefix(),
+            getattr(app.state, "web_theme_mode", None),
+        )
+        await asyncio.to_thread(sidecar.preflight)
+        sidecar.spawn()
+        await asyncio.to_thread(sidecar.wait_ready, SIDECAR_READY_TIMEOUT)
+    except Exception as exc:  # noqa: BLE001 — a dead panel must not block startup
+        # The readiness failures already quote the tail in their own message;
+        # the preflight ones carry none, so it is appended only when it is new.
+        tail = getattr(sidecar, "stderr_tail", "")
+        detail = f"{exc}\n{tail}" if tail and tail not in str(exc) else str(exc)
+        logger.warning("%s sidecar failed to start: %s", panel_id, detail)
+        if sidecar is not None:
+            await _stop_sidecar(panel_id, sidecar)
+        setattr(app.state, attr, None)
+        return
+
+    app.state.sidecars[panel_id] = sidecar
+    app.state.panel_auth_headers[panel_id] = sidecar.auth_headers
+    setattr(app.state, attr, sidecar.url)
+    logger.info("%s sidecar available at %s", panel_id, sidecar.url)
+
+    loop = asyncio.get_running_loop()
+
+    def retract() -> None:
+        setattr(app.state, attr, None)
+        app.state.panel_auth_headers.pop(panel_id, None)
+        logger.info("%s panel retracted; restart the terminal to bring it back", panel_id)
+
+    def on_exit() -> None:
+        # Runs on the sidecar's watcher thread; ``app.state`` belongs to the loop.
+        try:
+            loop.call_soon_threadsafe(retract)
+        except RuntimeError:
+            pass  # the loop is closed: shutdown has already torn the state down
+
+    # Registered last: a setter that fires when the exit already happened
+    # closes the gap between readiness and this line.
+    sidecar.on_exit = on_exit
+
+
+async def _stop_sidecar(panel_id: str, sidecar: object) -> None:
+    """Stop one sidecar off the loop, and never raise doing it.
+
+    Both callers have to survive a stop that fails: the launch path is already
+    handling one failure and must still retract the panel, and the lifespan
+    shutdown must reach the sidecars after this one. ``stop()`` also blocks
+    while the process is reaped, so it runs in a worker thread.
+
+    Args:
+        panel_id: The sidecar's panel id, for the log line.
+        sidecar: The sidecar object to stop.
+    """
+    try:
+        await asyncio.to_thread(sidecar.stop)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — one stuck sidecar must not block the rest
+        logger.warning("Could not stop the %s sidecar", panel_id, exc_info=True)
 
 
 def _launch_panel_server(app: FastAPI, key: str) -> None:
@@ -2279,7 +2409,14 @@ def _create_lifespan(
         except Exception:
             logger.warning("Local panel discovery failed; continuing.", exc_info=True)
 
+        # A sidecar's running process and the credential the proxy re-issues for
+        # it, keyed by panel id. Both stay empty when no sidecar panel is
+        # enabled, and a launch that failed adds to neither.
+        app.state.sidecars = {}
+        app.state.panel_auth_headers = {}
+
         _launch_enabled_panel_servers(app, enabled_panels)
+        await _launch_enabled_sidecars(app, enabled_panels)
 
         # Hook env placeholder — hooks read config.yml directly for
         # hot-reloadable settings (no env var propagation needed).
@@ -2331,6 +2468,9 @@ def _create_lifespan(
         from osprey.infrastructure.proxy.lifecycle import stop_proxy
 
         stop_proxy()
+
+        for panel_id, sidecar in app.state.sidecars.items():
+            await _stop_sidecar(panel_id, sidecar)
 
         app.state.watcher.stop()
         app.state.pty_registry.cleanup_all()

--- a/src/osprey/interfaces/web_terminal/jupyter_contents.py
+++ b/src/osprey/interfaces/web_terminal/jupyter_contents.py
@@ -1,0 +1,114 @@
+"""Contents manager that keeps the notebook sidecar inside its own root.
+
+``jupyter_server`` 2.21 resolves an API path with
+:func:`~jupyter_server.utils.to_os_path` and then checks that the *textual*
+result sits under ``root_dir``. Text is not the filesystem: a symlink whose
+name lives under the root but whose target does not passes that check, so the
+contents API would happily read and write through it. The confinement here
+resolves the symlink chain and compares the real path, which is the property
+the sidecar's root actually needs to hold.
+
+The base class is the one ``ServerApp`` picks by default —
+``AsyncLargeFileManager`` — so the sidecar keeps async contents handling and
+chunked uploads and never trips the synchronous-manager deprecation warning.
+``_get_os_path`` is defined once, on ``FileManagerMixin``, and every class
+that touches the disk inherits that single definition; the override lives in
+one mixin so that every such class gets the same check. Three classes reach
+the disk:
+
+* the contents manager itself, for every ``/api/contents`` operation;
+* the checkpoints, which carry their own ``root_dir`` and their own copy of
+  the mixin: listing and deleting a checkpoint resolve the notebook's parent
+  directory through it, and would create ``.ipynb_checkpoints`` there;
+* the raw file handler (``/files/<path>``, behind Download and Open in New
+  Browser Tab). ``FileContentsManager`` serves it through
+  ``AuthenticatedFileHandler``, a ``StaticFileHandler`` that reads straight off
+  ``root_dir`` and never asks the contents manager, so tornado's own textual
+  root check lets a symlink through. The manager's ``files_handler_class`` is
+  therefore pointed at ``jupyter_server``'s generic ``FilesHandler``, which
+  fetches the file through ``ContentsManager.get`` — and so through
+  ``_get_os_path``. The price is that a raw file is read into memory rather
+  than streamed, which the contents API already does for the same files.
+
+Importing this module must not build the web application: it is imported only
+inside the sidecar process, which serves no FastAPI route.
+"""
+
+from __future__ import annotations
+
+import os
+
+from jupyter_server.files.handlers import FilesHandler
+from jupyter_server.services.contents.filecheckpoints import AsyncFileCheckpoints
+from jupyter_server.services.contents.fileio import FileManagerMixin
+from jupyter_server.services.contents.largefilemanager import AsyncLargeFileManager
+from tornado.web import HTTPError, RequestHandler
+from traitlets import default
+
+__all__ = ["ConfinedFileCheckpoints", "ConfinedFileContentsManager", "RawFilesHandler"]
+
+
+class _ConfinedPaths(FileManagerMixin):
+    """``_get_os_path`` that refuses a path whose real location escapes ``root_dir``."""
+
+    root_dir: str  # the trait every concrete class below declares
+
+    def _get_os_path(self, path: str) -> str:
+        """Return the OS path for an API path, refusing one that escapes the root.
+
+        Args:
+            path: Relative API path to a file or directory.
+
+        Returns:
+            Native, absolute OS path, unresolved, exactly as the base class
+            returns it.
+
+        Raises:
+            HTTPError: 404 when the path, with every symlink resolved, is not
+                the root directory or somewhere beneath it.
+        """
+        os_path: str = super()._get_os_path(path)
+        root = os.path.realpath(self.root_dir)
+        resolved = os.path.realpath(os_path)
+        if resolved != root and not resolved.startswith(root + os.sep):
+            raise HTTPError(404, f"{path} is outside root contents directory")
+        return os_path
+
+
+class ConfinedFileCheckpoints(_ConfinedPaths, AsyncFileCheckpoints):
+    """File checkpoints whose paths must resolve inside ``root_dir``."""
+
+
+class RawFilesHandler(FilesHandler):
+    """``FilesHandler`` whose ``HEAD`` answers.
+
+    Upstream ``head`` calls the async ``get`` without awaiting it, and the
+    inherited ``compute_etag`` asserts a static-file attribute ``get`` never
+    sets, so every ``HEAD`` was a 500.
+    """
+
+    def compute_etag(self) -> str | None:
+        return None
+
+    async def head(self, path: str) -> None:  # type: ignore[override]
+        response = self.get(path, include_body=False)
+        if response is not None:
+            await response
+
+
+class ConfinedFileContentsManager(_ConfinedPaths, AsyncLargeFileManager):  # type: ignore[misc]
+    """A contents manager whose paths must resolve inside ``root_dir``.
+
+    The ignore is upstream's own: ``AsyncFileContentsManager`` carries it for
+    the same sync/async ``resolve_path`` pair, which surfaces again whenever a
+    class names two bases.
+    """
+
+    @default("checkpoints_class")
+    def _checkpoints_class_default(self) -> type[AsyncFileCheckpoints]:
+        return ConfinedFileCheckpoints
+
+    @default("files_handler_class")
+    def _files_handler_class_default(self) -> type[RequestHandler]:
+        """Serve ``/files/`` through :meth:`get`, so :meth:`_get_os_path` confines it."""
+        return RawFilesHandler

--- a/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
+++ b/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
@@ -118,6 +118,11 @@ _STOP_GRACE = 5.0
 #: How long a straggling kernel is given to take SIGTERM before it is killed.
 _REAP_GRACE = 3.0
 
+#: How long the reap waits for a straggler to *appear* before calling it clean.
+#: A kernel forked just before the server died is invisible to a command-line
+#: match until it execs, so the reap cannot trust its first snapshot.
+_REAP_SETTLE = 1.0
+
 
 def lab_theme_override(pinned_mode: str | None) -> dict[str, dict[str, str]] | None:
     """Return the labconfig override that pins JupyterLab's theme.
@@ -597,16 +602,28 @@ def _reap_stragglers(runtime_dir: str) -> None:
 
     The runtime dir is a 0700 tempdir unique to this launch, and every kernel
     names its connection file inside it, so matching on it cannot reach a
-    process belonging to anything else.
+    process belonging to anything else. That uniqueness is the whole safety
+    argument, and it is why the match is not widened to the shared root: that
+    one is shared across launches, and a signal sent on it could reach another
+    deployment's kernels.
+
+    A straggler is waited *for*, not merely sampled. A kernel the server forked
+    just before it died does not name the runtime dir until it execs — its
+    connection file is an argv entry — so a single snapshot taken the moment the
+    server dies races that exec and, losing, leaves the kernel running with
+    nothing above it. Hence the settle window: only a quiet
+    ``_REAP_SETTLE`` means there is genuinely nothing to reap.
 
     Args:
         runtime_dir: The sidecar's per-launch runtime directory.
     """
     if shutil.which("pgrep") is None:  # pragma: no cover - POSIX hosts have it
         return
-    survivors = _pids_naming(runtime_dir)
-    if not survivors:
-        return
+    appear_by = time.monotonic() + _REAP_SETTLE
+    while not (survivors := _pids_naming(runtime_dir)):
+        if time.monotonic() >= appear_by:
+            return
+        time.sleep(0.05)
     logger.info("%s reaping %d process(es) that outlived it", _NAME, len(survivors))
     for pid in survivors:
         _signal_pid(pid, signal.SIGTERM)

--- a/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
+++ b/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
@@ -62,9 +62,9 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import IO
+from typing import IO, Any
 
 import nbformat
 
@@ -109,6 +109,79 @@ STARTER_NOTEBOOK_NAME = "getting-started.ipynb"
 _STARTER_MARKDOWN = "This kernel follows your terminal session. Open a chat session before writing."
 _STARTER_CODE = "from osprey.runtime import read_channel, write_channel"
 
+#: The health check that names a channel the facility declares is still
+#: moving. Its whole purpose is to tell a live archive from a wedged one, so
+#: the channel it watches is the one a demo read can count on to show a value.
+_FRESHNESS_CHECK = "archiver_freshness"
+
+#: The probe channel the generic project template ships unfilled. The build
+#: refuses to write a real-looking one because a placeholder makes a target
+#: look reachable while naming a channel nothing serves; a starter cell that
+#: read it would fail on its first run, so it is skipped here for the same
+#: reason.
+_PROBE_PLACEHOLDER = "YOUR:PROBE:CHANNEL"
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return *value* when it is a mapping, else an empty one.
+
+    Config reaches here as whatever the deployment's YAML parsed to. A block
+    that is absent, ``None`` or the wrong shape is a deployment that declares
+    nothing, which is an answer rather than an error.
+    """
+    return value if isinstance(value, Mapping) else {}
+
+
+def _deployment_config() -> Mapping[str, Any]:
+    """Return the deployment's resolved configuration.
+
+    Imported at call time: the loader pulls in the workspace machinery, which
+    a sidecar has no other reason to carry.
+    """
+    from osprey.utils.workspace import load_osprey_config
+
+    return load_osprey_config()
+
+
+def starter_read_channel(config: Mapping[str, Any]) -> str | None:
+    """Return a channel *config* says this deployment can read, or ``None``.
+
+    The starter notebook shows a real read only where the deployment has
+    already named a channel it can serve. Nothing is guessed and no facility
+    name is baked in: a mock-only deployment such as the hello-world preset
+    declares no channel, and gets no read line.
+
+    Two declarations qualify, in this order:
+
+    1. an ``archiver_freshness`` health check's ``channel`` — the facility's
+       canary, chosen because it keeps moving;
+    2. a control target's ``probe_channel`` — the channel the target switch
+       reads to prove that target is reachable.
+
+    Args:
+        config: The deployment's resolved configuration.
+
+    Returns:
+        The channel address, or ``None`` when the deployment names none.
+    """
+    categories = _mapping(_mapping(config.get("health")).get("categories"))
+    for category in categories.values():
+        checks = _mapping(category).get("checks")
+        for check in checks if isinstance(checks, list) else []:
+            entry = _mapping(check)
+            channel = entry.get("channel")
+            if entry.get("type") == _FRESHNESS_CHECK and isinstance(channel, str) and channel:
+                return channel
+
+    targets = _mapping(_mapping(config.get("control_system")).get("connector"))
+    for target in targets.values():
+        probe = _mapping(target).get("probe_channel")
+        if isinstance(probe, str) and probe and probe != _PROBE_PLACEHOLDER:
+            return probe
+
+    return None
+
+
 #: How many stderr lines are kept for the failure report.
 _STDERR_TAIL_LINES = 20
 
@@ -150,11 +223,16 @@ def lab_page_config() -> dict[str, dict[str, bool]]:
     return {"disabledExtensions": dict.fromkeys(LAB_DISABLED_EXTENSIONS, True)}
 
 
-def seed_starter_notebook(notebooks_dir: Path) -> Path | None:
+def seed_starter_notebook(notebooks_dir: Path, example_channel: str | None = None) -> Path | None:
     """Write the starter notebook when *notebooks_dir* holds no notebook at all.
 
     Args:
         notebooks_dir: The directory JupyterLab opens.
+        example_channel: A channel this deployment can read, from
+            :func:`starter_read_channel`. When given, the code cell reads it,
+            so the first cell run returns a value instead of importing two
+            names and stopping. When ``None`` the cell is the import alone —
+            a deployment that names no channel is not given one to fail on.
 
     Returns:
         The path written, or ``None`` when a notebook already exists anywhere
@@ -162,10 +240,13 @@ def seed_starter_notebook(notebooks_dir: Path) -> Path | None:
     """
     if next(notebooks_dir.rglob("*.ipynb"), None) is not None:
         return None
+    code = _STARTER_CODE
+    if example_channel:
+        code = f'{_STARTER_CODE}\n\nread_channel("{example_channel}")'
     notebook = nbformat.v4.new_notebook(
         cells=[
             nbformat.v4.new_markdown_cell(_STARTER_MARKDOWN),
-            nbformat.v4.new_code_cell(_STARTER_CODE),
+            nbformat.v4.new_code_cell(code),
         ],
         metadata={
             "kernelspec": {
@@ -361,7 +442,12 @@ class JupyterSidecar:
             (labconfig / "default_setting_overrides.json").write_text(
                 json.dumps(override, indent=2) + "\n", encoding="utf-8"
             )
-        seed_starter_notebook(self.notebooks_dir)
+        try:
+            example_channel = starter_read_channel(_deployment_config())
+        except Exception:  # noqa: BLE001 — the read line is cosmetic, the panel is not
+            logger.debug("Starter notebook: config load failed", exc_info=True)
+            example_channel = None
+        seed_starter_notebook(self.notebooks_dir, example_channel)
 
     def _write_kernelspec(self) -> None:
         spec = {

--- a/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
+++ b/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
@@ -115,6 +115,9 @@ _STDERR_TAIL_LINES = 20
 _PREFLIGHT_TIMEOUT = 30.0
 _STOP_GRACE = 5.0
 
+#: How long a straggling kernel is given to take SIGTERM before it is killed.
+_REAP_GRACE = 3.0
+
 
 def lab_theme_override(pinned_mode: str | None) -> dict[str, dict[str, str]] | None:
     """Return the labconfig override that pins JupyterLab's theme.
@@ -537,6 +540,7 @@ class JupyterSidecar:
     def stop(self) -> None:
         """Terminate the process group and remove the per-launch tempdir. Idempotent."""
         self._stopping.set()
+        runtime_dir = self._runtime_dir
         process, self._process = self._process, None
         if process is not None:
             if process.poll() is None:
@@ -549,8 +553,10 @@ class JupyterSidecar:
             # The stderr pipe is left to the tail thread: closing it here
             # blocks on the reader, and a kernel the group signal did not
             # reach (kernels start their own session) can hold the write end
-            # open long after the server is gone.
+            # open until the reap below collects it.
             logger.info("%s stopped (pid %s)", _NAME, process.pid)
+        if runtime_dir is not None:
+            _reap_stragglers(runtime_dir)
         if self._watcher is not None:
             self._watcher.join(timeout=1)
             self._watcher = None
@@ -562,6 +568,63 @@ class JupyterSidecar:
         self._runtime_dir = None
         if tempdir is not None:
             shutil.rmtree(tempdir, ignore_errors=True)
+
+
+def _pids_naming(runtime_dir: str) -> list[int]:
+    """Return the pids of live processes whose command line names *runtime_dir*.
+
+    Args:
+        runtime_dir: The sidecar's per-launch runtime directory.
+
+    Returns:
+        Matching pids, never including this process.
+    """
+    found = subprocess.run(
+        ["pgrep", "-f", runtime_dir], capture_output=True, text=True, check=False
+    )
+    own = os.getpid()
+    return [int(f) for f in found.stdout.split() if f.isdigit() and int(f) != own]
+
+
+def _reap_stragglers(runtime_dir: str) -> None:
+    """Terminate anything that outlived the server still naming *runtime_dir*.
+
+    Kernels are started in their own session, so the group signal that stops
+    the server never reaches them. jupyter-server closes its kernels on its own
+    shutdown, but on a loaded host that shutdown can exceed ``_STOP_GRACE`` and
+    the server is killed first — leaving a kernel running, with the control
+    target and write posture it launched with, and no terminal above it.
+
+    The runtime dir is a 0700 tempdir unique to this launch, and every kernel
+    names its connection file inside it, so matching on it cannot reach a
+    process belonging to anything else.
+
+    Args:
+        runtime_dir: The sidecar's per-launch runtime directory.
+    """
+    if shutil.which("pgrep") is None:  # pragma: no cover - POSIX hosts have it
+        return
+    survivors = _pids_naming(runtime_dir)
+    if not survivors:
+        return
+    logger.info("%s reaping %d process(es) that outlived it", _NAME, len(survivors))
+    for pid in survivors:
+        _signal_pid(pid, signal.SIGTERM)
+    deadline = time.monotonic() + _REAP_GRACE
+    while time.monotonic() < deadline:
+        if not _pids_naming(runtime_dir):
+            return
+        time.sleep(0.1)
+    for pid in _pids_naming(runtime_dir):
+        _signal_pid(pid, signal.SIGKILL)
+
+
+def _signal_pid(pid: int, signum: signal.Signals) -> None:
+    """Send *signum* to *pid*; a process already gone is fine."""
+    try:
+        os.kill(pid, signum)
+    except (ProcessLookupError, PermissionError):
+        pass
 
 
 def _signal_group(pid: int, signum: signal.Signals) -> None:

--- a/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
+++ b/src/osprey/interfaces/web_terminal/jupyter_sidecar.py
@@ -1,0 +1,572 @@
+"""Launch and supervise the notebook sidecar behind the web terminal's panel.
+
+The sidecar is a ``jupyter_server`` process the terminal starts itself, bound
+to loopback on a port the OS assigns, protected by a token minted per launch.
+The proxy re-issues that token on every request, so the browser never holds it.
+
+Two interpreters are involved, and they are not the same one:
+
+* the **sidecar** runs under the terminal's own interpreter
+  (:data:`sys.executable`): it imports ``jupyter_server`` and this package's
+  confined contents manager, both of which live with the terminal;
+* every **kernel** runs under :func:`resolve_agent_interpreter`, the interpreter
+  that runs agent-authored code, so a cell imports the same packages the
+  project's own environment ships.
+
+Paths. Persistent state lives on the agent-data shared root, next to the
+session binding the kernel launcher reads::
+
+    <shared_root>/notebooks/                  ServerApp.root_dir
+    <shared_root>/jupyter/data/               JUPYTER_DATA_DIR
+    <shared_root>/jupyter/data/kernels/osprey/kernel.json
+    <shared_root>/jupyter/lab/settings/       JUPYTERLAB_SETTINGS_DIR
+    <shared_root>/jupyter/lab/workspaces/     JUPYTERLAB_WORKSPACES_DIR
+
+Per-launch secrets never touch the shared root, because agent tooling may read
+anything under it. They live in a ``tempfile.mkdtemp`` directory (mode 0700)
+that :meth:`JupyterSidecar.stop` removes::
+
+    <tempdir>/runtime/                        JUPYTER_RUNTIME_DIR
+    <tempdir>/config/                         JUPYTER_CONFIG_DIR
+    <tempdir>/config/labconfig/default_setting_overrides.json
+    <tempdir>/config/labconfig/page_config.json
+
+The runtime directory holds ``jpserver-<pid>.json`` (the port) and every
+kernel's connection file (its signing key); the config directory holds nothing
+the shared root should keep. The override file is where a pinned web theme
+reaches JupyterLab: ``jupyterlab_server`` reads it through
+``ConfigManager("labconfig")``, and a user's own theme pick, which lands in
+``JUPYTERLAB_SETTINGS_DIR`` on the shared root, still wins and still persists.
+``page_config.json`` is read the same way; it switches off the JupyterLab
+plugins that make no sense inside an embedded panel (see
+:data:`LAB_DISABLED_EXTENSIONS`).
+
+A sidecar that exits on its own — outside :meth:`JupyterSidecar.stop` — is
+reported once, with its last stderr lines, and :attr:`JupyterSidecar.on_exit`
+is invoked so the terminal can retract the panel. Nothing restarts it.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import logging
+import os
+import secrets
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from pathlib import Path
+from typing import IO
+
+import nbformat
+
+from osprey.jupyter_kernel import BINDING_RELPATH
+from osprey.mcp_server.python_executor.executor import resolve_agent_interpreter
+from osprey.mcp_server.sandbox_env import scrub_sandbox_child_env
+
+logger = logging.getLogger(__name__)
+
+_NAME = "Notebook sidecar"
+
+#: Path of the panel under the terminal's URL prefix; the sidecar's ``base_url``.
+_PANEL_PATH = "panel/jupyter"
+
+#: The one kernelspec the sidecar lists. ``KernelSpecManager.allowed_kernelspecs``
+#: is pinned to exactly this name, and ``ensure_native_kernel`` is off, so the
+#: interpreter's own ``python3`` spec never appears.
+KERNELSPEC_NAME = "osprey"
+
+#: The shared-root subtree that holds sidecar state. Derived from the session
+#: binding's path so the sidecar and the kernel launcher agree on one subtree.
+_SHARED_SUBTREE = Path(BINDING_RELPATH).parent
+
+#: The settings plugin JupyterLab reads its theme from, and the two theme
+#: names it ships. A pinned web theme is written as an override for this key.
+_THEME_PLUGIN = "@jupyterlab/apputils-extension:themes"
+_THEME_NAMES = {"dark": "JupyterLab Dark", "light": "JupyterLab Light"}
+
+#: JupyterLab plugins switched off through ``labconfig/page_config.json``.
+#: The extension manager offers installs into an image that cannot keep them;
+#: the announcements plugin is the news prompt and the update check.
+LAB_DISABLED_EXTENSIONS = (
+    "@jupyterlab/extensionmanager-extension",
+    "@jupyterlab/apputils-extension:announcements",
+)
+
+#: The ``LabApp`` class that answers "no update available"; named on the argv.
+_NEVER_CHECK_FOR_UPDATE = "jupyterlab.handlers.announcements.NeverCheckForUpdate"
+
+#: The notebook written into an empty ``notebooks/``, and its two cells.
+STARTER_NOTEBOOK_NAME = "getting-started.ipynb"
+_STARTER_MARKDOWN = "This kernel follows your terminal session. Open a chat session before writing."
+_STARTER_CODE = "from osprey.runtime import read_channel, write_channel"
+
+#: How many stderr lines are kept for the failure report.
+_STDERR_TAIL_LINES = 20
+
+_PREFLIGHT_TIMEOUT = 30.0
+_STOP_GRACE = 5.0
+
+
+def lab_theme_override(pinned_mode: str | None) -> dict[str, dict[str, str]] | None:
+    """Return the labconfig override that pins JupyterLab's theme.
+
+    Args:
+        pinned_mode: The web theme's already-resolved pinned mode. Only
+            ``'dark'`` and ``'light'`` name a JupyterLab theme; a family value
+            (``'retro'``, ``'desy'``) and ``None`` pin nothing.
+
+    Returns:
+        The override document, or ``None`` when nothing should be pinned.
+    """
+    theme = _THEME_NAMES.get(pinned_mode or "")
+    return {_THEME_PLUGIN: {"theme": theme}} if theme is not None else None
+
+
+def lab_page_config() -> dict[str, dict[str, bool]]:
+    """Return the labconfig ``page_config`` document the sidecar is seeded with.
+
+    ``jupyterlab_server`` merges this document into the page config it embeds
+    in the ``/lab`` page. ``disabledExtensions`` must be the mapping form
+    here: the list form is accepted only from the application settings
+    directory, and a list from labconfig breaks the merge.
+    """
+    return {"disabledExtensions": dict.fromkeys(LAB_DISABLED_EXTENSIONS, True)}
+
+
+def seed_starter_notebook(notebooks_dir: Path) -> Path | None:
+    """Write the starter notebook when *notebooks_dir* holds no notebook at all.
+
+    Args:
+        notebooks_dir: The directory JupyterLab opens.
+
+    Returns:
+        The path written, or ``None`` when a notebook already exists anywhere
+        under *notebooks_dir*. An existing file is never rewritten.
+    """
+    if next(notebooks_dir.rglob("*.ipynb"), None) is not None:
+        return None
+    notebook = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_markdown_cell(_STARTER_MARKDOWN),
+            nbformat.v4.new_code_cell(_STARTER_CODE),
+        ],
+        metadata={
+            "kernelspec": {
+                "name": KERNELSPEC_NAME,
+                "display_name": "OSPREY",
+                "language": "python",
+            }
+        },
+    )
+    path = notebooks_dir / STARTER_NOTEBOOK_NAME
+    with path.open("w", encoding="utf-8") as handle:
+        nbformat.write(notebook, handle)
+    return path
+
+
+class _StderrTail(threading.Thread):
+    """Drain a pipe on a daemon thread, keeping the last few lines."""
+
+    def __init__(self, pipe: IO[bytes]) -> None:
+        super().__init__(daemon=True, name="notebook-sidecar-stderr")
+        self._pipe = pipe
+        self._lines: collections.deque[str] = collections.deque(maxlen=_STDERR_TAIL_LINES)
+
+    def run(self) -> None:
+        for raw in self._pipe:
+            self._lines.append(raw.decode("utf-8", "replace").rstrip("\n"))
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self._lines)
+
+
+class JupyterSidecar:
+    """One notebook sidecar process: preflight, spawn, readiness, shutdown.
+
+    Args:
+        shared_root: The agent-data shared root. Notebooks and the sidecar's
+            persistent state live under it.
+        outer_prefix: The terminal's URL prefix (``compute_url_prefix()``);
+            empty on a single-user deployment.
+        pinned_mode: The web theme's pinned mode, ``'dark'``, ``'light'`` or
+            ``None``.
+    """
+
+    def __init__(self, shared_root: Path, outer_prefix: str, pinned_mode: str | None) -> None:
+        self._shared_root = Path(shared_root)
+        self._outer_prefix = outer_prefix
+        self._pinned_mode = pinned_mode
+        self._token: str | None = None
+        self._process: subprocess.Popen[bytes] | None = None
+        self._tail: _StderrTail | None = None
+        self._tempdir: Path | None = None
+        self._runtime_dir: Path | None = None
+        self._port: int | None = None
+        self._watcher: threading.Thread | None = None
+        self._stopping = threading.Event()
+        # Guards the pair below: the watcher thread records an exit, the
+        # loop thread registers the callback, and whichever comes second fires it.
+        self._exit_lock = threading.Lock()
+        self._exit_status: int | None = None
+        self._on_exit: Callable[[], None] | None = None
+
+    # -- shared-root layout -------------------------------------------------
+
+    @property
+    def notebooks_dir(self) -> Path:
+        return self._shared_root / "notebooks"
+
+    @property
+    def data_dir(self) -> Path:
+        return self._shared_root / _SHARED_SUBTREE / "data"
+
+    @property
+    def kernelspec_path(self) -> Path:
+        return self.data_dir / "kernels" / KERNELSPEC_NAME / "kernel.json"
+
+    @property
+    def settings_dir(self) -> Path:
+        return self._shared_root / _SHARED_SUBTREE / "lab" / "settings"
+
+    @property
+    def workspaces_dir(self) -> Path:
+        return self._shared_root / _SHARED_SUBTREE / "lab" / "workspaces"
+
+    @property
+    def base_url(self) -> str:
+        return f"{self._outer_prefix}/{_PANEL_PATH}/"
+
+    @property
+    def runtime_dir(self) -> Path | None:
+        """The per-launch ``JUPYTER_RUNTIME_DIR``; ``None`` between launches."""
+        return self._runtime_dir
+
+    # -- process facts ------------------------------------------------------
+
+    @property
+    def token(self) -> str | None:
+        return self._token
+
+    @property
+    def pid(self) -> int | None:
+        return self._process.pid if self._process is not None else None
+
+    @property
+    def stderr_tail(self) -> str:
+        return self._tail.text if self._tail is not None else ""
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        return {"authorization": f"Bearer {self._token}"}
+
+    @property
+    def url(self) -> str:
+        """The backend URL the proxy forwards to; no trailing slash."""
+        if self._port is None:
+            raise RuntimeError(f"{_NAME} is not ready")
+        return f"http://127.0.0.1:{self._port}{self._outer_prefix}/{_PANEL_PATH}"
+
+    @property
+    def on_exit(self) -> Callable[[], None] | None:
+        """Called once, from a worker thread, when the process exits outside :meth:`stop`.
+
+        Assigning it after the exit already happened fires it right away, so
+        a caller that registers after :meth:`wait_ready` cannot miss a death
+        in between. The callback runs on the watcher thread: hand loop-owned
+        state to the loop from inside it.
+        """
+        return self._on_exit
+
+    @on_exit.setter
+    def on_exit(self, callback: Callable[[], None] | None) -> None:
+        with self._exit_lock:
+            self._on_exit = callback
+            fire = callback is not None and self._exit_status is not None
+        if fire and callback is not None:
+            callback()
+
+    # -- preflight ----------------------------------------------------------
+
+    def preflight(self) -> None:
+        """Check what a launch needs; raise ``RuntimeError`` with one line otherwise.
+
+        Blocks for up to :data:`_PREFLIGHT_TIMEOUT` seconds while the agent
+        interpreter proves it can import the kernel's two dependencies.
+        """
+        if not os.environ.get("OSPREY_CONFIG"):
+            raise RuntimeError("OSPREY_CONFIG is not set")
+        interpreter = str(resolve_agent_interpreter())
+        try:
+            probe = subprocess.run(
+                [interpreter, "-c", "import ipykernel, osprey.runtime"],
+                capture_output=True,
+                text=True,
+                timeout=_PREFLIGHT_TIMEOUT,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"{interpreter} did not finish the import check in {_PREFLIGHT_TIMEOUT:.0f} s"
+            ) from exc
+        except OSError as exc:
+            raise RuntimeError(f"{interpreter} cannot be run: {exc}") from exc
+        if probe.returncode != 0:
+            reason = (probe.stderr.strip().splitlines() or ["no output"])[-1]
+            raise RuntimeError(
+                f"{interpreter} cannot import ipykernel and osprey.runtime: {reason}"
+            )
+
+    # -- launch assembly ----------------------------------------------------
+    # What a launch is made of: the seeded directories, the kernelspec, the
+    # command line and the child environment. Nothing here starts a process.
+
+    def _seed(self, config_dir: Path) -> None:
+        """Prepare the shared root and *config_dir* once, before the spawn.
+
+        Args:
+            config_dir: The per-launch ``JUPYTER_CONFIG_DIR``.
+        """
+        for directory in (
+            self.notebooks_dir,
+            self.kernelspec_path.parent,
+            self.settings_dir,
+            self.workspaces_dir,
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+        labconfig = config_dir / "labconfig"
+        labconfig.mkdir(parents=True, exist_ok=True)
+        (labconfig / "page_config.json").write_text(
+            json.dumps(lab_page_config(), indent=2) + "\n", encoding="utf-8"
+        )
+        override = lab_theme_override(self._pinned_mode)
+        if override is not None:
+            (labconfig / "default_setting_overrides.json").write_text(
+                json.dumps(override, indent=2) + "\n", encoding="utf-8"
+            )
+        seed_starter_notebook(self.notebooks_dir)
+
+    def _write_kernelspec(self) -> None:
+        spec = {
+            "argv": [
+                str(resolve_agent_interpreter()),
+                "-m",
+                "osprey.jupyter_kernel",
+                "-f",
+                "{connection_file}",
+            ],
+            "display_name": "OSPREY",
+            "language": "python",
+            "env": {
+                "JUPYTER_TOKEN": "",
+                "OSPREY_AGENT_DATA_ROOT": str(self._shared_root),
+            },
+        }
+        self.kernelspec_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+
+    def _argv(self) -> list[str]:
+        """The sidecar's command line. Every ``--Class.trait`` here is a pinned behavior."""
+        contents_manager = (
+            "osprey.interfaces.web_terminal.jupyter_contents.ConfinedFileContentsManager"
+        )
+        return [
+            sys.executable,
+            "-m",
+            "osprey.interfaces.web_terminal.jupyter_sidecar_main",
+            "--ServerApp.ip=127.0.0.1",
+            "--ServerApp.port=0",
+            "--ServerApp.port_retries=0",
+            "--ServerApp.terminals_enabled=False",
+            f"--ServerApp.base_url={self.base_url}",
+            f"--ServerApp.root_dir={self.notebooks_dir}",
+            f"--ServerApp.contents_manager_class={contents_manager}",
+            # Delete means delete, folders included: the trash would land on
+            # the shared volume.
+            "--FileContentsManager.delete_to_trash=False",
+            "--FileContentsManager.always_delete_dir=True",
+            "--KernelSpecManager.ensure_native_kernel=False",
+            f"--KernelSpecManager.allowed_kernelspecs=['{KERNELSPEC_NAME}']",
+            "--ServerApp.open_browser=False",
+            "--ServerApp.default_url=/lab",
+            # No news feed and no update check from inside an embedded panel.
+            "--LabApp.news_url=None",
+            f"--LabApp.check_for_updates_class={_NEVER_CHECK_FOR_UPDATE}",
+        ]
+
+    def _child_env(self, token: str, runtime_dir: Path, config_dir: Path) -> dict[str, str]:
+        """The sidecar's environment: the scrubbed parent's, plus the Jupyter directories.
+
+        Args:
+            token: The per-launch token the server requires on every request.
+            runtime_dir: The per-launch ``JUPYTER_RUNTIME_DIR``.
+            config_dir: The per-launch ``JUPYTER_CONFIG_DIR``.
+        """
+        env = scrub_sandbox_child_env(os.environ)
+        env.update(
+            {
+                "JUPYTER_TOKEN": token,
+                "JUPYTER_RUNTIME_DIR": str(runtime_dir),
+                "JUPYTER_CONFIG_DIR": str(config_dir),
+                "JUPYTER_DATA_DIR": str(self.data_dir),
+                "JUPYTERLAB_SETTINGS_DIR": str(self.settings_dir),
+                "JUPYTERLAB_WORKSPACES_DIR": str(self.workspaces_dir),
+            }
+        )
+        if "OSPREY_CONFIG" in os.environ:
+            env["OSPREY_CONFIG"] = os.environ["OSPREY_CONFIG"]
+        return env
+
+    # -- process lifecycle --------------------------------------------------
+
+    def spawn(self) -> None:
+        """Start the sidecar process. Blocks for the ``Popen`` only."""
+        if self._process is not None:
+            raise RuntimeError(f"{_NAME} is already running (pid {self._process.pid})")
+        self._stopping.clear()
+        with self._exit_lock:
+            self._exit_status = None
+        self._token = secrets.token_urlsafe(32)
+        self._tempdir = Path(tempfile.mkdtemp(prefix="osprey-notebook-sidecar-"))
+        self._runtime_dir = self._tempdir / "runtime"
+        config_dir = self._tempdir / "config"
+        self._runtime_dir.mkdir(mode=0o700)
+        config_dir.mkdir(mode=0o700)
+        self._seed(config_dir)
+        self._write_kernelspec()
+
+        self._process = subprocess.Popen(
+            self._argv(),
+            env=self._child_env(self._token, self._runtime_dir, config_dir),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        assert self._process.stderr is not None
+        self._tail = _StderrTail(self._process.stderr)
+        self._tail.start()
+        self._watcher = threading.Thread(
+            target=self._watch_exit,
+            args=(self._process, self._tail),
+            daemon=True,
+            name="notebook-sidecar-exit",
+        )
+        self._watcher.start()
+        logger.info("%s launched (pid %s)", _NAME, self._process.pid)
+
+    def _watch_exit(self, process: subprocess.Popen[bytes], tail: _StderrTail) -> None:
+        """Reap *process*; report an exit that :meth:`stop` did not cause.
+
+        The stderr pipe is inherited by every kernel, so its end of stream
+        cannot stand in for the exit: an orphaned kernel keeps it open.
+        ``wait()`` is what says the sidecar is gone. The report is skipped
+        while the sidecar was still coming up, because :meth:`wait_ready`
+        raises with the same tail and its caller logs that.
+        """
+        status = process.wait()
+        if self._stopping.is_set():
+            return
+        tail.join(timeout=1)
+        if self._port is not None:
+            text = tail.text
+            logger.warning("%s exited (rc=%s)%s", _NAME, status, f": {text}" if text else "")
+        with self._exit_lock:
+            self._exit_status = status
+            callback = self._on_exit
+        if callback is not None:
+            callback()
+
+    def _read_port(self) -> int | None:
+        assert self._runtime_dir is not None and self._process is not None
+        info = self._runtime_dir / f"jpserver-{self._process.pid}.json"
+        try:
+            return int(json.loads(info.read_text(encoding="utf-8"))["port"])
+        except (OSError, ValueError, KeyError, TypeError):
+            return None
+
+    def _answers(self, port: int) -> bool:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}{self.base_url}api/status",
+            headers={"Authorization": f"token {self._token}"},
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=2) as response:
+                return int(response.status) == 200
+        except (urllib.error.URLError, OSError):
+            return False
+
+    def wait_ready(self, timeout: float) -> None:
+        """Block until the sidecar answers ``api/status`` with the token.
+
+        Raises:
+            RuntimeError: the process exited, or *timeout* seconds passed,
+                before it answered. The message carries the stderr tail.
+        """
+        if self._process is None:
+            raise RuntimeError(f"{_NAME} was not spawned")
+        deadline = time.monotonic() + timeout
+        port: int | None = None
+        while True:
+            status = self._process.poll()
+            if status is not None:
+                raise RuntimeError(
+                    f"{_NAME} exited with status {status} before it was ready\n{self.stderr_tail}"
+                )
+            if port is None:
+                port = self._read_port()
+            if port is not None and self._answers(port):
+                self._port = port
+                logger.info("%s ready at %s", _NAME, self.url)
+                return
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"{_NAME} did not answer within {timeout:.0f} s\n{self.stderr_tail}"
+                )
+            time.sleep(0.1)
+
+    def stop(self) -> None:
+        """Terminate the process group and remove the per-launch tempdir. Idempotent."""
+        self._stopping.set()
+        process, self._process = self._process, None
+        if process is not None:
+            if process.poll() is None:
+                _signal_group(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(_STOP_GRACE)
+                except subprocess.TimeoutExpired:
+                    _signal_group(process.pid, signal.SIGKILL)
+                    process.wait()
+            # The stderr pipe is left to the tail thread: closing it here
+            # blocks on the reader, and a kernel the group signal did not
+            # reach (kernels start their own session) can hold the write end
+            # open long after the server is gone.
+            logger.info("%s stopped (pid %s)", _NAME, process.pid)
+        if self._watcher is not None:
+            self._watcher.join(timeout=1)
+            self._watcher = None
+        if self._tail is not None:
+            self._tail.join(timeout=1)
+            self._tail = None
+        self._port = None
+        tempdir, self._tempdir = self._tempdir, None
+        self._runtime_dir = None
+        if tempdir is not None:
+            shutil.rmtree(tempdir, ignore_errors=True)
+
+
+def _signal_group(pid: int, signum: signal.Signals) -> None:
+    """Send *signum* to the process group led by *pid*; a gone group is fine."""
+    try:
+        os.killpg(pid, signum)
+    except ProcessLookupError:
+        pass

--- a/src/osprey/interfaces/web_terminal/jupyter_sidecar_main.py
+++ b/src/osprey/interfaces/web_terminal/jupyter_sidecar_main.py
@@ -1,0 +1,30 @@
+"""Entry point for the Jupyter notebook sidecar subprocess.
+
+On a dev host the sidecar's parent is the OSPREY web terminal process; a parent
+poller thread exits the sidecar when that parent dies, since nothing else would
+notice an orphaned Jupyter server. In a container the sidecar's parent is PID 1,
+so the container's own lifecycle already bounds it and the poller is a no-op.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Start the parent-death poller, then launch the Jupyter server.
+
+    Args:
+        argv: Command-line arguments for ``ServerApp``, excluding the program
+            name. ``None`` lets ``ServerApp`` fall back to ``sys.argv[1:]``.
+    """
+    from ipykernel.parentpoller import ParentPollerUnix
+    from jupyter_server.serverapp import ServerApp
+
+    ParentPollerUnix(parent_pid=os.getppid()).start()
+    ServerApp.launch_instance(argv)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/osprey/interfaces/web_terminal/pty_manager.py
+++ b/src/osprey/interfaces/web_terminal/pty_manager.py
@@ -24,6 +24,30 @@ from osprey.utils.logger import get_logger
 logger = get_logger("pty_manager")
 
 
+def _clear_notebook_binding(session_id: str) -> None:
+    """Drop the notebook session binding if it still names *session_id*.
+
+    A session that goes away takes its binding with it, so a kernel started
+    afterwards does not join a dead PTY. The check inside ``clear_binding``
+    means a session superseded before it died leaves the live binding alone.
+
+    Imported inside the function: the resolver reads deployment config, and a
+    registry built in a test that never touches notebooks should not pay for
+    it. Failure is swallowed — a leftover binding costs a notebook its
+    session, and must not cost the pool its teardown.
+
+    Args:
+        session_id: The pool key being terminated or evicted.
+    """
+    try:
+        from osprey.interfaces.web_terminal.operator_session import resolve_agent_data_root
+        from osprey.interfaces.web_terminal.session_binding import clear_binding
+
+        clear_binding(resolve_agent_data_root(), session_id)
+    except Exception:  # noqa: BLE001 — teardown must not fail on the binding
+        logger.debug("Could not clear the notebook session binding for %s", session_id)
+
+
 def build_pty_env(extra_env: dict[str, str] | None = None) -> dict[str, str]:
     """Build the environment for the PTY child process.
 
@@ -579,9 +603,11 @@ class PtyRegistry:
         for key in list(self._sessions):
             if key not in self._attached:
                 evicted = self._sessions.pop(key)
+                bound_as = self.audit_session_key(key)
                 self._env_fingerprints.pop(key, None)
                 self._audit_keys.pop(key, None)
                 evicted.terminate()
+                _clear_notebook_binding(bound_as)
                 logger.info("Evicted LRU session %s", key)
                 return
 
@@ -634,14 +660,19 @@ class PtyRegistry:
 
         Drops the entry's recorded env fingerprint and audit alias with it, so
         the key is fully forgotten and a later spawn under the same key records
-        its own.
+        its own. The notebook session binding goes too, resolved through the
+        audit alias *before* it is dropped — the binding names a session by the
+        key its child stamps, which for a rekeyed session is not the pool key
+        being terminated here.
         """
         session = self._sessions.pop(session_id, None)
+        bound_as = self.audit_session_key(session_id)
         self._env_fingerprints.pop(session_id, None)
         self._audit_keys.pop(session_id, None)
         if session is not None:
             session.terminate()
         self._attached.discard(session_id)
+        _clear_notebook_binding(bound_as)
 
     def terminate_session_if_owner(self, session_id: str, owner: PtySession) -> None:
         """Terminate only if the caller still owns the session.

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -115,6 +115,14 @@ async def lattice_server_config(request: Request):
     return {"url": proxy_url, "available": proxy_url is not None}
 
 
+@router.get("/api/jupyter-server")
+async def jupyter_server_config(request: Request):
+    """Return the notebook sidecar URL for iframe embedding."""
+    url = getattr(request.app.state, "jupyter_server_url", None)
+    proxy_url = f"{compute_url_prefix()}/panel/jupyter" if url else None
+    return {"url": proxy_url, "available": proxy_url is not None}
+
+
 @router.get("/api/okf-server")
 async def okf_server_config(request: Request):
     """Return the OKF knowledge panel server URL for iframe embedding."""

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -1,7 +1,7 @@
 """Reverse proxy for companion panel servers running inside the container.
 
-Companion servers (artifact gallery, ARIEL, channel-finder, lattice, OKF)
-bind to 127.0.0.1 inside the Docker container.  The browser cannot reach them
+Companion servers (artifact gallery, ARIEL, channel-finder, lattice, OKF) and
+the notebook sidecar bind to 127.0.0.1 inside the Docker container.  The browser cannot reach them
 directly, so this proxy forwards ``/panel/{panel_id}/{path}`` to the internal
 server and rewrites root-absolute paths in HTML/JS/CSS responses.
 
@@ -32,8 +32,9 @@ What the injection still buys a backend, stated plainly: the header carries the
 **full** operator secret, so a backend that earns it can turn around and act as
 the operator against the terminal's own API. That is accepted here — the
 backends that earn it are config-declared loopback sidecars of the same
-deployment — and the follow-up is a scoped per-backend credential rather than
-the operator's own.
+deployment. The notebook sidecar also carries a credential of its own, minted
+per launch and injected by :func:`_panel_auth_header` on the same gate; a scoped
+credential in place of the operator's own is still the follow-up for the rest.
 """
 
 from __future__ import annotations
@@ -50,9 +51,11 @@ from urllib.parse import ParseResult, urljoin, urlparse, urlunsplit
 import httpx
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response, StreamingResponse
+from starlette.websockets import WebSocketState
 
 from osprey.interfaces.common_middleware import compute_url_prefix
 from osprey.interfaces.web_auth import get_web_credentials
+from osprey.profiles.web_panels import SIDECAR_PANELS
 from osprey.registry.web import FRAMEWORK_WEB_SERVERS, panel_url_state_attr
 from osprey.utils.http_proxy import HOP_BY_HOP
 
@@ -113,10 +116,13 @@ _DEFAULT_NO_CACHE = "no-cache, no-store, must-revalidate"
 # out a second time here. Both ends import it from the registry because they
 # cannot import each other, and a convention agreed on by two independent
 # f-strings is a convention only until one of them is edited.
+#
+# Sidecar panels have no registry key — the terminal starts them itself — so
+# their state attribute is derived from the panel id directly.
 _PANEL_STATE_MAP = {
     definition.panel_id: panel_url_state_attr(key)
     for key, definition in FRAMEWORK_WEB_SERVERS.items()
-}
+} | {panel_id: panel_url_state_attr(panel_id) for panel_id in SIDECAR_PANELS}
 
 
 def _resolve_panel_url(request: Request, panel_id: str) -> str | None:
@@ -368,23 +374,38 @@ def _panel_origin_is_declared(scope: Request | WebSocket, panel_id: str) -> bool
     return _panel_is_config_defined(scope, panel_id)
 
 
+def _backend_earns_credentials(scope: Request | WebSocket, panel_id: str, backend_url: str) -> bool:
+    """Whether a credential this process holds may be sent to this backend.
+
+    Both halves are required. A backend addressed at loopback but registered at
+    runtime is not enough: runtime registration is a path the agent's own
+    sandbox can reach, and a loopback listener it registered would be handed a
+    credential out of this process. A config-declared backend pointing off-box
+    is not enough either: the credential would leave the machine to a host the
+    operator's browser never authenticated to, over a hop that may not even be
+    TLS.
+
+    Every injection site — the operator secret and a sidecar's own launch
+    credential — asks this one question, so the two halves cannot drift apart
+    between them.
+
+    Args:
+        scope: The request or websocket being proxied.
+        panel_id: The panel id from the proxied URL.
+        backend_url: The resolved backend URL the request is being forwarded to.
+    """
+    return _panel_origin_is_declared(scope, panel_id) and _backend_is_loopback(backend_url)
+
+
 def _terminal_secret_header(
     scope: Request | WebSocket, panel_id: str, backend_url: str
 ) -> dict[str, str]:
     """The terminal-secret header to send upstream, or ``{}`` for no injection.
 
-    Both halves are required. A backend addressed at loopback but registered at
-    runtime is not enough: runtime registration is a path the agent's own
-    sandbox can reach, and a loopback listener it registered would be handed
-    the operator secret out of this process. A config-declared backend pointing
-    off-box is not enough either: the secret would leave the machine to a host
-    the operator's browser never authenticated to, over a hop that may not even
-    be TLS.
-
-    When either half is missing — or the process cannot produce credentials at
-    all — nothing is injected and the panel simply loads unauthenticated. That
-    is the failure an operator can see and act on; the alternative failure,
-    a leaked secret, is silent.
+    When the backend does not earn it (:func:`_backend_earns_credentials`) — or
+    the process cannot produce credentials at all — nothing is injected and the
+    panel simply loads unauthenticated. That is the failure an operator can see
+    and act on; the alternative failure, a leaked secret, is silent.
 
     Args:
         scope: The request or websocket being proxied.
@@ -395,9 +416,7 @@ def _terminal_secret_header(
         A single-entry mapping ready to merge into the outbound headers, or an
         empty mapping when this backend must not receive the secret.
     """
-    if not _panel_origin_is_declared(scope, panel_id):
-        return {}
-    if not _backend_is_loopback(backend_url):
+    if not _backend_earns_credentials(scope, panel_id, backend_url):
         return {}
 
     try:
@@ -411,6 +430,37 @@ def _terminal_secret_header(
 
     secret = credentials.operator_secret
     return {TERMINAL_SECRET_HEADER: secret} if secret else {}
+
+
+def _panel_auth_header(
+    scope: Request | WebSocket, panel_id: str, backend_url: str
+) -> dict[str, str]:
+    """The panel's own launch credential to send upstream, or ``{}``.
+
+    A sidecar this process starts is handed a credential of its own and refuses
+    anything that arrives without it. The launcher publishes that credential as
+    a ready-made header mapping on ``app.state.panel_auth_headers``, keyed by
+    panel id, and it is injected on this hop so the browser never holds it.
+
+    Gated exactly as the operator secret is
+    (:func:`_backend_earns_credentials`): a credential handed to a listener the
+    agent's own sandbox registered, or sent to a host the operator never
+    authenticated to, fails silently, so an absent header — the panel loads
+    unauthenticated and says so — is the one to prefer.
+
+    Args:
+        scope: The request or websocket being proxied.
+        panel_id: The panel id from the proxied URL.
+        backend_url: The resolved backend URL the request is being forwarded to.
+
+    Returns:
+        The headers to merge into the outbound set, or an empty mapping when
+        this backend must not receive them.
+    """
+    if not _backend_earns_credentials(scope, panel_id, backend_url):
+        return {}
+    published = getattr(scope.app.state, "panel_auth_headers", None) or {}
+    return dict(published.get(panel_id, {}))
 
 
 async def _request_no_redirect(
@@ -825,6 +875,9 @@ async def proxy_panel(panel_id: str, path: str, request: Request):
         if token:
             fwd_headers["authorization"] = f"Bearer {token}"
 
+    # A launched sidecar's own credential, on the same gate as the secret above.
+    fwd_headers.update(_panel_auth_header(request, panel_id, backend_url))
+
     outer_panel_prefix = f"{outer_prefix}/panel/{panel_id}"
 
     # The base a relative ``Location`` is resolved against, and the origin a
@@ -975,9 +1028,15 @@ async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
 
     The upstream handshake is built from scratch rather than by copying the
     browser's — so the operator's cookie and secret are absent by construction,
-    matching what :func:`proxy_panel` strips on the HTTP path. The only header
-    added is the operator secret, and only for a backend
-    :func:`_terminal_secret_header` vouches for.
+    matching what :func:`proxy_panel` strips on the HTTP path. The headers added
+    are the operator secret and a launched sidecar's own credential, each only
+    for a backend its own gate vouches for.
+
+    One field of the browser's handshake is relayed: its subprotocol offer.
+    The upstream picks from it, and the browser's own handshake is answered
+    with that pick — so the upstream connects first and the browser is
+    accepted second. A browser whose non-empty offer is answered with nothing
+    treats the handshake as failed.
     """
     backend_url = _resolve_panel_url(websocket, panel_id)
     if not backend_url:
@@ -987,6 +1046,11 @@ async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
     # Convert http(s) backend URL to ws(s)
     ws_url = backend_url.rstrip("/").replace("http://", "ws://").replace("https://", "wss://")
     target = f"{ws_url}/{path}"
+    # The query belongs to the upstream handshake, not to this route: a backend
+    # that keys a socket off a query parameter sees nothing without it. Mirrors
+    # what the HTTP leg forwards.
+    if websocket.url.query:
+        target = f"{target}?{websocket.url.query}"
 
     try:
         import websockets
@@ -995,26 +1059,43 @@ async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
         await websocket.close(code=4500, reason="WebSocket proxy unavailable")
         return
 
-    # Nothing from the browser's handshake is forwarded; this is the whole
-    # outbound header set, and it is empty unless the backend earns the secret.
+    # No browser header is forwarded; this is the whole outbound header set,
+    # and it is empty unless the backend earns the secret or a credential.
     upstream_headers = _terminal_secret_header(websocket, panel_id, backend_url)
+    upstream_headers.update(_panel_auth_header(websocket, panel_id, backend_url))
 
-    await websocket.accept()
+    # The browser's ``Sec-WebSocket-Protocol`` offer, as the ASGI server parsed it.
+    offered = list(websocket.scope.get("subprotocols") or [])
 
     # websockets' opening handshake follows 30x redirects (up to
     # WEBSOCKETS_MAX_REDIRECTS) and re-sends ``additional_headers`` verbatim to
     # each target — the ws↔ws analogue of the httpx redirect leak the HTTP path
     # guards against. When the secret is being carried, refuse to follow any
     # redirect so it cannot ride one off the loopback host the gate vouched for.
-    connector = websockets.connect(target, additional_headers=upstream_headers or None)
+    connector = websockets.connect(
+        target,
+        additional_headers=upstream_headers or None,
+        subprotocols=offered or None,
+    )
     if upstream_headers:
         # ``process_redirect`` returns the new URI to follow a redirect, or the
         # exception to refuse it; returning the exception unchanged declines
         # every redirect and surfaces it instead of chasing it with the secret.
         connector.process_redirect = lambda exc: exc
 
+    client_gone = False
     try:
         async with connector as upstream:
+            # Answer the browser with the upstream's pick — ``None`` when the
+            # two sides negotiated nothing.
+            try:
+                await websocket.accept(subprotocol=getattr(upstream, "subprotocol", None))
+            except (WebSocketDisconnect, OSError):
+                # The browser left while the upstream was connecting. Leaving
+                # the ``async with`` closes the upstream; nothing to relay.
+                client_gone = True
+                logger.debug("WebSocket client for panel %s left before accept", panel_id)
+                return
 
             async def client_to_upstream():
                 # receive() (not receive_text()) — binary-protocol panels
@@ -1058,7 +1139,14 @@ async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
     except Exception as exc:
         logger.warning("WebSocket proxy error for panel %s: %s", panel_id, exc)
     finally:
-        try:
-            await websocket.close()
-        except Exception:
-            pass
+        if not client_gone:
+            try:
+                if websocket.application_state is WebSocketState.CONNECTING:
+                    # The upstream handshake failed before the browser's was
+                    # answered: accept, then close normally (1000) rather than
+                    # refuse the handshake with a 403. A browser that offered a
+                    # subprotocol still fails its own handshake, as before.
+                    await websocket.accept()
+                await websocket.close()
+            except Exception:
+                pass

--- a/src/osprey/interfaces/web_terminal/routes/proxy.py
+++ b/src/osprey/interfaces/web_terminal/routes/proxy.py
@@ -1022,6 +1022,20 @@ async def proxy_panel_root(panel_id: str, request: Request):
     return await proxy_panel(panel_id, "", request)
 
 
+#: Seconds the upstream WebSocket handshake may take before the proxy gives up
+#: on it. ``websockets`` allows ten by default, and a panel is entitled to hold
+#: a handshake longer than that on purpose: jupyter-server answers a
+#: kernel-channel upgrade only once the kernel behind it has replied to a
+#: kernel-info request, and gives that reply a full minute
+#: (``MappingKernelManager.kernel_info_timeout``). A kernel joining a bound
+#: session imports the framework before it answers, so on a loaded host its
+#: reply lands after ten seconds — and it was this proxy, not the panel, that
+#: hung up, closing the browser normally before its first frame while the
+#: kernel came up fine behind it. The budget is the panel's, plus room for the
+#: upgrade itself; a handshake still unanswered after this is not going to be.
+UPSTREAM_OPEN_TIMEOUT = 90.0
+
+
 @router.websocket("/panel/{panel_id}/{path:path}")
 async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
     """Forward a WebSocket connection to the companion panel server.
@@ -1076,6 +1090,7 @@ async def proxy_panel_ws(panel_id: str, path: str, websocket: WebSocket):
         target,
         additional_headers=upstream_headers or None,
         subprotocols=offered or None,
+        open_timeout=UPSTREAM_OPEN_TIMEOUT,
     )
     if upstream_headers:
         # ``process_redirect`` returns the new URI to follow a redirect, or the

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -38,6 +38,7 @@ from osprey.interfaces.web_terminal.operator_session import (
     build_operator_child_env,
     resolve_agent_data_root,
 )
+from osprey.interfaces.web_terminal.session_binding import write_binding
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
 from osprey_connectors import session_store
 from osprey_connectors.control_system.base import is_readonly_run
@@ -406,6 +407,39 @@ def _spawn_posture_key(app, session_key: str) -> str:
         return session_key
     spawn_key = resolve(session_key)
     return spawn_key if isinstance(spawn_key, str) and spawn_key else session_key
+
+
+def _bind_notebook_session(app, registry, session, session_key: str) -> None:
+    """Point the notebook session binding at the PTY session just attached.
+
+    Called from both attach paths — the connect and the switch — so the
+    binding always names the session the operator is looking at, and a
+    notebook kernel started afterwards joins that one. Chat-pool children are
+    never bound: they have no PTY, and a kernel has nothing to join.
+
+    Nothing here may fail the attach. A binding that could not be written
+    costs a notebook its session, which the kernel handles by running
+    sandboxed; an exception escaping into the handler would cost the operator
+    their terminal.
+
+    Args:
+        app: The FastAPI app, for resolving the shared agent-data root.
+        registry: The PTY registry holding *session_key*.
+        session: The live :class:`~...pty_manager.PtySession`, for its pid.
+        session_key: The pool key just attached.
+    """
+    try:
+        root = resolve_agent_data_root(app)
+        resolve = getattr(registry, "audit_session_key", None)
+        spawn_key = resolve(session_key) if resolve is not None else session_key
+        write_binding(
+            root,
+            spawn_key if isinstance(spawn_key, str) and spawn_key else session_key,
+            session.pid,
+            root,
+        )
+    except Exception:  # noqa: BLE001 — an attach must not fail on a binding write
+        logger.debug("Could not bind the notebook session to %s", session_key, exc_info=True)
 
 
 def _posture_entry(app, session_key: str | None) -> dict[str, str]:
@@ -1229,6 +1263,7 @@ async def terminal_ws(websocket: WebSocket):
         cwd=websocket.app.state.project_cwd,
     )
     registry.attach_session(current_key)
+    _bind_notebook_session(websocket.app, registry, session, current_key)
 
     # Confirm the id immediately, whichever path spawned it. A new session's
     # id is the one this handler put on the CLI's command line; a resume's is
@@ -1341,6 +1376,7 @@ async def terminal_ws(websocket: WebSocket):
                                 cwd=websocket.app.state.project_cwd,
                             )
                             registry.attach_session(target_id)
+                            _bind_notebook_session(websocket.app, registry, session, target_id)
 
                             # 5. Notify client
                             await websocket.send_text(

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -40,6 +40,7 @@ from osprey.interfaces.web_terminal.operator_session import (
 )
 from osprey.interfaces.web_terminal.session_binding import write_binding
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from osprey.profiles.web_panels import JUPYTER_PANEL_ID
 from osprey_connectors import session_store
 from osprey_connectors.control_system.base import is_readonly_run
 
@@ -417,17 +418,26 @@ def _bind_notebook_session(app, registry, session, session_key: str) -> None:
     notebook kernel started afterwards joins that one. Chat-pool children are
     never bound: they have no PTY, and a kernel has nothing to join.
 
+    A deployment without the notebook panel is left alone entirely. Nothing
+    would ever read the binding there, and writing one creates
+    ``<root>/jupyter/`` under whatever the resolver answers — which, for a
+    server whose config does not resolve, is the process's own tree.
+
     Nothing here may fail the attach. A binding that could not be written
     costs a notebook its session, which the kernel handles by running
     sandboxed; an exception escaping into the handler would cost the operator
     their terminal.
 
     Args:
-        app: The FastAPI app, for resolving the shared agent-data root.
+        app: The FastAPI app, for the enabled panels and the shared
+            agent-data root.
         registry: The PTY registry holding *session_key*.
         session: The live :class:`~...pty_manager.PtySession`, for its pid.
         session_key: The pool key just attached.
     """
+    enabled = getattr(getattr(app, "state", None), "enabled_panels", None) or set()
+    if JUPYTER_PANEL_ID not in enabled:
+        return
     try:
         root = resolve_agent_data_root(app)
         resolve = getattr(registry, "audit_session_key", None)

--- a/src/osprey/interfaces/web_terminal/session_binding.py
+++ b/src/osprey/interfaces/web_terminal/session_binding.py
@@ -1,0 +1,86 @@
+"""Writes the session binding a notebook kernel reads at start-up.
+
+The document says which PTY session a kernel should join: the one **most
+recently attached** in the browser. The web terminal is the only writer, and it
+writes identity only — a session key, the PTY child's pid, and the shared
+agent-data root — never a posture or a control target. Those are looked up
+live by the kernel from the stores those two identifiers address, so a binding
+cannot go stale into a *wrong* answer; the worst it can be is a session that no
+longer exists, which the kernel resolves to "run sandboxed".
+
+The path constant and the reader live in :mod:`osprey.jupyter_kernel`, which is
+standard library only: a kernel process reads the binding without importing the
+web terminal, and this module imports the constant from there so the path has a
+single producer.
+
+Chat-pool children are never bound. They have no PTY, so there is no pid to
+name and nothing for a kernel to join.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from osprey.interfaces.web_terminal._json_store import read_json_object, write_json_atomic
+from osprey.jupyter_kernel import binding_path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["clear_binding", "write_binding"]
+
+
+def write_binding(
+    shared_root: str | os.PathLike[str],
+    session_id: str,
+    pty_pid: int | None,
+    agent_data_root: str,
+) -> None:
+    """Point the binding at *session_id*, replacing whatever it named before.
+
+    Failure is swallowed: a binding that cannot be written costs the operator
+    a notebook that runs sandboxed, and must never cost them the terminal
+    attach that triggered the write.
+
+    Args:
+        shared_root: The shared agent-data root the binding lives under.
+        session_id: The posture-store key the session's own child stamps —
+            ``PtyRegistry.audit_session_key`` of the pool key, so a rekeyed
+            session is named by the id its records carry.
+        pty_pid: The PTY child's process id, or ``None`` if it has none yet.
+        agent_data_root: The agent-data root the kernel should stamp, so it
+            reads the same stores the terminal writes.
+    """
+    path = binding_path(shared_root)
+    document = {
+        "session_id": session_id,
+        "pty_pid": pty_pid,
+        "agent_data_root": agent_data_root,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(path, document)
+    except OSError:
+        logger.warning("Could not write the notebook session binding %s", path, exc_info=True)
+
+
+def clear_binding(shared_root: str | os.PathLike[str], session_id: str) -> None:
+    """Remove the binding, but only while it still names *session_id*.
+
+    A terminated session that was superseded before it died must not take the
+    live binding with it — the ownership check is what keeps a background
+    session's eviction from unbinding the session the operator is looking at.
+
+    Args:
+        shared_root: The shared agent-data root the binding lives under.
+        session_id: The session being torn down, in the same key space
+            :func:`write_binding` recorded.
+    """
+    path = binding_path(shared_root)
+    document = read_json_object(path)
+    if document is None or document.get("session_id") != session_id:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Could not remove the notebook session binding %s", path, exc_info=True)

--- a/src/osprey/interfaces/web_terminal/static/js/activity-format.js
+++ b/src/osprey/interfaces/web_terminal/static/js/activity-format.js
@@ -79,6 +79,9 @@ export function formatActivity(frame, opts = {}) {
       }
       const verb = PANEL_VERBS[frame.tool];
       if (verb) return { verb, subject: label(t.panel) };
+      if (frame.tool === 'NotebookEdit') {
+        return { verb: 'agent edited', subject: t.detail || label(t.panel) };
+      }
       // Generic fallback: a panel-kind frame from some other tool.
       return { verb: 'agent touched', subject: t.panel || frame.tool };
     }

--- a/src/osprey/interfaces/web_terminal/static/js/panel-catalog.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-catalog.js
@@ -53,6 +53,12 @@ export const PANELS = [
     configEndpoint: '/api/lattice-server',
   },
   {
+    id: 'jupyter',
+    label: 'NOTEBOOKS',
+    configEndpoint: '/api/jupyter-server',
+    healthEndpoint: '/api/status', // the sidecar's own status route, reached through the panel proxy
+  },
+  {
     id: 'okf',
     label: 'KNOWLEDGE',
     configEndpoint: '/api/okf-server',

--- a/src/osprey/interfaces/web_terminal/static/js/panel-catalog.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-catalog.js
@@ -54,7 +54,7 @@ export const PANELS = [
   },
   {
     id: 'jupyter',
-    label: 'NOTEBOOKS',
+    label: 'JUPYTER',
     configEndpoint: '/api/jupyter-server',
     healthEndpoint: '/api/status', // the sidecar's own status route, reached through the panel proxy
   },

--- a/src/osprey/jupyter_kernel.py
+++ b/src/osprey/jupyter_kernel.py
@@ -1,0 +1,629 @@
+"""The notebook kernel's side of the session binding, and its launcher.
+
+A notebook kernel runs as its own process, started by the Jupyter server, with
+no handle on the web terminal that the operator is actually working in. The
+session binding is how it finds one: a single JSON document under the shared
+agent-data root naming the PTY session most recently attached in the browser,
+which the kernel reads at start-up to join that session's posture and control
+target instead of guessing at its own.
+
+Both ends of that document live here, and only the path constant and the
+reader are used by the web terminal — :mod:`osprey.interfaces.web_terminal`
+imports :data:`BINDING_RELPATH` so the path has exactly one producer. The
+dependency never runs the other way: a kernel process must not import the web
+terminal (it would pull FastAPI and uvicorn into every notebook), so every
+MODULE-LEVEL import here is standard library, and :func:`read_binding` repeats
+the tolerant-read contract of
+:func:`osprey.interfaces.web_terminal._json_store.read_json_object` rather than
+importing it. :func:`compute_stamps` and :func:`main` do reach into OSPREY —
+they resolve the same records the executor resolves, from the same modules —
+but every one of those imports sits inside the function body, so importing
+this module costs the terminal nothing but the standard library. ``ipykernel``
+is imported the same way, inside :func:`main`, so the binding reader stays
+importable in a process that has no kernel stack at all.
+
+A cell's refusals are the launcher's other job. A write the connector
+refuses raises in the cell rather than in an ``execute()`` call, so nothing on
+the executor's path files the record or explains the refusal;
+:func:`install_refusal_handler` puts both on the kernel's own exception hook.
+What the cell shows is the refusal and one action line, and nothing else: the
+process's log records are routed to the terminal log by
+:func:`_route_logs_to_process_stderr` rather than left to resolve stderr while
+``ipykernel`` is publishing it into the cell.
+
+A missing or damaged binding is a normal state, not an error — the terminal may
+never have attached a session, or the document may be mid-rewrite on a
+filesystem without atomic replace. :func:`read_binding` answers ``None`` for
+every such case, and the launcher treats ``None`` as "join nothing, run
+sandboxed".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from collections.abc import Mapping, MutableMapping
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+__all__ = [
+    "BINDING_RELPATH",
+    "binding_path",
+    "compute_stamps",
+    "install_refusal_handler",
+    "main",
+    "read_binding",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Location of the session-binding document, relative to the shared
+#: agent-data root. The writer and every reader derive their path from this
+#: one constant.
+BINDING_RELPATH = "jupyter/session-binding.json"
+
+
+def binding_path(shared_root: str | os.PathLike[str]) -> Path:
+    """Return the session-binding document's path under *shared_root*.
+
+    Args:
+        shared_root: The shared agent-data root — the one that spans sessions,
+            never a session-scoped directory.
+
+    Returns:
+        The absolute path of the binding document. The file itself, and the
+        directory holding it, may not exist yet.
+    """
+    return Path(shared_root) / BINDING_RELPATH
+
+
+def read_binding(shared_root: str | os.PathLike[str]) -> dict[str, Any] | None:
+    """Return the session binding under *shared_root*, or ``None``.
+
+    ``None`` covers every degraded outcome — no document, an unreadable one,
+    one that is not valid JSON, and one that parses to something other than an
+    object — so a caller has one branch to write and never a ``try``.
+
+    Args:
+        shared_root: The shared agent-data root to read the binding from.
+
+    Returns:
+        The binding as a mapping, or ``None`` when there isn't a readable one.
+    """
+    try:
+        document = json.loads(binding_path(shared_root).read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(document, dict):
+        return None
+    return document
+
+
+#: The Jupyter server's own token, re-issued per launch by the sidecar. A cell
+#: must not be able to read it, and the empty value the kernelspec carries is
+#: not enough on its own: the provisioner merges the kernelspec env OVER
+#: ``os.environ``, so an empty value keeps the KEY. :func:`main` pops the name
+#: outright, and a cell's environment then holds no ``JUPYTER_TOKEN`` at all.
+JUPYTER_TOKEN_ENV_VAR = "JUPYTER_TOKEN"
+
+#: The config path the sidecar passes down, and the one the config loader
+#: reads. They are different names: the web terminal resolves its deployment
+#: from ``OSPREY_CONFIG``, while :mod:`osprey_connectors.config` looks only at
+#: ``CONFIG_FILE`` or a ``config.yml`` in the working directory. A kernel's
+#: working directory is the notebooks folder, so without the second name every
+#: runtime call in a cell would fall back to defaults — a ``mock`` control
+#: system with no connector types registered. :func:`_prepare_environment`
+#: publishes the second from the first, the way the connector host does for
+#: its own child.
+OSPREY_CONFIG_ENV_VAR = "OSPREY_CONFIG"
+CONFIG_FILE_ENV_VAR = "CONFIG_FILE"
+
+
+def _bound_identity(binding: Mapping[str, Any] | None) -> tuple[str | None, str | None]:
+    """The session key and agent-data root *binding* names, or ``(None, None)``.
+
+    Both halves or neither: a binding that names a session but no root cannot
+    say which store that session is recorded in, and one that names a root but
+    no session addresses nothing in it. Answering ``(None, None)`` for either
+    puts such a document on the same fail-closed path as no document at all.
+    """
+    if not isinstance(binding, Mapping):
+        return None, None
+    session_id = binding.get("session_id")
+    agent_data_root = binding.get("agent_data_root")
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None, None
+    if not isinstance(agent_data_root, str) or not agent_data_root.strip():
+        return None, None
+    return session_id.strip(), agent_data_root.strip()
+
+
+def compute_stamps(
+    binding: Mapping[str, Any] | None,
+    env: MutableMapping[str, str],
+) -> dict[str, str]:
+    """Stamp the bound session's identity, posture and target into *env*.
+
+    The kernel is joining a session it is not a child of, so it stamps itself
+    with what that session's own children carry. The order is the contract:
+    the agent-data root and the posture session go first because everything
+    resolved afterwards is looked up UNDER them — the control-target state
+    directory follows the root stamp, and so does the posture store — then the
+    store's parsed copy is dropped, and only then is the live record resolved
+    and the target stamped from it.
+
+    The three target names are stamped exactly as
+    ``python_executor.executor._apply_target_stamp`` stamps them, by reusing
+    that module's constants and helpers rather than restating them: this is a
+    second producer of one routing contract, and a paraphrase is how two
+    producers come to disagree. The record is the only thing resolved
+    differently — the executor matches on its own parent, and a kernel has no
+    parent in the session at all, so it matches on the bound PTY's pid.
+
+    Fail-closed on one point of substance the executor does not share. Where
+    the executor's unstamped run means "a session whose target could not be
+    named", the kernel's means "no session", so the pin is the literal
+    ``*=sandbox`` rather than whatever the store would answer for a session key
+    that is not there: reads route to the deployment baseline and every write
+    is refused by the connector's launch pin.
+
+    Args:
+        binding: The session binding as :func:`read_binding` returns it, or
+            ``None`` when there is no readable one.
+        env: This process's own environment — ``os.environ``, and nothing else.
+            The resolvers called here read the PROCESS environment, so the
+            identity half has to be visible to them by the time the target half
+            is resolved. Stamped in place, and the three target names are
+            REMOVED from it on the fail-closed path, because an inherited stamp
+            passed through would route cells at a target nobody selected.
+
+    Returns:
+        The names this call stamped, mapped to their values. Removals are not
+        in it: they are absences, which is how every reader of the stamp reads
+        "no target".
+    """
+    from osprey.audit import posture
+    from osprey.mcp_server.control_system import target_banner
+    from osprey.mcp_server.python_executor import executor
+    from osprey_connectors import session_store
+
+    stamps: dict[str, str] = {}
+    session_id, agent_data_root = _bound_identity(binding)
+    if session_id is not None and agent_data_root is not None:
+        stamps[session_store.AGENT_DATA_ROOT_ENV_VAR] = agent_data_root
+        stamps[posture.POSTURE_SESSION_ENV_VAR] = session_id
+        env.update(stamps)
+    # The store may already be parsed from whatever root this process inherited.
+    session_store.invalidate_cache()
+
+    record = None
+    if session_id is not None and binding is not None:
+        record = target_banner.session_record_for_pid(binding.get("pty_pid"))
+
+    target = None
+    if record is not None:
+        # A record without an int generation cannot pin a run, which is the
+        # same bar `target_state.session_record(require_generation=True)` sets
+        # for the executor; `session_record_for_pid` does not apply it.
+        generation = record.get("generation")
+        candidate = str(record.get("target"))
+        if (
+            isinstance(generation, int)
+            and not isinstance(generation, bool)
+            and executor._target_is_resolvable(candidate)
+        ):
+            target = candidate
+
+    if record is None or target is None:
+        for name in executor._STAMP_ENV_NAMES:
+            env.pop(name, None)
+        stamps[executor.ENV_LAUNCH_POSTURE] = session_store.launch_posture_stamp(
+            None, session_store.POSTURE_SANDBOX
+        )
+    else:
+        stamps[executor.ENV_CONTROL_TARGET] = target
+        stamps[executor.ENV_CONTROL_TARGET_GENERATION] = str(int(record["generation"]))
+        # The record's identity, so a cell pins against this server's file and
+        # not against whatever else is in the state directory.
+        stamps[executor.ENV_CONTROL_TARGET_STATE_PID] = str(int(record["server_pid"]))
+        stamps[executor.ENV_LAUNCH_POSTURE] = executor._launch_posture(target)
+
+    env.update(stamps)
+    return stamps
+
+
+def _prepare_environment() -> dict[str, str]:
+    """Take the server's token away and join the bound session.
+
+    The root the binding lives under is the one
+    :func:`osprey_connectors.session_store.agent_data_root` answers: the
+    ``OSPREY_AGENT_DATA_ROOT`` stamp the kernelspec carries, else the config
+    derivation. That is the same rule the posture store and the control-target
+    state file already read by, so the kernel cannot look for the binding in
+    one directory and its session's records in another.
+
+    The config path is published first, under the name the loader reads, so
+    that the target resolution inside :func:`compute_stamps` — and every
+    runtime call a cell makes afterwards — sees the deployment rather than the
+    defaults. A ``CONFIG_FILE`` that already names a path is left alone:
+    whoever set it chose it on purpose. A blank one is not a choice — the
+    loader treats it as unset — so it is filled like an absent name rather
+    than preserved, which ``setdefault`` would have done.
+
+    Returns:
+        The stamps :func:`compute_stamps` applied, for a caller that wants to
+        report them. Nothing here raises on a missing binding: that is the
+        ordinary state of a kernel started before any terminal attached.
+    """
+    os.environ.pop(JUPYTER_TOKEN_ENV_VAR, None)
+    config_path = os.environ.get(OSPREY_CONFIG_ENV_VAR)
+    if config_path and not os.environ.get(CONFIG_FILE_ENV_VAR):
+        os.environ[CONFIG_FILE_ENV_VAR] = config_path
+
+    from osprey_connectors import session_store
+
+    root = session_store.agent_data_root()
+    binding = None if root is None else read_binding(root)
+    return compute_stamps(binding, os.environ)
+
+
+#: The audit surface a notebook cell's refusals file under. Named here rather
+#: than beside :data:`~osprey.audit.envelope.SURFACE_EXECUTOR` because that is
+#: where the executor's surface sits only for the ``source`` exemption it is
+#: granted; every other surface in the tree is declared by the module that
+#: emits it, and this one has no exemption to ask for.
+SURFACE_NOTEBOOK_KERNEL = "notebook_kernel"
+
+#: Audit ``subject`` for every record written here. A refusal that reached the
+#: kernel's hook was raised by a cell, and a cell has no name to give — the
+#: channel the write named goes in ``detail`` instead.
+REFUSAL_SUBJECT = "notebook_cell"
+
+#: ``reason`` codes, one per refusal class, keyed by class name so the mapping
+#: costs no import at module scope. A class that is not in it is a subclass of
+#: one that is, and files under the fallback rather than under a guess.
+_REFUSAL_REASONS = {
+    "ChannelWriteBlockedError": "channel_write_blocked",
+    "ChannelLimitsViolationError": "channel_limits_violation",
+    "ControlTargetChangedError": "control_target_changed",
+}
+
+#: The target moved after this kernel stamped itself. The kernel holds one
+#: stamp for its whole life, so following the new target takes a restart.
+HINT_TARGET_CHANGED = "The session's control target changed. Restart the kernel to follow it."
+
+#: The launch pin refused, and it was pinned everywhere: no session was bound
+#: when the kernel started, so there is nothing to turn on yet.
+HINT_NO_SESSION = (
+    "No chat session was open when this kernel started. Open one, then restart the kernel."
+)
+
+#: The launch pin refused for a named target: the session had writes off for it
+#: at launch, and the pin does not re-read the store.
+HINT_WRITES_OFF = (
+    "This kernel started with writes off. Turn writes on from the chip, then restart the kernel."
+)
+
+#: The session this kernel joined is gone rather than re-pointed — "+ New" in
+#: the session tile ends one session and attaches another. The pin refuses
+#: exactly as it does for a target switch, so without this line the operator is
+#: told the control target changed when it did not.
+HINT_SESSION_ENDED = "The chat session this kernel followed has ended. Restart the kernel."
+
+#: The connector's remedy for a launch-pin refusal, rewritten for this surface.
+#: A script picks up a write state set since it launched by being re-run; a
+#: kernel holds its launch stamp for its whole life, so only a restart does.
+#:
+#: The keys are pinned copies of the sentences ``_writes_disabled_result`` ends
+#: its two launch-pin messages with, in
+#: ``packages/osprey-connectors/src/osprey_connectors/control_system/base.py``.
+#: A wording change there would stop matching here and leave the script advice
+#: in the cell, so the tests assert these two sentences against the connector's
+#: own output rather than against this mapping alone.
+LAUNCH_PIN_REMEDIES = {
+    "Re-run the script to pick it up.": "Restart the kernel to pick it up.",
+    "Re-run the script to pick up the current write state.": (
+        "Restart the kernel to pick up the current write state."
+    ),
+}
+
+
+def _refusal_classes() -> tuple[type[BaseException], ...]:
+    """The exception classes the kernel's hook answers for.
+
+    Imported inside the function for the module's one-way dependency rule: a
+    process that only reads the binding must not pull the connectors package
+    in behind it.
+    """
+    from osprey.runtime import ControlTargetChangedError
+    from osprey_connectors.errors import ChannelLimitsViolationError, ChannelWriteBlockedError
+
+    return (ChannelWriteBlockedError, ChannelLimitsViolationError, ControlTargetChangedError)
+
+
+def _stamped_session_ended() -> bool:
+    """Whether the state record this kernel stamped itself from is gone.
+
+    The pin that raises ``ControlTargetChangedError`` cannot tell a switch from
+    an ending: it compares the stamp against what the controls server publishes
+    NOW, and a session that ended publishes nothing, so "the record moved" and
+    "the record is gone" arrive as the same refusal. The record is what
+    separates them, and :func:`osprey.runtime._current_target_record` is the
+    resolver that already reads it — the same one the pin itself consults, off
+    the ``OSPREY_CONTROL_TARGET_STATE_PID`` stamp
+    :func:`compute_stamps` wrote. Asking it a second time here rather than
+    resolving the record another way is what keeps the two answers from
+    disagreeing.
+
+    An unstamped kernel is not pinned and never reaches this, but the stamp is
+    checked anyway: without it, ``None`` would mean "no session was ever
+    joined" and be reported as one that ended.
+
+    Returns:
+        ``True`` only when this kernel joined a session whose record is no
+        longer readable. Every failure answers ``False``, which leaves the
+        target-changed line — both lines ask for the same restart, so the
+        fail-safe direction is the one that claims less.
+    """
+    try:
+        from osprey import runtime
+        from osprey.mcp_server.python_executor import executor
+
+        if not (os.environ.get(executor.ENV_CONTROL_TARGET_STATE_PID) or "").strip():
+            return False
+        return runtime._current_target_record() is None
+    except Exception:  # noqa: BLE001 - a hint is not worth failing a refusal over
+        logger.debug("Could not check the bound session's record", exc_info=True)
+        return False
+
+
+def _hint_for(value: BaseException) -> str | None:
+    """The one action line for *value*, or ``None`` when there is no action.
+
+    Every branch is read from the stamp this process already carries, so the
+    hint and the connector's own refusal text answer from one state rather
+    than from a flag the kernel would have to keep in step. A live-store
+    refusal and a limits violation get no line: the connector's message
+    already names what to do, and a second line would either repeat it or send
+    the operator somewhere the message did not.
+
+    The target-changed refusal covers two states and names one, so it forks on
+    :func:`_stamped_session_ended` before it is reported as a switch.
+
+    Args:
+        value: The refusal that reached the hook.
+
+    Returns:
+        The line to print before the traceback, or ``None`` to print none.
+    """
+    from osprey.mcp_server.python_executor import executor
+    from osprey.runtime import ControlTargetChangedError
+    from osprey_connectors import session_store
+    from osprey_connectors.errors import ChannelWriteBlockedError
+
+    if isinstance(value, ControlTargetChangedError):
+        return HINT_SESSION_ENDED if _stamped_session_ended() else HINT_TARGET_CHANGED
+    if not isinstance(value, ChannelWriteBlockedError):
+        return None
+    target = (os.environ.get(executor.ENV_CONTROL_TARGET) or "").strip() or None
+    if session_store.launch_permits(target):
+        return None
+    if session_store.launch_narrowed_target() == session_store.LAUNCH_POSTURE_ALL_TARGETS:
+        return HINT_NO_SESSION
+    return HINT_WRITES_OFF
+
+
+def _record_refusal(value: BaseException) -> None:
+    """File one audit record for *value* under :data:`SURFACE_NOTEBOOK_KERNEL`.
+
+    The fields are the executor's, resolved the same way. The writer swallows
+    its own failures, so the lazy imports are the only thing left that could
+    raise and they are guarded too: a refusal that could not be recorded is
+    still a refusal, and must still reach the cell.
+    """
+    try:
+        from osprey.audit import posture
+        from osprey.audit.envelope import DECISION_REFUSED
+        from osprey.audit.writer import record
+
+        channel = getattr(value, "channel_address", None)
+        record(
+            decision=DECISION_REFUSED,
+            reason=_REFUSAL_REASONS.get(type(value).__name__, "refused"),
+            surface=SURFACE_NOTEBOOK_KERNEL,
+            posture=posture.posture(),
+            posture_source=posture.posture_source(),
+            session=posture.posture_session(),
+            subject=REFUSAL_SUBJECT,
+            detail=f"channel={channel}" if isinstance(channel, str) and channel else None,
+        )
+    except Exception:  # noqa: BLE001 - the audit trail degrades; the refusal does not
+        logger.warning("Could not record the notebook refusal for audit", exc_info=True)
+
+
+def _rewrite_launch_pin_remedy(value: BaseException) -> None:
+    """Point a launch-pin refusal's own message at a kernel restart.
+
+    The connector writes one message for every surface, and its remedy —
+    re-run the script — is the wrong one here: a cell re-run reuses the kernel,
+    which still carries the launch stamp that refused. The hint above the
+    traceback says so, but the exception under it contradicts the hint, and the
+    exception is the line an operator acts on.
+
+    Rewritten by rebuilding ``args`` rather than by subclassing the connector's
+    error or patching its message builder: the class stays the connector's, and
+    only the surface that displays it is changed. A message that does not end
+    in a pinned sentence is left exactly as it is.
+
+    Args:
+        value: The refusal, mutated in place when its message matches.
+    """
+    args = getattr(value, "args", ())
+    if not args or not isinstance(args[0], str):
+        return
+    message = args[0]
+    for connector_remedy, kernel_remedy in LAUNCH_PIN_REMEDIES.items():
+        if message.endswith(connector_remedy):
+            value.args = (message[: -len(connector_remedy)] + kernel_remedy, *args[1:])
+            return
+
+
+def _refusal_handler(
+    shell: Any,
+    etype: type[BaseException],
+    value: BaseException,
+    tb: TracebackType | None,
+    tb_offset: int | None = None,
+) -> None:
+    """Record a refusal, say what to do about it, then show it as usual.
+
+    ``IPython`` binds this as a method of the shell, which is why *shell* is
+    the first argument rather than a closure.
+
+    The refusal itself is rewritten before it is shown where its remedy names
+    the wrong surface — see :func:`_rewrite_launch_pin_remedy`.
+
+    Args:
+        shell: The ``InteractiveShell`` the hook was installed on.
+        etype: The refusal's class.
+        value: The refusal.
+        tb: Its traceback.
+        tb_offset: Frames ``IPython`` wants skipped, passed straight through.
+
+    Returns:
+        ``None`` — the traceback is displayed by ``showtraceback`` here rather
+        than by handing a structured one back for ``IPython`` to display.
+    """
+    _record_refusal(value)
+    hint = _hint_for(value)
+    # The two launch-pin hints ARE the launch-pin predicate, already evaluated:
+    # deriving the rewrite from them rather than re-asking the store is what
+    # keeps one refusal from getting a hint and a remedy that disagree.
+    if hint in (HINT_NO_SESSION, HINT_WRITES_OFF):
+        _rewrite_launch_pin_remedy(value)
+    if hint is not None:
+        print(hint)
+    shell.showtraceback((etype, value, tb), tb_offset=tb_offset)
+
+
+def install_refusal_handler(shell: Any) -> None:
+    """Put the refusal hook on *shell*.
+
+    A cell's write goes to the connector directly, so a refusal surfaces as a
+    raised exception and nothing else — no audit record, and a traceback whose
+    remedy is a kernel restart the message has no way to ask for. This hook
+    supplies both, and leaves every other exception alone.
+
+    Args:
+        shell: The kernel's ``InteractiveShell``.
+    """
+    shell.set_custom_exc(_refusal_classes(), _refusal_handler)
+
+
+def _initialize_registry() -> None:
+    """Load the deployment's registry, the way the executor sandbox does.
+
+    A cell's ``read_channel`` builds its connector through the registry, and a
+    fresh process has nothing registered: the executor sandbox loads the
+    registry before user code runs, and a kernel is the same kind of process
+    without that preamble. The call, its arguments and its guard are the
+    sandbox's: a registry that fails to load leaves the kernel usable for
+    everything that does not need one, and the failure is in the log.
+    """
+    try:
+        from osprey.registry import initialize_registry
+
+        initialize_registry(auto_export=False, config_path=os.environ.get(CONFIG_FILE_ENV_VAR))
+    except Exception:  # noqa: BLE001 - the kernel still starts; the cause is logged
+        logger.warning("Registry initialization failed", exc_info=True)
+
+
+#: Format for this process's log records on the terminal log. Level and logger
+#: name are what make a kernel's line findable among the sidecar's own.
+LOG_FORMAT = "%(levelname)s %(name)s: %(message)s"
+
+#: The file descriptor a process inherits its standard error on.
+_STDERR_FD = 2
+
+
+def _writes_to_process_stderr(handler: logging.Handler) -> bool:
+    """Whether *handler* writes where ``ipykernel`` will put the cell."""
+    stream = getattr(handler, "stream", None)
+    if stream is None:
+        return False
+    if stream is sys.stderr or stream is sys.__stderr__:
+        return True
+    try:
+        return bool(stream.fileno() == _STDERR_FD)
+    except (AttributeError, OSError, ValueError):
+        return False
+
+
+def _route_logs_to_process_stderr() -> None:
+    """Send this process's log records to the stderr the kernel was started on.
+
+    A kernel's log records are for whoever reads the terminal log, and every
+    one of them was landing in the cell instead: ``ipykernel`` replaces
+    ``sys.stderr`` with a stream that publishes to the notebook, so a handler
+    that resolves stderr when it emits — the root logger's last-resort handler
+    included — writes a cell's refusal audit above the one line the operator is
+    meant to read.
+
+    Naming the descriptor is not enough either: with ``capture_fd_output`` on,
+    which is ``IPKernelApp``'s default, descriptor 2 itself is replaced by a
+    pipe that publishes to the cell AND echoes to the terminal, so a handler
+    holding descriptor 2 would print in both places. A duplicate taken before
+    the kernel exists refers to the original file, and the replacement does not
+    reach it.
+
+    Called once, first thing in :func:`main`, so that everything the
+    preparation and the registry log is already routed. No level is set: the
+    root logger's own decides, as it did before.
+    """
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if _writes_to_process_stderr(handler):
+            root.removeHandler(handler)
+    handler = logging.StreamHandler(os.fdopen(os.dup(_STDERR_FD), "w", buffering=1))
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    root.addHandler(handler)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run a notebook kernel joined to the bound terminal session.
+
+    ``ipykernel`` is imported here rather than at module scope so that reading
+    the binding costs a process no kernel stack.
+
+    Logging is routed before anything else runs, so that the preparation's and
+    the registry's own records go where the rest of this process's records go.
+
+    The environment is prepared before the registry is loaded, because the
+    registry is created from the config path the preparation publishes; and
+    both happen before the kernel exists, so no cell can run ahead of them.
+
+    The last three statements are three rather than one chained call because
+    the hook goes between the second and the third: ``initialize`` is what
+    builds the shell, and ``start`` does not return until the kernel stops.
+
+    Args:
+        argv: Kernel arguments. ``None`` takes them from the command line, the
+            way ``ipykernel``'s own entry point does.
+    """
+    _route_logs_to_process_stderr()
+    _prepare_environment()
+    _initialize_registry()
+
+    from ipykernel.kernelapp import IPKernelApp
+
+    app = IPKernelApp.instance()
+    app.initialize(argv)
+    install_refusal_handler(app.shell)
+    app.start()
+
+
+if __name__ == "__main__":  # pragma: no cover - the kernelspec's entry point
+    main()

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -50,7 +50,7 @@ hooks:
   - approval          # Gate logbook entry creation on user approval prompt
   - error-guidance    # Post-error hook that surfaces remediation hints
   - notebook-update   # Sync CLAUDE.md notebook after each session
-  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts
+  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts and notebooks
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Inject the web terminal panel inventory into agent context

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -59,7 +59,7 @@ hooks:
   - approval          # Enforce config.yml approval policy (fail-closed default for any write tool)
   - error-guidance    # Post-error hook that surfaces remediation hints
   - notebook-update   # Sync CLAUDE.md notebook after each session
-  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts
+  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts and notebooks
   - config-drift      # Warn at session start when config.yml drifted from generated artifacts
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -108,7 +108,7 @@ web_panels:
   - channel-finder  # Interactive channel-finder web UI
   - okf             # KNOWLEDGE tab, for browsing the facility knowledge bundle
   - system-health   # SYSTEM tab, a framework health dashboard
-  - jupyter         # NOTEBOOKS tab, JupyterLab with kernels that follow the terminal session
+  - jupyter         # JUPYTER tab, JupyterLab with kernels that follow the terminal session
   # The events and bluesky panels are declared by the write-armed personas
   # (readwrite and admin) instead, so the read-only login is built without them.
 

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -59,7 +59,7 @@ hooks:
   - writes-check      # Kill switch: refuse every write while writes_enabled is false
   - limits            # Enforce per-channel min/max limits before writes
   - error-guidance    # Post-error hook that surfaces remediation hints
-  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts
+  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts and notebooks
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
   - config-drift      # Warn at session start when the build is out of date
@@ -108,6 +108,7 @@ web_panels:
   - channel-finder  # Interactive channel-finder web UI
   - okf             # KNOWLEDGE tab, for browsing the facility knowledge bundle
   - system-health   # SYSTEM tab, a framework health dashboard
+  - jupyter         # NOTEBOOKS tab, JupyterLab with kernels that follow the terminal session
   # The events and bluesky panels are declared by the write-armed personas
   # (readwrite and admin) instead, so the read-only login is built without them.
 

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -58,7 +58,7 @@ hooks:
   - writes-check   # Kill switch: refuse every write while writes_enabled is false
   - approval       # Gate hardware-write tool calls on human approval prompt
   - limits         # Enforce per-channel min/max limits, from data/channel_limits.json
-  - memory-guard   # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts
+  - memory-guard   # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts and notebooks
   - config-drift   # Warn at session start when the build is out of date
   - focus-validate # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context # Tell the agent which web terminal panels exist

--- a/src/osprey/profiles/web_panels.py
+++ b/src/osprey/profiles/web_panels.py
@@ -46,12 +46,17 @@ class SidecarPanel:
     factory_path: str
 
 
+#: The notebook panel's id. Named rather than spelled, because the terminal
+#: reads it on a path that has nothing to do with panels — the session binding
+#: an attach writes is only worth writing where this panel is served.
+JUPYTER_PANEL_ID = "jupyter"
+
 #: Built-in panels the web terminal serves from a sidecar process rather than a
 #: registered companion server. Keyed by panel id, exactly like the ids derived
 #: from the companion registry, so every consumer of :data:`BUILTIN_PANELS`
 #: covers them without a second lookup.
 SIDECAR_PANELS: dict[str, SidecarPanel] = {
-    "jupyter": SidecarPanel(
+    JUPYTER_PANEL_ID: SidecarPanel(
         "JupyterLab notebooks",
         "osprey.interfaces.web_terminal.jupyter_sidecar:JupyterSidecar",
     ),
@@ -85,7 +90,7 @@ BUILTIN_PANEL_LABELS: dict[str, str] = {
     "ariel": "ARIEL",
     "channel-finder": "CHANNELS",
     "lattice": "LATTICE",
-    "jupyter": "NOTEBOOKS",
+    JUPYTER_PANEL_ID: "JUPYTER",
     "okf": "KNOWLEDGE",
     "system-health": "SYSTEM",
 }

--- a/src/osprey/profiles/web_panels.py
+++ b/src/osprey/profiles/web_panels.py
@@ -5,29 +5,70 @@ validator (``cli/templates/manifest.py``), and the preset profile validator
 (``cli/build_profile_model.py``) all gate on this set. Drift between them is what
 let unknown panel IDs slip past for two registries simultaneously.
 
-The set itself is derived from ``registry.web.FRAMEWORK_WEB_SERVERS`` — the panel
-ids and the companion servers behind them are one fact, and every place that
-kept its own copy of the panel-id ↔ registry-key relation drifted from the
-others. Cross between the two namespaces via
+The set itself is derived from ``registry.web.FRAMEWORK_WEB_SERVERS`` and
+:data:`SIDECAR_PANELS` — the panel ids and the servers behind them are one fact,
+and every place that kept its own copy of the panel-id ↔ registry-key relation
+drifted from the others. Cross between the two namespaces via
 ``registry.web.PANEL_ID_TO_REGISTRY_KEY`` or ``WebServerDefinition.panel_id``,
-never a local table.
+never a local table; a sidecar panel id is in neither, so cross with ``.get``.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 from osprey.registry.web import FRAMEWORK_WEB_SERVERS
 
 UNIVERSAL_PANELS: set[str] = {"artifacts"}
 
-#: Every panel id the framework serves itself, derived from the companion
-#: web-server registry rather than re-listed here.
+
+@dataclass(frozen=True)
+class SidecarPanel:
+    """A built-in panel served by a process the web terminal starts itself.
+
+    The companion-server registry (``registry.web``) is scoped to servers
+    ``ServerLauncher`` runs from a config section with a host, a port and an
+    ``auto_launch`` key. A sidecar has none of those: it is started by the
+    terminal's lifespan, listens on an ephemeral loopback port, and is reached
+    only through the terminal's own panel proxy. Registering one there would
+    hand it a port band, a port env var and a health probe that mean nothing.
+
+    Attributes:
+        name: One-line description, used as the build interview's menu entry
+            for the panel id.
+        factory_path: ``module:attribute`` of the sidecar class the terminal
+            imports to start it. A dotted path rather than the object so this
+            module stays importable without pulling the sidecar's dependencies
+            into every process that reads the panel registry.
+    """
+
+    name: str
+    factory_path: str
+
+
+#: Built-in panels the web terminal serves from a sidecar process rather than a
+#: registered companion server. Keyed by panel id, exactly like the ids derived
+#: from the companion registry, so every consumer of :data:`BUILTIN_PANELS`
+#: covers them without a second lookup.
+SIDECAR_PANELS: dict[str, SidecarPanel] = {
+    "jupyter": SidecarPanel(
+        "JupyterLab notebooks",
+        "osprey.interfaces.web_terminal.jupyter_sidecar:JupyterSidecar",
+    ),
+}
+
+#: Every panel id the framework serves itself: the companion web servers, plus
+#: the sidecars the terminal starts. Derived from both registries rather than
+#: re-listed here.
 #:
 #: Registering a companion server IS registering its panel: the registry entry
 #: already declares the panel id it is reached by
 #: (``WebServerDefinition.panel_id``), and a second hand-written copy of that
 #: namespace could only ever agree with the first by luck. Keeping it derived
 #: also means a new panel needs no edit in this file at all.
-BUILTIN_PANELS: set[str] = {definition.panel_id for definition in FRAMEWORK_WEB_SERVERS.values()}
+BUILTIN_PANELS: set[str] = {
+    definition.panel_id for definition in FRAMEWORK_WEB_SERVERS.values()
+} | set(SIDECAR_PANELS)
 
 # The event-dispatcher dashboard (``events``) is intentionally NOT a builtin: it
 # is a URL-backed custom panel (the control-assistant preset sets
@@ -44,6 +85,7 @@ BUILTIN_PANEL_LABELS: dict[str, str] = {
     "ariel": "ARIEL",
     "channel-finder": "CHANNELS",
     "lattice": "LATTICE",
+    "jupyter": "NOTEBOOKS",
     "okf": "KNOWLEDGE",
     "system-health": "SYSTEM",
 }

--- a/src/osprey/registry/manager.py
+++ b/src/osprey/registry/manager.py
@@ -324,7 +324,7 @@ def _create_registry_from_config(config_path: str | None = None) -> RegistryMana
     Supports multiple configuration formats for registry path specification:
 
     1. Environment variable (highest priority, for container overrides):
-       REGISTRY_PATH=/jupyter/repo_src/my_app/registry.py
+       REGISTRY_PATH=/app/repo_src/my_app/registry.py
 
     2. Top-level format (simple, for single-app projects):
        registry_path: ./src/my_app/registry.py

--- a/src/osprey/runtime/__init__.py
+++ b/src/osprey/runtime/__init__.py
@@ -372,19 +372,26 @@ def _run_async(coro) -> Any:
     """Run async coroutine synchronously.
 
     Handles both subprocess and Jupyter notebook contexts correctly.
+
+    Only the loop probe sits inside the ``try``: the ``RuntimeError`` it
+    raises is the one signal that there is no running loop. Whatever the
+    coroutine itself raises — including :class:`ControlTargetChangedError`,
+    which is a ``RuntimeError`` too — must propagate unchanged from either
+    branch, never be mistaken for that signal and retried.
     """
     try:
         # Try to get running loop (e.g., in Jupyter with nest_asyncio)
         asyncio.get_running_loop()
-        # If we have a running loop, we need to run in a new thread
-        import concurrent.futures
-
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future = executor.submit(asyncio.run, coro)
-            return future.result()
     except RuntimeError:
         # No running loop - we're in a subprocess, use asyncio.run()
         return asyncio.run(coro)
+
+    # If we have a running loop, we need to run in a new thread
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future = executor.submit(asyncio.run, coro)
+        return future.result()
 
 
 # ========================================================

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -254,7 +254,8 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             output_path=".claude/hooks/osprey_memory_guard.py",
             description=(
                 "PreToolUse gate for every file-writing tool: Write/MultiEdit are held "
-                "to Claude memory files, NotebookEdit to the agent-data artifacts tree"
+                "to Claude memory files, NotebookEdit to the agent-data artifacts and "
+                "notebooks trees"
             ),
         ),
         BuildArtifact(

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_memory_guard.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_memory_guard.py
@@ -2,8 +2,8 @@
 """
 ---
 name: Memory Write Guard
-description: Gates every file-writing tool — Write/MultiEdit to Claude memory files, NotebookEdit to the agent-data artifacts tree
-summary: Restricts Write/MultiEdit to the Claude memory directory and NotebookEdit to agent-data artifacts
+description: Gates every file-writing tool — Write/MultiEdit to Claude memory files, NotebookEdit to the agent-data artifacts and notebooks trees
+summary: Restricts Write/MultiEdit to the Claude memory directory and NotebookEdit to the agent-data artifacts and notebooks trees
 event: PreToolUse
 tools: Write|MultiEdit|NotebookEdit
 safety_layer: 0
@@ -40,11 +40,11 @@ stdin ──► Parse JSON
                                           │
                                           ▼
                                  Under <agent_data_root>/  ──YES──► ALLOW
-                                 artifacts/ ?
+                                 artifacts/ or notebooks/ ?
                                           │
                                          NO
                                           ▼
-                                 DENY: not an artifact notebook
+                                 DENY: not an agent-data notebook
 ```
 
 ## Details
@@ -62,12 +62,15 @@ memory system while preventing arbitrary file creation. The memory gallery
 frontend reads from the same directory, so saved memories appear in the UI
 automatically.
 
-``NotebookEdit`` is held to ``<agent_data_root>/artifacts/`` instead, mirroring
-the scoped ``NotebookEdit(<agent_data_root>/artifacts/**)`` allow rule that
-``settings.json.j2`` renders. Notebooks are the agent's own output and land in
-the artifact tree the gallery serves; holding them to the memory directory
-would deny the agent its own artifacts, and holding them to nothing at all
-would reopen arbitrary writes under a different tool name.
+``NotebookEdit`` is held to ``<agent_data_root>/artifacts/`` and
+``<agent_data_root>/notebooks/`` instead, mirroring the scoped
+``NotebookEdit(<agent_data_root>/artifacts/**)`` and
+``NotebookEdit(<agent_data_root>/notebooks/**)`` allow rules that
+``settings.json.j2`` renders. Both trees hold the agent's own notebooks — the
+artifact tree the gallery serves, and the notebooks tree the Jupyter panel
+serves. Holding them to the memory directory would deny the agent its own
+notebooks, and holding them to nothing at all would reopen arbitrary writes
+under a different tool name.
 
 All other targets are denied — the agent never sees a user prompt for a write
 this guard does not recognise.
@@ -101,7 +104,7 @@ _CLAUDE_PROJECT_DIR_NORMALIZE = re.compile(r"[^A-Za-z0-9-]")
 #: guard came to cover only half the surface it names.
 _MEMORY_TOOLS = frozenset({"Write", "MultiEdit"})
 
-#: The one tool held to the artifact tree instead.
+#: The one tool held to the agent-data notebook trees instead.
 _NOTEBOOK_TOOL = "NotebookEdit"
 
 #: Every tool this hook has an opinion about. Anything else exits silently.
@@ -118,10 +121,13 @@ _PATH_KEYS = {
     _NOTEBOOK_TOOL: ("notebook_path", "file_path"),
 }
 
-#: Subdirectory of the agent-data root that holds the agent's own outputs.
-#: This is the ``artifacts`` in ``NotebookEdit(<agent_data_root>/artifacts/**)``
-#: as rendered by ``settings.json.j2``.
-_ARTIFACTS_SUBDIR = "artifacts"
+#: Subdirectories of the agent-data root that ``NotebookEdit`` may write into:
+#: ``artifacts`` for the agent's generated output, ``notebooks`` for the tree the
+#: Jupyter panel serves. These are the two subdirectories in the
+#: ``NotebookEdit(<agent_data_root>/artifacts/**)`` and
+#: ``NotebookEdit(<agent_data_root>/notebooks/**)`` allow rules as rendered by
+#: ``settings.json.j2``. The order is the order a refusal lists them in.
+_NOTEBOOK_SUBDIRS = ("artifacts", "notebooks")
 
 # The framework DEFAULT agent-data root, imported rather than spelled out here
 # so the two cannot drift apart. Only the default is imported: a project that
@@ -177,8 +183,8 @@ def agent_data_base_dir(config: dict | None) -> str:
     return str(section.get("base_dir") or _DEFAULT_AGENT_DATA_ROOT)
 
 
-def resolve_artifacts_dirs(hook_input=None) -> list[Path]:
-    """Resolve the artifact directories ``NotebookEdit`` may write into.
+def resolve_agent_data_subdirs(hook_input, subdir) -> list[Path]:
+    """Resolve one agent-data subdirectory under every anchor it can have.
 
     A relative ``agent_data.base_dir`` — the normal case — needs an anchor, and
     under the four-zone layout there are two plausible ones: the repo root that
@@ -191,9 +197,10 @@ def resolve_artifacts_dirs(hook_input=None) -> list[Path]:
 
     Args:
         hook_input: The parsed hook payload, used to locate the project.
+        subdir: The agent-data subdirectory to resolve, e.g. ``artifacts``.
 
     Returns:
-        Resolved ``.../artifacts`` directories, deduplicated, possibly empty.
+        Resolved ``.../<subdir>`` directories, deduplicated, possibly empty.
     """
     base = Path(agent_data_base_dir(load_osprey_config(hook_input))).expanduser()
 
@@ -206,15 +213,35 @@ def resolve_artifacts_dirs(hook_input=None) -> list[Path]:
             if anchor
         ]
 
-    artifacts_dirs = []
+    subdirs = []
     for candidate in candidates:
         try:
-            resolved = (candidate / _ARTIFACTS_SUBDIR).resolve()
+            resolved = (candidate / subdir).resolve()
         except (OSError, ValueError):
             continue
-        if resolved not in artifacts_dirs:
-            artifacts_dirs.append(resolved)
-    return artifacts_dirs
+        if resolved not in subdirs:
+            subdirs.append(resolved)
+    return subdirs
+
+
+def resolve_notebook_dirs(hook_input=None) -> list[Path]:
+    """Resolve every directory ``NotebookEdit`` may write into.
+
+    The union of :data:`_NOTEBOOK_SUBDIRS` over every anchor, in declaration
+    order, so a refusal lists the artifacts tree before the notebooks tree.
+
+    Args:
+        hook_input: The parsed hook payload, used to locate the project.
+
+    Returns:
+        Resolved directories, deduplicated, possibly empty.
+    """
+    notebook_dirs: list[Path] = []
+    for subdir in _NOTEBOOK_SUBDIRS:
+        for resolved in resolve_agent_data_subdirs(hook_input, subdir):
+            if resolved not in notebook_dirs:
+                notebook_dirs.append(resolved)
+    return notebook_dirs
 
 
 def is_allowed_memory_write(file_path: str, memory_dir: Path) -> bool:
@@ -243,16 +270,17 @@ def is_allowed_memory_write(file_path: str, memory_dir: Path) -> bool:
     return True
 
 
-def is_allowed_notebook_edit(notebook_path: str, artifacts_dirs: list[Path]) -> bool:
-    """Check whether a notebook path sits inside one of the artifact directories.
+def is_allowed_notebook_edit(notebook_path: str, allowed_dirs: list[Path]) -> bool:
+    """Check whether a notebook path sits inside one of the allowed directories.
 
-    Recursive, unlike the memory rule: the rendered allow is
-    ``<agent_data_root>/artifacts/**``, and the artifact tree is nested by
-    design. The directory itself is not a writable target.
+    Recursive, unlike the memory rule: the rendered allows are
+    ``<agent_data_root>/artifacts/**`` and ``<agent_data_root>/notebooks/**``,
+    and both trees are nested by design. A directory itself is not a writable
+    target.
 
     Args:
         notebook_path: The path the tool call named, unmodified.
-        artifacts_dirs: Resolved directories from :func:`resolve_artifacts_dirs`.
+        allowed_dirs: Resolved directories from :func:`resolve_notebook_dirs`.
 
     Returns:
         ``True`` when the path resolves to something strictly inside one of them.
@@ -266,12 +294,12 @@ def is_allowed_notebook_edit(notebook_path: str, artifacts_dirs: list[Path]) -> 
     if ".." in notebook_path:
         return False
 
-    for artifacts_dir in artifacts_dirs:
+    for allowed_dir in allowed_dirs:
         try:
-            target.relative_to(artifacts_dir)
+            target.relative_to(allowed_dir)
         except ValueError:
             continue
-        if target != artifacts_dir:
+        if target != allowed_dir:
             return True
 
     return False
@@ -351,15 +379,13 @@ def main():
         sys.exit(0)
 
     if tool_name == _NOTEBOOK_TOOL:
-        artifacts_dirs = resolve_artifacts_dirs(hook_input)
-        allowed = is_allowed_notebook_edit(target_path, artifacts_dirs)
-        listed = "\n".join(f"  {d}/" for d in artifacts_dirs) or "  (none resolved)"
+        notebook_dirs = resolve_notebook_dirs(hook_input)
+        allowed = is_allowed_notebook_edit(target_path, notebook_dirs)
+        listed = "\n".join(f"  {d}/" for d in notebook_dirs) or "  (none resolved)"
         reason = (
             f"{_denied_header(tool_name)}\n\n"
-            "Notebook edits are restricted to the agent-data artifacts tree.\n"
-            f"Allowed directories:\n{listed}\n\n"
-            "Write notebooks through the workspace tools so they land in the "
-            "artifact gallery."
+            "Notebook edits are restricted to the agent-data artifacts and notebooks trees.\n"
+            f"Allowed directories:\n{listed}"
         )
     else:
         project_dir = get_project_dir(hook_input) or os.getcwd()

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_notebook_update.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_notebook_update.py
@@ -2,7 +2,7 @@
 """
 ---
 name: Notebook Update
-description: Invalidates the cached notebook HTML after NotebookEdit and badges the NOTEBOOKS panel when the edit lands in the notebooks tree
+description: Invalidates the cached notebook HTML after NotebookEdit and badges the JUPYTER panel when the edit lands in the notebooks tree
 summary: Tracks notebook edits as workspace artifacts and shows the operator which notebook the agent edited
 event: PostToolUse
 tools: NotebookEdit
@@ -54,8 +54,8 @@ operator should see: the hook reports it to the web terminal as
 ``POST /api/agent-activity`` with
 ``{"tool": "NotebookEdit", "target": {"kind": "panel", "panel": "jupyter",
 "detail": "<path relative to notebooks/>"}}``, which the frontend turns into a
-glow and a badge on the NOTEBOOKS rail entry. Only that tree emits — an edit
-under ``artifacts/`` belongs to the gallery, and badging NOTEBOOKS for it would
+glow and a badge on the JUPYTER rail entry. Only that tree emits — an edit
+under ``artifacts/`` belongs to the gallery, and badging JUPYTER for it would
 point the operator at the wrong panel.
 
 ## Notebooks tree
@@ -157,7 +157,7 @@ def _agent_data_base_dir(config):
 
 
 def resolve_notebooks_dirs(hook_input=None):
-    """Resolve the notebook directories whose edits badge the NOTEBOOKS panel.
+    """Resolve the notebook directories whose edits badge the JUPYTER panel.
 
     A relative ``agent_data.base_dir`` — the normal case — needs an anchor, and
     under the four-zone layout there are two plausible ones: the repo root that
@@ -255,7 +255,7 @@ def _activity_request(detail):
 
 
 def notify_notebook_edit(detail):
-    """Badge the NOTEBOOKS panel with the notebook the agent just edited.
+    """Badge the JUPYTER panel with the notebook the agent just edited.
 
     Fire-and-forget: an unreachable, refusing or slow web terminal costs the
     operator a badge and nothing else.
@@ -295,7 +295,7 @@ def main():
     except Exception:
         pass  # Never block on cache invalidation failure
 
-    # Badge the NOTEBOOKS panel, but only for the agent's own notebooks tree.
+    # Badge the JUPYTER panel, but only for the agent's own notebooks tree.
     try:
         detail = notebook_relpath(notebook_path, resolve_notebooks_dirs(hook_input))
         if detail:

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_notebook_update.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_notebook_update.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
 ---
-name: Notebook Cache Invalidation
-description: Invalidates cached notebook HTML after NotebookEdit so the gallery re-renders
-summary: Tracks notebook edits as workspace artifacts
+name: Notebook Update
+description: Invalidates the cached notebook HTML after NotebookEdit and badges the NOTEBOOKS panel when the edit lands in the notebooks tree
+summary: Tracks notebook edits as workspace artifacts and shows the operator which notebook the agent edited
 event: PostToolUse
 tools: NotebookEdit
 safety_layer: 99
@@ -25,13 +25,16 @@ stdin ──► Parse JSON
          Locate _notebook_cache/
          {stem}_rendered.html
               │
+              ├──► exists? ──YES──► Delete cached HTML
+              │
               ▼
-         Cached file exists? ──NO──► EXIT
+         Under <agent-data root>/notebooks/? ──NO──► EXIT
               │
              YES
               │
               ▼
-         Delete cached HTML
+         POST /api/agent-activity
+         (1 s, fail-open)
               │
               ▼
          EXIT
@@ -39,17 +42,228 @@ stdin ──► Parse JSON
 
 ## Details
 
-Lightweight utility hook with no safety implications. When Claude edits a
-notebook via `NotebookEdit`, the gallery's cached HTML rendering becomes
-stale. This hook deletes it so the next gallery view triggers a fresh render.
+Lightweight utility hook with no safety implications, doing two things after
+the agent edits a notebook.
+
+**Cache invalidation.** The gallery's cached HTML rendering goes stale the
+moment the notebook changes, so this hook deletes it and the next gallery view
+triggers a fresh render.
+
+**Panel badge.** An edit inside the agent's own notebooks tree is something the
+operator should see: the hook reports it to the web terminal as
+``POST /api/agent-activity`` with
+``{"tool": "NotebookEdit", "target": {"kind": "panel", "panel": "jupyter",
+"detail": "<path relative to notebooks/>"}}``, which the frontend turns into a
+glow and a badge on the NOTEBOOKS rail entry. Only that tree emits — an edit
+under ``artifacts/`` belongs to the gallery, and badging NOTEBOOKS for it would
+point the operator at the wrong panel.
+
+## Notebooks tree
+
+The tree is ``<agent-data root>/notebooks/``, resolved exactly the way
+``osprey_memory_guard.py`` resolves the sibling trees it gates: the
+``agent_data.base_dir`` config key, anchored — when it is relative, the normal
+case — on both the repo root that owns durable agent state and the render
+Claude Code runs in, which coincide in a flat layout and diverge in a zoned
+one. The two hooks must agree on the answer, or an edit the guard allowed would
+badge nothing. The resolution is restated here rather than imported: these are
+standalone scripts copied into a deployment, and a badge has no business
+importing a write gate.
+
+## Terminal-API authorization
+
+The POST carries ``Authorization: Bearer <OSPREY_PANEL_TOKEN>`` whenever that
+variable holds a non-blank value in the environment the hook inherits — the web
+terminal exports it into the agent it launches. When it is unset, empty or
+whitespace-only the header is omitted entirely rather than sent blank, matching
+how the server-side ``mcp_server.http._panel_auth_headers`` reads the same
+carrier.
+
+Everything about the emit is fail-open and bounded at a second: a terminal that
+is down, refuses the call, or rejects the payload costs the operator a badge,
+never the tool call.
+
+stdlib-only — the sibling ``osprey_hook_log`` aside, this file must NOT import
+osprey, yaml, requests, or any third-party lib. That contract is why the web
+terminal's port is written out here rather than looked up: ``osprey.port_layout``
+is where every framework port lives, and this file may not import it. The
+literal is the ``web`` slot at the layout's default base — what
+``default_port('web', 0)`` returns — and it is a *fallback*, reached only when
+``OSPREY_WEB_PORT`` is unset. A deployment that moved its block exports the
+variable, so the literal is never what such a deployment dials. It carries the
+``osprey:not-a-port`` marker so the retired-number lint reads it as the stated
+exception it is; move it if the layout's ``web`` offset or default base ever
+moves.
 """
 
+import json
 import os
 import sys
+import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from osprey_hook_log import get_hook_input, log_hook
+from osprey_hook_log import (
+    get_hook_input,
+    get_project_dir,
+    get_repo_root,
+    load_osprey_config,
+    log_hook,
+)
+
+#: Subdirectory of the agent-data root that holds the agent's notebooks. This
+#: is the ``notebooks`` in ``NotebookEdit(<agent_data_root>/notebooks/**)`` as
+#: rendered by ``settings.json.j2`` and gated by ``osprey_memory_guard.py``.
+_NOTEBOOKS_SUBDIR = "notebooks"
+
+# The framework DEFAULT agent-data root, imported rather than spelled out here
+# so the two cannot drift apart. Only the default is imported: a project that
+# overrides ``agent_data.base_dir`` is honoured through the config read in
+# :func:`_agent_data_base_dir` below. The literal fallback covers a hook running
+# with osprey off the path, the one case where guessing beats crashing.
+try:
+    from osprey.utils.workspace import DEFAULT_AGENT_DATA_BASE_DIR as _DEFAULT_AGENT_DATA_ROOT
+except Exception:  # pragma: no cover - hooks must never crash the agent
+    _DEFAULT_AGENT_DATA_ROOT = "var/agent_data"
+
+#: The panel the badge lands on, and the tool the frame reports. The panel id
+#: is the one ``jupyter`` panel the web terminal registers.
+_ACTIVITY_PANEL = "jupyter"
+_ACTIVITY_TOOL = "NotebookEdit"
+
+#: Seconds the emit may spend. The hook's own budget is five, and the operator
+#: is waiting on the tool call behind it.
+_ACTIVITY_TIMEOUT = 1
+
+#: The web terminal's port when ``OSPREY_WEB_PORT`` names none. Written out
+#: rather than looked up because this file may not import osprey; the module
+#: docstring states the contract and why the literal is the honest fallback.
+_DEFAULT_WEB_PORT = "10100"  # osprey:not-a-port — stdlib-only hook contract (see module docstring); equals default_port('web', 0)
+
+
+def _agent_data_base_dir(config):
+    """Read ``agent_data.base_dir`` out of an already-loaded config mapping.
+
+    Args:
+        config: Loaded ``config.yml`` mapping, or ``None``.
+
+    Returns:
+        The configured base directory, possibly relative to a project anchor.
+    """
+    section = (config or {}).get("agent_data") or {}
+    if not isinstance(section, dict):
+        return _DEFAULT_AGENT_DATA_ROOT
+    return str(section.get("base_dir") or _DEFAULT_AGENT_DATA_ROOT)
+
+
+def resolve_notebooks_dirs(hook_input=None):
+    """Resolve the notebook directories whose edits badge the NOTEBOOKS panel.
+
+    A relative ``agent_data.base_dir`` — the normal case — needs an anchor, and
+    under the four-zone layout there are two plausible ones: the repo root that
+    owns durable agent state and the render Claude Code actually runs in. They
+    coincide in a flat layout and diverge in a zoned one, so both are accepted.
+    An absolute ``base_dir`` needs no anchor and yields exactly one directory.
+
+    Args:
+        hook_input: The parsed hook payload, used to locate the project.
+
+    Returns:
+        Resolved ``.../notebooks`` directories, deduplicated, possibly empty.
+    """
+    base = Path(_agent_data_base_dir(load_osprey_config(hook_input))).expanduser()
+
+    if base.is_absolute():
+        candidates = [base]
+    else:
+        candidates = [
+            Path(anchor).expanduser() / base
+            for anchor in (get_repo_root(hook_input), get_project_dir(hook_input))
+            if anchor
+        ]
+
+    notebooks_dirs = []
+    for candidate in candidates:
+        try:
+            resolved = (candidate / _NOTEBOOKS_SUBDIR).resolve()
+        except (OSError, ValueError):
+            continue
+        if resolved not in notebooks_dirs:
+            notebooks_dirs.append(resolved)
+    return notebooks_dirs
+
+
+def notebook_relpath(notebook_path, notebooks_dirs):
+    """Return the edited notebook's path relative to its notebooks root.
+
+    Args:
+        notebook_path: The path the tool call named, unmodified.
+        notebooks_dirs: Resolved roots from :func:`resolve_notebooks_dirs`.
+
+    Returns:
+        A POSIX-style relative path when the edit landed strictly inside one of
+        the roots, else None — which is the whole test for whether this edit
+        badges anything. Traversal components are rejected on the raw input for
+        the same reason ``osprey_memory_guard.py`` rejects them: a path the
+        guard would have refused must not be reported as one the agent edited.
+    """
+    if ".." in notebook_path:
+        return None
+
+    try:
+        target = Path(notebook_path).expanduser().resolve()
+    except (OSError, ValueError):
+        return None
+
+    for notebooks_dir in notebooks_dirs:
+        try:
+            relative = target.relative_to(notebooks_dir)
+        except ValueError:
+            continue
+        if target != notebooks_dir:
+            return relative.as_posix()
+
+    return None
+
+
+def _activity_request(detail):
+    """Build the ``POST /api/agent-activity`` request carrying *detail*.
+
+    The body is the route's fixed contract; the bearer is sent only when
+    ``OSPREY_PANEL_TOKEN`` holds a non-blank value, because a blank one would
+    be a credential claim this hook cannot back.
+    """
+    payload = json.dumps(
+        {
+            "tool": _ACTIVITY_TOOL,
+            "target": {"kind": "panel", "panel": _ACTIVITY_PANEL, "detail": detail},
+        }
+    ).encode()
+
+    headers = {"Content-Type": "application/json"}
+    token = (os.environ.get("OSPREY_PANEL_TOKEN") or "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    port = os.environ.get("OSPREY_WEB_PORT", _DEFAULT_WEB_PORT)
+    return urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/agent-activity",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+
+
+def notify_notebook_edit(detail):
+    """Badge the NOTEBOOKS panel with the notebook the agent just edited.
+
+    Fire-and-forget: an unreachable, refusing or slow web terminal costs the
+    operator a badge and nothing else.
+    """
+    try:
+        urllib.request.urlopen(_activity_request(detail), timeout=_ACTIVITY_TIMEOUT).close()
+    except Exception:
+        pass
 
 
 def main():
@@ -80,6 +294,14 @@ def main():
             )
     except Exception:
         pass  # Never block on cache invalidation failure
+
+    # Badge the NOTEBOOKS panel, but only for the agent's own notebooks tree.
+    try:
+        detail = notebook_relpath(notebook_path, resolve_notebooks_dirs(hook_input))
+        if detail:
+            notify_notebook_edit(detail)
+    except Exception:
+        pass  # Never block on a badge
 
     sys.exit(0)
 

--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -74,6 +74,7 @@
 {%- endfor -%}
 {%- endfor -%}
 {%- set _ = allow_entries.append('"NotebookEdit(' ~ agent_data_root ~ '/artifacts/**)"') -%}
+{%- set _ = allow_entries.append('"NotebookEdit(' ~ agent_data_root ~ '/notebooks/**)"') -%}
 {#- Per-agent Task() permissions -#}
 {%- for a in agents if a.enabled -%}
 {%- set _ = allow_entries.append('"Task(' ~ a.name ~ ')"') -%}

--- a/tests/cli/test_build_profile_panels.py
+++ b/tests/cli/test_build_profile_panels.py
@@ -237,3 +237,24 @@ def test_nothing_to_judge_warns_nothing(config) -> None:
     """Shape problems are the server loader's to report; this only speaks to a
     readable entry naming a gated item."""
     assert bar_items_selection_warnings(config, []) == []
+
+
+# ---------------------------------------------------------------------------
+# artifact_menu_catalog — what the build interview offers
+# ---------------------------------------------------------------------------
+
+
+def test_every_offered_panel_carries_a_description() -> None:
+    """An entry with an empty description is a menu line the reader cannot judge.
+
+    Descriptions came from the companion-server registry alone, so a panel
+    served any other way — a sidecar the web terminal starts itself — was
+    offered as a bare id with a trailing blank comment.
+    """
+    from osprey.cli.build_profile_emit import artifact_menu_catalog
+    from osprey.profiles.web_panels import BUILTIN_PANELS, UNIVERSAL_PANELS
+
+    entries = artifact_menu_catalog()["web_panels"]
+
+    assert {name for name, _ in entries} == BUILTIN_PANELS - UNIVERSAL_PANELS
+    assert [name for name, description in entries if not description] == []

--- a/tests/cli/test_hello_world_tutorial.py
+++ b/tests/cli/test_hello_world_tutorial.py
@@ -183,7 +183,7 @@ class TestHelloWorldBuildOutput:
         # hand-edited config.yml never silently runs stale settings (#244).
         assert (hooks_dir / "osprey_config_drift.py").exists()
         # memory-guard gates Write/MultiEdit to Claude memory files and
-        # NotebookEdit to the agent-data artifacts tree.
+        # NotebookEdit to the agent-data artifacts and notebooks trees.
         assert (hooks_dir / "osprey_memory_guard.py").exists()
 
 

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -503,7 +503,7 @@ class TestControlAssistantWebTier:
         assert "ariel" in base.web_panels
 
     def test_notebook_tab_is_a_family_wide_default(self) -> None:
-        """The NOTEBOOKS tab is declared once, in the base, and every tier gets it.
+        """The JUPYTER tab is declared once, in the base, and every tier gets it.
 
         Both groups are derived from the bundled presets on disk rather than
         listed here, so a tier added later is covered without editing this

--- a/tests/cli/test_persona_presets.py
+++ b/tests/cli/test_persona_presets.py
@@ -56,6 +56,7 @@ import pytest
 import yaml
 
 from osprey.cli.build_profile import BuildProfile, list_presets, resolve_build_profile
+from osprey.cli.build_profile_presets import _presets_dir
 from osprey.deployment.qmd_service import DEFAULT_PORT as QMD_DEFAULT_PORT
 from osprey.deployment.qmd_service import resolve_qmd_service_config
 from osprey.deployment.web_terminals.lint import Finding, lint_web_terminals
@@ -500,6 +501,39 @@ class TestControlAssistantWebTier:
         base = resolve_preset("control-assistant")
         assert "channel-finder" in base.web_panels
         assert "ariel" in base.web_panels
+
+    def test_notebook_tab_is_a_family_wide_default(self) -> None:
+        """The NOTEBOOKS tab is declared once, in the base, and every tier gets it.
+
+        Both groups are derived from the bundled presets on disk rather than
+        listed here, so a tier added later is covered without editing this
+        test: it fails if the tab is declared per tier instead of inherited,
+        and it fails if a tier subtracts it through ``exclude:``.
+
+        The standalone presets are the control group. They extend nothing and
+        run no terminal session for a kernel to follow, so the tab must not
+        reach them.
+        """
+        parents = {
+            name: yaml.safe_load((_presets_dir() / f"{name}.yml").read_text(encoding="utf-8")).get(
+                "extends"
+            )
+            for name in list_presets()
+        }
+        tiers = sorted(name for name, parent in parents.items() if parent == "control-assistant")
+        standalone = sorted(
+            name
+            for name, parent in parents.items()
+            if parent is None and name != "control-assistant"
+        )
+        assert tiers, "no bundled preset extends control-assistant"
+        assert standalone == ["ariel-standalone", "channel-finder-standalone", "hello-world"]
+
+        assert "jupyter" in resolve_preset("control-assistant").web_panels
+        for name in tiers:
+            assert "jupyter" in resolve_preset(name).web_panels, name
+        for name in standalone:
+            assert "jupyter" not in resolve_preset(name).web_panels, name
 
     def test_derived_web_container_names_are_valid_docker_names(self, tmp_path: Path) -> None:
         """The container names derived from the rendered prefix —

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -201,7 +201,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # already-deployed control-assistant projects is the correct signal.
     # Moved once more, and all seven control-assistant entries together, when
     # the base preset gained the `jupyter` web panel: a rebuilt project's
-    # terminals grow a NOTEBOOKS tab running JupyterLab, with kernels that
+    # terminals grow a JUPYTER tab running JupyterLab, with kernels that
     # follow the terminal session. Deploy-visible — the rebuilt deployment
     # serves one more panel — so the staleness advisory firing on
     # already-deployed control-assistant projects is the correct signal. The
@@ -220,7 +220,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
-    # Moved with the base above: the NOTEBOOKS tab.
+    # Moved with the base above: the JUPYTER tab.
     "control-assistant-admin": (
         "sha256:184f6c4f1a377f29007d713aabc3bb24aa7ddda79d48d24b2459d3594d944442"
     ),
@@ -231,7 +231,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
-    # Moved with the base above: the NOTEBOOKS tab.
+    # Moved with the base above: the JUPYTER tab.
     "control-assistant-logbook": (
         "sha256:aaf0d35ccf2d2c3219d196e2888fcea36450489d197d2412c714197aa6cb82b5"
     ),
@@ -241,7 +241,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # writes pinned off on all three keys, and the one bundle-writing tool
     # (`draft_concept`) denied.
     # Moved with the base above: the plan queue comes up armed.
-    # Moved with the base above: the NOTEBOOKS tab.
+    # Moved with the base above: the JUPYTER tab.
     "control-assistant-knowledge": (
         "sha256:0777311b1d4e018fcb27a8d3c178c7591ef3cee4c94bece650dbb673b78ad96a"
     ),
@@ -306,7 +306,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
-    # Moved with the base above: the NOTEBOOKS tab.
+    # Moved with the base above: the JUPYTER tab.
     "control-assistant-readonly": (
         "sha256:cfeb9f033ceab1ebf1c9353b681512370ecb89494463738861ace01ab58db36a"
     ),
@@ -316,7 +316,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
-    # Moved with the base above: the NOTEBOOKS tab.
+    # Moved with the base above: the JUPYTER tab.
     "control-assistant-readwrite": (
         "sha256:32ccac3d13793f322596f51a440b6e9ce1f93ef3469c35ed4a763f70a334ce40"
     ),
@@ -332,7 +332,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
-    # Moved with the base above: the NOTEBOOKS tab.
+    # Moved with the base above: the JUPYTER tab.
     "control-assistant-va-readwrite": (
         "sha256:161d353e06f81965954d1d3c56f98053460ff9af02e1b2519e9f1758690237f9"
     ),

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -199,7 +199,15 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # separate Start. Deploy-visible on the bridge: a rebuilt project's queue
     # starts in the armed posture, so the staleness advisory firing on
     # already-deployed control-assistant projects is the correct signal.
-    "control-assistant": "sha256:f20e0a2a42d1f0fd054505c1e5a35d4c9afb6acc33aa3e399ccdeef008264ef1",
+    # Moved once more, and all seven control-assistant entries together, when
+    # the base preset gained the `jupyter` web panel: a rebuilt project's
+    # terminals grow a NOTEBOOKS tab running JupyterLab, with kernels that
+    # follow the terminal session. Deploy-visible — the rebuilt deployment
+    # serves one more panel — so the staleness advisory firing on
+    # already-deployed control-assistant projects is the correct signal. The
+    # three standalone digests are unchanged, which is the check that the tab
+    # reached the control-assistant family and nothing else.
+    "control-assistant": "sha256:56c00c4b3c1792fc62aa8df77482da07e6b7cfcb530a811c5ff1affae0f3e511",
     # Moved with the base above: `live_standin` baseline + strict limits pair.
     # Moved again with the base: permissive `virtual_accelerator` limits block.
     # Moved alone when the admin tier gained the EVENTS/BLUESKY `web_panels`
@@ -212,8 +220,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
+    # Moved with the base above: the NOTEBOOKS tab.
     "control-assistant-admin": (
-        "sha256:c087379741bf8a14679cb6b46973d3e7e37e2208e99970ca38942decd65949fa"
+        "sha256:184f6c4f1a377f29007d713aabc3bb24aa7ddda79d48d24b2459d3594d944442"
     ),
     # Moved with the base above: `live_standin` baseline + strict limits pair.
     # Moved again with the base: permissive `virtual_accelerator` limits block.
@@ -222,8 +231,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
+    # Moved with the base above: the NOTEBOOKS tab.
     "control-assistant-logbook": (
-        "sha256:0190871b889dccba18826481961c4078b2c1ad5f510e1ea7c324f08d67660124"
+        "sha256:aaf0d35ccf2d2c3219d196e2888fcea36450489d197d2412c714197aa6cb82b5"
     ),
     # New: the second standalone persona. The facility knowledge graph, the
     # graph-mode channel finder and the knowledge bundle behind one shared
@@ -231,8 +241,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # writes pinned off on all three keys, and the one bundle-writing tool
     # (`draft_concept`) denied.
     # Moved with the base above: the plan queue comes up armed.
+    # Moved with the base above: the NOTEBOOKS tab.
     "control-assistant-knowledge": (
-        "sha256:661b1cce7930685b27c5414bce56be95e059ef40fb4390d16da58de43ce2b873"
+        "sha256:0777311b1d4e018fcb27a8d3c178c7591ef3cee4c94bece650dbb673b78ad96a"
     ),
     # The two operator tiers below moved together, and alone, when each gained
     # the single dotted key `services.graphdb.port_host: 7687` in its `config:`
@@ -295,8 +306,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
+    # Moved with the base above: the NOTEBOOKS tab.
     "control-assistant-readonly": (
-        "sha256:2976482d462ba979595e9cf495ac8cc36c124377af0880a84f12b5938861e603"
+        "sha256:cfeb9f033ceab1ebf1c9353b681512370ecb89494463738861ace01ab58db36a"
     ),
     # Moved with the base above: `live_standin` baseline + strict limits pair.
     # Moved again with the base: permissive `virtual_accelerator` limits block.
@@ -304,8 +316,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
+    # Moved with the base above: the NOTEBOOKS tab.
     "control-assistant-readwrite": (
-        "sha256:ba4d533bfabcc7696eff52b0c58196406bd1719c75af57287abacfa8096c5fad"
+        "sha256:32ccac3d13793f322596f51a440b6e9ce1f93ef3469c35ed4a763f70a334ce40"
     ),
     # New with per-target write posture, not a moved entry: the rung between
     # the two flat tiers, armed on the virtual accelerator alone. It pins the
@@ -319,15 +332,17 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: graph channel finder.
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
+    # Moved with the base above: the NOTEBOOKS tab.
     "control-assistant-va-readwrite": (
-        "sha256:969539a57fc48ce9610d36c635f9de9c1b162659d759daa898f1da9d9e237a20"
+        "sha256:161d353e06f81965954d1d3c56f98053460ff9af02e1b2519e9f1758690237f9"
     ),
     # Moved when the onboarding rewrite dropped the `facility` rule. The
     # wholesale comment rewrite that shipped alongside it contributed nothing:
     # the digest is comment-blind, so the rule drop is the entire delta.
     # Moved again when the preset gained the `memory-guard` hook entry, so a
     # rebuilt project's PreToolUse chain now also gates Write/MultiEdit to
-    # Claude memory files and NotebookEdit to the agent-data artifacts tree.
+    # Claude memory files and NotebookEdit to the agent-data artifacts and
+    # notebooks trees.
     # The comment-only fixes that shipped alongside it (correcting the
     # mislabelled memory-guard/writes-check comments in the other presets)
     # contributed nothing to any digest, including this one.

--- a/tests/cli/test_profile_card.py
+++ b/tests/cli/test_profile_card.py
@@ -188,8 +188,11 @@ def test_the_panels_row_is_the_union_across_personas(exemplar_lines: list[str]) 
     # EVENTS and BLUESKY are declared by the readwrite persona, not the host
     # profile; a card that read only the host would miss them. Their labels
     # come from `web.panels.<id>.label` — they are not built-ins.
+    # The order is declaration order: the host profile's `web_panels` first, in
+    # the order it lists them, then whatever the persona deltas add. NOTEBOOKS
+    # follows SYSTEM because the profile lists `jupyter` after `system-health`.
     panels = line_with(exemplar_lines, "panels")
-    assert "ARIEL · CHANNELS · KNOWLEDGE · SYSTEM · EVENTS · BLUESKY" in panels
+    assert "ARIEL · CHANNELS · KNOWLEDGE · SYSTEM · NOTEBOOKS · EVENTS · BLUESKY" in panels
 
 
 def test_the_agent_group_names_servers_and_counts_its_toolkit(

--- a/tests/cli/test_profile_card.py
+++ b/tests/cli/test_profile_card.py
@@ -189,10 +189,10 @@ def test_the_panels_row_is_the_union_across_personas(exemplar_lines: list[str]) 
     # profile; a card that read only the host would miss them. Their labels
     # come from `web.panels.<id>.label` — they are not built-ins.
     # The order is declaration order: the host profile's `web_panels` first, in
-    # the order it lists them, then whatever the persona deltas add. NOTEBOOKS
+    # the order it lists them, then whatever the persona deltas add. JUPYTER
     # follows SYSTEM because the profile lists `jupyter` after `system-health`.
     panels = line_with(exemplar_lines, "panels")
-    assert "ARIEL · CHANNELS · KNOWLEDGE · SYSTEM · NOTEBOOKS · EVENTS · BLUESKY" in panels
+    assert "ARIEL · CHANNELS · KNOWLEDGE · SYSTEM · JUPYTER · EVENTS · BLUESKY" in panels
 
 
 def test_the_agent_group_names_servers_and_counts_its_toolkit(

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -741,14 +741,20 @@ class TestPreflightCompanionPortCollision:
         its own key → id table, and that table had already lost the gallery's
         `artifacts` entry; reading `WebServerDefinition.panel_id` means every
         registered server is covered by construction.
+
+        Sidecar panels bind no port of their own — the terminal starts them on
+        an ephemeral loopback port — so pre-flight has nothing to check for
+        them and they are the one part of `BUILTIN_PANELS` it does not cover.
         """
         import inspect
 
         from osprey.cli import web_cmd
-        from osprey.profiles.web_panels import BUILTIN_PANELS
+        from osprey.profiles.web_panels import BUILTIN_PANELS, SIDECAR_PANELS
         from osprey.registry.web import FRAMEWORK_WEB_SERVERS
 
-        assert {defn.panel_id for defn in FRAMEWORK_WEB_SERVERS.values()} == BUILTIN_PANELS
+        assert {defn.panel_id for defn in FRAMEWORK_WEB_SERVERS.values()} | set(
+            SIDECAR_PANELS
+        ) == BUILTIN_PANELS
         assert "_PANEL_ID_FOR_REGISTRY_KEY" not in inspect.getsource(web_cmd)
 
 

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -519,6 +519,72 @@ def _worker_mcp_surface() -> str:
     )
 
 
+#: Upper bound on each captured blob in a failure message, so a verbose run
+#: record or a chatty worker cannot bury the assertion it is attached to.
+_EVIDENCE_CAP = 6000
+
+
+def _docker_capture(argv: list[str]) -> str:
+    """Run one ``docker`` command and return its trimmed output, never raising.
+
+    Every helper here runs in a failing assertion's message, where an exception
+    would replace the failure it was meant to explain.
+    """
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"(could not run {' '.join(argv[:3])}: {exc})"
+    out = ((proc.stdout or "") + (proc.stderr or "")).strip() or "(no output)"
+    if len(out) > _EVIDENCE_CAP:
+        out = out[-_EVIDENCE_CAP:]
+        out = f"...(truncated to the last {_EVIDENCE_CAP} chars)\n{out}"
+    return out
+
+
+def _worker_run_evidence(run: dict | None) -> str:
+    """Return what the worker itself recorded about the ``save-report`` run.
+
+    The ``.mcp.json`` probe above says whether the save tool *could* have
+    existed; it cannot say whether the agent saw it or what the run did instead.
+    Both are on the worker: the run feed carries the tool count and the agent's
+    final text, the persisted record at ``<agent_data>/dispatch/<run_id>.json``
+    carries every tool call, and the container log says which MCP servers were
+    ready before the first turn. The stack is torn down before any CI diagnostics
+    step runs, so a failure that does not carry these here loses them for good.
+    """
+    lines = ["=== save-report run evidence ==="]
+    if run is None:
+        lines.append("run feed: no save-report run in the feed")
+        return "\n".join(lines)
+    feed = {
+        key: run.get(key)
+        for key in ("run_id", "status", "tool_count", "num_turns", "duration_sec", "error")
+    }
+    lines.append(f"run feed: {feed}")
+    text = (run.get("text_output") or "").strip()
+    if text:
+        lines.append(f"agent text_output:\n{text[:_EVIDENCE_CAP]}")
+    run_id = run.get("run_id")
+    if run_id:
+        record = _docker_capture(
+            [
+                "docker",
+                "exec",
+                WORKER_CONTAINER,
+                "cat",
+                f"{WORKER_AGENT_DATA}/dispatch/{run_id}.json",
+            ]
+        )
+        lines.append(f"--- persisted run record ({run_id}.json) ---\n{record}")
+    listing = _docker_capture(
+        ["docker", "exec", WORKER_CONTAINER, "ls", "-la", f"{WORKER_AGENT_DATA}/artifacts"]
+    )
+    lines.append(f"--- {WORKER_AGENT_DATA}/artifacts ---\n{listing}")
+    log_tail = _docker_capture(["docker", "logs", "--tail", "150", WORKER_CONTAINER])
+    lines.append(f"--- {WORKER_CONTAINER} (last 150 log lines) ---\n{log_tail}")
+    return "\n".join(lines)
+
+
 def _runs_by_trigger() -> dict[str, dict]:
     """Snapshot the dispatcher run feed keyed by trigger_name (latest wins).
 
@@ -604,7 +670,8 @@ def test_full_stack_dispatch(deployed_stack: Path) -> None:
     artifacts = _worker_artifact_files()
     assert artifacts, (
         "save-report completed but no .md artifact was persisted to the worker "
-        f"workspace.\n{_worker_mcp_surface()}"
+        f"workspace.\n{_worker_mcp_surface()}\n"
+        f"{_worker_run_evidence(by_trigger.get('save-report'))}"
     )
 
     # The denylisted trigger is rejected at the worker /dispatch endpoint BEFORE

--- a/tests/e2e/test_jupyter_panel_lifecycle.py
+++ b/tests/e2e/test_jupyter_panel_lifecycle.py
@@ -542,18 +542,41 @@ def _run_cell(socket: Any, code: str, session_id: str) -> CellResult:
         socket.send(json.dumps(request))
     except ConnectionClosed as exc:
         # The proxy closes the browser side normally whatever happened upstream,
-        # so the close alone says nothing about why. The terminal's log holds
-        # the proxy's own account of it and the sidecar's stderr behind that.
+        # so the close alone says nothing about why. The terminal's log carries
+        # the proxy's own account of it. It does NOT carry the kernel's: the
+        # sidecar's stderr is drained into a short in-memory tail that is
+        # printed only when the sidecar itself exits, so a kernel traceback
+        # never reaches this log. Read it for the proxy's side and no further.
         raise AssertionError(
             f"the kernel channel was closed before the cell could be sent: {exc}\n"
             f"{_logs(_web_container())}"
         ) from exc
     result = CellResult("", "", None, "", "")
+    # Every frame this call sees, matched or not. A kernel that dies at start
+    # is restarted by ``jupyter_client``'s restarter and finally declared dead,
+    # and the two frames that say so — ``status: restarting`` and
+    # ``status: dead`` — carry an empty parent header, so the match below drops
+    # them. Dropping them silently is what makes a crash loop and a slow start
+    # look identical from here, which is the whole difficulty of this failure.
+    seen: list[str] = []
     deadline = time.monotonic() + CELL_TIMEOUT_SEC
     while time.monotonic() < deadline:
-        raw = socket.recv(timeout=max(1.0, deadline - time.monotonic()))
+        try:
+            raw = socket.recv(timeout=max(1.0, deadline - time.monotonic()))
+        except TimeoutError as exc:
+            raise AssertionError(
+                f"the kernel channel went quiet within {CELL_TIMEOUT_SEC:.0f} s: {exc}\n"
+                f"frames seen while waiting: {seen or '(none at all)'}"
+            ) from exc
         message = json.loads(raw)
-        if (message.get("parent_header") or {}).get("msg_id") != request["header"]["msg_id"]:
+        parent = (message.get("parent_header") or {}).get("msg_id")
+        state = (message.get("content") or {}).get("execution_state")
+        seen.append(
+            f"{message['header']['msg_type']}"
+            f"{'/' + state if state else ''}"
+            f"{'' if parent == request['header']['msg_id'] else ' (other parent)'}"
+        )
+        if parent != request["header"]["msg_id"]:
             continue
         msg_type = message["header"]["msg_type"]
         content = message.get("content") or {}
@@ -841,13 +864,29 @@ def test_a_target_switch_is_refused_until_the_kernel_restarts(terminal: Terminal
         assert new_records[0]["surface"] == SURFACE
 
         restarted = terminal.post(f"{PANEL}/api/kernels/{terminal.kernel_id}/restart")
+        # A 200 here means a process was spawned, not that it came up: the
+        # handler writes the model without awaiting the future that resolves on
+        # the restarted kernel's ``kernel_info_reply``. Nor does the websocket
+        # handshake below settle it — the server caches the kernel-info future
+        # on the kernel manager and never invalidates it on restart, so a
+        # reconnect resolves instantly against the kernel that just went away.
+        # The REST model is the one reading of kernel liveness that no proxy
+        # and no cache sits in front of, so it is what the failure quotes.
         assert restarted.status_code == 200, restarted.text
         channel_session = uuid.uuid4().hex
-        with terminal.kernel_channels(terminal.kernel_id, channel_session) as socket:
-            followed = _run_ok(
-                socket, 'import os\nprint(os.environ["OSPREY_CONTROL_TARGET"])\n', channel_session
-            )
-            assert followed.strip() == other, followed
+        try:
+            with terminal.kernel_channels(terminal.kernel_id, channel_session) as socket:
+                followed = _run_ok(
+                    socket,
+                    'import os\nprint(os.environ["OSPREY_CONTROL_TARGET"])\n',
+                    channel_session,
+                )
+                assert followed.strip() == other, followed
+        except AssertionError as exc:
+            model = terminal.get(f"{PANEL}/api/kernels/{terminal.kernel_id}")
+            raise AssertionError(
+                f"{exc}\nkernel model after the restart: {model.status_code} {model.text.strip()}"
+            ) from exc
     finally:
         terminal.delete(f"{PANEL}/api/sessions/{terminal.notebook_session_id}")
 

--- a/tests/e2e/test_jupyter_panel_lifecycle.py
+++ b/tests/e2e/test_jupyter_panel_lifecycle.py
@@ -1,0 +1,982 @@
+"""Real-container lifecycle of the NOTEBOOKS panel: a kernel that follows the terminal.
+
+The unit tests pin the kernel launcher's stamps against a synthetic binding,
+and the proxy integration test pins the panel's HTTP and websocket legs against
+a sidecar started by hand. Neither can answer the question this file exists
+for: inside a deployed persona container, with a real terminal session, a real
+controls MCP server and a real control system behind the cells, does a
+notebook kernel read, refuse, follow and survive the way the panel promises?
+
+THE DEPLOYMENT THIS BUILDS
+--------------------------
+One ``osprey up --dev`` of a ``control-assistant`` render, trimmed to one
+roster user (``alice``) on one persona that keeps the preset's write gate armed
+and inherits the preset's panel set — which is what selects the NOTEBOOKS
+panel. The control system is the virtual accelerator, baselined as the ``va``
+target, with the live stand-in deployed beside it as the ``standin`` target: a
+switch needs two targets, and the mock connector cannot be one — its baseline
+is ``live``, which a mock deployment cannot resolve, so a kernel bound to a
+mock session would always run fail-closed and never carry a target stamp.
+
+Everything is reached at the per-user web port directly, carrying the operator
+secret as the header nginx injects in the container shape (``token`` posture
+clears a client-supplied copy at nginx, so the direct port is the one place a
+test can present it). The notebook panel lives behind the terminal's own panel
+proxy (``/panel/jupyter/...``), so every request to the sidecar passes through
+the proxy that re-issues the sidecar's credential.
+
+WHAT IS ASSERTED, IN ORDER
+--------------------------
+The order is load-bearing: the first kernel must start before any terminal
+session exists, and the restart must come last.
+
+1. The starter notebook is listed on first open, and only the ``osprey``
+   kernelspec exists.
+2. A kernel started with NO chat session reads a channel, and refuses a write
+   with the open-a-session line and one audit record.
+3. Attaching a terminal binds the session, and the controls server publishes
+   the session's target.
+4. A kernel started while the session's writes were off reads, and refuses a
+   write with the executor's text plus the turn-writes-on line and exactly one
+   audit record on the ``notebook_kernel`` surface.
+5. After a chip target switch the same kernel's next write raises
+   ``ControlTargetChangedError`` with the restart line; a restarted kernel
+   follows the new target.
+6. ``NotebookEdit`` under ``notebooks/`` is allowed by the rendered settings and
+   the guard hook and badges the panel; outside it is denied.
+7. The sidecar's runtime directory is not under the agent-data root.
+8. Notebooks survive ``osprey down && osprey up``; kernels do not.
+
+CONTAINER-OPS SAFETY: every runtime-mutating call below names an EXACT resource
+this test created — the ``<prefix>-*`` containers, this project's volumes and
+the ``:local`` image tags — or is the project-scoped ``compose down`` the deploy
+lifecycle itself uses. Nothing here ever runs a prune, an ``-a``/``--all``
+sweep, or a wildcard removal. Set ``E2E_REUSE_IMAGES`` to keep the built images
+between runs.
+
+CI: the ``dockerbuild`` marker keeps this module out of the shared ``e2e-tests``
+lane, which ``--ignore``s every marked file. It runs in its own job,
+``jupyter-panel-e2e``, whose result the merge gate reads. It is excluded from
+the model matrix: nothing here contacts a model.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import nbformat
+import pytest
+import yaml
+from websockets.sync.client import connect as ws_connect
+
+from osprey.deployment.web_terminals.auth_credentials import terminal_secret_var
+from osprey.port_layout import PORT_BASE_CONFIG_KEY, default_port
+from osprey.utils.dotenv import parse_dotenv_file
+from tests.e2e._orm_stack import VA_CA_PORT
+from tests.e2e._volumes import remove_project_volumes
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.dockerbuild]
+
+RUNTIME = "docker"
+
+#: The repo DIRECTORY name — the compose project name and the ``com.osprey.project``
+#: label on every image this deploy builds.
+PROJECT_NAME = "osprey-e2e-jnb"
+PREFIX = "jnb"
+PRESET = "control-assistant"
+USER = "alice"
+PERSONA = "operator"
+#: ``osprey build`` renders a persona delta to ``build/<repo>-<persona>``, and
+#: the catalog must name that same project or a start refuses the render.
+PERSONA_PROJECT = f"{PROJECT_NAME}-{PERSONA}"
+PERSONA_IMAGE_TAG = f"{PERSONA_PROJECT}:local"
+#: Service images ``osprey up`` builds per project, exact tags for the teardown.
+SERVICE_IMAGE_TAGS = (f"{PROJECT_NAME}-va:local", f"{PROJECT_NAME}-qmd:local")
+
+#: This module's own thousand-port block; every host port follows it.
+PORT_BASE = 24000
+WEB_PORT = default_port("web", base=PORT_BASE)
+BASE_URL = f"http://127.0.0.1:{WEB_PORT}"
+WS_URL = f"ws://127.0.0.1:{WEB_PORT}"
+#: The origin nginx publishes and every mutating request must name.
+ORIGIN = f"http://127.0.0.1:{default_port('nginx', base=PORT_BASE)}"
+PANEL = "/panel/jupyter"
+KERNELSPEC = "osprey"
+STARTER_NOTEBOOK = "getting-started.ipynb"
+SURVIVOR_NOTEBOOK = "e2e-survives.ipynb"
+
+#: A readback the virtual accelerator always serves.
+CHANNEL = "SR:DIAG:DCCT:01:CURRENT:RB"
+
+#: The three hint lines the kernel prints before a refusal's traceback.
+HINT_NO_SESSION = (
+    "No chat session was open when this kernel started. Open one, then restart the kernel."
+)
+HINT_WRITES_OFF = (
+    "This kernel started with writes off. Turn writes on from the chip, then restart the kernel."
+)
+HINT_TARGET_CHANGED = "The session's control target changed. Restart the kernel to follow it."
+
+#: The audit surface a cell's refusals file under, and the ledger it lands in.
+SURFACE = "notebook_kernel"
+LEDGER = Path("var") / "audit" / USER / f"{SURFACE}.jsonl"
+
+DEPLOY_UP_TIMEOUT_SEC = 2400
+VERB_TIMEOUT_SEC = 180
+RENDER_TIMEOUT_SEC = 600
+READY_TIMEOUT_SEC = 300.0
+#: How long a kernel gets to answer one cell. The first cell imports the
+#: framework runtime, which is the slow one.
+CELL_TIMEOUT_SEC = 240.0
+#: How long the controls server inside a fresh ``claude`` gets to publish.
+SESSION_TARGET_TIMEOUT_SEC = 240.0
+SWITCH_TIMEOUT_SEC = 120.0
+
+_ENV_APPEND = "ANTHROPIC_API_KEY=fake-llm-key-value\nZO_INGEST_SA_TOKEN=fake-telemetry-token\n"
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+# ---------------------------------------------------------------------------
+# Runtime and CLI helpers
+# ---------------------------------------------------------------------------
+
+
+def _runtime_cli(*args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run([RUNTIME, *args], capture_output=True, text=True, timeout=timeout)
+
+
+def _fmt(label: str, result: subprocess.CompletedProcess) -> str:
+    return (
+        f"{label} failed (rc={result.returncode}):\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+def _find_osprey_console_script() -> Path:
+    candidate = Path(sys.executable).parent / "osprey"
+    if candidate.exists():
+        return candidate
+    found = shutil.which("osprey")
+    if found:
+        return Path(found)
+    raise RuntimeError("Could not locate the 'osprey' console script.")
+
+
+def _run_osprey(
+    osprey_bin: Path, args: list[str], cwd: Path, timeout: int = VERB_TIMEOUT_SEC
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(osprey_bin), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "CLAUDECODE": "", "CONTAINER_RUNTIME": RUNTIME},
+    )
+
+
+def _web_container() -> str:
+    return f"{PREFIX}-web-{USER}"
+
+
+def _logs(name: str) -> str:
+    result = _runtime_cli("logs", "--tail", "80", name, timeout=20)
+    return f"--- {name} stdout ---\n{result.stdout}\n--- {name} stderr ---\n{result.stderr}"
+
+
+def _exec(*argv: str, user: str = "1000", cwd: str | None = None, stdin: str | None = None):
+    """Run one command inside the terminal container, as the runtime uid."""
+    args = [RUNTIME, "exec", "-i", "--user", user]
+    if cwd:
+        args += ["-w", cwd]
+    args += [_web_container(), *argv]
+    return subprocess.run(args, input=stdin, capture_output=True, text=True, timeout=60)
+
+
+def _exec_text(*argv: str) -> str:
+    result = _exec(*argv)
+    assert result.returncode == 0, _fmt(f"docker exec {' '.join(argv)}", result)
+    return result.stdout
+
+
+def _process_env(pid: int) -> dict[str, str]:
+    """The environment of *pid* inside the container, read off ``/proc``."""
+    result = subprocess.run(
+        [RUNTIME, "exec", "--user", "1000", _web_container(), "cat", f"/proc/{pid}/environ"],
+        capture_output=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"could not read /proc/{pid}/environ: {result.stderr!r}"
+    return dict(item.split("=", 1) for item in result.stdout.decode().split("\0") if "=" in item)
+
+
+def _state_records(agent_data_root: str) -> list[dict[str, Any]]:
+    """Every control-target state record under the container's agent-data root."""
+    listing = _exec("sh", "-c", f"cat {agent_data_root}/control_target/target_state_*.json")
+    if listing.returncode != 0:
+        return []
+    decoder = json.JSONDecoder()
+    records: list[dict[str, Any]] = []
+    text = listing.stdout.strip()
+    while text:
+        record, end = decoder.raw_decode(text)
+        records.append(record)
+        text = text[end:].strip()
+    return records
+
+
+# ---------------------------------------------------------------------------
+# The repo
+# ---------------------------------------------------------------------------
+
+
+def _override_text() -> str:
+    """The ``--override`` overlay for the deployment.
+
+    The virtual accelerator is the baseline and the stand-in the second target;
+    the preset's archive stays (a simulated machine may not be paired with an
+    invented history) but shrunk to seconds of seeding. The bluesky stack, the
+    dispatcher and telemetry are dropped: nothing here reaches them, and every
+    container they add is a minute of build. ``modules.web_terminals`` cannot
+    carry the roster from here — list values union with the preset's — so the
+    roster and the persona catalog are rewritten in :func:`_shape_repo`.
+    """
+    return yaml.safe_dump(
+        {
+            "config": {
+                "container_runtime": RUNTIME,
+                "facility.name": "E2E Notebook Panel Fixture",
+                "facility.prefix": PREFIX,
+                "facility.timezone": "UTC",
+                "deploy.fqdn": "127.0.0.1",
+                PORT_BASE_CONFIG_KEY: PORT_BASE,
+                "control_system.type": "virtual_accelerator",
+                "claude_code.telemetry.enabled": False,
+                "claude_code.servers.bluesky.enabled": False,
+                "claude_code.servers.health.enabled": False,
+                "modules.web_terminals": {
+                    "enabled": True,
+                    "image_source": "local",
+                    "default_persona": PERSONA,
+                    "auth": {"method": "token"},
+                },
+            },
+            "channel_finder_mode": "hierarchical",
+            "dispatch": None,
+            "bluesky": None,
+            "bluesky_web": None,
+            "va_archiver": {"retention_days": 2, "hot_span_hours": 2},
+        },
+        sort_keys=False,
+    )
+
+
+def _shape_repo(repo: Path) -> None:
+    """One roster user on one persona delta, after ``osprey init`` materialized the preset's.
+
+    ``osprey init`` renders one delta per preset persona and unions the roster
+    override onto the preset's own; the profile is rewritten here to the shape
+    this lane deploys. The delta keeps the write gate armed the way the preset's
+    read-write persona does, and declares no ``extends`` — a file in
+    ``personas/`` inherits from the profile beside it.
+    """
+    profile_path = repo / "profile.yml"
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    terminals = profile["config"]["modules.web_terminals"]
+    terminals["users"] = [{"name": USER, "index": 0, "persona": PERSONA}]
+    terminals["personas"] = {
+        PERSONA: {
+            "project": PERSONA_PROJECT,
+            "project_path": f"build/{PERSONA_PROJECT}",
+            "build_profile": f"personas/{PERSONA}.yml",
+        }
+    }
+    terminals["default_persona"] = PERSONA
+    profile_path.write_text(yaml.safe_dump(profile, sort_keys=False), encoding="utf-8")
+
+    personas = repo / "personas"
+    for delta in personas.glob("*.yml"):
+        delta.unlink()
+    (personas / f"{PERSONA}.yml").write_text(
+        f"name: {PROJECT_NAME} ({PERSONA})\n"
+        "deploy_services: false\n"
+        "config:\n"
+        "  control_system.writes_enabled: true\n"
+        "  web.ui_mode: expert\n"
+        "  modules.web_terminals.enabled: false\n",
+        encoding="utf-8",
+    )
+
+
+def _make_repo(tmp_path: Path, osprey_bin: Path) -> Path:
+    repo = tmp_path / PROJECT_NAME
+    override_path = tmp_path / "override.yml"
+    override_path.write_text(_override_text(), encoding="utf-8")
+
+    init = _run_osprey(
+        osprey_bin,
+        [
+            "init",
+            str(repo),
+            "--preset",
+            PRESET,
+            "--no-git",
+            "--override",
+            str(override_path),
+            "--set",
+            f"virtual_accelerator.port={VA_CA_PORT}",
+        ],
+        tmp_path,
+        timeout=RENDER_TIMEOUT_SEC,
+    )
+    assert init.returncode == 0, _fmt("osprey init (notebook panel)", init)
+    _shape_repo(repo)
+
+    build = _run_osprey(
+        osprey_bin,
+        ["build", "--repo", str(repo), "--skip-deps", "--skip-lifecycle", "--dev"],
+        tmp_path,
+        timeout=RENDER_TIMEOUT_SEC,
+    )
+    assert build.returncode == 0, _fmt("osprey build (notebook panel)", build)
+
+    rendered = yaml.safe_load((repo / "build" / "config.yml").read_text(encoding="utf-8"))
+    resolved_base = (rendered.get("deployment") or {}).get("port_base")
+    assert resolved_base == PORT_BASE, (
+        f"{PROJECT_NAME} resolved {PORT_BASE_CONFIG_KEY}={resolved_base!r}, not {PORT_BASE}"
+    )
+
+    # `osprey build` pointed .env at the channel manifest; append, never replace.
+    env_path = repo / ".env"
+    with env_path.open("a", encoding="utf-8") as handle:
+        handle.write(_ENV_APPEND)
+    os.chmod(env_path, 0o600)
+    return repo
+
+
+def _compose_project() -> str | None:
+    """The compose project stamped on the terminal container, if it exists."""
+    result = _runtime_cli(
+        "inspect",
+        "--type",
+        "container",
+        "-f",
+        '{{index .Config.Labels "com.docker.compose.project"}}',
+        _web_container(),
+        timeout=15,
+    )
+    return result.stdout.strip() or None if result.returncode == 0 else None
+
+
+def _teardown(project: str | None) -> None:
+    """Exact-named sweep; failures swallowed (a safety net, never an assertion)."""
+    _runtime_cli("rm", "-f", _web_container())
+    _runtime_cli("rm", "-f", f"{PREFIX}-nginx")
+    for project_name in {project, PROJECT_NAME} - {None}:
+        _runtime_cli("compose", "-p", str(project_name), "down", timeout=120)
+        remove_project_volumes(str(project_name), runtime=RUNTIME)
+    if not os.environ.get("E2E_REUSE_IMAGES"):
+        for tag in (PERSONA_IMAGE_TAG, *SERVICE_IMAGE_TAGS):
+            _runtime_cli("rmi", "-f", tag, timeout=120)
+
+
+# ---------------------------------------------------------------------------
+# HTTP against the terminal
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Terminal:
+    """One deployed terminal, reached at its web port with the operator secret."""
+
+    repo: Path
+    osprey_bin: Path
+    secret: str
+    client: httpx.Client
+    #: State the ordered tests hand each other.
+    session_id: str | None = None
+    pty_pid: int | None = None
+    kernel_id: str | None = None
+    notebook_session_id: str | None = None
+    first_target: str | None = None
+    agent_data_root: str | None = None
+    starter_cells: list[Any] = field(default_factory=list)
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {"X-Osprey-Terminal-Secret": self.secret}
+
+    @property
+    def mutating_headers(self) -> dict[str, str]:
+        return {**self.headers, "Origin": ORIGIN}
+
+    def get(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.client.get(f"{BASE_URL}{path}", headers=self.headers, **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.client.post(f"{BASE_URL}{path}", headers=self.mutating_headers, **kwargs)
+
+    def put(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.client.put(f"{BASE_URL}{path}", headers=self.mutating_headers, **kwargs)
+
+    def delete(self, path: str) -> httpx.Response:
+        return self.client.delete(f"{BASE_URL}{path}", headers=self.mutating_headers)
+
+    def posture(self) -> dict[str, Any]:
+        response = self.get("/api/terminal/posture", params={"session_id": self.session_id})
+        assert response.status_code == 200, response.text
+        return response.json()
+
+    def ledger(self) -> list[dict[str, Any]]:
+        path = self.repo / LEDGER
+        if not path.is_file():
+            return []
+        return [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def start_notebook_session(self, notebook: str) -> dict[str, Any]:
+        response = self.post(
+            f"{PANEL}/api/sessions",
+            json={
+                "path": notebook,
+                "name": notebook,
+                "type": "notebook",
+                "kernel": {"name": KERNELSPEC},
+            },
+        )
+        assert response.status_code == 201, response.text
+        return response.json()
+
+    def kernel_channels(self, kernel_id: str, session_id: str):
+        return ws_connect(
+            f"{WS_URL}{PANEL}/api/kernels/{kernel_id}/channels?session_id={session_id}",
+            additional_headers=self.headers,
+            max_size=None,
+            open_timeout=60,
+        )
+
+
+def _wait_for_ready(terminal: Terminal, timeout: float) -> None:
+    """Poll until the terminal answers and reports the notebook sidecar available."""
+    deadline = time.monotonic() + timeout
+    last = "(no attempt yet)"
+    while time.monotonic() < deadline:
+        try:
+            response = terminal.get("/api/jupyter-server")
+            if response.status_code == 200 and response.json().get("available"):
+                return
+            last = f"HTTP {response.status_code}: {response.text[:200]}"
+        except httpx.HTTPError as exc:
+            last = str(exc)
+        time.sleep(3.0)
+    raise AssertionError(
+        f"the notebook panel never became available after {timeout:.0f}s (last: {last})\n"
+        f"{_logs(_web_container())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Talking to a kernel over the proxied channels socket
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CellResult:
+    stdout: str
+    stderr: str
+    error_name: str | None
+    error_value: str
+    traceback: str
+
+
+def _message(msg_type: str, content: dict[str, Any], session_id: str) -> dict[str, Any]:
+    return {
+        "header": {
+            "msg_id": uuid.uuid4().hex,
+            "session": session_id,
+            "username": "osprey",
+            "date": datetime.now(UTC).isoformat(),
+            "msg_type": msg_type,
+            "version": "5.3",
+        },
+        "parent_header": {},
+        "metadata": {},
+        "content": content,
+        "channel": "shell",
+        "buffers": [],
+    }
+
+
+def _run_cell(socket: Any, code: str, session_id: str) -> CellResult:
+    """Execute *code* and collect what it wrote, up to the ``idle`` status."""
+    request = _message(
+        "execute_request",
+        {
+            "code": code,
+            "silent": False,
+            "store_history": False,
+            "user_expressions": {},
+            "allow_stdin": False,
+            "stop_on_error": True,
+        },
+        session_id,
+    )
+    socket.send(json.dumps(request))
+    result = CellResult("", "", None, "", "")
+    deadline = time.monotonic() + CELL_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        raw = socket.recv(timeout=max(1.0, deadline - time.monotonic()))
+        message = json.loads(raw)
+        if (message.get("parent_header") or {}).get("msg_id") != request["header"]["msg_id"]:
+            continue
+        msg_type = message["header"]["msg_type"]
+        content = message.get("content") or {}
+        if msg_type == "stream":
+            text = str(content.get("text", ""))
+            if content.get("name") == "stdout":
+                result.stdout += text
+            else:
+                result.stderr += text
+        elif msg_type == "error":
+            result.error_name = content.get("ename")
+            result.error_value = _ANSI.sub("", str(content.get("evalue", "")))
+            result.traceback = _ANSI.sub("", "\n".join(content.get("traceback", [])))
+        elif msg_type == "status" and content.get("execution_state") == "idle":
+            return result
+    raise AssertionError(f"the cell did not finish within {CELL_TIMEOUT_SEC:.0f} s")
+
+
+def _run_ok(socket: Any, code: str, session_id: str) -> str:
+    result = _run_cell(socket, code, session_id)
+    assert result.error_name is None, (
+        f"cell raised {result.error_name}: {result.error_value}\n{result.traceback}\n"
+        f"stderr: {result.stderr}"
+    )
+    return result.stdout
+
+
+#: A cell that prints the stamps a kernel carries, as JSON.
+STAMPS_CELL = (
+    "import os, json\n"
+    "print(json.dumps({k: v for k, v in os.environ.items() if k.startswith('OSPREY_CONTROL') "
+    "or k in ('OSPREY_LAUNCH_POSTURE', 'OSPREY_POSTURE_SESSION', 'OSPREY_AGENT_DATA_ROOT') "
+    "or k == 'JUPYTER_TOKEN'}))\n"
+)
+READ_CELL = f"from osprey.runtime import read_channel\nprint(repr(read_channel({CHANNEL!r})))\n"
+WRITE_CELL = f"from osprey.runtime import write_channel\nwrite_channel({CHANNEL!r}, 1.0)\n"
+
+
+def _stamps(socket: Any, session_id: str) -> dict[str, str]:
+    return json.loads(_run_ok(socket, STAMPS_CELL, session_id))
+
+
+def _read_value(socket: Any, session_id: str) -> float:
+    printed = _run_ok(socket, READ_CELL, session_id).strip()
+    try:
+        return float(printed)
+    except ValueError:
+        raise AssertionError(
+            f"read_channel({CHANNEL!r}) printed {printed!r}, not a number"
+        ) from None
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def terminal(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Terminal]:
+    """One ``osprey up --dev`` for the whole module; torn down whatever happens."""
+    if shutil.which(RUNTIME) is None:
+        pytest.skip(f"{RUNTIME} not available")
+    if _runtime_cli("ps", timeout=10).returncode != 0:
+        pytest.skip(f"{RUNTIME} daemon not responding")
+
+    tmp_path = tmp_path_factory.mktemp("notebook-panel")
+    osprey_bin = _find_osprey_console_script()
+    repo = _make_repo(tmp_path, osprey_bin)
+
+    client = httpx.Client(timeout=60)
+    try:
+        _teardown(_compose_project())
+        up = _run_osprey(osprey_bin, ["up", "--dev"], repo, timeout=DEPLOY_UP_TIMEOUT_SEC)
+        assert up.returncode == 0, _fmt("osprey up --dev (notebook panel)", up)
+        secret = (parse_dotenv_file(repo / ".env").get(terminal_secret_var(USER)) or "").strip()
+        assert secret, f"{terminal_secret_var(USER)} was not provisioned into the deploy .env"
+        deployed = Terminal(repo=repo, osprey_bin=osprey_bin, secret=secret, client=client)
+        _wait_for_ready(deployed, READY_TIMEOUT_SEC)
+        yield deployed
+    finally:
+        project = _compose_project()
+        _run_osprey(osprey_bin, ["down"], repo)
+        _teardown(project)
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. First open
+# ---------------------------------------------------------------------------
+
+
+def test_the_starter_notebook_is_present_on_first_open(terminal: Terminal) -> None:
+    contents = terminal.get(f"{PANEL}/api/contents")
+    assert contents.status_code == 200, contents.text
+    names = [entry["name"] for entry in contents.json()["content"]]
+    assert names == [STARTER_NOTEBOOK], names
+
+    kernelspecs = terminal.get(f"{PANEL}/api/kernelspecs")
+    assert kernelspecs.status_code == 200, kernelspecs.text
+    specs = kernelspecs.json()["kernelspecs"]
+    assert sorted(specs) == [KERNELSPEC]
+    terminal.agent_data_root = specs[KERNELSPEC]["spec"]["env"]["OSPREY_AGENT_DATA_ROOT"]
+
+    starter = terminal.get(f"{PANEL}/api/contents/{STARTER_NOTEBOOK}", params={"content": "1"})
+    assert starter.status_code == 200, starter.text
+    terminal.starter_cells = starter.json()["content"]["cells"]
+    assert any(
+        cell["cell_type"] == "code" and "osprey.runtime" in cell["source"]
+        for cell in terminal.starter_cells
+    ), terminal.starter_cells
+
+
+# ---------------------------------------------------------------------------
+# 2. No chat session
+# ---------------------------------------------------------------------------
+
+
+def test_a_kernel_with_no_chat_session_reads_and_refuses_writes(terminal: Terminal) -> None:
+    """Started before any terminal attached: no binding, fail-closed pin, reads route to the baseline."""
+    assert terminal.get(f"{PANEL}/api/kernels").json() == []
+    session = terminal.start_notebook_session(STARTER_NOTEBOOK)
+    kernel_id = session["kernel"]["id"]
+    channel_session = uuid.uuid4().hex
+    records_before = len(terminal.ledger())
+    try:
+        with terminal.kernel_channels(kernel_id, channel_session) as socket:
+            stamps = _stamps(socket, channel_session)
+            assert "JUPYTER_TOKEN" not in stamps
+            assert stamps.get("OSPREY_LAUNCH_POSTURE") == "*=sandbox", stamps
+            assert "OSPREY_CONTROL_TARGET" not in stamps, stamps
+
+            assert _read_value(socket, channel_session) == pytest.approx(500.0, abs=50.0)
+
+            refused = _run_cell(socket, WRITE_CELL, channel_session)
+            assert refused.error_name == "ChannelWriteBlockedError", refused
+            assert f"Write to '{CHANNEL}' blocked" in refused.error_value, refused.error_value
+            assert HINT_NO_SESSION in refused.stdout, refused.stdout
+    finally:
+        terminal.delete(f"{PANEL}/api/sessions/{session['id']}")
+
+    new_records = terminal.ledger()[records_before:]
+    assert len(new_records) == 1, new_records
+    assert new_records[0]["surface"] == SURFACE
+    assert new_records[0]["decision"] == "refused"
+    assert new_records[0]["reason"] == "channel_write_blocked"
+
+
+# ---------------------------------------------------------------------------
+# 3. A terminal session binds the kernel launcher
+# ---------------------------------------------------------------------------
+
+
+def test_attaching_a_terminal_binds_the_session(terminal: Terminal) -> None:
+    """The attach writes the binding; the controls server inside the session publishes its target."""
+    with ws_connect(
+        f"{WS_URL}/ws/terminal?mode=new",
+        additional_headers=terminal.headers,
+        max_size=None,
+        open_timeout=60,
+    ) as socket:
+        deadline = time.monotonic() + 60
+        while terminal.session_id is None and time.monotonic() < deadline:
+            raw = socket.recv(timeout=max(1.0, deadline - time.monotonic()))
+            if isinstance(raw, str) and raw.startswith("{"):
+                frame = json.loads(raw)
+                if frame.get("type") == "session_info":
+                    terminal.session_id = frame["session_id"]
+    assert terminal.session_id, "the terminal never sent session_info"
+
+    assert terminal.agent_data_root
+    binding = json.loads(
+        _exec_text("cat", f"{terminal.agent_data_root}/jupyter/session-binding.json")
+    )
+    assert binding["session_id"] == terminal.session_id, binding
+    assert binding["agent_data_root"] == terminal.agent_data_root, binding
+    assert isinstance(binding["pty_pid"], int) and binding["pty_pid"] > 0, binding
+    terminal.pty_pid = binding["pty_pid"]
+
+    # The published record is the evidence: ``session_target`` on the posture
+    # route answers the deployment baseline until the controls server inside
+    # the fresh ``claude`` has written its state file, so a target read off the
+    # route says nothing about whether a switch could be asked for yet.
+    deadline = time.monotonic() + SESSION_TARGET_TIMEOUT_SEC
+    record: dict[str, Any] | None = None
+    while record is None and time.monotonic() < deadline:
+        for entry in _state_records(terminal.agent_data_root):
+            if entry.get("owner_ppid") == terminal.pty_pid:
+                record = entry
+        if record is None:
+            time.sleep(2.0)
+    assert record is not None, (
+        f"no controls server published a state record for pid {terminal.pty_pid} within "
+        f"{SESSION_TARGET_TIMEOUT_SEC:.0f}s\n{_logs(_web_container())}"
+    )
+    terminal.first_target = record["target"]
+    assert terminal.first_target in ("va", "standin"), record
+    assert terminal.posture()["session_target"] == terminal.first_target
+
+
+# ---------------------------------------------------------------------------
+# 4. Writes off at launch
+# ---------------------------------------------------------------------------
+
+
+def test_a_sandbox_pinned_kernel_refuses_writes_with_the_turn_writes_on_line(
+    terminal: Terminal,
+) -> None:
+    assert terminal.session_id and terminal.first_target
+    target = terminal.first_target
+    narrowed = terminal.post(
+        "/api/terminal/posture",
+        json={"session_id": terminal.session_id, "target": target, "posture": "sandbox"},
+    )
+    assert narrowed.status_code == 200, narrowed.text
+    assert narrowed.json()["entry"].get(target) == "sandbox", narrowed.text
+
+    session = terminal.start_notebook_session(STARTER_NOTEBOOK)
+    terminal.kernel_id = session["kernel"]["id"]
+    terminal.notebook_session_id = session["id"]
+    channel_session = uuid.uuid4().hex
+    records_before = len(terminal.ledger())
+    with terminal.kernel_channels(terminal.kernel_id, channel_session) as socket:
+        stamps = _stamps(socket, channel_session)
+        assert stamps.get("OSPREY_POSTURE_SESSION") == terminal.session_id, stamps
+        assert stamps.get("OSPREY_CONTROL_TARGET") == target, stamps
+        assert stamps.get("OSPREY_LAUNCH_POSTURE") == f"{target}=sandbox", stamps
+
+        assert _read_value(socket, channel_session) == pytest.approx(500.0, abs=50.0)
+
+        refused = _run_cell(socket, WRITE_CELL, channel_session)
+        assert refused.error_name == "ChannelWriteBlockedError", refused
+        assert (
+            f"Write to '{CHANNEL}' blocked: this run launched while writes were off for "
+            f"'{target}' in this session" in refused.error_value
+        ), refused.error_value
+        assert HINT_WRITES_OFF in refused.stdout, refused.stdout
+
+    new_records = terminal.ledger()[records_before:]
+    assert len(new_records) == 1, new_records
+    record = new_records[0]
+    assert record["surface"] == SURFACE
+    assert record["decision"] == "refused"
+    assert record["reason"] == "channel_write_blocked"
+    assert record["session"] == terminal.session_id
+    assert record["subject"] == "notebook_cell"
+    assert record["detail"] == f"channel={CHANNEL}"
+
+
+# ---------------------------------------------------------------------------
+# 5. A chip target switch
+# ---------------------------------------------------------------------------
+
+
+def test_a_target_switch_is_refused_until_the_kernel_restarts(terminal: Terminal) -> None:
+    assert terminal.session_id and terminal.first_target and terminal.kernel_id
+    other = "standin" if terminal.first_target == "va" else "va"
+    switched = terminal.post(
+        "/api/terminal/target", json={"session_id": terminal.session_id, "target": other}
+    )
+    assert switched.status_code == 202, switched.text
+
+    deadline = time.monotonic() + SWITCH_TIMEOUT_SEC
+    posture = terminal.posture()
+    while posture.get("session_target") != other and time.monotonic() < deadline:
+        time.sleep(1.0)
+        posture = terminal.posture()
+    assert posture.get("session_target") == other, (
+        f"the session never moved to {other!r}: {posture.get('last_switch')}"
+    )
+
+    records_before = len(terminal.ledger())
+    channel_session = uuid.uuid4().hex
+    try:
+        with terminal.kernel_channels(terminal.kernel_id, channel_session) as socket:
+            refused = _run_cell(socket, WRITE_CELL, channel_session)
+            assert refused.error_name == "ControlTargetChangedError", refused
+            assert "Refusing to write: this execution was started against control target" in (
+                refused.error_value
+            ), refused.error_value
+            assert HINT_TARGET_CHANGED in refused.stdout, refused.stdout
+
+        new_records = terminal.ledger()[records_before:]
+        assert len(new_records) == 1, new_records
+        assert new_records[0]["reason"] == "control_target_changed"
+        assert new_records[0]["surface"] == SURFACE
+
+        restarted = terminal.post(f"{PANEL}/api/kernels/{terminal.kernel_id}/restart")
+        assert restarted.status_code == 200, restarted.text
+        channel_session = uuid.uuid4().hex
+        with terminal.kernel_channels(terminal.kernel_id, channel_session) as socket:
+            followed = _run_ok(
+                socket, 'import os\nprint(os.environ["OSPREY_CONTROL_TARGET"])\n', channel_session
+            )
+            assert followed.strip() == other, followed
+    finally:
+        terminal.delete(f"{PANEL}/api/sessions/{terminal.notebook_session_id}")
+
+
+# ---------------------------------------------------------------------------
+# 6. NotebookEdit: settings, guard, badge
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(
+    script: str, payload: dict[str, Any], env: dict[str, str]
+) -> subprocess.CompletedProcess:
+    """Run one rendered hook inside the container with a synthetic hook input."""
+    args = [RUNTIME, "exec", "-i", "--user", "1000"]
+    for name, value in env.items():
+        args += ["-e", f"{name}={value}"]
+    args += [_web_container(), "python3", script]
+    return subprocess.run(
+        args, input=json.dumps(payload), capture_output=True, text=True, timeout=60
+    )
+
+
+def test_notebook_edit_is_allowed_under_notebooks_and_badges_the_panel(terminal: Terminal) -> None:
+    """The rendered allow rules, the guard's verdicts, and the badge the update hook posts.
+
+    The hooks are driven the way ``tests/hooks`` drives them — the script on
+    stdin with a synthetic tool call — but inside the container, under the
+    environment of the ``claude`` process the terminal launched, which is what
+    hands the update hook the panel token and web port it posts with.
+    """
+    assert terminal.agent_data_root and terminal.pty_pid
+    settings = json.loads(
+        (terminal.repo / "build" / PERSONA_PROJECT / ".claude" / "settings.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    allow = settings["permissions"]["allow"]
+    assert "NotebookEdit(var/agent_data/notebooks/**)" in allow, allow
+    assert "NotebookEdit(var/agent_data/artifacts/**)" in allow, allow
+
+    agent_env = _process_env(terminal.pty_pid)
+    config_path = agent_env["OSPREY_CONFIG"]
+    hooks_dir = str(Path(config_path).parent / ".claude" / "hooks")
+    project_dir = str(Path(config_path).parent)
+    hook_env = {
+        name: agent_env[name]
+        for name in ("OSPREY_PANEL_TOKEN", "OSPREY_WEB_PORT", "OSPREY_CONFIG")
+        if name in agent_env
+    }
+    assert hook_env.get("OSPREY_PANEL_TOKEN"), "the agent carries no panel token"
+
+    inside = f"{terminal.agent_data_root}/notebooks/x.ipynb"
+    outside = f"{terminal.agent_data_root}/foo.ipynb"
+
+    def pre_tool_use(path: str) -> dict[str, Any]:
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "NotebookEdit",
+            "tool_input": {"notebook_path": path, "cell_id": "0", "new_source": "print(1)"},
+            "cwd": project_dir,
+        }
+
+    allowed = _run_hook(f"{hooks_dir}/osprey_memory_guard.py", pre_tool_use(inside), hook_env)
+    assert allowed.returncode == 0, _fmt("memory guard (inside)", allowed)
+    assert json.loads(allowed.stdout)["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    denied = _run_hook(f"{hooks_dir}/osprey_memory_guard.py", pre_tool_use(outside), hook_env)
+    assert denied.returncode == 0, _fmt("memory guard (outside)", denied)
+    verdict = json.loads(denied.stdout)["hookSpecificOutput"]
+    assert verdict["permissionDecision"] == "deny", verdict
+    assert "NOTEBOOK EDIT DENIED" in verdict["permissionDecisionReason"], verdict
+
+    badged = _run_hook(
+        f"{hooks_dir}/osprey_notebook_update.py",
+        {**pre_tool_use(inside), "hook_event_name": "PostToolUse", "tool_response": {}},
+        hook_env,
+    )
+    assert badged.returncode == 0, _fmt("notebook update", badged)
+    assert badged.stdout == "", badged.stdout
+
+    # The strip renders a NotebookEdit panel frame as "agent edited <detail>"
+    # (static/js/activity-format.js); the frame is what the history endpoint holds.
+    recent = terminal.get("/api/agent-activity/recent")
+    assert recent.status_code == 200, recent.text
+    frames = [event for event in recent.json()["events"] if event["tool"] == "NotebookEdit"]
+    assert frames, recent.text
+    assert frames[0]["target"] == {"kind": "panel", "panel": "jupyter", "detail": "x.ipynb"}
+
+
+# ---------------------------------------------------------------------------
+# 7. The runtime directory
+# ---------------------------------------------------------------------------
+
+
+def test_the_runtime_dir_is_not_under_the_agent_data_root(terminal: Terminal) -> None:
+    assert terminal.agent_data_root
+    pids = _exec_text("pgrep", "-f", "jupyter_sidecar_main").split()
+    assert len(pids) == 1, pids
+    sidecar_env = _process_env(int(pids[0]))
+    runtime_dir = sidecar_env["JUPYTER_RUNTIME_DIR"]
+    root = terminal.agent_data_root.rstrip("/") + "/"
+    assert not runtime_dir.startswith(root), runtime_dir
+    assert sidecar_env["JUPYTER_DATA_DIR"].startswith(root), sidecar_env["JUPYTER_DATA_DIR"]
+    listing = _exec_text("ls", runtime_dir).split()
+    assert f"jpserver-{pids[0]}.json" in listing, listing
+
+
+# ---------------------------------------------------------------------------
+# 8. down && up
+# ---------------------------------------------------------------------------
+
+
+def test_notebooks_survive_a_restart_and_kernels_do_not(terminal: Terminal) -> None:
+    notebook = nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell("print('survives')")])
+    saved = terminal.put(
+        f"{PANEL}/api/contents/{SURVIVOR_NOTEBOOK}",
+        json={"type": "notebook", "format": "json", "content": notebook},
+    )
+    assert saved.status_code == 201, saved.text
+    terminal.start_notebook_session(SURVIVOR_NOTEBOOK)
+    assert len(terminal.get(f"{PANEL}/api/kernels").json()) >= 1
+
+    down = _run_osprey(terminal.osprey_bin, ["down"], terminal.repo)
+    assert down.returncode == 0, _fmt("osprey down", down)
+    up = _run_osprey(
+        terminal.osprey_bin, ["up", "--dev"], terminal.repo, timeout=DEPLOY_UP_TIMEOUT_SEC
+    )
+    assert up.returncode == 0, _fmt("osprey up --dev (second start)", up)
+    _wait_for_ready(terminal, READY_TIMEOUT_SEC)
+
+    names = sorted(
+        entry["name"] for entry in terminal.get(f"{PANEL}/api/contents").json()["content"]
+    )
+    assert names == sorted([STARTER_NOTEBOOK, SURVIVOR_NOTEBOOK]), names
+    assert terminal.get(f"{PANEL}/api/kernels").json() == []
+    assert terminal.get(f"{PANEL}/api/sessions").json() == []
+
+    survivor = terminal.get(f"{PANEL}/api/contents/{SURVIVOR_NOTEBOOK}", params={"content": "1"})
+    assert survivor.json()["content"]["cells"][0]["source"] == "print('survives')"
+    # The seed is written into an EMPTY tree only; a restart never rewrites it.
+    starter = terminal.get(f"{PANEL}/api/contents/{STARTER_NOTEBOOK}", params={"content": "1"})
+    assert starter.json()["content"]["cells"] == terminal.starter_cells

--- a/tests/e2e/test_jupyter_panel_lifecycle.py
+++ b/tests/e2e/test_jupyter_panel_lifecycle.py
@@ -80,6 +80,7 @@ import httpx
 import nbformat
 import pytest
 import yaml
+from websockets.exceptions import ConnectionClosed
 from websockets.sync.client import connect as ws_connect
 
 from osprey.deployment.web_terminals.auth_credentials import terminal_secret_var
@@ -537,7 +538,16 @@ def _run_cell(socket: Any, code: str, session_id: str) -> CellResult:
         },
         session_id,
     )
-    socket.send(json.dumps(request))
+    try:
+        socket.send(json.dumps(request))
+    except ConnectionClosed as exc:
+        # The proxy closes the browser side normally whatever happened upstream,
+        # so the close alone says nothing about why. The terminal's log holds
+        # the proxy's own account of it and the sidecar's stderr behind that.
+        raise AssertionError(
+            f"the kernel channel was closed before the cell could be sent: {exc}\n"
+            f"{_logs(_web_container())}"
+        ) from exc
     result = CellResult("", "", None, "", "")
     deadline = time.monotonic() + CELL_TIMEOUT_SEC
     while time.monotonic() < deadline:

--- a/tests/e2e/test_jupyter_panel_lifecycle.py
+++ b/tests/e2e/test_jupyter_panel_lifecycle.py
@@ -1,4 +1,4 @@
-"""Real-container lifecycle of the NOTEBOOKS panel: a kernel that follows the terminal.
+"""Real-container lifecycle of the JUPYTER panel: a kernel that follows the terminal.
 
 The unit tests pin the kernel launcher's stamps against a synthetic binding,
 and the proxy integration test pins the panel's HTTP and websocket legs against
@@ -11,7 +11,7 @@ THE DEPLOYMENT THIS BUILDS
 --------------------------
 One ``osprey up --dev`` of a ``control-assistant`` render, trimmed to one
 roster user (``alice``) on one persona that keeps the preset's write gate armed
-and inherits the preset's panel set — which is what selects the NOTEBOOKS
+and inherits the preset's panel set — which is what selects the JUPYTER
 panel. The control system is the virtual accelerator, baselined as the ``va``
 target, with the live stand-in deployed beside it as the ``standin`` target: a
 switch needs two targets, and the mock connector cannot be one — its baseline

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -245,7 +245,7 @@ web_panels:
   - channel-finder  # Interactive channel-finder web UI
   - okf             # KNOWLEDGE tab, for browsing the facility knowledge bundle
   - system-health   # SYSTEM tab, a framework health dashboard
-  - jupyter         # NOTEBOOKS tab, JupyterLab with kernels that follow the terminal session
+  - jupyter         # JUPYTER tab, JupyterLab with kernels that follow the terminal session
   # The events and bluesky panels are declared by the write-armed personas
   # (readwrite and admin) instead, so the read-only login is built without them.
   # Available — uncomment to enable:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -184,7 +184,7 @@ hooks:
   - writes-check      # Kill switch: refuse every write while writes_enabled is false
   - limits            # Enforce per-channel min/max limits before writes
   - error-guidance    # Post-error hook that surfaces remediation hints
-  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts
+  - memory-guard      # Gate Write/MultiEdit to memory files, NotebookEdit to agent-data artifacts and notebooks
   - notebook-update   # Sync CLAUDE.md notebook after each session
   - cf-feedback-capture  # Capture channel-finder accuracy feedback for tuning
   - config-drift      # Warn at session start when the build is out of date
@@ -245,6 +245,7 @@ web_panels:
   - channel-finder  # Interactive channel-finder web UI
   - okf             # KNOWLEDGE tab, for browsing the facility knowledge bundle
   - system-health   # SYSTEM tab, a framework health dashboard
+  - jupyter         # NOTEBOOKS tab, JupyterLab with kernels that follow the terminal session
   # The events and bluesky panels are declared by the write-armed personas
   # (readwrite and admin) instead, so the read-only login is built without them.
   # Available — uncomment to enable:

--- a/tests/health/core/test_web_panels.py
+++ b/tests/health/core/test_web_panels.py
@@ -259,11 +259,53 @@ class TestBuiltinAddressResolution:
         The health category's own copy of the panel-id → registry-key map had
         already drifted from the CLI's copy (it carried an `artifacts` entry the
         CLI omitted). Derived from the registry, the two cannot disagree.
+
+        Sidecar panels are the one class outside that map: nothing launches them
+        from a config section, so they carry no registry key and are never
+        probed at an address.
         """
-        from osprey.profiles.web_panels import BUILTIN_PANELS
+        from osprey.profiles.web_panels import BUILTIN_PANELS, SIDECAR_PANELS
         from osprey.registry.web import PANEL_ID_TO_REGISTRY_KEY
 
-        assert set(PANEL_ID_TO_REGISTRY_KEY) == BUILTIN_PANELS
+        assert set(PANEL_ID_TO_REGISTRY_KEY) | set(SIDECAR_PANELS) == BUILTIN_PANELS
+
+
+class TestSidecarPanels:
+    """A panel the web terminal serves itself is reported, never probed."""
+
+    async def test_enabled_sidecar_gets_a_skip_row(self):
+        """Skip, not OK: this category never established the sidecar is up.
+
+        The sidecar has no address of its own — it is reached through the
+        terminal's panel proxy — so an OK row would assert a liveness nothing
+        here measured, and a warning would call every terminal-less host broken.
+        """
+        rows = await _run(_cfg({"jupyter": True}))
+        row = rows["web_panels.jupyter"]
+
+        assert row.status is Status.SKIP
+        assert row.message == (
+            "NOTEBOOKS: not probed — served inside the web terminal; a grey tab "
+            "means the sidecar did not start, see the terminal log"
+        )
+
+    async def test_disabled_sidecar_gets_no_row(self):
+        rows = await _run(_cfg({"jupyter": {"enabled": False}}))
+
+        assert "web_panels.jupyter" not in rows
+
+    async def test_sidecar_is_never_fetched(self):
+        """No request leaves the category for a sidecar panel."""
+        seen: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(str(request.url))
+            return httpx.Response(200)
+
+        await _run(_cfg({"jupyter": True}), handler=handler)
+
+        # Only the universal artifacts panel is probed.
+        assert seen == [f"http://127.0.0.1:{default_port('artifact')}/health"]
 
 
 class TestMisplacedConfigKeys:

--- a/tests/health/core/test_web_panels.py
+++ b/tests/health/core/test_web_panels.py
@@ -285,7 +285,7 @@ class TestSidecarPanels:
 
         assert row.status is Status.SKIP
         assert row.message == (
-            "NOTEBOOKS: not probed — served inside the web terminal; a grey tab "
+            "JUPYTER: not probed — served inside the web terminal; a grey tab "
             "means the sidecar did not start, see the terminal log"
         )
 

--- a/tests/hooks/test_notebook_update_hook.py
+++ b/tests/hooks/test_notebook_update_hook.py
@@ -2,7 +2,7 @@
 
 This hook invalidates cached rendered HTML when a notebook is edited
 via NotebookEdit, ensuring the gallery re-renders on next view, and badges the
-NOTEBOOKS panel when the edit landed in the agent's own notebooks tree.
+JUPYTER panel when the edit landed in the agent's own notebooks tree.
 
 The observable contract is small: delete ``_notebook_cache/{stem}_rendered.html``
 when it is there, leave the tree alone when it is not, log which of the two
@@ -215,10 +215,10 @@ def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     assert snapshot(tmp_path) == before
 
 
-# --- NOTEBOOKS panel badge -------------------------------------------------
+# --- JUPYTER panel badge -------------------------------------------------
 #
 # An edit inside ``<agent-data root>/notebooks/`` is reported to the web
-# terminal as an agent-activity frame, so the NOTEBOOKS rail entry glows and
+# terminal as an agent-activity frame, so the JUPYTER rail entry glows and
 # badges. The contract is the payload, the tree it fires for, and that a web
 # terminal which is not there costs a badge and nothing else.
 
@@ -312,7 +312,7 @@ def test_artifacts_edit_posts_nothing(
     """An edit under ``artifacts/`` badges nothing.
 
     Notebooks the agent writes into the gallery tree belong to WORKSPACE;
-    glowing the NOTEBOOKS entry for one would point the operator at a panel
+    glowing the JUPYTER entry for one would point the operator at a panel
     that does not hold the file.
     """
     port, received = activity_server

--- a/tests/hooks/test_notebook_update_hook.py
+++ b/tests/hooks/test_notebook_update_hook.py
@@ -1,17 +1,31 @@
 """Tests for the osprey_notebook_update PostToolUse hook.
 
 This hook invalidates cached rendered HTML when a notebook is edited
-via NotebookEdit, ensuring the gallery re-renders on next view.
+via NotebookEdit, ensuring the gallery re-renders on next view, and badges the
+NOTEBOOKS panel when the edit landed in the agent's own notebooks tree.
 
 The observable contract is small: delete ``_notebook_cache/{stem}_rendered.html``
 when it is there, leave the tree alone when it is not, log which of the two
-happened under debug, and never fail the tool call — whatever the input or the
-state of the filesystem.
+happened under debug, post exactly one agent-activity frame for an edit under
+``<agent-data root>/notebooks/`` and none for an edit anywhere else, and never
+fail the tool call — whatever the input, the state of the filesystem, or
+whether a web terminal is listening.
 """
+
+import json
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
+from osprey.utils.workspace import DEFAULT_AGENT_DATA_BASE_DIR
+
 HOOK_NAME = "osprey_notebook_update.py"
+
+#: The agent-data subdirectory the badge fires for. Kept in step with the
+#: hook's own ``_NOTEBOOKS_SUBDIR`` and the rendered ``NotebookEdit`` allow.
+NOTEBOOKS_SUBDIR = "notebooks"
 
 
 def snapshot(root):
@@ -199,3 +213,179 @@ def test_malformed_stdin_fails_open(tmp_path, hook_runner_raw, stdin):
     assert stdout.strip() == ""
     assert "Traceback" not in stderr
     assert snapshot(tmp_path) == before
+
+
+# --- NOTEBOOKS panel badge -------------------------------------------------
+#
+# An edit inside ``<agent-data root>/notebooks/`` is reported to the web
+# terminal as an agent-activity frame, so the NOTEBOOKS rail entry glows and
+# badges. The contract is the payload, the tree it fires for, and that a web
+# terminal which is not there costs a badge and nothing else.
+
+
+@pytest.fixture
+def activity_server():
+    """Stub web terminal recording POST /api/agent-activity bodies.
+
+    Yields ``(port, received)``; ``received`` grows a decoded body per POST,
+    appended before the response is written, so a hook subprocess that has
+    exited has necessarily already been recorded.
+    """
+    received = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 - http.server API
+            length = int(self.headers.get("Content-Length", 0))
+            received.append(
+                {
+                    "path": self.path,
+                    "body": json.loads(self.rfile.read(length) or b"{}"),
+                    "content_type": self.headers.get("Content-Type"),
+                }
+            )
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *args):  # silence test output
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1], received
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def closed_port():
+    """A port with nothing listening (bound momentarily, then released)."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def make_notebook(tmp_path, relpath, subdir=NOTEBOOKS_SUBDIR):
+    """Create an empty notebook at ``<agent-data root>/<subdir>/<relpath>``."""
+    path = tmp_path / DEFAULT_AGENT_DATA_BASE_DIR / subdir / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}")
+    return path
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "relpath, detail",
+    [("scan.ipynb", "scan.ipynb"), ("runs/day2/scan.ipynb", "runs/day2/scan.ipynb")],
+    ids=["top-level", "nested"],
+)
+def test_notebooks_edit_posts_one_activity_frame(
+    tmp_path, monkeypatch, run_notebook_update_hook, activity_server, relpath, detail
+):
+    """An edit under ``notebooks/`` badges the jupyter panel, once, with the path.
+
+    The frame is the route's fixed contract, and ``detail`` is the path
+    *relative to* the notebooks root — an absolute path would name a container
+    directory the operator never sees.
+    """
+    port, received = activity_server
+    monkeypatch.setenv("OSPREY_WEB_PORT", str(port))
+    nb_path = make_notebook(tmp_path, relpath)
+
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert len(received) == 1
+    assert received[0]["path"] == "/api/agent-activity"
+    assert received[0]["content_type"] == "application/json"
+    assert received[0]["body"] == {
+        "tool": "NotebookEdit",
+        "target": {"kind": "panel", "panel": "jupyter", "detail": detail},
+    }
+
+
+@pytest.mark.unit
+def test_artifacts_edit_posts_nothing(
+    tmp_path, monkeypatch, run_notebook_update_hook, activity_server
+):
+    """An edit under ``artifacts/`` badges nothing.
+
+    Notebooks the agent writes into the gallery tree belong to WORKSPACE;
+    glowing the NOTEBOOKS entry for one would point the operator at a panel
+    that does not hold the file.
+    """
+    port, received = activity_server
+    monkeypatch.setenv("OSPREY_WEB_PORT", str(port))
+    nb_path = make_notebook(tmp_path, "plot.ipynb", subdir="artifacts")
+
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert received == []
+
+
+@pytest.mark.unit
+def test_notebook_outside_agent_data_posts_nothing(
+    tmp_path, monkeypatch, run_notebook_update_hook, activity_server
+):
+    """A notebook edited anywhere else in the project badges nothing either."""
+    port, received = activity_server
+    monkeypatch.setenv("OSPREY_WEB_PORT", str(port))
+    nb_path = tmp_path / "loose.ipynb"
+    nb_path.write_text("{}")
+
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert received == []
+
+
+@pytest.mark.unit
+def test_badge_survives_down_web_terminal(tmp_path, monkeypatch, run_notebook_update_hook):
+    """No web terminal costs a badge, not the tool call — and not the cache.
+
+    The invalidation runs before the emit, so the one observable effect the
+    hook owns unconditionally still happens with nothing listening.
+    """
+    monkeypatch.setenv("OSPREY_WEB_PORT", str(closed_port()))
+    nb_path = make_notebook(tmp_path, "scan.ipynb")
+    cached_html = nb_path.parent / "_notebook_cache" / "scan_rendered.html"
+    cached_html.parent.mkdir()
+    cached_html.write_text("<html>cached</html>")
+
+    run_notebook_update_hook({"notebook_path": str(nb_path)}, cwd=tmp_path)
+
+    assert not cached_html.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "token, expected",
+    [("panel-secret", "Bearer panel-secret"), ("  ", None), ("", None)],
+    ids=["token", "whitespace-only", "empty"],
+)
+def test_activity_request_carries_the_panel_token(hook_module, monkeypatch, token, expected):
+    """The bearer rides along only when the carrier holds a real value.
+
+    A blank ``OSPREY_PANEL_TOKEN`` — an uninterpolated compose variable, a
+    hand-edited one — is a credential this hook cannot back, so the header is
+    omitted entirely rather than sent empty. Exercised in-process because the
+    hook subprocess runs on a curated environment that does not forward the
+    carrier.
+    """
+    hook = hook_module("osprey_notebook_update")
+    monkeypatch.setenv("OSPREY_PANEL_TOKEN", token)
+
+    request = hook._activity_request("scan.ipynb")
+
+    assert request.headers.get("Authorization") == expected
+
+
+@pytest.mark.unit
+def test_activity_request_targets_the_configured_web_port(hook_module, monkeypatch):
+    """The emit dials ``OSPREY_WEB_PORT`` on loopback."""
+    hook = hook_module("osprey_notebook_update")
+    monkeypatch.setenv("OSPREY_WEB_PORT", "10999")
+
+    request = hook._activity_request("scan.ipynb")
+
+    assert request.full_url == "http://127.0.0.1:10999/api/agent-activity"

--- a/tests/interfaces/test_panel_launch_gating.py
+++ b/tests/interfaces/test_panel_launch_gating.py
@@ -228,10 +228,18 @@ class TestEnabledPanelSelection:
         assert launch_calls == []
 
     def test_every_builtin_panel_is_launchable(self, stub_app, launch_calls):
-        """No built-in panel may be enabled with nothing to launch behind it."""
-        from osprey.profiles.web_panels import BUILTIN_PANELS
+        """No built-in panel may be enabled with nothing to launch behind it.
 
-        web_terminal_app._launch_enabled_panel_servers(stub_app, set(BUILTIN_PANELS))
+        Scoped to the companion servers. A sidecar panel is built in too, but
+        nothing in ``registry.web`` launches it — it is started from
+        :data:`~osprey.profiles.web_panels.SIDECAR_PANELS` instead — so feeding
+        its id to this launcher would assert the wrong contract.
+        """
+        from osprey.profiles.web_panels import BUILTIN_PANELS, SIDECAR_PANELS
+
+        web_terminal_app._launch_enabled_panel_servers(
+            stub_app, BUILTIN_PANELS - set(SIDECAR_PANELS)
+        )
 
         assert sorted(launch_calls) == ALL_KEYS
 

--- a/tests/interfaces/web_terminal/activity-strip.test.mjs
+++ b/tests/interfaces/web_terminal/activity-strip.test.mjs
@@ -319,6 +319,25 @@ describe('panel action verbs', () => {
     strip.handleActivity(frame({ kind: 'panel', panel: 'lattice' }, 'close_panel'));
     expect(mount.textContent).toContain('agent closed');
   });
+
+  test('NotebookEdit with a detail reads "agent edited <notebook>"', () => {
+    const strip = makeStrip();
+    strip.handleActivity(
+      frame({ kind: 'panel', panel: 'jupyter', detail: 'getting-started.ipynb' }, 'NotebookEdit'),
+    );
+
+    expect(mount.textContent).toContain('agent edited');
+    expect(mount.textContent).toContain('getting-started.ipynb');
+  });
+
+  test('NotebookEdit with no detail falls back to the panel label', () => {
+    const strip = makeStrip();
+    strip.handleActivity(frame({ kind: 'panel', panel: 'jupyter' }, 'NotebookEdit'));
+
+    expect(mount.textContent).toContain('agent edited');
+    expect(mount.textContent).toContain('jupyter');
+    expect(mount.textContent).not.toContain('agent touched');
+  });
 });
 
 describe('arrange coalescing', () => {

--- a/tests/interfaces/web_terminal/test_jupyter_contents.py
+++ b/tests/interfaces/web_terminal/test_jupyter_contents.py
@@ -1,0 +1,146 @@
+"""Tests for the notebook sidecar's confined contents manager.
+
+The upstream root check is textual, so these cover the case it misses — a name
+under the root whose target is not — alongside the ordinary paths that must
+keep working, and the import isolation the sidecar process depends on.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from jupyter_server.base.handlers import AuthenticatedFileHandler
+from jupyter_server.files.handlers import FilesHandler
+from jupyter_server.services.contents.filecheckpoints import AsyncFileCheckpoints
+from jupyter_server.services.contents.filemanager import AsyncFileContentsManager
+from tornado.web import HTTPError
+
+from osprey.interfaces.web_terminal.jupyter_contents import (
+    ConfinedFileCheckpoints,
+    ConfinedFileContentsManager,
+    RawFilesHandler,
+)
+
+
+@pytest.fixture
+def root(tmp_path: Path) -> Path:
+    """Return a contents root with a sibling directory to escape into."""
+    contents_root = tmp_path / "notebooks"
+    contents_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret")
+    return contents_root
+
+
+@pytest.fixture
+def manager(root: Path) -> ConfinedFileContentsManager:
+    return ConfinedFileContentsManager(root_dir=str(root))
+
+
+def test_the_sidecar_uses_an_async_manager() -> None:
+    assert issubclass(ConfinedFileContentsManager, AsyncFileContentsManager)
+
+
+def test_a_file_in_the_root_resolves(manager: ConfinedFileContentsManager, root: Path) -> None:
+    (root / "run.ipynb").write_text("{}")
+
+    assert manager._get_os_path("run.ipynb") == str(root / "run.ipynb")
+
+
+def test_a_path_that_does_not_exist_yet_resolves(
+    manager: ConfinedFileContentsManager, root: Path
+) -> None:
+    assert manager._get_os_path("new.ipynb") == str(root / "new.ipynb")
+
+
+def test_the_root_itself_resolves(manager: ConfinedFileContentsManager, root: Path) -> None:
+    assert manager._get_os_path("") == str(root)
+
+
+def test_a_symlink_inside_the_root_resolves(
+    manager: ConfinedFileContentsManager, root: Path
+) -> None:
+    (root / "real.ipynb").write_text("{}")
+    (root / "alias.ipynb").symlink_to(root / "real.ipynb")
+
+    assert manager._get_os_path("alias.ipynb") == str(root / "alias.ipynb")
+
+
+def test_a_symlink_out_of_the_root_is_not_found(
+    manager: ConfinedFileContentsManager, root: Path
+) -> None:
+    (root / "escape.txt").symlink_to(root.parent / "outside" / "secret.txt")
+
+    with pytest.raises(HTTPError) as excinfo:
+        manager._get_os_path("escape.txt")
+
+    assert excinfo.value.status_code == 404
+
+
+def test_a_symlinked_directory_out_of_the_root_is_not_found(
+    manager: ConfinedFileContentsManager, root: Path
+) -> None:
+    (root / "elsewhere").symlink_to(root.parent / "outside", target_is_directory=True)
+
+    with pytest.raises(HTTPError) as excinfo:
+        manager._get_os_path("elsewhere/secret.txt")
+
+    assert excinfo.value.status_code == 404
+
+
+def test_a_parent_traversal_is_not_found(manager: ConfinedFileContentsManager) -> None:
+    with pytest.raises(HTTPError) as excinfo:
+        manager._get_os_path("../outside/secret.txt")
+
+    assert excinfo.value.status_code == 404
+
+
+def test_importing_the_module_does_not_build_the_web_application() -> None:
+    probe = (
+        "import sys\n"
+        "import osprey.interfaces.web_terminal.jupyter_contents\n"
+        "print('osprey.interfaces.web_terminal.app' in sys.modules)\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_raw_files_are_served_through_the_contents_manager(
+    manager: ConfinedFileContentsManager, root: Path
+) -> None:
+    """``/files/`` must reach ``_get_os_path``; the static handler never does."""
+    assert manager.files_handler_class is RawFilesHandler
+    assert issubclass(RawFilesHandler, FilesHandler)
+    assert not issubclass(manager.files_handler_class, AuthenticatedFileHandler)
+
+    handlers = manager.get_extra_handlers()
+
+    assert handlers == [(r"/files/(.*)", RawFilesHandler, {"path": str(root)})]
+
+
+def test_checkpoints_share_the_confinement(
+    manager: ConfinedFileContentsManager, root: Path
+) -> None:
+    """The checkpoints resolve paths with their own copy of the mixin."""
+    (root / "elsewhere").symlink_to(root.parent / "outside", target_is_directory=True)
+    checkpoints = manager.checkpoints
+
+    assert isinstance(checkpoints, ConfinedFileCheckpoints)
+    assert isinstance(checkpoints, AsyncFileCheckpoints)
+    assert checkpoints.root_dir == str(root)
+    assert checkpoints._get_os_path("run.ipynb") == str(root / "run.ipynb")
+    with pytest.raises(HTTPError) as excinfo:
+        checkpoints.checkpoint_path("checkpoint", "elsewhere/x.ipynb")
+    assert excinfo.value.status_code == 404
+    assert not (root.parent / "outside" / ".ipynb_checkpoints").exists()

--- a/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
+++ b/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
@@ -102,6 +102,12 @@ def shared_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
       attribute on its own module.
     * ``OSPREY_CONFIG`` only has to be SET — the sidecar's preflight refuses to
       launch without it and reads nothing out of it.
+    * ``routes.websocket`` binds ``resolve_agent_data_root`` with a
+      module-level ``from ... import``, so the name it calls is its own and the
+      patch on ``operator_session`` never reaches it. That is the root
+      ``write_binding`` writes under; unpatched it derives the cwd, dropping
+      ``var/agent_data/jupyter/session-binding.json`` into the repository and
+      failing the session posture leak guard.
     * ``OSPREY_WEB_THEME`` resolves to a pinned mode of ``dark`` during startup,
       which is the value that reaches the sidecar's labconfig override.
 
@@ -116,12 +122,14 @@ def shared_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         The shared root the sidecar will use.
     """
     from osprey.interfaces.web_terminal import operator_session
+    from osprey.interfaces.web_terminal.routes import websocket
 
     root = tmp_path / "agent_data"
     root.mkdir()
     monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "does-not-exist.yml"))
     monkeypatch.setenv("OSPREY_WEB_THEME", "dark")
     monkeypatch.setattr(operator_session, "resolve_agent_data_root", lambda app=None: str(root))
+    monkeypatch.setattr(websocket, "resolve_agent_data_root", lambda app=None: str(root))
     return root
 
 

--- a/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
+++ b/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
@@ -1,0 +1,387 @@
+"""Browser smoke: the NOTEBOOKS panel, from the rail entry to a cell's output.
+
+One flow through the whole stack a real operator touches, with nothing stubbed
+below the browser: the terminal's lifespan spawns a real ``jupyter_server``
+sidecar on an ephemeral loopback port, the rail entry's health poll reaches it
+through the panel proxy, the panel iframe loads JupyterLab from
+``/panel/jupyter``, the starter notebook opens from the file browser, and its
+cells run on a real kernel started through the OSPREY kernelspec.
+
+What only a browser can prove, and why each step is here:
+
+  * the rail entry becomes ENABLED — the health poll really reaches the
+    sidecar's ``api/status`` through the proxy, with the per-launch token
+    re-issued server-side (the browser never holds it);
+  * the panel iframe really renders JupyterLab, rather than the bare
+    "Jupyter Server" landing page the sidecar serves without a pinned
+    ``default_url``;
+  * a pinned dark web theme reaches JupyterLab through the labconfig override
+    the sidecar writes — the override file existing proves nothing about
+    whether ``jupyterlab_server`` applied it;
+  * ``getting-started.ipynb`` is listed and opens, and its import cell runs
+    with no output at all — the kernel's interpreter can import
+    ``osprey.runtime``, which no in-process test can establish;
+  * a fresh cell round-trips ``1+1`` to ``2``, so the proxy's WebSocket leg
+    carries the kernel channels in both directions;
+  * nothing outlives the server: no sidecar, no kernel.
+
+The kernel's first start runs a fresh interpreter through the launcher, so the
+timeouts here are generous by design rather than by superstition.
+
+Run:
+    uv run pytest tests/interfaces/web_terminal/test_jupyter_panel_browser.py -m browser -q
+
+Skips cleanly when the chromium headless binary is not installed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from tests.interfaces._panel_launch import DEFAULT_ARTIFACT_URL, publish_artifact_url
+from tests.interfaces.conftest import _run_app_server
+
+# ---------------------------------------------------------------------------
+# Playwright availability guard
+# ---------------------------------------------------------------------------
+
+try:
+    from playwright.sync_api import Page, expect
+
+    _PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PLAYWRIGHT_AVAILABLE = False
+
+pytestmark = [pytest.mark.browser, pytest.mark.slow]
+
+#: JupyterLab's own boot inside the panel iframe. The bundle is large and every
+#: byte of it crosses the terminal's panel proxy.
+_LAB_BOOT_MS = 90_000
+
+#: A kernel's first start: a fresh interpreter that imports ``osprey.runtime``
+#: before it answers anything.
+_KERNEL_TIMEOUT = 180.0
+
+#: A cell's round trip once the kernel is already idle.
+_EXEC_MS = 60_000
+
+#: Wide enough that JupyterLab keeps its left sidebar open inside the panel
+#: tile. Below roughly 600px of iframe width Lab collapses to its narrow
+#: layout and the file browser is no longer on screen to double-click.
+_VIEWPORT = {"width": 1600, "height": 1000}
+
+#: Seeded before load: marks the onboarding tour dismissed, so its invite card
+#: cannot overlay the shell and swallow the rail click. Same seed the sibling
+#: dock suite uses; the tour has its own coverage.
+_DISMISS_RAIL_HINT = "try { localStorage.setItem('osprey-tour-dismissed-v1', '1') } catch (e) {}"
+
+
+# ---------------------------------------------------------------------------
+# Environment: a shared root and a pinned theme, both inside tmp_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def shared_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the sidecar at a throwaway agent-data root and pin the theme dark.
+
+    Three seams, all of them read during the lifespan rather than by the test:
+
+    * ``resolve_agent_data_root`` is what ``_launch_sidecar`` hands the sidecar
+      as its shared root, so repointing it puts ``notebooks/`` and the sidecar's
+      persistent state under *tmp_path* instead of the developer's own
+      ``var/agent_data``. It is imported inside the function, so the seam is the
+      attribute on its own module.
+    * ``OSPREY_CONFIG`` only has to be SET — the sidecar's preflight refuses to
+      launch without it and reads nothing out of it.
+    * ``OSPREY_WEB_THEME`` resolves to a pinned mode of ``dark`` during startup,
+      which is the value that reaches the sidecar's labconfig override.
+
+    ``TMPDIR`` is deliberately NOT set. The sidecar's per-launch tempdir is a
+    ``tempfile.mkdtemp`` in this same process, and ``tempfile`` caches its
+    directory on first use — which ``tmp_path``'s own factory has already
+    triggered before any fixture runs. Setting it here would read as though the
+    runtime dir were being relocated while changing nothing at all, so the
+    teardown check asks the sidecar where its runtime dir actually is instead.
+
+    Returns:
+        The shared root the sidecar will use.
+    """
+    from osprey.interfaces.web_terminal import operator_session
+
+    root = tmp_path / "agent_data"
+    root.mkdir()
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "does-not-exist.yml"))
+    monkeypatch.setenv("OSPREY_WEB_THEME", "dark")
+    monkeypatch.setattr(operator_session, "resolve_agent_data_root", lambda app=None: str(root))
+    return root
+
+
+@contextmanager
+def _live_server(workspace_dir: Path):
+    """Launch a real web terminal with the NOTEBOOKS panel enabled.
+
+    The patch set is the sibling dock suite's, minus the parts this flow does
+    not need: the artifacts panel is published at the shared unserved address
+    (it is the default panel and would otherwise hold the boot open), and the
+    panel config is handed over directly rather than read from a profile.
+
+    Nothing about the sidecar is patched — the lifespan spawns it for real,
+    which is the point of this module.
+
+    Args:
+        workspace_dir: The directory the file watcher is pointed at.
+
+    Yields:
+        ``(base_url, app)`` — the live server address and the FastAPI app.
+    """
+    with (
+        patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace_dir)},
+        ),
+        patch(
+            "osprey.interfaces.web_terminal.app._load_panel_config",
+            return_value=({"artifacts", "jupyter"}, [], None),
+        ),
+        patch(
+            "osprey.interfaces.web_terminal.app._launch_panel_server",
+            side_effect=publish_artifact_url(DEFAULT_ARTIFACT_URL),
+        ),
+    ):
+        from osprey.interfaces.web_terminal.app import create_app
+
+        app = create_app(shell_command=["echo", "hello"])
+        with _run_app_server(app) as base_url:
+            yield base_url, app
+
+
+# ---------------------------------------------------------------------------
+# Page helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_page(browser, base_url: str) -> Page:
+    """Open the terminal and wait for the rail and the dock grid to render.
+
+    Args:
+        browser: The function-scoped chromium fixture.
+        base_url: The live server's address.
+
+    Returns:
+        A page whose rail and dockview grid are both on screen.
+    """
+    page = browser.new_page(viewport=_VIEWPORT)
+    page.add_init_script(_DISMISS_RAIL_HINT)
+    page.goto(base_url, wait_until="domcontentloaded")
+    expect(page.locator('button.panel-rail-button[data-panel-id="artifacts"]')).to_be_attached(
+        timeout=10_000
+    )
+    expect(page.locator(".dv-groupview").first).to_be_visible(timeout=10_000)
+    return page
+
+
+def _rail_entry(page: Page, panel_id: str):
+    """The rail button for *panel_id*, healthy or not."""
+    return page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]')
+
+
+def _enabled_rail_entry(page: Page, panel_id: str):
+    """The rail button for *panel_id*, only once its health poll settled healthy.
+
+    The rail signals availability with the ``disabled`` CSS class rather than
+    the HTML attribute (``panel-rail.js`` ``setEntryEnabled``), so the enabled
+    state is a class assertion — the same handle the sibling dock suite waits
+    on.
+    """
+    return page.locator(f'button.panel-rail-button[data-panel-id="{panel_id}"]:not(.disabled)')
+
+
+def _lab(page: Page):
+    """A frame locator scoped to the NOTEBOOKS panel's overlay iframe.
+
+    Service panels render into an overlay iframe layer that tracks the dock
+    group's geometry (``dock-iframe.js``), so the iframe is addressed by its
+    ``data-panel-id`` inside that layer rather than by position.
+    """
+    return page.frame_locator('.dock-iframe-overlay iframe[data-panel-id="jupyter"]')
+
+
+def _wait_for_idle_kernel(base_url: str, timeout: float) -> dict:
+    """Block until the sidecar reports a notebook session with an idle kernel.
+
+    Driven from the test process rather than from the DOM. The kernel's first
+    start runs a fresh interpreter through the OSPREY launcher, and the
+    server's own session list is the one unambiguous signal that it came up —
+    a toolbar indicator reads "idle" just as readily before any kernel was
+    requested at all.
+
+    Args:
+        base_url: The live server's address; the sidecar is reached through its
+            panel proxy.
+        timeout: Seconds to wait before failing.
+
+    Returns:
+        The session record whose kernel reported idle.
+
+    Raises:
+        AssertionError: No session reported an idle kernel in time.
+    """
+    deadline = time.monotonic() + timeout
+    seen: object = None
+    while time.monotonic() < deadline:
+        response = requests.get(f"{base_url}/panel/jupyter/api/sessions", timeout=10)
+        if response.ok:
+            seen = response.json()
+            for session in seen:
+                if (session.get("kernel") or {}).get("execution_state") == "idle":
+                    return session
+        time.sleep(0.5)
+    raise AssertionError(f"No idle kernel within {timeout:.0f} s; sessions: {seen}")
+
+
+def _assert_nothing_outlived(*patterns: str) -> None:
+    """Fail if any process still names one of *patterns* after the server stopped.
+
+    Both processes this feature starts have to be named, and they are named by
+    different paths:
+
+    * the SIDECAR by the shared root, which its argv carries as
+      ``--ServerApp.root_dir=<shared root>/notebooks``;
+    * every KERNEL by the sidecar's per-launch runtime directory, which its argv
+      carries as ``-f <runtime dir>/kernel-<id>.json``. That directory is a
+      ``tempfile.mkdtemp`` in the system temp dir, NOT under ``tmp_path``, so
+      the shared root alone would never match a kernel — and a kernel is the
+      process most worth checking, because ``jupyter_client`` starts it in its
+      own session, outside the group the sidecar signals. It survives unless
+      jupyter_server's own shutdown reaps it, which is exactly the path this
+      guards.
+
+    Both paths are unique to one run, so neither can trip over a Jupyter the
+    developer is running themselves.
+
+    Polled rather than sampled once: the server thread is joined with its own
+    timeout, so the lifespan's shutdown may still be terminating processes when
+    this is reached.
+
+    Args:
+        *patterns: Absolute paths to look for in full command lines.
+
+    Raises:
+        AssertionError: A process still names one of them after the grace window.
+    """
+    if shutil.which("pgrep") is None:  # pragma: no cover - POSIX runners have it
+        return
+    deadline = time.monotonic() + 15.0
+    listing = ""
+    while time.monotonic() < deadline:
+        found = subprocess.run(
+            ["pgrep", "-fl", "|".join(str(p) for p in patterns)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if found.returncode != 0:
+            return
+        listing = found.stdout
+        time.sleep(0.5)
+    raise AssertionError(f"Processes outlived the server:\n{listing}")
+
+
+# ===========================================================================
+# The flow
+# ===========================================================================
+
+
+def test_notebooks_panel_opens_jupyterlab_and_runs_cells_on_a_real_kernel(
+    tmp_path, chromium_browser, shared_root
+):
+    """The NOTEBOOKS panel, end to end: rail entry, JupyterLab, a live kernel.
+
+    Ordered so a failure names its own step. The rail entry is asserted enabled
+    BEFORE it is clicked: a disabled entry is ``pointer-events: none``, so a
+    click alone would wait out the health poll silently and report a timeout on
+    the wrong element.
+
+    The import cell is asserted to produce NO output rather than "no error
+    output": a successful ``from osprey.runtime import ...`` renders nothing at
+    all, so an empty output area is the stronger statement and a traceback
+    fails it. That check is deliberately the LAST one in the flow — see the
+    comment at its call site.
+    """
+    workspace = tmp_path / "watch"
+    workspace.mkdir()
+
+    with _live_server(workspace) as (base_url, app):
+        assert getattr(app.state, "jupyter_server_url", None), (
+            "the lifespan published no sidecar URL — the launch failed before the browser"
+        )
+
+        page = _open_page(chromium_browser, base_url)
+
+        # The health poll goes through /panel/jupyter/api/status, with the
+        # per-launch token re-issued server-side.
+        expect(_enabled_rail_entry(page, "jupyter")).to_be_attached(timeout=60_000)
+
+        # A rail click takes the focused tile over (one panel per tile).
+        _rail_entry(page, "jupyter").click()
+        expect(page.locator('.tile-tab[aria-label="NOTEBOOKS"]')).to_have_count(1, timeout=10_000)
+
+        lab = _lab(page)
+        expect(lab.locator("#jp-main-dock-panel")).to_be_visible(timeout=_LAB_BOOT_MS)
+
+        # The pinned dark web theme reached JupyterLab through the labconfig
+        # override the sidecar wrote for this launch.
+        body = lab.locator("body")
+        expect(body).to_have_attribute("data-jp-theme-light", "false", timeout=_LAB_BOOT_MS)
+        expect(body).to_have_attribute("data-jp-theme-name", "JupyterLab Dark")
+
+        # The starter notebook seeded into the empty notebooks/ is listed, and
+        # opens the way an operator opens it.
+        starter = lab.locator(".jp-DirListing-item").filter(has_text="getting-started.ipynb")
+        expect(starter).to_have_count(1, timeout=_LAB_BOOT_MS)
+        starter.dblclick()
+        expect(lab.locator(".jp-NotebookPanel")).to_be_visible(timeout=_LAB_BOOT_MS)
+
+        _wait_for_idle_kernel(base_url, _KERNEL_TIMEOUT)
+
+        # Run the import cell. Shift+Enter on the last cell also appends a
+        # fresh one, which is the cell the arithmetic goes into below.
+        import_cell = lab.locator(".jp-CodeCell").first
+        import_cell.locator(".cm-content").click()
+        page.keyboard.press("Shift+Enter")
+
+        expect(import_cell.locator(".jp-InputArea-prompt")).to_have_text("[1]:", timeout=_EXEC_MS)
+
+        cells = lab.locator(".jp-CodeCell")
+        expect(cells).to_have_count(2, timeout=_EXEC_MS)
+        arithmetic = cells.nth(1)
+        arithmetic.locator(".cm-content").click()
+        page.keyboard.type("1+1")
+        page.keyboard.press("Shift+Enter")
+
+        expect(arithmetic.locator(".jp-OutputArea-output")).to_have_text("2", timeout=_EXEC_MS)
+
+        # Checked last, not beside the prompt above. The prompt comes from the
+        # shell reply while a traceback arrives separately on iopub, so a check
+        # taken the moment the prompt lands can read an output area that is
+        # merely still empty. By the time the SECOND cell has rendered its
+        # result, everything the first cell will ever emit has arrived.
+        expect(import_cell.locator(".jp-OutputArea-output")).to_have_count(0)
+
+        # Read while the sidecar is still up: stop() clears the property and
+        # removes the directory.
+        runtime_dir = app.state.sidecars["jupyter"].runtime_dir
+        assert runtime_dir is not None, "the sidecar reported no runtime dir while running"
+
+        page.close()
+
+    _assert_nothing_outlived(str(shared_root), str(runtime_dir))

--- a/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
+++ b/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
@@ -289,19 +289,39 @@ def _assert_nothing_outlived(*patterns: str) -> None:
     if shutil.which("pgrep") is None:  # pragma: no cover - POSIX runners have it
         return
     deadline = time.monotonic() + 15.0
-    listing = ""
+    pids: list[str] = []
     while time.monotonic() < deadline:
         found = subprocess.run(
-            ["pgrep", "-fl", "|".join(str(p) for p in patterns)],
+            ["pgrep", "-f", "|".join(str(p) for p in patterns)],
             capture_output=True,
             text=True,
             check=False,
         )
         if found.returncode != 0:
             return
-        listing = found.stdout
+        pids = found.stdout.split()
         time.sleep(0.5)
-    raise AssertionError(f"Processes outlived the server:\n{listing}")
+    raise AssertionError(f"Processes outlived the server:\n{_describe(pids)}")
+
+
+def _describe(pids: list[str]) -> str:
+    """Render *pids* as one ``pid: command line`` per line, for a failure message.
+
+    ``pgrep -l`` is not enough: on Linux it prints the process *name*, so every
+    survivor reads ``python`` and the report cannot say which of the two paths
+    it was matched on. ``pgrep -a`` would print the command line but is not in
+    macOS's pgrep, so the lookup goes through ``ps``, which both have.
+    """
+    described = []
+    for pid in pids:
+        shown = subprocess.run(
+            ["ps", "-p", pid, "-o", "command="],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        described.append(f"  {pid}: {shown.stdout.strip() or '<gone>'}")
+    return "\n".join(described)
 
 
 # ===========================================================================

--- a/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
+++ b/tests/interfaces/web_terminal/test_jupyter_panel_browser.py
@@ -1,4 +1,4 @@
-"""Browser smoke: the NOTEBOOKS panel, from the rail entry to a cell's output.
+"""Browser smoke: the JUPYTER panel, from the rail entry to a cell's output.
 
 One flow through the whole stack a real operator touches, with nothing stubbed
 below the browser: the terminal's lifespan spawns a real ``jupyter_server``
@@ -135,7 +135,7 @@ def shared_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @contextmanager
 def _live_server(workspace_dir: Path):
-    """Launch a real web terminal with the NOTEBOOKS panel enabled.
+    """Launch a real web terminal with the JUPYTER panel enabled.
 
     The patch set is the sibling dock suite's, minus the parts this flow does
     not need: the artifacts panel is published at the shared unserved address
@@ -214,7 +214,7 @@ def _enabled_rail_entry(page: Page, panel_id: str):
 
 
 def _lab(page: Page):
-    """A frame locator scoped to the NOTEBOOKS panel's overlay iframe.
+    """A frame locator scoped to the JUPYTER panel's overlay iframe.
 
     Service panels render into an overlay iframe layer that tracks the dock
     group's geometry (``dock-iframe.js``), so the iframe is addressed by its
@@ -312,7 +312,7 @@ def _assert_nothing_outlived(*patterns: str) -> None:
 def test_notebooks_panel_opens_jupyterlab_and_runs_cells_on_a_real_kernel(
     tmp_path, chromium_browser, shared_root
 ):
-    """The NOTEBOOKS panel, end to end: rail entry, JupyterLab, a live kernel.
+    """The JUPYTER panel, end to end: rail entry, JupyterLab, a live kernel.
 
     Ordered so a failure names its own step. The rail entry is asserted enabled
     BEFORE it is clicked: a disabled entry is ``pointer-events: none``, so a
@@ -341,7 +341,7 @@ def test_notebooks_panel_opens_jupyterlab_and_runs_cells_on_a_real_kernel(
 
         # A rail click takes the focused tile over (one panel per tile).
         _rail_entry(page, "jupyter").click()
-        expect(page.locator('.tile-tab[aria-label="NOTEBOOKS"]')).to_have_count(1, timeout=10_000)
+        expect(page.locator('.tile-tab[aria-label="JUPYTER"]')).to_have_count(1, timeout=10_000)
 
         lab = _lab(page)
         expect(lab.locator("#jp-main-dock-panel")).to_be_visible(timeout=_LAB_BOOT_MS)

--- a/tests/interfaces/web_terminal/test_jupyter_sidecar.py
+++ b/tests/interfaces/web_terminal/test_jupyter_sidecar.py
@@ -1,0 +1,708 @@
+"""The notebook sidecar: a real ``jupyter_server`` on port 0 under a temp shared root.
+
+Every test that spawns a server does so through :class:`JupyterSidecar` itself,
+so what is pinned here is the launch contract the terminal relies on: the
+token gate, the single kernelspec, where the secrets live, and that nothing
+survives ``stop()`` or a dead parent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import nbformat
+import pytest
+
+from osprey.interfaces.web_terminal import jupyter_sidecar
+from osprey.interfaces.web_terminal.jupyter_sidecar import (
+    KERNELSPEC_NAME,
+    LAB_DISABLED_EXTENSIONS,
+    JupyterSidecar,
+    lab_page_config,
+    lab_theme_override,
+    seed_starter_notebook,
+)
+from osprey.mcp_server.python_executor.executor import resolve_agent_interpreter
+
+READY_TIMEOUT = 90.0
+
+spawns = pytest.mark.slow
+
+
+@pytest.fixture
+def shared_root(tmp_path: Path) -> Path:
+    return tmp_path / "shared"
+
+
+@pytest.fixture
+def config_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OSPREY_CONFIG", str(tmp_path / "does-not-exist.yml"))
+    # Keep every per-launch tempdir under the test's own tree.
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+
+
+def _running(shared_root: Path, outer_prefix: str = "") -> Iterator[JupyterSidecar]:
+    sidecar = JupyterSidecar(shared_root, outer_prefix, None)
+    try:
+        sidecar.spawn()
+        sidecar.wait_ready(READY_TIMEOUT)
+        yield sidecar
+    finally:
+        sidecar.stop()
+
+
+@pytest.fixture
+def sidecar(config_env: None, shared_root: Path) -> Iterator[JupyterSidecar]:
+    yield from _running(shared_root)
+
+
+def _get(url: str, headers: dict[str, str] | None = None) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read()
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """An opener that reports a redirect instead of following it."""
+
+    def redirect_request(self, *args: object, **kwargs: object) -> urllib.request.Request | None:
+        return None
+
+
+_no_redirect_opener = urllib.request.build_opener(_NoRedirect)
+
+
+def _get_no_redirect(url: str, headers: dict[str, str] | None = None) -> tuple[int, str]:
+    """GET *url* without following a redirect; returns status and ``Location``."""
+    request = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with _no_redirect_opener.open(request, timeout=10) as response:
+            return int(response.status), response.headers.get("Location", "")
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.headers.get("Location", "")
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def _wait_gone(pid: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _alive(pid):
+            return True
+        time.sleep(0.1)
+    return not _alive(pid)
+
+
+# ---------------------------------------------------------------------------
+# A running sidecar
+# ---------------------------------------------------------------------------
+
+
+@spawns
+def test_status_answers_with_the_token_and_refuses_without(sidecar: JupyterSidecar) -> None:
+    with_token, _ = _get(f"{sidecar.url}/api/status", sidecar.auth_headers)
+    without, _ = _get(f"{sidecar.url}/api/status")
+
+    assert with_token == 200
+    assert without == 403
+
+
+@spawns
+def test_only_the_osprey_kernelspec_is_listed(sidecar: JupyterSidecar) -> None:
+    status, body = _get(f"{sidecar.url}/api/kernelspecs", sidecar.auth_headers)
+
+    assert status == 200
+    assert sorted(json.loads(body)["kernelspecs"]) == [KERNELSPEC_NAME]
+
+
+@spawns
+def test_the_url_names_the_panel_without_a_trailing_slash(sidecar: JupyterSidecar) -> None:
+    assert sidecar.pid is not None
+    assert sidecar.url.startswith("http://127.0.0.1:")
+    assert sidecar.url.endswith("/panel/jupyter")
+    assert sidecar.token is not None
+    assert sidecar.auth_headers == {"authorization": f"Bearer {sidecar.token}"}
+
+
+@spawns
+def test_the_root_redirects_to_jupyterlab_not_the_server_landing_page(
+    sidecar: JupyterSidecar,
+) -> None:
+    status, location = _get_no_redirect(f"{sidecar.url}/", sidecar.auth_headers)
+    assert status == 302
+    assert location == f"{sidecar.base_url}lab?"
+
+    lab_status, body = _get(f"{sidecar.url}/lab", sidecar.auth_headers)
+    assert lab_status == 200
+    assert b"<title>JupyterLab</title>" in body
+    assert b"A Jupyter Server is running" not in body
+
+
+@spawns
+def test_the_outer_prefix_is_part_of_the_base_url(config_env: None, shared_root: Path) -> None:
+    for prefixed in _running(shared_root, "/u/alice"):
+        assert prefixed.url.endswith("/u/alice/panel/jupyter")
+        status, _ = _get(f"{prefixed.url}/api/status", prefixed.auth_headers)
+        assert status == 200
+
+
+@spawns
+def test_the_runtime_dir_is_outside_the_shared_root(
+    sidecar: JupyterSidecar, shared_root: Path
+) -> None:
+    runtime_dir = sidecar.runtime_dir
+
+    assert runtime_dir is not None
+    assert not runtime_dir.resolve().is_relative_to(shared_root.resolve())
+    assert (runtime_dir / f"jpserver-{sidecar.pid}.json").exists()
+    assert list(shared_root.rglob("jpserver-*.json")) == []
+    assert (runtime_dir.parent.stat().st_mode & 0o777) == 0o700
+
+
+@spawns
+def test_the_kernelspec_runs_the_agent_interpreter_with_the_two_env_keys(
+    sidecar: JupyterSidecar, shared_root: Path
+) -> None:
+    spec = json.loads(sidecar.kernelspec_path.read_text(encoding="utf-8"))
+
+    assert spec["argv"] == [
+        str(resolve_agent_interpreter()),
+        "-m",
+        "osprey.jupyter_kernel",
+        "-f",
+        "{connection_file}",
+    ]
+    assert spec["language"] == "python"
+    assert spec["env"] == {"JUPYTER_TOKEN": "", "OSPREY_AGENT_DATA_ROOT": str(shared_root)}
+    assert sidecar.notebooks_dir == shared_root / "notebooks"
+    assert sidecar.notebooks_dir.is_dir()
+
+
+@spawns
+def test_stop_leaves_no_process_and_removes_the_tempdir(
+    config_env: None, shared_root: Path
+) -> None:
+    sidecar = JupyterSidecar(shared_root, "", None)
+    sidecar.stop()  # nothing spawned yet: a no-op
+    sidecar.spawn()
+    try:
+        sidecar.wait_ready(READY_TIMEOUT)
+        pid = sidecar.pid
+        runtime_dir = sidecar.runtime_dir
+        assert pid is not None and runtime_dir is not None
+    finally:
+        sidecar.stop()
+
+    assert not _alive(pid)
+    assert not runtime_dir.parent.exists()
+    assert sidecar.pid is None
+    assert sidecar.runtime_dir is None
+    sidecar.stop()  # a second stop is a no-op too
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_names_the_missing_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+
+    with pytest.raises(RuntimeError) as failure:
+        JupyterSidecar(Path("/unused"), "", None).preflight()
+
+    assert str(failure.value) == "OSPREY_CONFIG is not set"
+
+
+def test_preflight_names_an_interpreter_that_cannot_import(
+    config_env: None, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = tmp_path / "python"
+    fake.write_text(
+        "#!/bin/sh\necho \"ModuleNotFoundError: No module named 'ipykernel'\" >&2\nexit 1\n"
+    )
+    fake.chmod(0o755)
+    monkeypatch.setattr(jupyter_sidecar, "resolve_agent_interpreter", lambda: fake)
+
+    with pytest.raises(RuntimeError) as failure:
+        JupyterSidecar(tmp_path / "shared", "", None).preflight()
+
+    message = str(failure.value)
+    assert "\n" not in message
+    assert message.startswith(f"{fake} cannot import ipykernel and osprey.runtime: ")
+    assert message.endswith("ModuleNotFoundError: No module named 'ipykernel'")
+
+
+def test_preflight_passes_with_the_real_interpreter(config_env: None, tmp_path: Path) -> None:
+    JupyterSidecar(tmp_path / "shared", "", None).preflight()
+
+
+@spawns
+def test_an_early_exit_surfaces_the_stderr_tail(
+    config_env: None, shared_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = tmp_path / "python"
+    fake.write_text('#!/bin/sh\necho "first line" >&2\necho "the reason" >&2\nexit 3\n')
+    fake.chmod(0o755)
+    monkeypatch.setattr(jupyter_sidecar.sys, "executable", str(fake))
+    sidecar = JupyterSidecar(shared_root, "", None)
+    sidecar.spawn()
+    try:
+        with pytest.raises(RuntimeError) as failure:
+            sidecar.wait_ready(10)
+    finally:
+        sidecar.stop()
+
+    message = str(failure.value)
+    assert message.startswith("Notebook sidecar exited with status 3 before it was ready")
+    assert message.endswith("first line\nthe reason")
+
+
+# ---------------------------------------------------------------------------
+# Dev host: the sidecar follows its parent
+# ---------------------------------------------------------------------------
+
+_PARENT_SCRIPT = textwrap.dedent(
+    """
+    import sys, time
+    from pathlib import Path
+    from osprey.interfaces.web_terminal.jupyter_sidecar import JupyterSidecar
+
+    sidecar = JupyterSidecar(Path(sys.argv[1]), "", None)
+    sidecar.spawn()
+    sidecar.wait_ready(float(sys.argv[2]))
+    print(sidecar.pid, flush=True)
+    time.sleep(3600)
+    """
+)
+
+
+@spawns
+def test_the_sidecar_exits_when_its_parent_is_killed(
+    config_env: None, shared_root: Path, tmp_path: Path
+) -> None:
+    script = tmp_path / "parent.py"
+    script.write_text(_PARENT_SCRIPT)
+    parent = subprocess.Popen(
+        [sys.executable, str(script), str(shared_root), str(READY_TIMEOUT)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    sidecar_pid: int | None = None
+    try:
+        assert parent.stdout is not None
+        line = parent.stdout.readline()
+        assert line.strip(), "the parent did not report a sidecar pid"
+        sidecar_pid = int(line)
+        assert _alive(sidecar_pid)
+
+        os.kill(parent.pid, signal.SIGKILL)
+        parent.wait(10)
+
+        assert _wait_gone(sidecar_pid, 5.0), "the sidecar outlived its parent"
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait()
+        if sidecar_pid is not None and _alive(sidecar_pid):
+            os.killpg(sidecar_pid, signal.SIGKILL)
+
+
+# ---------------------------------------------------------------------------
+# Seeds at spawn: the pinned theme and the starter notebook
+# ---------------------------------------------------------------------------
+
+THEME_PLUGIN = "@jupyterlab/apputils-extension:themes"
+OVERRIDE_RELPATH = Path("labconfig") / "default_setting_overrides.json"
+PAGE_CONFIG_RELPATH = Path("labconfig") / "page_config.json"
+
+
+@pytest.mark.parametrize(
+    ("pinned_mode", "expected"),
+    [
+        ("dark", {THEME_PLUGIN: {"theme": "JupyterLab Dark"}}),
+        ("light", {THEME_PLUGIN: {"theme": "JupyterLab Light"}}),
+        (None, None),
+        ("retro", None),
+        ("desy", None),
+    ],
+)
+def test_only_dark_and_light_name_a_jupyterlab_theme(
+    pinned_mode: str | None, expected: dict[str, dict[str, str]] | None
+) -> None:
+    assert lab_theme_override(pinned_mode) == expected
+
+
+def test_a_pinned_theme_is_seeded_into_the_launch_config_dir(
+    shared_root: Path, tmp_path: Path
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    JupyterSidecar(shared_root, "", "dark")._seed(config_dir)
+
+    override = json.loads((config_dir / OVERRIDE_RELPATH).read_text(encoding="utf-8"))
+    assert override == {THEME_PLUGIN: {"theme": "JupyterLab Dark"}}
+
+
+def test_a_family_theme_seeds_no_override_file(shared_root: Path, tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    JupyterSidecar(shared_root, "", "retro")._seed(config_dir)
+
+    assert not (config_dir / OVERRIDE_RELPATH).exists()
+    assert [p.name for p in config_dir.rglob("*") if p.is_file()] == ["page_config.json"]
+
+
+def test_the_page_config_switches_off_the_panel_foreign_plugins(
+    shared_root: Path, tmp_path: Path
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    JupyterSidecar(shared_root, "", None)._seed(config_dir)
+
+    page_config = json.loads((config_dir / PAGE_CONFIG_RELPATH).read_text(encoding="utf-8"))
+    assert page_config == lab_page_config()
+    assert page_config == {
+        "disabledExtensions": {
+            "@jupyterlab/extensionmanager-extension": True,
+            "@jupyterlab/apputils-extension:announcements": True,
+        }
+    }
+    assert set(page_config["disabledExtensions"]) == set(LAB_DISABLED_EXTENSIONS)
+
+
+def test_the_argv_pins_the_server_traits(shared_root: Path) -> None:
+    argv = JupyterSidecar(shared_root, "/u/alice", None)._argv()
+
+    assert argv[:3] == [sys.executable, "-m", "osprey.interfaces.web_terminal.jupyter_sidecar_main"]
+    assert "--FileContentsManager.delete_to_trash=False" in argv
+    assert "--FileContentsManager.always_delete_dir=True" in argv
+    assert "--LabApp.news_url=None" in argv
+    assert (
+        "--LabApp.check_for_updates_class=jupyterlab.handlers.announcements.NeverCheckForUpdate"
+        in argv
+    )
+    assert "--ServerApp.base_url=/u/alice/panel/jupyter/" in argv
+    assert f"--KernelSpecManager.allowed_kernelspecs=['{KERNELSPEC_NAME}']" in argv
+
+
+def test_the_starter_notebook_is_written_into_an_empty_notebooks_dir(
+    shared_root: Path, tmp_path: Path
+) -> None:
+    sidecar = JupyterSidecar(shared_root, "", None)
+
+    sidecar._seed(tmp_path / "config")
+
+    notebook = nbformat.read(sidecar.notebooks_dir / "getting-started.ipynb", as_version=4)
+    assert [(cell.cell_type, cell.source) for cell in notebook.cells] == [
+        (
+            "markdown",
+            "This kernel follows your terminal session. Open a chat session before writing.",
+        ),
+        ("code", "from osprey.runtime import read_channel, write_channel"),
+    ]
+    assert notebook.metadata["kernelspec"]["name"] == KERNELSPEC_NAME
+
+
+def test_a_notebook_in_a_subdirectory_suppresses_the_starter(tmp_path: Path) -> None:
+    notebooks_dir = tmp_path / "notebooks"
+    (notebooks_dir / "runs").mkdir(parents=True)
+    (notebooks_dir / "runs" / "yesterday.ipynb").write_text("{}", encoding="utf-8")
+
+    assert seed_starter_notebook(notebooks_dir) is None
+    assert list(notebooks_dir.glob("*.ipynb")) == []
+
+
+def test_the_starter_is_never_rewritten(tmp_path: Path) -> None:
+    notebooks_dir = tmp_path / "notebooks"
+    notebooks_dir.mkdir()
+    written = seed_starter_notebook(notebooks_dir)
+    assert written is not None
+    written.write_text("edited by the user", encoding="utf-8")
+    before = written.stat().st_mtime_ns
+
+    assert seed_starter_notebook(notebooks_dir) is None
+
+    assert written.read_text(encoding="utf-8") == "edited by the user"
+    assert written.stat().st_mtime_ns == before
+
+
+@spawns
+def test_the_starter_notebook_is_listed_by_a_running_sidecar(sidecar: JupyterSidecar) -> None:
+    status, body = _get(f"{sidecar.url}/api/contents/", sidecar.auth_headers)
+
+    assert status == 200
+    listed = {entry["name"]: entry["type"] for entry in json.loads(body)["content"]}
+    assert listed["getting-started.ipynb"] == "notebook"
+
+
+# ---------------------------------------------------------------------------
+# What the running server does with the pinned traits and the page config
+# ---------------------------------------------------------------------------
+
+
+def _request(
+    method: str, url: str, headers: dict[str, str], body: bytes | None = None
+) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read()
+
+
+@spawns
+def test_raw_files_obey_the_same_confinement_as_the_contents_api(
+    sidecar: JupyterSidecar, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    (sidecar.notebooks_dir / "escape-file").symlink_to(outside / "secret.txt")
+    (sidecar.notebooks_dir / "escape-dir").symlink_to(outside, target_is_directory=True)
+    (sidecar.notebooks_dir / "alias.ipynb").symlink_to(
+        sidecar.notebooks_dir / "getting-started.ipynb"
+    )
+    headers = sidecar.auth_headers
+
+    status, body = _get(f"{sidecar.url}/files/getting-started.ipynb", headers)
+    assert status == 200
+    assert b'"cells"' in body
+
+    status, body = _request("HEAD", f"{sidecar.url}/files/getting-started.ipynb", headers)
+    assert status == 200
+    assert body == b""
+
+    status, _ = _get(f"{sidecar.url}/files/alias.ipynb", headers)
+    assert status == 200
+
+    for escape in (
+        "escape-file",
+        "escape-dir/secret.txt",
+        "../outside/secret.txt",
+        "..%2Foutside%2Fsecret.txt",
+        "%2e%2e/outside/secret.txt",
+    ):
+        files_status, files_body = _get(f"{sidecar.url}/files/{escape}", headers)
+        contents_status, _ = _get(f"{sidecar.url}/api/contents/{escape}", headers)
+        assert files_status == 404, (escape, files_body)
+        assert contents_status == 404, escape
+        assert b"secret" not in files_body
+
+
+@spawns
+def test_delete_removes_the_file_instead_of_trashing_it(
+    sidecar: JupyterSidecar, shared_root: Path
+) -> None:
+    headers = {**sidecar.auth_headers, "content-type": "application/json"}
+    document = json.dumps({"type": "file", "format": "text", "content": "doomed"}).encode()
+
+    status, _ = _request("PUT", f"{sidecar.url}/api/contents/doomed.txt", headers, document)
+    assert status == 201
+    assert (sidecar.notebooks_dir / "doomed.txt").read_text(encoding="utf-8") == "doomed"
+
+    status, _ = _request("DELETE", f"{sidecar.url}/api/contents/doomed.txt", headers)
+    assert status == 204
+
+    assert not (sidecar.notebooks_dir / "doomed.txt").exists()
+
+    folder = sidecar.notebooks_dir / "doomed-dir"
+    folder.mkdir()
+    (folder / "kept.txt").write_text("inside", encoding="utf-8")
+
+    status, body = _request("DELETE", f"{sidecar.url}/api/contents/doomed-dir", headers)
+    assert status == 204, body
+
+    assert not folder.exists()
+    assert list(shared_root.rglob(".Trash*")) == []
+
+
+@spawns
+def test_checkpoints_obey_the_same_confinement_as_the_contents_api(
+    sidecar: JupyterSidecar, tmp_path: Path
+) -> None:
+    outside = tmp_path / "outside"
+    (outside / ".ipynb_checkpoints").mkdir(parents=True)
+    (outside / "x.ipynb").write_text("{}", encoding="utf-8")
+    (outside / ".ipynb_checkpoints" / "x-checkpoint.ipynb").write_text("{}", encoding="utf-8")
+    (sidecar.notebooks_dir / "escape-dir").symlink_to(outside, target_is_directory=True)
+    headers = sidecar.auth_headers
+    escaped = f"{sidecar.url}/api/contents/escape-dir/x.ipynb/checkpoints"
+
+    status, _ = _get(escaped, headers)
+    assert status == 404
+    status, _ = _request("DELETE", f"{escaped}/checkpoint", headers)
+    assert status == 404
+    status, _ = _request("POST", escaped, headers, b"")
+    assert status == 404
+    assert (outside / ".ipynb_checkpoints" / "x-checkpoint.ipynb").exists()
+
+    inside = f"{sidecar.url}/api/contents/getting-started.ipynb/checkpoints"
+    status, body = _request("POST", inside, headers, b"")
+    assert status == 201
+    checkpoint_id = json.loads(body)["id"]
+    status, body = _get(inside, headers)
+    assert status == 200
+    assert [entry["id"] for entry in json.loads(body)] == [checkpoint_id]
+    status, _ = _request("POST", f"{inside}/{checkpoint_id}", headers, b"")
+    assert status == 204
+    status, _ = _request("DELETE", f"{inside}/{checkpoint_id}", headers)
+    assert status == 204
+    assert list(sidecar.notebooks_dir.rglob("*-checkpoint.ipynb")) == []
+
+
+def _page_config(lab_html: bytes) -> dict[str, object]:
+    marker = b'id="jupyter-config-data" type="application/json">'
+    start = lab_html.index(marker) + len(marker)
+    end = lab_html.index(b"</script>", start)
+    return json.loads(lab_html[start:end])
+
+
+@spawns
+def test_the_lab_page_lists_the_disabled_plugins_and_no_news(sidecar: JupyterSidecar) -> None:
+    status, html = _get(f"{sidecar.url}/lab", sidecar.auth_headers)
+    assert status == 200
+
+    page_config = _page_config(html)
+    disabled = page_config["disabledExtensions"]
+    assert isinstance(disabled, list)
+    assert set(LAB_DISABLED_EXTENSIONS) <= set(disabled)
+    assert page_config["news"] == {"disabled": True}
+
+
+# ---------------------------------------------------------------------------
+# A sidecar that dies later
+# ---------------------------------------------------------------------------
+
+
+def _exit_records(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelname == "WARNING" and " exited (rc=" in record.getMessage()
+    ]
+
+
+@spawns
+def test_a_sidecar_that_dies_later_is_reported_once_with_its_stderr_tail(
+    sidecar: JupyterSidecar, caplog: pytest.LogCaptureFixture
+) -> None:
+    fired = threading.Event()
+    sidecar.on_exit = fired.set
+    pid = sidecar.pid
+    assert pid is not None
+
+    with caplog.at_level("WARNING", logger=jupyter_sidecar.__name__):
+        os.kill(pid, signal.SIGKILL)
+        assert fired.wait(5.0), "on_exit did not fire"
+
+    records = _exit_records(caplog)
+    assert len(records) == 1
+    message = records[0]
+    assert message.startswith(f"Notebook sidecar exited (rc={-signal.SIGKILL})")
+    tail = sidecar.stderr_tail
+    assert tail, "the sidecar wrote nothing to stderr before it was killed"
+    assert message.endswith(tail)
+
+
+@spawns
+def test_on_exit_registered_after_the_death_fires_at_once(sidecar: JupyterSidecar) -> None:
+    reaped = threading.Event()
+    sidecar.on_exit = reaped.set
+    pid = sidecar.pid
+    assert pid is not None
+    os.kill(pid, signal.SIGKILL)
+    assert reaped.wait(5.0)
+
+    late = threading.Event()
+    sidecar.on_exit = late.set
+
+    assert late.is_set()
+
+
+@spawns
+def test_stop_reports_no_exit_and_fires_no_callback(
+    config_env: None, shared_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    sidecar = JupyterSidecar(shared_root, "", None)
+    fired = threading.Event()
+    sidecar.on_exit = fired.set
+    sidecar.spawn()
+    sidecar.wait_ready(READY_TIMEOUT)
+
+    with caplog.at_level("WARNING", logger=jupyter_sidecar.__name__):
+        sidecar.stop()
+        time.sleep(0.2)
+
+    assert not fired.is_set()
+    assert _exit_records(caplog) == []
+
+
+#: A stand-in sidecar: hands its stderr to a child in its own session, the way a
+#: kernel inherits it, then idles until it is signalled.
+_ORPHAN_SCRIPT = (
+    "import subprocess, sys, time\n"
+    "child = subprocess.Popen(['sleep', '3600'], start_new_session=True)\n"
+    "open(sys.argv[1], 'w').write(str(child.pid))\n"
+    "time.sleep(3600)\n"
+)
+
+
+@spawns
+def test_stop_returns_while_an_orphan_still_holds_the_stderr_pipe(
+    config_env: None, shared_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pid_file = tmp_path / "orphan.pid"
+    script = tmp_path / "orphan.py"
+    script.write_text(_ORPHAN_SCRIPT, encoding="utf-8")
+    fake = tmp_path / "python"
+    fake.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}" "{pid_file}"\n')
+    fake.chmod(0o755)
+    monkeypatch.setattr(jupyter_sidecar.sys, "executable", str(fake))
+    sidecar = JupyterSidecar(shared_root, "", None)
+    sidecar.spawn()
+    orphan: int | None = None
+    try:
+        deadline = time.monotonic() + 10
+        while not pid_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        orphan = int(pid_file.read_text())
+        assert _alive(orphan)
+
+        stopper = threading.Thread(target=sidecar.stop, daemon=True)
+        started = time.monotonic()
+        stopper.start()
+        stopper.join(jupyter_sidecar._STOP_GRACE + 5)
+
+        assert not stopper.is_alive(), "stop() hung on the orphan's pipe"
+        assert time.monotonic() - started < jupyter_sidecar._STOP_GRACE + 5
+        assert _alive(orphan), "the orphan is the test's own; stop() must not need it gone"
+    finally:
+        if orphan is not None and _alive(orphan):
+            os.kill(orphan, signal.SIGKILL)
+        sidecar.stop()

--- a/tests/interfaces/web_terminal/test_jupyter_sidecar.py
+++ b/tests/interfaces/web_terminal/test_jupyter_sidecar.py
@@ -32,6 +32,7 @@ from osprey.interfaces.web_terminal.jupyter_sidecar import (
     lab_page_config,
     lab_theme_override,
     seed_starter_notebook,
+    starter_read_channel,
 )
 from osprey.mcp_server.python_executor.executor import resolve_agent_interpreter
 
@@ -411,8 +412,12 @@ def test_the_argv_pins_the_server_traits(shared_root: Path) -> None:
 
 
 def test_the_starter_notebook_is_written_into_an_empty_notebooks_dir(
-    shared_root: Path, tmp_path: Path
+    shared_root: Path, tmp_path: Path, monkeypatch
 ) -> None:
+    # Pinned to a deployment that declares no channel, so this asserts the
+    # starter's shape rather than whatever config the test host happens to
+    # resolve. The channel-bearing case is covered separately.
+    monkeypatch.setattr(jupyter_sidecar, "_deployment_config", dict)
     sidecar = JupyterSidecar(shared_root, "", None)
 
     sidecar._seed(tmp_path / "config")
@@ -778,3 +783,188 @@ def test_a_straggler_that_takes_sigterm_is_not_killed(monkeypatch) -> None:
 
     assert (7, signal.SIGTERM) in sent
     assert (7, signal.SIGKILL) not in sent
+
+
+class TestTheStarterNotebooksExampleRead:
+    """Which channel the starter notebook reads, and when it reads nothing.
+
+    A deployment is entitled to serve no channel at all — the hello-world
+    preset runs a mock connector and stands up no server of its own — so the
+    read line is earned, never assumed. Two config blocks already name a
+    channel the deployment says it can read; nothing here invents a third.
+    """
+
+    def test_the_archivers_canary_channel_is_the_example(self) -> None:
+        """A freshness canary is declared to keep moving, so it shows a value.
+
+        The archiver check names the one channel a facility promises is still
+        changing. That is what makes a demo read worth running twice.
+        """
+        config = {
+            "health": {
+                "categories": {
+                    "archiver": {
+                        "checks": [
+                            {
+                                "type": "archiver_freshness",
+                                "channel": "SR:DIAG:DCCT:01:CURRENT:RB",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+
+        assert starter_read_channel(config) == "SR:DIAG:DCCT:01:CURRENT:RB"
+
+    def test_a_targets_probe_channel_is_the_fallback(self) -> None:
+        """Without an archiver, the target switch still names a readable channel."""
+        config = {
+            "control_system": {
+                "connector": {"va": {"probe_channel": "SR:VAC:GAUGE:SR01:PRESSURE:RB"}}
+            }
+        }
+
+        assert starter_read_channel(config) == "SR:VAC:GAUGE:SR01:PRESSURE:RB"
+
+    def test_the_canary_outranks_a_probe_channel(self) -> None:
+        config = {
+            "health": {
+                "categories": {
+                    "archiver": {
+                        "checks": [
+                            {
+                                "type": "archiver_freshness",
+                                "channel": "SR:DIAG:DCCT:01:CURRENT:RB",
+                            }
+                        ]
+                    }
+                }
+            },
+            "control_system": {
+                "connector": {"va": {"probe_channel": "SR:VAC:GAUGE:SR01:PRESSURE:RB"}}
+            },
+        }
+
+        assert starter_read_channel(config) == "SR:DIAG:DCCT:01:CURRENT:RB"
+
+    def test_the_generic_templates_placeholder_is_not_a_channel(self) -> None:
+        """``YOUR:PROBE:CHANNEL`` ships unfilled and names nothing.
+
+        The build refuses to write a placeholder probe channel for the same
+        reason: it would make a target look reachable while naming a channel
+        nothing serves. A starter cell reading it fails on its first run.
+        """
+        config = {
+            "control_system": {"connector": {"live": {"probe_channel": "YOUR:PROBE:CHANNEL"}}}
+        }
+
+        assert starter_read_channel(config) is None
+
+    def test_a_mock_only_deployment_names_no_channel(self) -> None:
+        """The hello-world shape: a mock connector, no server, no declaration."""
+        config = {"control_system": {"type": "mock", "writes_enabled": False}}
+
+        assert starter_read_channel(config) is None
+
+    def test_the_starter_reads_the_channel_it_is_given(self, tmp_path: Path) -> None:
+        notebooks_dir = tmp_path / "notebooks"
+        notebooks_dir.mkdir()
+
+        seed_starter_notebook(notebooks_dir, "SR:DIAG:DCCT:01:CURRENT:RB")
+
+        notebook = nbformat.read(notebooks_dir / "getting-started.ipynb", as_version=4)
+        code = [cell.source for cell in notebook.cells if cell.cell_type == "code"]
+        assert code == [
+            "from osprey.runtime import read_channel, write_channel\n\n"
+            'read_channel("SR:DIAG:DCCT:01:CURRENT:RB")'
+        ]
+
+    def test_no_channel_leaves_the_import_line_alone(self, tmp_path: Path) -> None:
+        notebooks_dir = tmp_path / "notebooks"
+        notebooks_dir.mkdir()
+
+        seed_starter_notebook(notebooks_dir, None)
+
+        notebook = nbformat.read(notebooks_dir / "getting-started.ipynb", as_version=4)
+        code = [cell.source for cell in notebook.cells if cell.cell_type == "code"]
+        assert code == ["from osprey.runtime import read_channel, write_channel"]
+
+    def test_a_built_control_assistant_offers_its_beam_current(self, tmp_path: Path) -> None:
+        """The resolver is pinned to the shape the build really emits.
+
+        The canary is declared as ``va_archiver.freshness_channel`` and reaches
+        the deployed config only after the build derives a health check from it
+        and writes that under a dotted key. Hand-building the nested dict here
+        would test the resolver against an assumption; this renders the config
+        through ``osprey build``'s own override machinery instead, so a change
+        in how those keys are written fails here rather than in a deployment.
+        """
+        import yaml
+
+        from osprey.cli.build_cmd import _apply_config_overrides
+        from osprey.cli.build_profile_archiver import (
+            VAArchiverConfig,
+            va_archiver_config_overrides,
+        )
+
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "config.yml").write_text(
+            "control_system:\n"
+            "  type: mock\n"
+            "  connector:\n"
+            "    va:\n"
+            "      probe_channel: SR:VAC:GAUGE:SR01:PRESSURE:RB\n",
+            encoding="utf-8",
+        )
+        # The channel the control-assistant preset names as its canary.
+        overrides = va_archiver_config_overrides(
+            VAArchiverConfig(freshness_channel="SR:DIAG:DCCT:01:CURRENT:RB")
+        )
+        _apply_config_overrides(project, overrides)
+        config = yaml.safe_load((project / "config.yml").read_text(encoding="utf-8"))
+
+        assert starter_read_channel(config) == "SR:DIAG:DCCT:01:CURRENT:RB"
+
+    def test_the_seed_reads_the_deployments_own_channel(
+        self, shared_root: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The sidecar resolves the channel from the deployment it runs in."""
+        monkeypatch.setattr(
+            jupyter_sidecar,
+            "_deployment_config",
+            lambda: {
+                "control_system": {"connector": {"va": {"probe_channel": "SR:MY:OWN:CHANNEL"}}}
+            },
+        )
+        sidecar = JupyterSidecar(shared_root, "", None)
+
+        sidecar._seed(tmp_path / "config")
+
+        notebook = nbformat.read(sidecar.notebooks_dir / "getting-started.ipynb", as_version=4)
+        code = [cell.source for cell in notebook.cells if cell.cell_type == "code"]
+        assert code == [
+            'from osprey.runtime import read_channel, write_channel\n\nread_channel("SR:MY:OWN:CHANNEL")'
+        ]
+
+    def test_an_unreadable_config_still_seeds_a_notebook(
+        self, shared_root: Path, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A config that will not load costs the read line, never the panel.
+
+        The starter notebook is a convenience. Failing the sidecar's seed over
+        it would take the whole tab down for a cosmetic line.
+        """
+
+        def _boom() -> dict[str, object]:
+            raise RuntimeError("no config here")
+
+        monkeypatch.setattr(jupyter_sidecar, "_deployment_config", _boom)
+        sidecar = JupyterSidecar(shared_root, "", None)
+
+        sidecar._seed(tmp_path / "config")
+
+        notebook = nbformat.read(sidecar.notebooks_dir / "getting-started.ipynb", as_version=4)
+        code = [cell.source for cell in notebook.cells if cell.cell_type == "code"]
+        assert code == ["from osprey.runtime import read_channel, write_channel"]

--- a/tests/interfaces/web_terminal/test_jupyter_sidecar.py
+++ b/tests/interfaces/web_terminal/test_jupyter_sidecar.py
@@ -706,3 +706,75 @@ def test_stop_returns_while_an_orphan_still_holds_the_stderr_pipe(
         if orphan is not None and _alive(orphan):
             os.kill(orphan, signal.SIGKILL)
         sidecar.stop()
+
+
+# ---------------------------------------------------------------------------
+# The straggler reap
+# ---------------------------------------------------------------------------
+
+
+def _reap_with(monkeypatch, snapshots: list[list[int]]) -> list[tuple[int, int]]:
+    """Run ``_reap_stragglers`` against a scripted sequence of pgrep results.
+
+    Args:
+        monkeypatch: The fixture used to stub the reaper's two shell touchpoints.
+        snapshots: One ``_pids_naming`` return per call; the last repeats once
+            the script runs out, so a test only spells out the interesting head.
+
+    Returns:
+        The ``(pid, signal)`` pairs the reap sent, in order.
+    """
+    calls = iter(snapshots)
+    last: list[list[int]] = [snapshots[-1]]
+
+    def _naming(_runtime_dir: str) -> list[int]:
+        last[0] = next(calls, last[0])
+        return list(last[0])
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(jupyter_sidecar.shutil, "which", lambda _name: "/usr/bin/pgrep")
+    monkeypatch.setattr(jupyter_sidecar, "_pids_naming", _naming)
+    monkeypatch.setattr(jupyter_sidecar, "_signal_pid", lambda pid, sig: sent.append((pid, sig)))
+    jupyter_sidecar._reap_stragglers("/tmp/does-not-matter")
+    return sent
+
+
+def test_a_kernel_that_appears_after_the_first_snapshot_is_still_reaped(monkeypatch) -> None:
+    """The reap waits for a straggler rather than trusting one sample.
+
+    A kernel the server forked just before it died does not name the runtime
+    dir until it execs, so the first snapshot can legitimately come back empty
+    while a kernel is still on its way up. Returning there left it running with
+    the control target and write posture it launched with, and nothing above it.
+    """
+    sent = _reap_with(monkeypatch, [[], [], [4242], []])
+
+    assert (4242, signal.SIGTERM) in sent
+
+
+def test_a_clean_stop_signals_nothing_and_does_not_wait_out_the_grace(monkeypatch) -> None:
+    """Nothing to reap is the common path: no signals, and no _REAP_GRACE spent."""
+    started = time.monotonic()
+    sent = _reap_with(monkeypatch, [[]])
+    elapsed = time.monotonic() - started
+
+    assert sent == []
+    # The settle window is bounded and the SIGTERM grace is never entered.
+    assert elapsed < jupyter_sidecar._REAP_SETTLE + jupyter_sidecar._REAP_GRACE
+
+
+def test_a_straggler_that_ignores_sigterm_is_killed(monkeypatch) -> None:
+    """SIGTERM first, then SIGKILL once the grace elapses with it still listed."""
+    sent = _reap_with(monkeypatch, [[99]])
+
+    assert (99, signal.SIGTERM) in sent
+    assert (99, signal.SIGKILL) in sent
+    assert sent.index((99, signal.SIGTERM)) < sent.index((99, signal.SIGKILL))
+
+
+def test_a_straggler_that_takes_sigterm_is_not_killed(monkeypatch) -> None:
+    """A process that goes away during the grace never receives SIGKILL."""
+    sent = _reap_with(monkeypatch, [[7], [7], []])
+
+    assert (7, signal.SIGTERM) in sent
+    assert (7, signal.SIGKILL) not in sent

--- a/tests/interfaces/web_terminal/test_proxy.py
+++ b/tests/interfaces/web_terminal/test_proxy.py
@@ -676,10 +676,10 @@ class TestResponseBoundary:
     def test_websocket_handshake_relays_nothing_from_the_backend(self, panels_app):
         """The WS accept is built by this app, so no upstream header can ride it.
 
-        The upstream connection is established *after* ``websocket.accept()``,
-        and accept carries no headers — pinned here so a later change that
-        forwarded the upstream handshake's response headers (``Set-Cookie``
-        included) would be caught.
+        The upstream connects first, and ``websocket.accept()`` then carries
+        only the negotiated subprotocol, no headers — pinned here so a later
+        change that forwarded the upstream handshake's response headers
+        (``Set-Cookie`` included) would be caught.
         """
         app, _client = panels_app
         fake = _FakeConnect()

--- a/tests/interfaces/web_terminal/test_proxy.py
+++ b/tests/interfaces/web_terminal/test_proxy.py
@@ -53,6 +53,7 @@ from osprey.interfaces.web_terminal.app import UNIVERSAL_PANELS, create_app
 from osprey.interfaces.web_terminal.routes.proxy import (
     _PANEL_STATE_MAP,
     TERMINAL_SECRET_HEADER,
+    UPSTREAM_OPEN_TIMEOUT,
     _backend_is_loopback,
     _is_stripped_header,
 )
@@ -1133,6 +1134,28 @@ class TestWebSocketBoundary:
         assert fake.kwargs["additional_headers"] is None
         # No secret in flight → the default redirect handling is left in place.
         assert getattr(fake, "process_redirect", None) is None
+
+    def test_upstream_handshake_outlasts_a_kernel_start(self, panels_app):
+        """The upstream open timeout covers a handshake the panel holds on purpose.
+
+        jupyter-server answers a kernel-channel upgrade only once the kernel
+        behind it has replied to a kernel-info request, and it allows that reply
+        its ``MappingKernelManager.kernel_info_timeout``. A kernel that joins a
+        bound session imports the framework before it answers anything, so on a
+        loaded host that reply lands after ``websockets``' default ten-second
+        opening timeout — and the proxy, not the panel, hung up: the browser got
+        a normal close before its first frame, with the kernel alive and well
+        behind it. The proxy's budget for an upstream handshake must therefore
+        be no shorter than the longest one a panel is allowed to hold.
+        """
+        from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
+
+        _app, client = panels_app
+
+        fake = self._connect(client, "/panel/trusted/ws/stream")
+
+        assert fake.kwargs["open_timeout"] == UPSTREAM_OPEN_TIMEOUT
+        assert UPSTREAM_OPEN_TIMEOUT >= MappingKernelManager.kernel_info_timeout.default_value
 
     def test_offbox_panel_ws_carries_no_headers(self, panels_app):
         _app, client = panels_app

--- a/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
+++ b/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
@@ -1,0 +1,397 @@
+"""The notebook panel end to end: a real sidecar behind the terminal's panel proxy.
+
+The sidecar tests pin the launch contract against the server directly; the
+panel-proxy tests pin the header boundary against a stubbed backend. This module
+puts the two together — a real ``jupyter_server`` on loopback, reached only
+through ``/panel/jupyter/*`` — so what is asserted here is what a browser at the
+terminal's own origin actually gets: the lab page, a kernel on the one
+kernelspec, a live channels socket, and neither the sidecar's token nor its
+cookies.
+
+Every test shares one sidecar and one kernel (module-scoped fixtures). Starting
+either is the expensive part, and nothing here mutates state another test reads.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+import websockets
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.common_middleware import compute_url_prefix
+from osprey.interfaces.web_terminal.app import UNIVERSAL_PANELS, create_app
+from osprey.interfaces.web_terminal.jupyter_sidecar import (
+    KERNELSPEC_NAME,
+    STARTER_NOTEBOOK_NAME,
+    JupyterSidecar,
+)
+
+#: Both halves of every test here spawn a process: the sidecar, then a kernel.
+pytestmark = pytest.mark.slow
+
+READY_TIMEOUT = 90.0
+
+#: How long a kernel gets to answer one request. Generous: the first message on
+#: a fresh socket waits for the interpreter to import the whole kernel stack.
+KERNEL_TIMEOUT = 180.0
+
+#: The panel's path under the terminal's origin — the only way in, here.
+PANEL = "/panel/jupyter"
+
+#: An identity the deployment stamps on the terminal. ``scrub_sandbox_child_env``
+#: keeps it, so it must reach a cell; a name in the ``OSPREY_TERMINAL_`` family
+#: is dropped, so its absence in a cell must be the scrub's doing and not the
+#: test environment simply never having set one.
+AUDIT_IDENTITY = "notebook-integration"
+TERMINAL_FAMILY_PROBE = "OSPREY_TERMINAL_PROBE"
+
+#: What a cell reports about its own environment.
+PROBE_CODE = (
+    "import os, json; "
+    'print(json.dumps({"tok": "JUPYTER_TOKEN" in os.environ, '
+    '"term": [k for k in os.environ if k.startswith("OSPREY_TERMINAL_")], '
+    '"cfg": "OSPREY_CONFIG" in os.environ, '
+    '"audit": "OSPREY_AUDIT_IDENTITY" in os.environ}))'
+)
+
+#: The Jupyter messaging-protocol version a hand-built message declares.
+PROTOCOL_VERSION = "5.3"
+
+#: The websocket subprotocol JupyterLab offers on a kernel's channels socket.
+KERNEL_WS_PROTOCOL_V1 = "v1.kernel.websocket.jupyter.org"
+
+
+# ---------------------------------------------------------------------------
+# The sidecar, the terminal, and one kernel
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def notebook_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """The environment a sidecar launch reads, and a root to keep it all under."""
+    root = tmp_path_factory.mktemp("notebook-panel")
+    with pytest.MonkeyPatch.context() as environment:
+        environment.setenv("OSPREY_CONFIG", str(root / "does-not-exist.yml"))
+        # Keep every per-launch tempdir under the test's own tree.
+        environment.setenv("TMPDIR", str(root))
+        environment.setenv("OSPREY_AUDIT_IDENTITY", AUDIT_IDENTITY)
+        environment.setenv(TERMINAL_FAMILY_PROBE, "reachable-from-the-terminal")
+        yield root
+
+
+@pytest.fixture(scope="module")
+def sidecar(notebook_env: Path) -> Iterator[JupyterSidecar]:
+    """A real ``jupyter_server`` on an OS-assigned loopback port."""
+    running = JupyterSidecar(notebook_env / "shared", compute_url_prefix(), None)
+    try:
+        running.preflight()
+        running.spawn()
+        running.wait_ready(READY_TIMEOUT)
+        yield running
+    finally:
+        running.stop()
+
+
+@pytest.fixture(scope="module")
+def proxied(sidecar: JupyterSidecar, notebook_env: Path) -> Iterator[TestClient]:
+    """A web terminal whose ``jupyter`` panel resolves to the running sidecar.
+
+    The launcher's two publications are made by hand rather than by enabling the
+    panel, so a failed launch shows up as this fixture erroring with the
+    sidecar's own message instead of as a 404 from a lifespan that swallowed it.
+    """
+    workspace = notebook_env / "_agent_data"
+    workspace.mkdir(exist_ok=True)
+    with (
+        patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace)},
+        ),
+        patch(
+            "osprey.interfaces.web_terminal.app._load_panel_config",
+            return_value=(set(UNIVERSAL_PANELS), [], None),
+        ),
+    ):
+        app = create_app(shell_command="echo")
+        with TestClient(app) as client:
+            app.state.jupyter_server_url = sidecar.url
+            app.state.panel_auth_headers = {"jupyter": dict(sidecar.auth_headers)}
+            yield client
+
+
+@pytest.fixture(scope="module")
+def started_session(proxied: TestClient) -> Iterator[httpx.Response]:
+    """One notebook session, started through the proxy and deleted afterwards."""
+    response = proxied.post(
+        f"{PANEL}/api/sessions",
+        json={
+            "path": STARTER_NOTEBOOK_NAME,
+            "name": STARTER_NOTEBOOK_NAME,
+            "type": "notebook",
+            "kernel": {"name": KERNELSPEC_NAME},
+        },
+    )
+    try:
+        yield response
+    finally:
+        if response.status_code == 201:
+            proxied.delete(f"{PANEL}/api/sessions/{response.json()['id']}")
+
+
+@pytest.fixture(scope="module")
+def kernel_id(started_session: httpx.Response) -> str:
+    return str(started_session.json()["kernel"]["id"])
+
+
+# ---------------------------------------------------------------------------
+# Talking to a kernel over the proxied channels socket
+# ---------------------------------------------------------------------------
+
+
+def _message(msg_type: str, content: dict[str, Any], session_id: str) -> dict[str, Any]:
+    """One Jupyter message in the JSON form the default subprotocol carries."""
+    return {
+        "header": {
+            "msg_id": uuid.uuid4().hex,
+            "session": session_id,
+            "username": "osprey",
+            "date": datetime.now(UTC).isoformat(),
+            "msg_type": msg_type,
+            "version": PROTOCOL_VERSION,
+        },
+        "parent_header": {},
+        "metadata": {},
+        "content": content,
+        "channel": "shell",
+        "buffers": [],
+    }
+
+
+def _reply_to(socket: Any, request: dict[str, Any], msg_type: str) -> dict[str, Any]:
+    """Read until *request*'s reply of *msg_type* arrives, or fail on the deadline."""
+    deadline = time.monotonic() + KERNEL_TIMEOUT
+    while time.monotonic() < deadline:
+        message = socket.receive_json()
+        header = message.get("header") or {}
+        parent = message.get("parent_header") or {}
+        if (
+            header.get("msg_type") == msg_type
+            and parent.get("msg_id") == request["header"]["msg_id"]
+        ):
+            return message
+    raise AssertionError(f"no {msg_type} within {KERNEL_TIMEOUT:.0f} s")
+
+
+def _run_cell(socket: Any, code: str, session_id: str) -> str:
+    """Execute *code* on the kernel and return everything it wrote to stdout.
+
+    Reads to the ``idle`` status parented by the request rather than to the
+    reply: the reply rides the shell channel and the output rides iopub, and
+    only ``idle`` says the kernel is done with both.
+    """
+    request = _message(
+        "execute_request",
+        {
+            "code": code,
+            "silent": False,
+            "store_history": False,
+            "user_expressions": {},
+            "allow_stdin": False,
+            "stop_on_error": True,
+        },
+        session_id,
+    )
+    socket.send_json(request)
+
+    written: list[str] = []
+    deadline = time.monotonic() + KERNEL_TIMEOUT
+    while time.monotonic() < deadline:
+        message = socket.receive_json()
+        header = message.get("header") or {}
+        parent = message.get("parent_header") or {}
+        if parent.get("msg_id") != request["header"]["msg_id"]:
+            continue
+        content = message.get("content") or {}
+        if header.get("msg_type") == "stream" and content.get("name") == "stdout":
+            written.append(str(content.get("text", "")))
+        elif header.get("msg_type") == "error":
+            raise AssertionError("\n".join(content.get("traceback", [])))
+        elif header.get("msg_type") == "status" and content.get("execution_state") == "idle":
+            return "".join(written)
+    raise AssertionError(f"the cell did not finish within {KERNEL_TIMEOUT:.0f} s")
+
+
+class _RecordingConnect:
+    """``websockets.connect``, wrapped to record the handshake it then performs."""
+
+    def __init__(self) -> None:
+        self._connect = websockets.connect
+        self.target: str | None = None
+        self.headers: dict[str, str] = {}
+
+    def __call__(self, target: str, **kwargs: Any) -> Any:
+        self.target = target
+        self.headers = dict(kwargs.get("additional_headers") or {})
+        return self._connect(target, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Talking to the sidecar without the proxy, to show what the proxy supplies
+# ---------------------------------------------------------------------------
+
+
+def _direct(url: str, headers: dict[str, str] | None = None) -> tuple[int, dict[str, str]]:
+    """Request *url* off the proxy's path; answer its status and headers."""
+    request = urllib.request.Request(url, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return int(response.status), {k.lower(): v for k, v in response.headers.items()}
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        return int(exc.code), {k.lower(): v for k, v in exc.headers.items()}
+
+
+# ---------------------------------------------------------------------------
+# The panel over HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_the_panel_answers_through_the_proxy(proxied: TestClient) -> None:
+    lab = proxied.get(f"{PANEL}/lab")
+    status = proxied.get(f"{PANEL}/api/status")
+    kernelspecs = proxied.get(f"{PANEL}/api/kernelspecs")
+
+    assert lab.status_code == 200
+    assert status.status_code == 200
+    assert kernelspecs.status_code == 200
+    assert sorted(kernelspecs.json()["kernelspecs"]) == [KERNELSPEC_NAME]
+
+
+def test_the_backend_refuses_what_the_proxy_does_not_sign(
+    proxied: TestClient, sidecar: JupyterSidecar
+) -> None:
+    """The credential the proxy injects is the one the sidecar is gating on."""
+    unsigned, _ = _direct(f"{sidecar.url}/api/status")
+
+    assert unsigned == 403
+    assert proxied.get(f"{PANEL}/api/status").status_code == 200
+
+
+def test_no_backend_cookie_reaches_the_browser(
+    proxied: TestClient, sidecar: JupyterSidecar
+) -> None:
+    """The sidecar sets a login cookie; it must not be stored for the terminal."""
+    _status, upstream_headers = _direct(f"{sidecar.url}/lab", sidecar.auth_headers)
+
+    through_proxy = proxied.get(f"{PANEL}/lab")
+
+    assert "set-cookie" in upstream_headers
+    assert "set-cookie" not in {name.lower() for name in through_proxy.headers}
+
+
+def test_a_session_starts_on_the_osprey_kernelspec(started_session: httpx.Response) -> None:
+    assert started_session.status_code == 201
+    assert started_session.json()["kernel"]["name"] == KERNELSPEC_NAME
+
+
+# ---------------------------------------------------------------------------
+# The channels socket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(KERNEL_TIMEOUT)
+def test_a_kernel_answers_over_the_proxied_socket(
+    proxied: TestClient, sidecar: JupyterSidecar, kernel_id: str
+) -> None:
+    """A kernel_info round trip, and the upstream handshake that carried it."""
+    session_id = uuid.uuid4().hex
+    recorded = _RecordingConnect()
+
+    with patch("websockets.connect", recorded):
+        with proxied.websocket_connect(
+            f"{PANEL}/api/kernels/{kernel_id}/channels?session_id={session_id}"
+        ) as socket:
+            request = _message("kernel_info_request", {}, session_id)
+            socket.send_json(request)
+            reply = _reply_to(socket, request, "kernel_info_reply")
+
+    assert reply["content"]["status"] == "ok"
+    assert recorded.target is not None
+    assert recorded.target.endswith(
+        f"{PANEL}/api/kernels/{kernel_id}/channels?session_id={session_id}"
+    )
+    handshake = {name.lower(): value for name, value in recorded.headers.items()}
+    assert handshake["authorization"] == f"Bearer {sidecar.token}"
+
+
+@pytest.mark.timeout(KERNEL_TIMEOUT)
+def test_a_cell_sees_no_server_token_and_no_terminal_family(
+    proxied: TestClient, kernel_id: str
+) -> None:
+    """What a cell inherits: the config and the audit identity, and nothing else.
+
+    ``JUPYTER_TOKEN`` is the sidecar's own credential — the kernelspec carries it
+    empty and the launcher pops the name outright, so a cell holds neither. The
+    ``OSPREY_TERMINAL_`` family is dropped by ``scrub_sandbox_child_env``, which
+    is only visible because the terminal's environment set one.
+    """
+    session_id = uuid.uuid4().hex
+
+    with proxied.websocket_connect(
+        f"{PANEL}/api/kernels/{kernel_id}/channels?session_id={session_id}"
+    ) as socket:
+        reported = json.loads(_run_cell(socket, PROBE_CODE, session_id))
+
+    assert reported == {"tok": False, "term": [], "cfg": True, "audit": True}
+
+
+@pytest.mark.timeout(KERNEL_TIMEOUT)
+def test_the_kernel_protocol_the_browser_offers_is_negotiated_through_the_proxy(
+    proxied: TestClient, kernel_id: str
+) -> None:
+    """JupyterLab offers the v1 kernel protocol; the proxy must answer with it.
+
+    Under v1 every message is one binary frame, so the round trip here is
+    framed with the server's own v1 helpers rather than as JSON.
+    """
+    from jupyter_server.services.kernels.connection.base import (
+        deserialize_msg_from_ws_v1,
+        serialize_msg_to_ws_v1,
+    )
+
+    session_id = uuid.uuid4().hex
+    request = _message("kernel_info_request", {}, session_id)
+
+    with proxied.websocket_connect(
+        f"{PANEL}/api/kernels/{kernel_id}/channels?session_id={session_id}",
+        subprotocols=[KERNEL_WS_PROTOCOL_V1],
+    ) as socket:
+        assert socket.accepted_subprotocol == KERNEL_WS_PROTOCOL_V1
+
+        socket.send_bytes(
+            serialize_msg_to_ws_v1(request, "shell", pack=lambda obj: json.dumps(obj).encode())
+        )
+        deadline = time.monotonic() + KERNEL_TIMEOUT
+        while time.monotonic() < deadline:
+            _channel, parts = deserialize_msg_from_ws_v1(socket.receive_bytes())
+            header, parent = json.loads(parts[0]), json.loads(parts[1])
+            if (
+                header.get("msg_type") == "kernel_info_reply"
+                and parent.get("msg_id") == request["header"]["msg_id"]
+            ):
+                assert json.loads(parts[3])["status"] == "ok"
+                break
+        else:
+            raise AssertionError(f"no kernel_info_reply within {KERNEL_TIMEOUT:.0f} s")

--- a/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
+++ b/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
@@ -123,6 +123,21 @@ def proxied(sidecar: JupyterSidecar, notebook_env: Path) -> Iterator[TestClient]
             "osprey.interfaces.web_terminal.app._load_panel_config",
             return_value=(set(UNIVERSAL_PANELS), [], None),
         ),
+        # Entering the TestClient runs the app's lifespan, which auto-launches a
+        # companion server for every enabled panel — and ``UNIVERSAL_PANELS`` is
+        # ``{"artifacts"}``, so the artifact server starts for real: a daemon
+        # thread running uvicorn on a configured port, whose app factory resolves
+        # the shared data root. Two consequences, both observed: unstamped, that
+        # root is the repository, so the thread creates ``var/agent_data/artifacts``
+        # and trips the repo-leak guard; and the port is fixed rather than
+        # OS-assigned, so under xdist a second worker's launch loses the bind and
+        # the thread dies in uvicorn's startup path. This module exercises
+        # ``/panel/jupyter`` and nothing else, and publishes that URL by hand
+        # below, so it needs no companion server at all.
+        patch(
+            "osprey.infrastructure.server_launcher.ensure_web_server",
+            lambda key: None,
+        ),
     ):
         app = create_app(shell_command="echo")
         with TestClient(app) as client:

--- a/tests/interfaces/web_terminal/test_proxy_panel.py
+++ b/tests/interfaces/web_terminal/test_proxy_panel.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import threading
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+import websockets
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from osprey.interfaces.web_terminal.app import UNIVERSAL_PANELS, create_app
+from osprey.interfaces.web_terminal.routes.proxy import _PANEL_STATE_MAP
 
 
 def _make_client(workspace_dir, custom_panels):
@@ -286,3 +293,275 @@ class TestProxyCacheControlDefault:
         resp = client.get("/panel/my-dash/static/js/vendor/plotly-3.3.1.min.js")
         assert resp.status_code == 200
         assert resp.headers["cache-control"] == immutable
+
+
+#: One framework panel, read from the registry-derived map rather than named, so
+#: a panel that is renamed or added does not quietly stop being covered here.
+LAUNCHED_PANEL_ID, LAUNCHED_STATE_ATTR = sorted(_PANEL_STATE_MAP.items())[0]
+
+#: Where that panel's backend listens, and the header its launcher published.
+LAUNCHED_BACKEND_URL = "http://127.0.0.1:9500"
+LAUNCH_TOKEN = "panel-launch-token"
+LAUNCH_HEADERS = {"Authorization": f"Bearer {LAUNCH_TOKEN}"}
+
+
+def _lower(headers):
+    return {k.lower(): v for k, v in headers.items()}
+
+
+class _FakeUpstreamSocket:
+    """A websocket upstream that stays open until the relay task is cancelled."""
+
+    def __init__(self):
+        self.sent: list[object] = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await asyncio.Event().wait()  # pragma: no cover - cancelled at teardown
+        raise AssertionError("unreachable")
+
+
+class _FakeConnect:
+    """Stands in for ``websockets.connect``, recording the handshake arguments."""
+
+    def __init__(self):
+        self.target = None
+        self.kwargs = None
+
+    def __call__(self, target, **kwargs):
+        self.target = target
+        self.kwargs = kwargs
+        return self
+
+    async def __aenter__(self):
+        return _FakeUpstreamSocket()
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class TestPanelLaunchCredentialInjection:
+    """A launched panel's own credential rides both legs, and only where earned.
+
+    The launcher publishes the credential on ``app.state.panel_auth_headers``
+    and the proxy injects it, so the browser never holds it. The gate is the one
+    the operator secret already uses — declared by OSPREY *and* addressed at
+    loopback — so a runtime registration squatting the id, or a declared panel
+    pointing off-box, is handed nothing.
+    """
+
+    @pytest.fixture
+    def app_and_client_launched(self, workspace_dir):
+        custom = [
+            # Declared by config but off-box: the credential must not leave the machine.
+            {
+                "id": "offbox",
+                "label": "OFFBOX",
+                "url": "http://panel.facility.lan:9500",
+                "configDefined": True,
+            },
+            # Loopback but registered at runtime — the shape an agent can create.
+            {"id": "registered", "label": "REGISTERED", "url": "http://127.0.0.1:9501"},
+        ]
+        for app, client in _make_client(workspace_dir, custom):
+            # A framework panel's URL is written to app.state by its launcher.
+            setattr(app.state, LAUNCHED_STATE_ATTR, LAUNCHED_BACKEND_URL)
+            # Published under all three ids on purpose: the gate, not the map, is
+            # what must keep the credential away from the two unearned panels.
+            app.state.panel_auth_headers = {
+                LAUNCHED_PANEL_ID: dict(LAUNCH_HEADERS),
+                "offbox": dict(LAUNCH_HEADERS),
+                "registered": dict(LAUNCH_HEADERS),
+            }
+            yield app, client
+
+    @staticmethod
+    def _capture_request(app):
+        captured: dict[str, str] = {}
+
+        async def fake_request(*, method, url, headers, content, follow_redirects=True):
+            captured.update(headers)
+            return httpx.Response(
+                200, json={"ok": True}, headers={"content-type": "application/json"}
+            )
+
+        app.state.proxy_client.request = AsyncMock(side_effect=fake_request)
+        return captured
+
+    @staticmethod
+    def _connect(client, path):
+        fake = _FakeConnect()
+        with patch("websockets.connect", fake):
+            with client.websocket_connect(path):
+                pass
+        return fake
+
+    def test_http_leg_injects_for_a_declared_loopback_panel(self, app_and_client_launched):
+        app, client = app_and_client_launched
+        captured = self._capture_request(app)
+
+        resp = client.get(f"/panel/{LAUNCHED_PANEL_ID}/api/status")
+
+        assert resp.status_code == 200
+        assert _lower(captured)["authorization"] == f"Bearer {LAUNCH_TOKEN}"
+
+    def test_ws_leg_injects_for_a_declared_loopback_panel(self, app_and_client_launched):
+        _app, client = app_and_client_launched
+
+        fake = self._connect(client, f"/panel/{LAUNCHED_PANEL_ID}/api/kernels/k1/channels")
+
+        assert fake.kwargs["additional_headers"]["Authorization"] == f"Bearer {LAUNCH_TOKEN}"
+
+    @pytest.mark.parametrize("panel_id", ["offbox", "registered"])
+    def test_http_leg_withholds_from_an_unearned_panel(self, app_and_client_launched, panel_id):
+        app, client = app_and_client_launched
+        captured = self._capture_request(app)
+
+        resp = client.get(f"/panel/{panel_id}/api/status")
+
+        assert resp.status_code == 200
+        assert "authorization" not in _lower(captured)
+        assert LAUNCH_TOKEN not in " ".join(captured.values())
+
+    @pytest.mark.parametrize("panel_id", ["offbox", "registered"])
+    def test_ws_leg_withholds_from_an_unearned_panel(self, app_and_client_launched, panel_id):
+        _app, client = app_and_client_launched
+
+        fake = self._connect(client, f"/panel/{panel_id}/ws/stream")
+
+        sent = fake.kwargs["additional_headers"] or {}
+        assert LAUNCH_TOKEN not in " ".join(sent.values())
+
+    def test_ws_upstream_carries_the_browser_query(self, app_and_client_launched):
+        """A backend that keys a socket off a query parameter gets to see it."""
+        _app, client = app_and_client_launched
+
+        fake = self._connect(
+            client, f"/panel/{LAUNCHED_PANEL_ID}/api/kernels/k1/channels?session_id=s1"
+        )
+
+        assert fake.target == "ws://127.0.0.1:9500/api/kernels/k1/channels?session_id=s1"
+
+    def test_ws_upstream_without_a_query_is_unchanged(self, app_and_client_launched):
+        _app, client = app_and_client_launched
+
+        fake = self._connect(client, f"/panel/{LAUNCHED_PANEL_ID}/api/kernels/k1/channels")
+
+        assert fake.target == "ws://127.0.0.1:9500/api/kernels/k1/channels"
+
+
+@contextlib.contextmanager
+def _echo_upstream(subprotocols: list[str] | None = None) -> Iterator[int]:
+    """A real websocket echo server on loopback; yields its port.
+
+    It runs on its own loop in a thread so the proxy under test reaches it over
+    a real socket, and the subprotocol negotiation is the library's, not a
+    stub's. With *subprotocols* the server picks the first it offers that the
+    client also offered; without, it negotiates nothing.
+    """
+    ready = threading.Event()
+    state: dict[str, object] = {}
+
+    async def _serve() -> None:
+        stop = asyncio.Event()
+        state["loop"] = asyncio.get_running_loop()
+        state["stop"] = stop
+
+        async def handler(connection):
+            async for frame in connection:
+                await connection.send(frame)
+
+        async with websockets.serve(handler, "127.0.0.1", 0, subprotocols=subprotocols) as server:
+            state["port"] = server.sockets[0].getsockname()[1]
+            ready.set()
+            await stop.wait()
+
+    thread = threading.Thread(target=lambda: asyncio.run(_serve()), daemon=True)
+    thread.start()
+    assert ready.wait(10), "the echo upstream did not start"
+    try:
+        yield int(state["port"])  # type: ignore[call-overload]
+    finally:
+        loop = state["loop"]
+        stop = state["stop"]
+        loop.call_soon_threadsafe(stop.set)  # type: ignore[attr-defined]
+        thread.join(10)
+
+
+class TestPanelSubprotocolNegotiation:
+    """The browser's subprotocol offer reaches the upstream, and its pick comes back.
+
+    A browser that offers a subprotocol and is accepted without one treats the
+    handshake as failed. So the proxy relays the offer, lets the upstream choose,
+    and accepts the browser with that choice — which means the upstream connects
+    first. What that ordering must not change: a failed upstream handshake still
+    ends in an accepted-then-closed browser socket, as before.
+    """
+
+    PANEL = "echo"
+    OFFER = "v1.example.protocol"
+
+    @staticmethod
+    def _client(workspace_dir, port):
+        custom = [{"id": "echo", "label": "ECHO", "url": f"http://127.0.0.1:{port}"}]
+        return _make_client(workspace_dir, custom)
+
+    def test_accepts_the_subprotocol_the_upstream_selects(self, workspace_dir):
+        with _echo_upstream(subprotocols=[self.OFFER]) as port:
+            for _app, client in self._client(workspace_dir, port):
+                with client.websocket_connect(
+                    f"/panel/{self.PANEL}/ws", subprotocols=[self.OFFER]
+                ) as session:
+                    session.send_text("ping")
+
+                    assert session.accepted_subprotocol == self.OFFER
+                    assert session.receive_text() == "ping"
+
+    def test_offering_none_is_accepted_with_none(self, workspace_dir):
+        with _echo_upstream() as port:
+            for _app, client in self._client(workspace_dir, port):
+                with client.websocket_connect(f"/panel/{self.PANEL}/ws") as session:
+                    session.send_text("ping")
+
+                    assert session.accepted_subprotocol is None
+                    assert session.receive_text() == "ping"
+
+    def test_upstream_selecting_none_is_accepted_with_none(self, workspace_dir):
+        """An offer the upstream does not take up is answered the way it answered."""
+        with _echo_upstream() as port:
+            for _app, client in self._client(workspace_dir, port):
+                with client.websocket_connect(
+                    f"/panel/{self.PANEL}/ws", subprotocols=[self.OFFER]
+                ) as session:
+                    session.send_text("ping")
+
+                    assert session.accepted_subprotocol is None
+                    assert session.receive_text() == "ping"
+
+    def test_binary_frames_relay_unchanged_both_ways(self, workspace_dir):
+        """A negotiated binary protocol rides bytes frames; the echo proves both legs."""
+        payload = bytes(range(256))
+        with _echo_upstream(subprotocols=[self.OFFER]) as port:
+            for _app, client in self._client(workspace_dir, port):
+                with client.websocket_connect(
+                    f"/panel/{self.PANEL}/ws", subprotocols=[self.OFFER]
+                ) as session:
+                    session.send_bytes(payload)
+
+                    assert session.receive_bytes() == payload
+
+    def test_failed_upstream_handshake_still_closes_the_accepted_socket(self, workspace_dir):
+        """The upstream requires a subprotocol the browser did not offer and
+        refuses the handshake; the browser is accepted and closed normally."""
+        with _echo_upstream(subprotocols=[self.OFFER]) as port:
+            for _app, client in self._client(workspace_dir, port):
+                with client.websocket_connect(f"/panel/{self.PANEL}/ws") as session:
+                    with pytest.raises(WebSocketDisconnect) as closed:
+                        session.receive_text()
+
+                assert closed.value.code == 1000

--- a/tests/interfaces/web_terminal/test_session_binding.py
+++ b/tests/interfaces/web_terminal/test_session_binding.py
@@ -1,0 +1,188 @@
+"""Tests for the session binding a notebook kernel joins a PTY session by.
+
+The binding is a single document with one rule: it names the PTY session most
+recently attached. Everything here pins one half of that rule — the write that
+moves it forward, the ownership check that stops a superseded session from
+taking it away, and the tolerant read a kernel process relies on when the
+document is absent or damaged.
+
+The reader lives in :mod:`osprey.jupyter_kernel` and is standard library only,
+because a kernel must not import the web terminal to find out which session it
+belongs to. Tests exercise both ends against the same directory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from osprey.interfaces.web_terminal import pty_manager
+from osprey.interfaces.web_terminal.session_binding import clear_binding, write_binding
+from osprey.jupyter_kernel import BINDING_RELPATH, binding_path, read_binding
+
+
+def _document(root: Path) -> dict:
+    return json.loads((root / BINDING_RELPATH).read_text())
+
+
+# ── write_binding ──────────────────────────────────────────────────────────
+
+
+def test_binding_lands_at_the_shared_path(tmp_path: Path) -> None:
+    write_binding(tmp_path, "sess-1", 4321, str(tmp_path))
+
+    assert (tmp_path / "jupyter" / "session-binding.json").is_file()
+    assert binding_path(tmp_path) == tmp_path / BINDING_RELPATH
+
+
+def test_binding_records_identity_only(tmp_path: Path) -> None:
+    write_binding(tmp_path, "sess-1", 4321, "/srv/agent_data")
+
+    assert _document(tmp_path) == {
+        "session_id": "sess-1",
+        "pty_pid": 4321,
+        "agent_data_root": "/srv/agent_data",
+    }
+
+
+def test_binding_names_the_session_attached_last(tmp_path: Path) -> None:
+    write_binding(tmp_path, "sess-1", 111, str(tmp_path))
+    write_binding(tmp_path, "sess-2", 222, str(tmp_path))
+
+    assert _document(tmp_path)["session_id"] == "sess-2"
+    assert _document(tmp_path)["pty_pid"] == 222
+
+
+def test_binding_write_survives_an_unusable_root(tmp_path: Path) -> None:
+    # A file where the root should be: the directory creation cannot succeed.
+    blocked = tmp_path / "not-a-directory"
+    blocked.write_text("")
+
+    write_binding(blocked, "sess-1", 111, str(blocked))
+
+    assert not binding_path(blocked).exists()
+
+
+# ── clear_binding ──────────────────────────────────────────────────────────
+
+
+def test_clearing_the_bound_session_removes_the_document(tmp_path: Path) -> None:
+    write_binding(tmp_path, "sess-1", 111, str(tmp_path))
+
+    clear_binding(tmp_path, "sess-1")
+
+    assert not binding_path(tmp_path).exists()
+
+
+def test_clearing_another_session_leaves_the_document(tmp_path: Path) -> None:
+    write_binding(tmp_path, "sess-1", 111, str(tmp_path))
+    write_binding(tmp_path, "sess-2", 222, str(tmp_path))
+
+    # sess-1 was superseded before it died; the live binding is not its to drop.
+    clear_binding(tmp_path, "sess-1")
+
+    assert _document(tmp_path)["session_id"] == "sess-2"
+
+
+def test_clearing_without_a_binding_is_silent(tmp_path: Path) -> None:
+    clear_binding(tmp_path, "sess-1")
+
+    assert not binding_path(tmp_path).exists()
+
+
+def test_clearing_a_damaged_binding_leaves_it_alone(tmp_path: Path) -> None:
+    path = binding_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json")
+
+    clear_binding(tmp_path, "sess-1")
+
+    # Nothing names sess-1, so nothing is claimed — and a damaged document is
+    # not evidence that it belonged to the session being torn down.
+    assert path.read_text() == "{not json"
+
+
+# ── read_binding ───────────────────────────────────────────────────────────
+
+
+def test_read_binding_round_trips_a_write(tmp_path: Path) -> None:
+    write_binding(tmp_path, "sess-1", 4321, "/srv/agent_data")
+
+    assert read_binding(tmp_path) == {
+        "session_id": "sess-1",
+        "pty_pid": 4321,
+        "agent_data_root": "/srv/agent_data",
+    }
+
+
+def test_read_binding_answers_none_when_there_is_none(tmp_path: Path) -> None:
+    assert read_binding(tmp_path) is None
+
+
+@pytest.mark.parametrize("payload", ["{not json", '"a string"', "[1, 2]", ""])
+def test_read_binding_answers_none_for_an_unusable_document(tmp_path: Path, payload: str) -> None:
+    path = binding_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(payload)
+
+    assert read_binding(tmp_path) is None
+
+
+# ── PTY teardown ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def bound_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the registry's binding teardown at ``tmp_path``."""
+    monkeypatch.setattr(
+        "osprey.interfaces.web_terminal.operator_session.resolve_agent_data_root",
+        lambda app=None: str(tmp_path),
+    )
+    return tmp_path
+
+
+def test_terminating_the_bound_session_clears_the_binding(bound_root: Path) -> None:
+    registry = pty_manager.PtyRegistry()
+    registry._sessions["sess-1"] = MagicMock()
+    write_binding(bound_root, "sess-1", 111, str(bound_root))
+
+    registry.terminate_session("sess-1")
+
+    assert not binding_path(bound_root).exists()
+
+
+def test_terminating_another_session_leaves_the_binding(bound_root: Path) -> None:
+    registry = pty_manager.PtyRegistry()
+    registry._sessions["sess-1"] = MagicMock()
+    registry._sessions["sess-2"] = MagicMock()
+    write_binding(bound_root, "sess-2", 222, str(bound_root))
+
+    registry.terminate_session("sess-1")
+
+    assert _document(bound_root)["session_id"] == "sess-2"
+
+
+def test_terminating_a_rekeyed_session_clears_its_spawn_key(bound_root: Path) -> None:
+    registry = pty_manager.PtyRegistry()
+    registry._sessions["claude-uuid"] = MagicMock()
+    registry._audit_keys["claude-uuid"] = "telemetry-id"
+    # The binding names the key the child stamps, not the current pool key.
+    write_binding(bound_root, "telemetry-id", 333, str(bound_root))
+
+    registry.terminate_session("claude-uuid")
+
+    assert not binding_path(bound_root).exists()
+
+
+def test_evicting_a_background_session_clears_its_binding(bound_root: Path) -> None:
+    registry = pty_manager.PtyRegistry(max_background=1)
+    registry._sessions["sess-1"] = MagicMock()
+    write_binding(bound_root, "sess-1", 111, str(bound_root))
+
+    registry._evict_lru()
+
+    assert "sess-1" not in registry._sessions
+    assert not binding_path(bound_root).exists()

--- a/tests/interfaces/web_terminal/test_session_binding.py
+++ b/tests/interfaces/web_terminal/test_session_binding.py
@@ -186,3 +186,50 @@ def test_evicting_a_background_session_clears_its_binding(bound_root: Path) -> N
 
     assert "sess-1" not in registry._sessions
     assert not binding_path(bound_root).exists()
+
+
+# ── the attach-time gate ───────────────────────────────────────────────────
+
+
+def _attach(tmp_path: Path, enabled: set[str]) -> Path:
+    """Run one attach against an app serving *enabled*, and return its root.
+
+    Args:
+        tmp_path: The throwaway agent-data root the attach should resolve to.
+        enabled: The panel ids the app has enabled.
+
+    Returns:
+        The root, so the caller can assert on what the attach left in it.
+    """
+    from osprey.interfaces.web_terminal.routes import websocket
+
+    app = MagicMock()
+    app.state.enabled_panels = enabled
+    registry = MagicMock()
+    registry.audit_session_key.return_value = "sess-1"
+    session = MagicMock()
+    session.pid = 4321
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(websocket, "resolve_agent_data_root", lambda app=None: str(tmp_path))
+        websocket._bind_notebook_session(app, registry, session, "sess-1")
+    return tmp_path
+
+
+def test_attaching_writes_the_binding_where_the_panel_is_served(tmp_path: Path) -> None:
+    _attach(tmp_path, {"artifacts", "jupyter"})
+
+    assert _document(tmp_path)["session_id"] == "sess-1"
+
+
+def test_attaching_writes_nothing_where_the_panel_is_absent(tmp_path: Path) -> None:
+    """No notebook panel, no notebook state — not even the directory.
+
+    Nothing would ever read the binding in such a deployment, and creating
+    ``<root>/jupyter/`` under a root the server only guessed at is how an
+    empty directory ends up in a tree that has nothing to do with notebooks.
+    """
+    _attach(tmp_path, {"artifacts"})
+
+    assert not binding_path(tmp_path).exists()
+    assert not (tmp_path / "jupyter").exists()

--- a/tests/interfaces/web_terminal/test_web_custom_panels.py
+++ b/tests/interfaces/web_terminal/test_web_custom_panels.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from osprey.interfaces.web_terminal import app as web_terminal_app
 from osprey.interfaces.web_terminal.app import (
     BUILTIN_PANELS,
     UNIVERSAL_PANELS,
@@ -16,7 +22,7 @@ from osprey.interfaces.web_terminal.app import (
     create_app,
 )
 from osprey.interfaces.web_terminal.routes import panels as panels_module
-from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
+from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS, SIDECAR_PANELS
 
 from .conftest import HOST_ADDRS_TARGET, StubWorkspaceWatcher
 
@@ -33,13 +39,80 @@ def workspace_dir(tmp_path):
     return ws
 
 
-def _make_client(workspace_dir, enabled_panels=None, custom_panels=None):
+#: The panel id of the sidecar under test, and the dotted path of the class the
+#: lifespan imports for it. Both read off the registry so this module pins the
+#: launch path rather than a spelling.
+SIDECAR_ID = next(iter(sorted(SIDECAR_PANELS)))
+_SIDECAR_FACTORY_TARGET = SIDECAR_PANELS[SIDECAR_ID].factory_path.replace(":", ".")
+
+
+class SidecarScript:
+    """What a stub sidecar does when the lifespan launches it, and what it saw.
+
+    The real class starts a server process; nothing in this module may. The
+    default script fails preflight, so every client fixture here gets the
+    unavailable-panel path unless it asks for a ready one.
+    """
+
+    def __init__(
+        self, preflight_error="stub sidecar: not launched", stderr_tail="", wait_ready_error=None
+    ):
+        self.preflight_error = preflight_error
+        self.wait_ready_error = wait_ready_error
+        self.stderr_tail = stderr_tail
+        self.url = "http://127.0.0.1:9/panel/" + SIDECAR_ID
+        self.auth_headers = {"authorization": "Bearer stub-token"}
+        self.constructed: list[tuple] = []
+        self.spawned = 0
+        self.waited: list[float] = []
+        self.stopped = 0
+
+
+def _stub_sidecar_class(script):
+    """A stand-in sidecar class bound to *script*, matching the real signature."""
+
+    class _StubSidecar:
+        def __init__(self, shared_root, outer_prefix, pinned_mode):
+            script.constructed.append((shared_root, outer_prefix, pinned_mode))
+
+        @property
+        def stderr_tail(self):
+            return script.stderr_tail
+
+        @property
+        def auth_headers(self):
+            return dict(script.auth_headers)
+
+        @property
+        def url(self):
+            return script.url
+
+        def preflight(self):
+            if script.preflight_error:
+                raise RuntimeError(script.preflight_error)
+
+        def spawn(self):
+            script.spawned += 1
+
+        def wait_ready(self, timeout):
+            script.waited.append(timeout)
+            if script.wait_ready_error:
+                raise RuntimeError(script.wait_ready_error)
+
+        def stop(self):
+            script.stopped += 1
+
+    return _StubSidecar
+
+
+def _make_client(workspace_dir, enabled_panels=None, custom_panels=None, sidecar_script=None):
     """Create a TestClient with the given panel config."""
     if enabled_panels is None:
         enabled_panels = set(UNIVERSAL_PANELS)
     if custom_panels is None:
         custom_panels = []
     with (
+        patch(_SIDECAR_FACTORY_TARGET, _stub_sidecar_class(sidecar_script or SidecarScript())),
         patch(
             "osprey.interfaces.web_terminal.app._load_web_config",
             return_value={"watch_dir": str(workspace_dir)},
@@ -1056,3 +1129,252 @@ class TestConfigDefinedPanelReservation:
         assert len(events) == 1
         assert events[0]["url"] == "http://localhost:8020"  # original, not attacker's
         assert events[0]["label"] == "EVENTS"
+
+
+# ---- Sidecar panels ----
+
+
+@pytest.fixture
+def ready_sidecar():
+    """A script whose sidecar comes up: preflight passes, readiness returns."""
+    return SidecarScript(preflight_error=None)
+
+
+@pytest.fixture
+def client_with_sidecar(workspace_dir, ready_sidecar):
+    """Client with the sidecar panel enabled and its launch succeeding."""
+    yield from _make_client(
+        workspace_dir,
+        enabled_panels={SIDECAR_ID} | set(UNIVERSAL_PANELS),
+        sidecar_script=ready_sidecar,
+    )
+
+
+def _stub_app():
+    """The minimum app surface the two launch helpers write to."""
+    return SimpleNamespace(state=SimpleNamespace(sidecars={}, panel_auth_headers={}))
+
+
+class TestSidecarLaunchRouting:
+    """Which launcher each built-in panel id reaches.
+
+    A sidecar is in no companion registry, so feeding its id to the companion
+    launcher raises on the registry-key lookup rather than starting anything.
+    """
+
+    def test_no_sidecar_id_reaches_the_companion_launcher(self, monkeypatch):
+        keys: list[str] = []
+        monkeypatch.setattr(
+            web_terminal_app, "_launch_panel_server", lambda app, key: keys.append(key)
+        )
+
+        web_terminal_app._launch_enabled_panel_servers(_stub_app(), set(BUILTIN_PANELS))
+
+        assert len(keys) == len(BUILTIN_PANELS) - len(SIDECAR_PANELS)
+        assert set(keys).isdisjoint(SIDECAR_PANELS)
+
+    def test_every_sidecar_id_reaches_the_sidecar_launcher(self, monkeypatch):
+        launched: list[str] = []
+
+        async def _record(app, panel_id):
+            launched.append(panel_id)
+
+        monkeypatch.setattr(web_terminal_app, "_launch_sidecar", _record)
+
+        asyncio.run(web_terminal_app._launch_enabled_sidecars(_stub_app(), set(BUILTIN_PANELS)))
+
+        assert launched == sorted(SIDECAR_PANELS)
+
+    def test_a_disabled_sidecar_is_not_launched(self, monkeypatch):
+        launched: list[str] = []
+
+        async def _record(app, panel_id):
+            launched.append(panel_id)
+
+        monkeypatch.setattr(web_terminal_app, "_launch_sidecar", _record)
+
+        asyncio.run(web_terminal_app._launch_enabled_sidecars(_stub_app(), set(UNIVERSAL_PANELS)))
+
+        assert launched == []
+
+
+class TestSidecarPanelAvailability:
+    """What a launched — or failed — sidecar publishes, and what the panel says."""
+
+    def test_the_sidecar_panel_is_a_builtin_in_the_panels_api(self, client_all_panels):
+        data = client_all_panels.get("/api/panels").json()
+
+        assert SIDECAR_ID in data["enabled"]
+        assert data["labels"][SIDECAR_ID] == BUILTIN_PANEL_LABELS[SIDECAR_ID]
+
+    def test_a_ready_sidecar_publishes_its_url_and_credential(
+        self, client_with_sidecar, ready_sidecar
+    ):
+        state = client_with_sidecar.app.state
+
+        assert getattr(state, f"{SIDECAR_ID}_server_url") == ready_sidecar.url
+        assert state.panel_auth_headers[SIDECAR_ID] == ready_sidecar.auth_headers
+        assert state.sidecars[SIDECAR_ID] is not None
+        assert ready_sidecar.spawned == 1
+        assert ready_sidecar.waited == [web_terminal_app.SIDECAR_READY_TIMEOUT]
+
+    def test_the_sidecar_is_built_from_the_app_s_own_root_prefix_and_theme(
+        self, client_with_sidecar, ready_sidecar
+    ):
+        state = client_with_sidecar.app.state
+        (shared_root, outer_prefix, pinned_mode) = ready_sidecar.constructed[0]
+
+        assert str(shared_root)
+        assert outer_prefix == ""
+        assert pinned_mode == state.web_theme_mode
+
+    def test_the_route_reports_the_proxy_url_when_the_sidecar_is_ready(self, client_with_sidecar):
+        resp = client_with_sidecar.get(f"/api/{SIDECAR_ID}-server")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"url": f"/panel/{SIDECAR_ID}", "available": True}
+
+    def test_the_route_reports_unavailable_when_the_sidecar_did_not_start(self, client_all_panels):
+        resp = client_all_panels.get(f"/api/{SIDECAR_ID}-server")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"url": None, "available": False}
+
+    def test_a_failed_launch_publishes_neither_url_nor_credential(self, client_all_panels):
+        state = client_all_panels.app.state
+
+        assert getattr(state, f"{SIDECAR_ID}_server_url") is None
+        assert SIDECAR_ID not in state.panel_auth_headers
+        assert SIDECAR_ID not in state.sidecars
+
+    def test_a_sidecar_that_never_answers_is_stopped_and_publishes_nothing(
+        self, workspace_dir, caplog
+    ):
+        """The one path that leaves a live process behind if ``stop()`` is dropped.
+
+        Preflight passes and the process is spawned, so a readiness failure has
+        a server to reap. ``wait_ready`` quotes the stderr tail in its own
+        message, which is why the warning must carry it exactly once.
+        """
+        tail = "OSError: address already in use"
+        script = SidecarScript(
+            preflight_error=None,
+            stderr_tail=tail,
+            wait_ready_error=f"did not answer within 60 s\n{tail}",
+        )
+
+        with caplog.at_level("WARNING", logger=web_terminal_app.__name__):
+            gen = _make_client(workspace_dir, enabled_panels={SIDECAR_ID}, sidecar_script=script)
+            client = next(gen)
+            state = client.app.state
+
+            assert script.spawned == 1
+            assert script.stopped == 1
+            assert getattr(state, f"{SIDECAR_ID}_server_url") is None
+            assert SIDECAR_ID not in state.panel_auth_headers
+            assert SIDECAR_ID not in state.sidecars
+
+            with pytest.raises(StopIteration):
+                next(gen)
+
+        # Shutdown must not reap it a second time — it was never published.
+        assert script.stopped == 1
+        failure = [
+            r.getMessage() for r in caplog.records if "sidecar failed to start" in r.getMessage()
+        ]
+        assert len(failure) == 1
+        assert failure[0].count(tail) == 1
+
+    def test_a_failing_preflight_is_logged_with_the_stderr_tail(self, workspace_dir, caplog):
+        script = SidecarScript(preflight_error="no interpreter", stderr_tail="Traceback: boom")
+
+        with caplog.at_level("WARNING", logger=web_terminal_app.__name__):
+            for _client in _make_client(
+                workspace_dir, enabled_panels={SIDECAR_ID}, sidecar_script=script
+            ):
+                pass
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        failure = [m for m in warnings if "sidecar failed to start" in m]
+        assert len(failure) == 1
+        assert SIDECAR_ID in failure[0]
+        assert "no interpreter" in failure[0]
+        assert "Traceback: boom" in failure[0]
+
+    def test_shutdown_stops_a_launched_sidecar(self, workspace_dir, ready_sidecar):
+        client_gen = _make_client(
+            workspace_dir, enabled_panels={SIDECAR_ID}, sidecar_script=ready_sidecar
+        )
+        next(client_gen)
+        assert ready_sidecar.stopped == 0
+
+        with pytest.raises(StopIteration):
+            next(client_gen)
+
+        assert ready_sidecar.stopped == 1
+
+
+class TestSidecarCredentialThroughTheProxy:
+    """The launch credential is injected on the proxy hop, not held by the browser."""
+
+    def test_the_backend_receives_the_published_authorization_header(self, client_all_panels):
+        seen: list[str | None] = []
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802 — BaseHTTPRequestHandler's own spelling
+                seen.append(self.headers.get("authorization"))
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"ok": true}')
+
+            def log_message(self, *args):
+                """Keep the handler out of the test's stderr."""
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            state = client_all_panels.app.state
+            setattr(state, f"{SIDECAR_ID}_server_url", f"http://127.0.0.1:{server.server_port}")
+            state.panel_auth_headers[SIDECAR_ID] = {"authorization": "Bearer stub-token"}
+
+            resp = client_all_panels.get(f"/panel/{SIDECAR_ID}/api/status")
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+            server.server_close()
+
+        assert resp.status_code == 200
+        assert seen == ["Bearer stub-token"]
+
+
+class TestSidecarExitsLater:
+    """A sidecar that dies after it was published is retracted, not restarted."""
+
+    def test_the_launch_registers_an_exit_hook_on_the_sidecar(self, client_with_sidecar):
+        sidecar = client_with_sidecar.app.state.sidecars[SIDECAR_ID]
+
+        assert callable(sidecar.on_exit)
+
+    def test_an_exit_retracts_the_url_and_the_credential(self, client_with_sidecar, ready_sidecar):
+        state = client_with_sidecar.app.state
+        assert client_with_sidecar.get(f"/api/{SIDECAR_ID}-server").json()["available"] is True
+
+        # The real sidecar fires this from its watcher thread; the hook hands
+        # the loop the retraction, so the route may need one more turn.
+        threading.Thread(target=state.sidecars[SIDECAR_ID].on_exit).start()
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            resp = client_with_sidecar.get(f"/api/{SIDECAR_ID}-server")
+            if resp.json()["available"] is False:
+                break
+            time.sleep(0.05)
+
+        assert resp.json() == {"url": None, "available": False}
+        assert getattr(state, f"{SIDECAR_ID}_server_url") is None
+        assert SIDECAR_ID not in state.panel_auth_headers
+        # It stays registered so shutdown still removes its per-launch state.
+        assert state.sidecars[SIDECAR_ID] is not None
+        assert ready_sidecar.stopped == 0

--- a/tests/registry/test_sidecar_panels.py
+++ b/tests/registry/test_sidecar_panels.py
@@ -37,7 +37,7 @@ SIDECAR_IDS = sorted(SIDECAR_PANELS)
 def test_the_notebooks_panel_is_the_registered_sidecar():
     """The one entry, pinned so the id and its label cannot drift apart."""
     assert SIDECAR_IDS == ["jupyter"]
-    assert BUILTIN_PANEL_LABELS["jupyter"] == "NOTEBOOKS"
+    assert BUILTIN_PANEL_LABELS["jupyter"] == "JUPYTER"
 
 
 @pytest.mark.parametrize("panel_id", SIDECAR_IDS)

--- a/tests/registry/test_sidecar_panels.py
+++ b/tests/registry/test_sidecar_panels.py
@@ -1,0 +1,104 @@
+"""Sidecar panels are built in, and are in none of the companion-server tables.
+
+A sidecar is a panel the web terminal starts itself: no config section with a
+host and a port, no port band, no ``auto_launch`` key, no ``/health`` address.
+It is reached only through the terminal's own panel proxy. Every one of those is
+a thing ``registry.web`` hands a companion server, so registering a sidecar
+there would give it four facts that mean nothing — while leaving it out of
+``BUILTIN_PANELS`` would make ``web.panels.jupyter`` an unknown panel id the
+build refuses.
+
+These tests hold both halves at once: the sidecar id is a first-class built-in
+everywhere panel ids are read, and absent everywhere registry keys are. The
+health category's ``skip`` row is pinned in
+``tests/health/core/test_web_panels.py``, and the build interview's menu entry
+in ``tests/cli/test_build_profile_panels.py``, beside the fixtures each needs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from osprey.deployment.web_terminals.ports import FAMILY_BASE_FIELDS
+from osprey.profiles.web_panels import (
+    BUILTIN_PANEL_LABELS,
+    BUILTIN_PANELS,
+    SIDECAR_PANELS,
+    UNIVERSAL_PANELS,
+)
+from osprey.registry.web import PANEL_ID_TO_REGISTRY_KEY, panel_url_state_attr
+
+SIDECAR_IDS = sorted(SIDECAR_PANELS)
+
+
+def test_the_notebooks_panel_is_the_registered_sidecar():
+    """The one entry, pinned so the id and its label cannot drift apart."""
+    assert SIDECAR_IDS == ["jupyter"]
+    assert BUILTIN_PANEL_LABELS["jupyter"] == "NOTEBOOKS"
+
+
+@pytest.mark.parametrize("panel_id", SIDECAR_IDS)
+class TestSidecarIsABuiltinPanel:
+    """Everything keyed on a panel id covers a sidecar without a second lookup."""
+
+    def test_it_is_a_builtin_panel(self, panel_id):
+        assert panel_id in BUILTIN_PANELS
+        assert panel_id not in UNIVERSAL_PANELS
+
+    def test_it_has_a_display_label(self, panel_id):
+        """An unlabelled builtin renders its raw id in the rail."""
+        assert BUILTIN_PANEL_LABELS[panel_id]
+
+    def test_the_proxy_resolves_it(self, panel_id):
+        """Without a state-attr entry the proxy treats it as a custom panel and
+        looks for a config-declared url that does not exist — a dead tab."""
+        from osprey.interfaces.web_terminal.routes.proxy import _PANEL_STATE_MAP
+
+        assert _PANEL_STATE_MAP[panel_id] == panel_url_state_attr(panel_id)
+
+    def test_the_factory_is_a_dotted_path_not_an_import(self, panel_id):
+        """``module:attribute``, resolved by the launcher, so reading the panel
+        registry never pulls the sidecar's dependencies into the process."""
+        module, sep, attribute = SIDECAR_PANELS[panel_id].factory_path.partition(":")
+        assert sep, "expected 'module:attribute'"
+        assert module and attribute
+
+
+@pytest.mark.parametrize("panel_id", SIDECAR_IDS)
+class TestSidecarIsNotACompanionServer:
+    """The registry-key tables stay scoped to what ``ServerLauncher`` runs."""
+
+    def test_it_has_no_registry_key(self, panel_id):
+        assert panel_id not in PANEL_ID_TO_REGISTRY_KEY
+
+    def test_it_gets_no_port_family(self, panel_id):
+        """A deployment allocates a port band per family. A sidecar binds an
+        ephemeral loopback port the terminal picks, so a band would reserve
+        ports nothing ever listens on."""
+        assert f"{panel_id}_base_port" not in FAMILY_BASE_FIELDS
+        assert panel_id not in FAMILY_BASE_FIELDS.values()
+
+
+def test_importing_the_package_does_not_build_the_web_application():
+    """A sidecar process imports a sibling module, not FastAPI and uvicorn.
+
+    Checked in a subprocess: an ``app`` already imported by an earlier test in
+    this session would make an in-process ``sys.modules`` assertion pass no
+    matter what the package ``__init__`` does.
+    """
+    probe = (
+        "import sys; import osprey.interfaces.web_terminal as pkg; "
+        "print('osprey.interfaces.web_terminal.app' in sys.modules); "
+        "print(pkg.run_web.__module__)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    imported, run_web_module = result.stdout.split()
+
+    assert imported == "False", "importing the package built the web application"
+    # …and the lazy export still resolves to the real function.
+    assert run_web_module == "osprey.interfaces.web_terminal.app"

--- a/tests/registry/test_web_panel_namespaces.py
+++ b/tests/registry/test_web_panel_namespaces.py
@@ -21,6 +21,7 @@ from osprey.profiles.web_panels import (
     BUILTIN_PANEL_LABELS,
     BUILTIN_PANELS,
     DEFAULT_PANEL_FALLBACK,
+    SIDECAR_PANELS,
     UNIVERSAL_PANELS,
 )
 from osprey.registry.web import (
@@ -42,8 +43,12 @@ class TestOneDeclarationPerPanel:
             assert PANEL_ID_TO_REGISTRY_KEY[defn.panel_id] == key
 
     def test_builtin_panels_is_exactly_the_registered_panel_ids(self):
-        """``BUILTIN_PANELS`` is derived, so registering a server registers its panel."""
-        assert BUILTIN_PANELS == set(PANEL_ID_TO_REGISTRY_KEY)
+        """``BUILTIN_PANELS`` is derived, so registering a server registers its panel.
+
+        Both registries count: the companion servers, and the sidecars the web
+        terminal starts itself. Neither is hand-listed in ``BUILTIN_PANELS``.
+        """
+        assert BUILTIN_PANELS == set(PANEL_ID_TO_REGISTRY_KEY) | set(SIDECAR_PANELS)
 
     def test_the_gallery_is_registry_key_artifact_and_panel_artifacts(self):
         """The plural/singular pair that drifted, pinned in both directions.
@@ -97,4 +102,6 @@ class TestDerivedConsumers:
 
         assert set(_PANEL_STATE_MAP) == BUILTIN_PANELS
         for panel_id, attr in _PANEL_STATE_MAP.items():
-            assert attr == panel_url_state_attr(PANEL_ID_TO_REGISTRY_KEY[panel_id])
+            # A sidecar panel has no registry key — it is not a `ServerLauncher`
+            # server — so its attribute is derived from the panel id itself.
+            assert attr == panel_url_state_attr(PANEL_ID_TO_REGISTRY_KEY.get(panel_id, panel_id))

--- a/tests/runtime/test_executor_target_stamp.py
+++ b/tests/runtime/test_executor_target_stamp.py
@@ -1,12 +1,15 @@
 """The control-target stamp: host stamps it, sandbox routes and pins on it.
 
-Two processes are involved and neither can see the other's state directly. The
+Three processes are involved and none can see the other's state directly. The
 host (``python_executor.executor``) resolves which controls server belongs to
 this session and writes the target into the sandbox environment; the sandbox
 (``osprey.runtime``) builds its connector from that stamp and refuses writes
-once the generation it was stamped at has moved on.
+once the generation it was stamped at has moved on. The third is the notebook
+kernel launcher (``osprey.jupyter_kernel``), a second producer of the same
+stamp: it resolves the record from a session binding rather than from its own
+parent, and stamps it into its own environment before the kernel starts.
 
-Every test here drives one of those two halves against a real state file in
+Every test here drives one of those halves against a real state file in
 ``tmp_path``. Nothing touches EPICS: the sandbox half registers a fake connector
 class inside ``isolated_connector_registries`` and asserts on the config that
 class was handed, which is the only evidence that routing actually happened.
@@ -21,9 +24,12 @@ from typing import Any
 
 import pytest
 
+from osprey import jupyter_kernel
+from osprey.audit import posture
 from osprey.mcp_server.control_system import target_state
 from osprey.mcp_server.python_executor import executor as host_executor
 from osprey.runtime import ControlTargetChangedError
+from osprey_connectors import session_store
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -96,8 +102,6 @@ def posture_store(state_root, monkeypatch):
     bound resolver, and the store follows the ``OSPREY_AGENT_DATA_ROOT`` stamp,
     so this points the stamp at the same directory. Returns a writer.
     """
-    from osprey_connectors import session_store
-
     monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(state_root))
     monkeypatch.setenv("OSPREY_POSTURE_SESSION", POSTURE_SESSION_KEY)
     monkeypatch.delenv(session_store.LAUNCH_POSTURE_ENV_VAR, raising=False)
@@ -724,3 +728,202 @@ class TestWritePin:
         runtime._runtime_connector = _Reader()
 
         assert runtime.read_channel("TEST:PV") == 42.0
+
+
+# ---------------------------------------------------------------------------
+# Third party: the notebook kernel launcher, stamping from a session binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kernel_env(monkeypatch):
+    """This process's environment, restored whole afterwards.
+
+    The launcher stamps ``os.environ`` and nothing else: the resolvers it calls
+    read the process environment, so a dict handed in would be invisible to
+    them. Declared with ``monkeypatch`` so the restore below runs inside the
+    same teardown the other environment fixtures use.
+    """
+    saved = dict(os.environ)
+    yield os.environ
+    os.environ.clear()
+    os.environ.update(saved)
+
+
+def binding_for(root, *, pty_pid, session_id: str = POSTURE_SESSION_KEY) -> dict[str, Any]:
+    """A session binding naming *pty_pid*, in the shape the terminal writes."""
+    return {"session_id": session_id, "pty_pid": pty_pid, "agent_data_root": str(root)}
+
+
+@pytest.fixture
+def unstamped_kernel(kernel_env, posture_store, monkeypatch):
+    """A kernel process that has joined nothing yet.
+
+    The identity the launcher is supposed to stamp is removed first, so a test
+    asserting on it is reading the launcher's work rather than the fixture's.
+    ``posture_store`` is still what anchors the store and the state file to one
+    directory. Returns the store writer.
+    """
+    monkeypatch.delenv(session_store.AGENT_DATA_ROOT_ENV_VAR, raising=False)
+    monkeypatch.delenv(posture.POSTURE_SESSION_ENV_VAR, raising=False)
+    session_store.invalidate_cache()
+    return posture_store
+
+
+class TestNotebookLauncherStamps:
+    """What a kernel carries after joining the session its binding names.
+
+    The launcher is the second producer of the routing stamp, so the cases
+    below are the executor's cases asked of a different resolver: the record is
+    found from the bound PTY's pid rather than from this process's parent, and
+    the fail-closed branch has one more way to arrive — a binding that names no
+    live session at all.
+    """
+
+    def test_the_bound_session_is_stamped_whole(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """Identity, target and pin, from one binding and one record."""
+        write_record(target="va", generation=7, owner_ppid=os.getpid())
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=os.getpid()), kernel_env)
+
+        assert kernel_env[session_store.AGENT_DATA_ROOT_ENV_VAR] == str(state_root)
+        assert kernel_env[posture.POSTURE_SESSION_ENV_VAR] == POSTURE_SESSION_KEY
+        assert kernel_env[host_executor.ENV_CONTROL_TARGET] == "va"
+        assert kernel_env[host_executor.ENV_CONTROL_TARGET_GENERATION] == "7"
+        assert kernel_env[host_executor.ENV_CONTROL_TARGET_STATE_PID] == str(os.getpid())
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "va=writes"
+
+    def test_the_launcher_stamps_what_the_executor_stamps(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """One record, two producers, the same three routing names.
+
+        The executor matches on ``owner_ppid == os.getppid()`` and the launcher
+        walks the ancestors of the record's owner up to the bound pid, so this
+        record is written to satisfy both at once — which is the arrangement in
+        production, where the controls server runs inside the bound PTY.
+        """
+        write_record(target="va", generation=4, owner_ppid=os.getppid())
+        sandbox_env: dict[str, str] = {}
+        host_executor._apply_target_stamp(sandbox_env)
+
+        stamps = jupyter_kernel.compute_stamps(
+            binding_for(state_root, pty_pid=os.getppid()), kernel_env
+        )
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert stamps[name] == sandbox_env[name]
+
+    def test_a_narrowed_target_pins_the_kernel_sandboxed(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        unstamped_kernel({POSTURE_SESSION_KEY: {"va": "sandbox"}})
+        write_record(target="va", generation=7, owner_ppid=os.getpid())
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=os.getpid()), kernel_env)
+
+        assert kernel_env[host_executor.ENV_CONTROL_TARGET] == "va"
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "va=sandbox"
+
+    def test_a_binding_with_no_pty_yet_stamps_no_target(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """``pty_pid`` is ``None`` between a session being created and started."""
+        write_record(target="va", generation=7, owner_ppid=os.getpid())
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=None), kernel_env)
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert name not in kernel_env
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "*=sandbox"
+
+    def test_a_binding_naming_a_dead_pty_stamps_no_target(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """A session that ended leaves a binding no live record answers for."""
+        write_record(target="va", generation=7, owner_ppid=os.getpid())
+        stranger = os.getpid() + 1_000_000
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=stranger), kernel_env)
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert name not in kernel_env
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "*=sandbox"
+
+    def test_no_binding_pins_sandboxed_even_where_the_store_permits(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """The one place the launcher parts company with the executor.
+
+        An executor run that cannot name its target still belongs to a session,
+        so its pin is whatever the store answers for that session. A kernel with
+        no binding belongs to no session, and a pin computed for one it is not
+        in would grant writes nobody asked for — so the pin is the literal
+        ``*=sandbox``, with an unnarrowed store in place.
+        """
+        write_record(target="va", generation=7, owner_ppid=os.getpid())
+
+        jupyter_kernel.compute_stamps(None, kernel_env)
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert name not in kernel_env
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "*=sandbox"
+
+    def test_an_inherited_target_stamp_is_stripped(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """The sidecar's environment reaches the kernel; its stamp must not.
+
+        The kernel inherits from the Jupyter server, which inherited from the
+        terminal, so a stale routing stamp can be sitting there — pointing at
+        whatever that process was launched under, not at the bound session.
+        """
+        kernel_env[host_executor.ENV_CONTROL_TARGET] = "live"
+        kernel_env[host_executor.ENV_CONTROL_TARGET_GENERATION] = "2"
+        kernel_env[host_executor.ENV_CONTROL_TARGET_STATE_PID] = "4321"
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=None), kernel_env)
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert name not in kernel_env
+
+    def test_a_target_this_deployment_cannot_build_is_declined(
+        self, state_root, unstamped_kernel, kernel_env, monkeypatch
+    ):
+        """Same rule as the executor's: an unresolvable target is not stamped.
+
+        Stamping 'live' on a mock-only checkout would turn every cell that
+        touches the control system into a ValueError the operator did not cause.
+        """
+        monkeypatch.setattr(
+            "osprey_connectors.config.get_config_value", _section_reader(MOCK_ONLY_SECTION)
+        )
+        write_record(target="live", generation=1, owner_ppid=os.getpid())
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=os.getpid()), kernel_env)
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert name not in kernel_env
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "*=sandbox"
+
+    def test_a_record_without_a_generation_cannot_pin_a_kernel(
+        self, state_root, deployment_config, unstamped_kernel, kernel_env
+    ):
+        """The bar the executor sets with ``require_generation``.
+
+        ``session_record_for_pid`` does not apply it, so the launcher does: a
+        record carrying no int generation cannot say which generation a cell's
+        writes would be refused against.
+        """
+        path = write_record(target="va", generation=0, owner_ppid=os.getpid())
+        record = json.loads(path.read_text())
+        record.pop("generation")
+        path.write_text(json.dumps(record), encoding="utf-8")
+
+        jupyter_kernel.compute_stamps(binding_for(state_root, pty_pid=os.getpid()), kernel_env)
+
+        for name in host_executor._STAMP_ENV_NAMES:
+            assert name not in kernel_env
+        assert kernel_env[host_executor.ENV_LAUNCH_POSTURE] == "*=sandbox"

--- a/tests/runtime/test_jupyter_kernel.py
+++ b/tests/runtime/test_jupyter_kernel.py
@@ -1,0 +1,689 @@
+"""The notebook kernel launcher: what it takes away, and what it must not pull in.
+
+The stamping itself is exercised beside the executor's, in
+``test_executor_target_stamp.py``, because the two are one routing contract and
+belong in one file. What is left here is the launcher's own two jobs: preparing
+the process before a kernel exists, and staying importable in processes that
+have no kernel stack at all.
+
+The refusal hook is the launcher's third job and is exercised here in full: a
+stub shell stands in for ``IPython``'s, so the handler can be fired with a real
+refusal without a kernel behind it.
+
+Nothing here starts a kernel. ``main()`` is the four statements after the
+preparation, and running them would hand the test session's stdio to
+``ipykernel``; the preparation is called directly instead, and the one test
+that does call ``main()`` puts a stub in ``IPKernelApp``'s place.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from osprey import jupyter_kernel
+from osprey.audit import posture
+from osprey.audit.envelope import DECISION_REFUSED
+from osprey.mcp_server.python_executor import executor
+from osprey.runtime import ControlTargetChangedError
+from osprey_connectors import session_store
+from osprey_connectors.control_system import base
+from osprey_connectors.errors import ChannelLimitsViolationError, ChannelWriteBlockedError
+
+#: The posture-store key the bound session is recorded under.
+SESSION_KEY = "4f1c2a7e-0000-4000-8000-000000000002"
+
+
+@pytest.fixture
+def kernel_env(monkeypatch):
+    """This process's environment, restored whole afterwards.
+
+    The launcher stamps ``os.environ`` and nothing else: the resolvers it calls
+    read the process environment, so a dict handed in would be invisible to
+    them.
+    """
+    saved = dict(os.environ)
+    yield os.environ
+    os.environ.clear()
+    os.environ.update(saved)
+    session_store.invalidate_cache()
+
+
+def write_binding_document(root: Path, **fields) -> None:
+    """Put a binding under *root*, in the shape the web terminal writes."""
+    document = {"session_id": SESSION_KEY, "pty_pid": None, "agent_data_root": str(root)}
+    document.update(fields)
+    path = jupyter_kernel.binding_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+class TestPreparingTheProcess:
+    """What the kernel's environment holds by the time a cell can read it."""
+
+    def test_the_server_token_is_removed(self, tmp_path, kernel_env, monkeypatch):
+        """A cell must find no ``JUPYTER_TOKEN`` key, not an empty one.
+
+        The kernelspec carries the name with an empty value and the provisioner
+        merges that env OVER ``os.environ``, so setting it empty is what puts
+        the key there. Only a pop takes it away.
+        """
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(jupyter_kernel.JUPYTER_TOKEN_ENV_VAR, "")
+
+        jupyter_kernel._prepare_environment()
+
+        assert jupyter_kernel.JUPYTER_TOKEN_ENV_VAR not in kernel_env
+
+    def test_a_real_token_is_removed_too(self, tmp_path, kernel_env, monkeypatch):
+        """The inherited value, not only the kernelspec's empty one."""
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(jupyter_kernel.JUPYTER_TOKEN_ENV_VAR, "not-for-cells")
+
+        jupyter_kernel._prepare_environment()
+
+        assert jupyter_kernel.JUPYTER_TOKEN_ENV_VAR not in kernel_env
+
+    def test_the_binding_is_read_from_the_stamped_root(self, tmp_path, kernel_env, monkeypatch):
+        """Where the launcher looks, and which root then wins.
+
+        It looks under the root ``session_store.agent_data_root()`` answers —
+        the ``OSPREY_AGENT_DATA_ROOT`` stamp the kernelspec carries. The root
+        stamped afterwards is the one the BINDING names, which is what makes a
+        kernel read the same stores the terminal writes even where the sidecar
+        was started somewhere else.
+        """
+        located = tmp_path / "located"
+        bound = tmp_path / "bound"
+        bound.mkdir()
+        write_binding_document(located, agent_data_root=str(bound))
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(located))
+
+        stamps = jupyter_kernel._prepare_environment()
+
+        assert stamps[session_store.AGENT_DATA_ROOT_ENV_VAR] == str(bound)
+        assert kernel_env[posture.POSTURE_SESSION_ENV_VAR] == SESSION_KEY
+
+    def test_no_binding_leaves_the_kernel_pinned_sandboxed(self, tmp_path, kernel_env, monkeypatch):
+        """The ordinary state of a kernel started before any terminal attached."""
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+
+        stamps = jupyter_kernel._prepare_environment()
+
+        assert stamps[session_store.LAUNCH_POSTURE_ENV_VAR] == "*=sandbox"
+        assert kernel_env[session_store.LAUNCH_POSTURE_ENV_VAR] == "*=sandbox"
+
+    def test_a_damaged_binding_is_the_same_as_none(self, tmp_path, kernel_env, monkeypatch):
+        """A document caught mid-rewrite must not fail a kernel start."""
+        path = jupyter_kernel.binding_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+
+        stamps = jupyter_kernel._prepare_environment()
+
+        assert stamps[session_store.LAUNCH_POSTURE_ENV_VAR] == "*=sandbox"
+
+    def test_a_binding_naming_no_session_is_the_same_as_none(
+        self, tmp_path, kernel_env, monkeypatch
+    ):
+        """Identity is both halves or neither: no session key, nothing joined."""
+        write_binding_document(tmp_path, session_id="")
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.delenv(posture.POSTURE_SESSION_ENV_VAR, raising=False)
+
+        stamps = jupyter_kernel._prepare_environment()
+
+        assert posture.POSTURE_SESSION_ENV_VAR not in stamps
+        assert stamps[session_store.LAUNCH_POSTURE_ENV_VAR] == "*=sandbox"
+
+    def test_the_config_path_is_published_under_the_name_the_loader_reads(
+        self, tmp_path, kernel_env, monkeypatch
+    ):
+        """``OSPREY_CONFIG`` is what the sidecar passes; ``CONFIG_FILE`` is what loads.
+
+        The kernel's working directory is the notebooks folder, so without the
+        second name every runtime call in a cell resolves the defaults.
+        """
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(jupyter_kernel.OSPREY_CONFIG_ENV_VAR, str(tmp_path / "config.yml"))
+        monkeypatch.delenv(jupyter_kernel.CONFIG_FILE_ENV_VAR, raising=False)
+
+        jupyter_kernel._prepare_environment()
+
+        assert kernel_env[jupyter_kernel.CONFIG_FILE_ENV_VAR] == str(tmp_path / "config.yml")
+
+    def test_an_existing_config_file_is_not_overridden(self, tmp_path, kernel_env, monkeypatch):
+        """Whoever set ``CONFIG_FILE`` chose it; the sidecar's name only fills a gap."""
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(jupyter_kernel.OSPREY_CONFIG_ENV_VAR, str(tmp_path / "config.yml"))
+        monkeypatch.setenv(jupyter_kernel.CONFIG_FILE_ENV_VAR, str(tmp_path / "chosen.yml"))
+
+        jupyter_kernel._prepare_environment()
+
+        assert kernel_env[jupyter_kernel.CONFIG_FILE_ENV_VAR] == str(tmp_path / "chosen.yml")
+
+    def test_a_blank_config_file_is_filled_like_an_absent_one(
+        self, tmp_path, kernel_env, monkeypatch
+    ):
+        """An empty value is not a choice — the loader reads it as unset.
+
+        The provisioner merges the kernelspec's env over ``os.environ``, so a
+        name carried empty arrives as an empty value rather than as no name at
+        all. Keeping it would leave every runtime call in a cell on the
+        defaults, which is the case the publication exists to prevent.
+        """
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.setenv(jupyter_kernel.OSPREY_CONFIG_ENV_VAR, str(tmp_path / "config.yml"))
+        monkeypatch.setenv(jupyter_kernel.CONFIG_FILE_ENV_VAR, "")
+
+        jupyter_kernel._prepare_environment()
+
+        assert kernel_env[jupyter_kernel.CONFIG_FILE_ENV_VAR] == str(tmp_path / "config.yml")
+
+    def test_no_config_path_publishes_nothing(self, tmp_path, kernel_env, monkeypatch):
+        """Neither name set: the launcher invents no path, empty or otherwise."""
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(tmp_path))
+        monkeypatch.delenv(jupyter_kernel.OSPREY_CONFIG_ENV_VAR, raising=False)
+        monkeypatch.delenv(jupyter_kernel.CONFIG_FILE_ENV_VAR, raising=False)
+
+        jupyter_kernel._prepare_environment()
+
+        assert jupyter_kernel.CONFIG_FILE_ENV_VAR not in kernel_env
+
+
+def test_importing_the_module_pulls_in_no_kernel_stack():
+    """The binding reader is imported by the web terminal, which has no kernel.
+
+    ``ipykernel`` is imported inside ``main()`` for this reason, and the web
+    terminal is never imported here at all — the dependency runs one way only.
+    A subprocess is the only honest way to ask: this test session has both
+    packages imported already.
+    """
+    probe = (
+        "import sys; import osprey.jupyter_kernel; "
+        "print(','.join(n for n in "
+        "('ipykernel', 'fastapi', 'osprey.interfaces.web_terminal') if n in sys.modules))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert result.stdout.strip() == ""
+
+
+class StubShell:
+    """As much of an ``InteractiveShell`` as the hook touches."""
+
+    def __init__(self):
+        self.registered = None
+        self.shown = []
+
+    def set_custom_exc(self, exc_tuple, handler):
+        self.registered = (exc_tuple, handler)
+
+    def showtraceback(self, exc_tuple=None, tb_offset=None):
+        self.shown.append((exc_tuple, tb_offset))
+
+
+@pytest.fixture
+def shell():
+    """A stub shell, fresh per test."""
+    return StubShell()
+
+
+@pytest.fixture
+def audit_records(monkeypatch):
+    """Every field set the handler hands the audit writer, in order."""
+    written = []
+
+    def fake_record(**fields):
+        written.append(fields)
+        return None
+
+    monkeypatch.setattr("osprey.audit.writer.record", fake_record)
+    return written
+
+
+@pytest.fixture
+def unstamped(monkeypatch):
+    """No launch pin and no target stamp — what every hint case narrows from."""
+    monkeypatch.delenv(session_store.LAUNCH_POSTURE_ENV_VAR, raising=False)
+    monkeypatch.delenv(posture.CONTROL_TARGET_ENV_VAR, raising=False)
+    monkeypatch.delenv(executor.ENV_CONTROL_TARGET_STATE_PID, raising=False)
+    return monkeypatch
+
+
+def joined_a_session(monkeypatch, record):
+    """Stamp a state pid, and make the record behind it answer *record*.
+
+    *record* is what the controls server that stamped this kernel publishes
+    now: a mapping while its session is live, ``None`` once that session has
+    ended and its record is gone.
+    """
+    monkeypatch.setenv(executor.ENV_CONTROL_TARGET_STATE_PID, "4242")
+    monkeypatch.setattr("osprey.runtime._current_target_record", lambda: record)
+
+
+def raised(error):
+    """*error* with a real traceback, in the triple the shell's hook receives."""
+    try:
+        raise error
+    except Exception:
+        return type(error), error, sys.exc_info()[2]
+
+
+def fire(shell, error, tb_offset=None):
+    """Run the handler over *error* and hand back the triple it was given."""
+    triple = raised(error)
+    jupyter_kernel._refusal_handler(shell, *triple, tb_offset=tb_offset)
+    return triple
+
+
+#: One instance of each class the hook answers for, by the name a test reads.
+REFUSALS = {
+    "write_blocked": lambda: ChannelWriteBlockedError("SR:MAG:1", "WRITES_DISABLED"),
+    "limits": lambda: ChannelLimitsViolationError("SR:MAG:1", 42.0, "range", "above maximum"),
+    "target_changed": lambda: ControlTargetChangedError("the target moved"),
+}
+
+
+class TestInstallingTheHook:
+    """What the shell is asked to trap, and where the asking happens."""
+
+    def test_the_three_refusal_classes_are_registered_as_a_tuple(self, shell):
+        """``set_custom_exc`` rejects a list, and a subclass check needs a tuple."""
+        jupyter_kernel.install_refusal_handler(shell)
+
+        exc_tuple, handler = shell.registered
+        assert isinstance(exc_tuple, tuple)
+        assert set(exc_tuple) == {
+            ChannelWriteBlockedError,
+            ChannelLimitsViolationError,
+            ControlTargetChangedError,
+        }
+        assert handler is jupyter_kernel._refusal_handler
+
+    def test_the_hook_goes_on_between_initialize_and_start(self, monkeypatch):
+        """``initialize`` is what builds the shell; ``start`` does not return.
+
+        So the hook has exactly one place to go, and a chained call would have
+        left it nowhere. The registry is loaded before any of that, from the
+        config path the preparation publishes, and the call is the executor
+        sandbox's: no export, the path from ``CONFIG_FILE``. Log routing comes
+        before all of it, so that what the preparation and the registry log is
+        already going to the terminal.
+        """
+        order = []
+        registry_calls = []
+        config_path = "/deployment/config.yml"
+
+        def prepare():
+            order.append("prepare")
+            monkeypatch.setenv(jupyter_kernel.CONFIG_FILE_ENV_VAR, config_path)
+            return {}
+
+        def initialize_registry(**kwargs):
+            order.append("initialize_registry")
+            registry_calls.append(kwargs)
+
+        class RecordingShell(StubShell):
+            def set_custom_exc(self, exc_tuple, handler):
+                order.append("set_custom_exc")
+                super().set_custom_exc(exc_tuple, handler)
+
+        class StubKernelApp:
+            @classmethod
+            def instance(cls):
+                app = cls()
+                app.shell = RecordingShell()
+                return app
+
+            def initialize(self, argv):
+                order.append("initialize")
+
+            def start(self):
+                order.append("start")
+
+        monkeypatch.setattr(
+            jupyter_kernel, "_route_logs_to_process_stderr", lambda: order.append("route_logs")
+        )
+        monkeypatch.setattr(jupyter_kernel, "_prepare_environment", prepare)
+        monkeypatch.setattr("osprey.registry.initialize_registry", initialize_registry)
+        monkeypatch.setattr("ipykernel.kernelapp.IPKernelApp", StubKernelApp)
+
+        jupyter_kernel.main([])
+
+        assert order == [
+            "route_logs",
+            "prepare",
+            "initialize_registry",
+            "initialize",
+            "set_custom_exc",
+            "start",
+        ]
+        assert registry_calls == [{"auto_export": False, "config_path": config_path}]
+
+    def test_a_registry_that_fails_to_load_does_not_stop_the_kernel(self, monkeypatch, caplog):
+        """The executor sandbox's guard: the failure is logged, the kernel starts."""
+        order = []
+
+        def initialize_registry(**kwargs):
+            raise RuntimeError("no registry here")
+
+        class StubKernelApp:
+            @classmethod
+            def instance(cls):
+                app = cls()
+                app.shell = StubShell()
+                return app
+
+            def initialize(self, argv):
+                order.append("initialize")
+
+            def start(self):
+                order.append("start")
+
+        monkeypatch.setattr(jupyter_kernel, "_route_logs_to_process_stderr", lambda: None)
+        monkeypatch.setattr(jupyter_kernel, "_prepare_environment", dict)
+        monkeypatch.setattr("osprey.registry.initialize_registry", initialize_registry)
+        monkeypatch.setattr("ipykernel.kernelapp.IPKernelApp", StubKernelApp)
+
+        with caplog.at_level("WARNING", logger=jupyter_kernel.__name__):
+            jupyter_kernel.main([])
+
+        assert order == ["initialize", "start"]
+        assert "Registry initialization failed" in caplog.text
+
+
+class TestTheAuditRecord:
+    """One refusal, one record — the ledger's whole claim about a cell."""
+
+    @pytest.mark.parametrize("name", sorted(REFUSALS))
+    def test_each_refusal_files_exactly_one_record(self, name, shell, audit_records, unstamped):
+        """Every class the hook traps is audited, not only the write refusals."""
+        fire(shell, REFUSALS[name]())
+
+        assert len(audit_records) == 1
+        assert audit_records[0]["surface"] == jupyter_kernel.SURFACE_NOTEBOOK_KERNEL
+        assert audit_records[0]["decision"] == DECISION_REFUSED
+        assert audit_records[0]["subject"] == jupyter_kernel.REFUSAL_SUBJECT
+
+    def test_the_channel_is_the_detail_and_the_class_is_the_reason(
+        self, shell, audit_records, unstamped
+    ):
+        """A cell has no name to give, so the channel is what identifies the write."""
+        fire(shell, REFUSALS["write_blocked"]())
+
+        assert audit_records[0]["reason"] == "channel_write_blocked"
+        assert audit_records[0]["detail"] == "channel=SR:MAG:1"
+
+    def test_a_refusal_with_no_channel_carries_no_detail(self, shell, audit_records, unstamped):
+        """``ControlTargetChangedError`` names no channel, and detail is optional."""
+        fire(shell, REFUSALS["target_changed"]())
+
+        assert audit_records[0]["detail"] is None
+        assert audit_records[0]["reason"] == "control_target_changed"
+
+    def test_a_writer_that_fails_does_not_swallow_the_refusal(self, shell, monkeypatch, unstamped):
+        """The audit trail degrades; the traceback the cell needs still arrives."""
+
+        def explode(**fields):
+            raise OSError("read-only audit zone")
+
+        monkeypatch.setattr("osprey.audit.writer.record", explode)
+
+        fire(shell, REFUSALS["write_blocked"]())
+
+        assert len(shell.shown) == 1
+
+
+class TestTheActionLine:
+    """At most one line, and only where a restart is what changes the answer."""
+
+    def test_a_moved_target_asks_for_a_restart(self, shell, audit_records, unstamped, capsys):
+        """The kernel holds one stamp for its whole life."""
+        joined_a_session(unstamped, {"target": "accelerator", "generation": 3})
+
+        fire(shell, REFUSALS["target_changed"]())
+
+        assert capsys.readouterr().out == jupyter_kernel.HINT_TARGET_CHANGED + "\n"
+
+    def test_a_session_that_ended_is_not_reported_as_a_switch(
+        self, shell, audit_records, unstamped, capsys
+    ):
+        """ "+ New" ends one session and attaches another; the target never moved.
+
+        The pin raises the same refusal either way — it compares the stamp
+        against what is published now, and an ended session publishes nothing —
+        so the record is what tells the two apart.
+        """
+        joined_a_session(unstamped, None)
+
+        fire(shell, REFUSALS["target_changed"]())
+
+        assert capsys.readouterr().out == jupyter_kernel.HINT_SESSION_ENDED + "\n"
+
+    def test_a_kernel_that_joined_no_session_still_gets_the_target_line(
+        self, shell, audit_records, unstamped, capsys
+    ):
+        """No stamp, no record — which is not the same as a record that went away."""
+        unstamped.setattr("osprey.runtime._current_target_record", lambda: None)
+
+        fire(shell, REFUSALS["target_changed"]())
+
+        assert capsys.readouterr().out == jupyter_kernel.HINT_TARGET_CHANGED + "\n"
+
+    def test_a_record_check_that_raises_falls_back_to_the_target_line(
+        self, shell, audit_records, unstamped, capsys
+    ):
+        """Both lines ask for the same restart, so the fail-safe claims less."""
+
+        def explode():
+            raise OSError("no state directory here")
+
+        joined_a_session(unstamped, None)
+        unstamped.setattr("osprey.runtime._current_target_record", explode)
+
+        fire(shell, REFUSALS["target_changed"]())
+
+        assert capsys.readouterr().out == jupyter_kernel.HINT_TARGET_CHANGED + "\n"
+
+    def test_a_run_pinned_everywhere_asks_for_a_session(
+        self, shell, audit_records, unstamped, capsys
+    ):
+        """``*=sandbox`` is the launcher's "no session was bound" pin."""
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "*=sandbox")
+
+        fire(shell, REFUSALS["write_blocked"]())
+
+        assert capsys.readouterr().out == jupyter_kernel.HINT_NO_SESSION + "\n"
+
+    def test_a_run_pinned_on_a_named_target_asks_for_the_chip(
+        self, shell, audit_records, unstamped, capsys
+    ):
+        """Writes were off for that target at launch, and the pin never re-reads."""
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "accelerator=sandbox")
+        unstamped.setenv(posture.CONTROL_TARGET_ENV_VAR, "accelerator")
+
+        fire(shell, REFUSALS["write_blocked"]())
+
+        assert capsys.readouterr().out == jupyter_kernel.HINT_WRITES_OFF + "\n"
+
+    def test_a_live_store_refusal_gets_no_line(self, shell, audit_records, unstamped, capsys):
+        """The pin permits, so the store refused — and its message already says so."""
+        fire(shell, REFUSALS["write_blocked"]())
+
+        assert capsys.readouterr().out == ""
+
+    def test_a_limits_violation_gets_no_line(self, shell, audit_records, unstamped, capsys):
+        """A restart changes nothing about a value outside the configured range."""
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "*=sandbox")
+
+        fire(shell, REFUSALS["limits"]())
+
+        assert capsys.readouterr().out == ""
+
+
+def launch_pin_message(monkeypatch, control_target):
+    """The refusal message the connector writes when the launch pin refuses.
+
+    Taken from the connector rather than restated, so that a rewrite test
+    stops passing the moment the sentence it rewrites stops being written.
+    """
+    monkeypatch.delenv("OSPREY_EXECUTION_MODE", raising=False)
+    monkeypatch.setattr(base, "_deployment_writes_enabled", lambda *args, **kwargs: True)
+    result = base._writes_disabled_result(
+        "SR:MAG:1", 1.0, control_target=control_target, store_permits=False
+    )
+    return result.error_message
+
+
+class TestTheRefusalsOwnRemedy:
+    """The connector's message names a remedy; on this surface it is a restart."""
+
+    def test_the_connector_still_writes_the_sentences_this_module_pins(self, unstamped):
+        """The rewrite is a string match, so the strings are asserted at the source.
+
+        Both launch-pin wordings are checked, and a change to either fails here
+        rather than reaching a cell as advice that does nothing.
+        """
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "accelerator=sandbox")
+        named = launch_pin_message(unstamped, "accelerator")
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "*=sandbox")
+        everywhere = launch_pin_message(unstamped, None)
+
+        assert named.endswith("Re-run the script to pick it up.")
+        assert everywhere.endswith("Re-run the script to pick up the current write state.")
+        assert set(jupyter_kernel.LAUNCH_PIN_REMEDIES) == {
+            "Re-run the script to pick it up.",
+            "Re-run the script to pick up the current write state.",
+        }
+
+    def test_a_named_targets_pin_asks_for_a_restart_not_a_re_run(
+        self, shell, audit_records, unstamped
+    ):
+        """Re-running the cell reuses the kernel, which still carries the stamp."""
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "accelerator=sandbox")
+        unstamped.setenv(posture.CONTROL_TARGET_ENV_VAR, "accelerator")
+        message = launch_pin_message(unstamped, "accelerator")
+
+        fire(shell, ChannelWriteBlockedError("SR:MAG:1", "WRITES_DISABLED", message))
+
+        shown = str(shell.shown[0][0][1])
+        assert shown.endswith("Restart the kernel to pick it up.")
+        assert "Re-run the script" not in shown
+        assert (
+            shown[: -len("Restart the kernel to pick it up.")]
+            == message[: -len("Re-run the script to pick it up.")]
+        )
+
+    def test_the_pinned_everywhere_message_is_rewritten_too(self, shell, audit_records, unstamped):
+        """Its remedy is the same re-run, in the wording that names the state."""
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "*=sandbox")
+        message = launch_pin_message(unstamped, None)
+
+        fire(shell, ChannelWriteBlockedError("SR:MAG:1", "WRITES_DISABLED", message))
+
+        assert str(shell.shown[0][0][1]).endswith(
+            "Restart the kernel to pick up the current write state."
+        )
+
+    def test_a_live_store_refusal_keeps_its_own_message(self, shell, audit_records, unstamped):
+        """The pin permits, so the chip is the remedy and nothing is rewritten."""
+        message = "Write to 'SR:MAG:1' blocked: Re-run the script to pick it up."
+
+        fire(shell, ChannelWriteBlockedError("SR:MAG:1", "WRITES_DISABLED", message))
+
+        assert str(shell.shown[0][0][1]) == message
+
+    def test_a_message_without_the_pinned_sentence_is_left_alone(
+        self, shell, audit_records, unstamped
+    ):
+        """A wording this module does not know is shown as the connector wrote it."""
+        unstamped.setenv(session_store.LAUNCH_POSTURE_ENV_VAR, "*=sandbox")
+        message = "Write to 'SR:MAG:1' blocked: some wording nobody pinned."
+
+        fire(shell, ChannelWriteBlockedError("SR:MAG:1", "WRITES_DISABLED", message))
+
+        assert str(shell.shown[0][0][1]) == message
+
+
+@pytest.fixture
+def root_handlers():
+    """The root logger's handlers, restored whole afterwards."""
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    yield root
+    for handler in list(root.handlers):
+        if handler not in saved:
+            root.removeHandler(handler)
+            stream = getattr(handler, "stream", None)
+            handler.close()
+            if stream is not None:
+                stream.close()
+    root.handlers[:] = saved
+
+
+class TestTheProcessLog:
+    """A cell shows the refusal and the action line; the log goes to the terminal."""
+
+    def test_records_reach_the_inherited_stderr_and_not_the_replaced_one(
+        self, root_handlers, monkeypatch, capfd
+    ):
+        """``ipykernel`` publishes ``sys.stderr`` into the cell; the log must miss it.
+
+        The replaced stream stands in for that: a handler that resolves stderr
+        when it emits writes there, and one holding a duplicate of the
+        descriptor the process started on does not.
+        """
+        cell = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", cell)
+
+        jupyter_kernel._route_logs_to_process_stderr()
+        logging.getLogger("osprey_connectors.probe").warning("Blocked write to a channel")
+
+        assert "Blocked write to a channel" not in cell.getvalue()
+        assert "Blocked write to a channel" in capfd.readouterr().err
+
+    def test_a_handler_bound_to_the_replaced_stderr_is_taken_off(
+        self, root_handlers, monkeypatch, capfd
+    ):
+        """Otherwise the same record arrives twice, once of them in the cell."""
+        cell = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", cell)
+        stale = logging.StreamHandler(sys.stderr)
+        root_handlers.addHandler(stale)
+
+        jupyter_kernel._route_logs_to_process_stderr()
+
+        assert stale not in root_handlers.handlers
+
+    def test_the_level_the_root_logger_had_is_the_level_it_keeps(
+        self, root_handlers, monkeypatch, capfd
+    ):
+        """Routing is a destination change; what is logged at all is not touched."""
+        before = root_handlers.level
+
+        jupyter_kernel._route_logs_to_process_stderr()
+
+        assert root_handlers.level == before
+        assert root_handlers.handlers[-1].level == logging.NOTSET
+
+
+class TestTheTraceback:
+    """The hook adds to the cell's output; it never takes the traceback away."""
+
+    def test_the_original_triple_is_delegated(self, shell, audit_records, unstamped):
+        """Not a rebuilt one: the frames a cell needs are the ones that raised."""
+        triple = fire(shell, REFUSALS["write_blocked"](), tb_offset=2)
+
+        assert shell.shown == [(triple, 2)]

--- a/tests/runtime/test_runtime_async_bridge.py
+++ b/tests/runtime/test_runtime_async_bridge.py
@@ -1,0 +1,95 @@
+"""The runtime's sync-over-async bridge, in both of the contexts it serves.
+
+``_run_async`` is how every synchronous runtime call (``read_channel``,
+``write_channel``) reaches its coroutine. It has two callers with two
+different loops: the executor subprocess, which has none, and a notebook
+kernel, which is already inside one. The one thing a test can pin about the
+bridge is that the coroutine's own outcome — its value or its exception —
+comes back unchanged from either context. ``ControlTargetChangedError`` is the
+case that matters: it is a ``RuntimeError``, and so is the "no running loop"
+signal the bridge probes for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from osprey.runtime import ControlTargetChangedError, _run_async
+
+
+class SubclassedRuntimeError(RuntimeError):
+    """Any ``RuntimeError`` subclass; the refusal class is one of them."""
+
+
+async def answer(value):
+    """A coroutine that returns *value*."""
+    return value
+
+
+async def refuse(error):
+    """A coroutine that raises *error*."""
+    raise error
+
+
+def inside_a_running_loop(call):
+    """Run *call* synchronously from inside a coroutine on a fresh loop.
+
+    That is a notebook kernel's shape: the cell's synchronous code executes
+    while the kernel's own loop is running on the same thread.
+    """
+
+    async def driver():
+        return call()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(driver())
+    finally:
+        loop.close()
+
+
+ERRORS = {
+    "runtime_subclass": lambda: SubclassedRuntimeError("the coroutine's own"),
+    "control_target_changed": lambda: ControlTargetChangedError("the target moved"),
+    "value_error": lambda: ValueError("not a RuntimeError at all"),
+}
+
+
+class TestWithoutARunningLoop:
+    """The executor subprocess: ``asyncio.run`` directly."""
+
+    def test_the_value_comes_back(self):
+        assert _run_async(answer(42)) == 42
+
+    @pytest.mark.parametrize("name", sorted(ERRORS))
+    def test_the_coroutines_exception_propagates_unchanged(self, name):
+        error = ERRORS[name]()
+
+        with pytest.raises(type(error)) as caught:
+            _run_async(refuse(error))
+
+        assert caught.value is error
+
+
+class TestInsideARunningLoop:
+    """The notebook kernel: a worker thread with a loop of its own."""
+
+    def test_the_value_comes_back(self):
+        assert inside_a_running_loop(lambda: _run_async(answer(42))) == 42
+
+    @pytest.mark.parametrize("name", sorted(ERRORS))
+    def test_the_coroutines_exception_propagates_unchanged(self, name):
+        """A ``RuntimeError`` from the coroutine is not the "no loop" signal.
+
+        Mistaking it for one would retry ``asyncio.run`` on the thread whose
+        loop is running, and the refusal would surface as "asyncio.run()
+        cannot be called from a running event loop" instead.
+        """
+        error = ERRORS[name]()
+
+        with pytest.raises(type(error)) as caught:
+            inside_a_running_loop(lambda: _run_async(refuse(error)))
+
+        assert caught.value is error

--- a/tests/templates/test_memory_guard_widening.py
+++ b/tests/templates/test_memory_guard_widening.py
@@ -15,7 +15,7 @@ introduced:
   (``osprey.cli.templates.claude_code`` builds the rule from it), so the
   frontmatter *is* the matcher;
 * the ``NotebookEdit`` scope agrees with the ``NotebookEdit(<agent_data_root>/
-  artifacts/**)`` allow rule ``settings.json.j2`` renders — two independent
+  <subdir>/**)`` allow rules ``settings.json.j2`` renders — two independent
   spellings of one policy, which is exactly the pair that silently forks;
 * each tool is actually gated end to end, by running the hook the way Claude
   Code runs it.
@@ -30,6 +30,7 @@ home.
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -49,8 +50,29 @@ SETTINGS_TEMPLATE = (
 #: through unchallenged.
 WRITE_TOOLS = frozenset({"Write", "MultiEdit", "NotebookEdit"})
 
-#: Subdirectory of the agent-data root that ``NotebookEdit`` is scoped to.
+#: The agent-data subdirectories ``NotebookEdit`` is scoped to: the artifact
+#: tree the gallery serves, and the notebooks tree the Jupyter panel serves.
 ARTIFACTS_SUBDIR = "artifacts"
+NOTEBOOKS_SUBDIR = "notebooks"
+NOTEBOOK_SUBDIRS = frozenset({ARTIFACTS_SUBDIR, NOTEBOOKS_SUBDIR})
+
+#: Both spellings of the allow rule, as they appear in the two files. The
+#: template renders one Jinja append per subdirectory; the hook declares the
+#: same set as a tuple.
+_TEMPLATE_ALLOW_RE = re.compile(r"""NotebookEdit\(' ~ agent_data_root ~ '/([^/]+)/\*\*\)""")
+_HOOK_SUBDIRS_RE = re.compile(r"_NOTEBOOK_SUBDIRS = \(([^)]*)\)")
+
+
+def _template_notebook_subdirs() -> set[str]:
+    """Every agent-data subdirectory the rendered ``NotebookEdit`` allows name."""
+    return set(_TEMPLATE_ALLOW_RE.findall(SETTINGS_TEMPLATE.read_text(encoding="utf-8")))
+
+
+def _hook_notebook_subdirs() -> set[str]:
+    """Every agent-data subdirectory the guard scopes ``NotebookEdit`` to."""
+    match = _HOOK_SUBDIRS_RE.search(MEMORY_GUARD.read_text(encoding="utf-8"))
+    assert match, "the guard no longer declares _NOTEBOOK_SUBDIRS"
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
 
 
 def _frontmatter() -> dict:
@@ -138,8 +160,6 @@ def _decision(result):
 
 def memory_dir_for(hook_home, project):
     """The memory directory the hook computes, rebuilt from its documented rule."""
-    import re
-
     encoded = re.sub(r"[^A-Za-z0-9-]", "-", str(project.resolve()))
     return hook_home / ".claude" / "projects" / encoded / "memory"
 
@@ -185,24 +205,21 @@ def test_guard_stays_the_outermost_pretooluse_gate():
 
 
 @pytest.mark.unit
-def test_settings_template_still_scopes_notebookedit_to_artifacts():
-    """``settings.json.j2`` grants ``NotebookEdit`` only under the artifacts tree.
+def test_settings_template_scopes_notebookedit_to_the_agent_data_subdirs():
+    """``settings.json.j2`` grants ``NotebookEdit`` under those two trees and no other.
 
-    The hook denies outside that same directory. If this allow rule is ever
-    respelled, the hook's scope has to move with it or the two halves of one
-    policy disagree.
+    The hook denies outside the same directories. If an allow rule is ever
+    respelled or a third tree added, the hook's scope has to move with it or the
+    two halves of one policy disagree.
     """
-    template = SETTINGS_TEMPLATE.read_text(encoding="utf-8")
-
-    assert f"NotebookEdit(' ~ agent_data_root ~ '/{ARTIFACTS_SUBDIR}/**)" in template
+    assert _template_notebook_subdirs() == NOTEBOOK_SUBDIRS
 
 
 @pytest.mark.unit
-def test_hook_scopes_notebookedit_to_the_same_subdirectory():
-    """The hook names the same ``artifacts`` subdirectory the allow rule does."""
-    source = MEMORY_GUARD.read_text(encoding="utf-8")
-
-    assert f'_ARTIFACTS_SUBDIR = "{ARTIFACTS_SUBDIR}"' in source
+def test_hook_scopes_notebookedit_to_the_same_subdirectories():
+    """The guard names exactly the subdirectories the allow rules do."""
+    assert _hook_notebook_subdirs() == NOTEBOOK_SUBDIRS
+    assert _hook_notebook_subdirs() == _template_notebook_subdirs()
 
 
 # -- MultiEdit is gated like Write --
@@ -238,14 +255,15 @@ def test_multiedit_deny_message_names_the_memory_directory(run_guard, project):
     assert "memory" in reason.lower()
 
 
-# -- NotebookEdit is scoped to the artifacts tree --
+# -- NotebookEdit is scoped to the agent-data artifacts and notebooks trees --
 
 
 @pytest.mark.unit
-def test_notebookedit_inside_artifacts_is_allowed(run_guard, project, write_config):
-    """A notebook under ``<agent_data_root>/artifacts`` is the agent's own output."""
+@pytest.mark.parametrize("subdir", sorted(NOTEBOOK_SUBDIRS))
+def test_notebookedit_inside_an_allowed_subdir_is_allowed(run_guard, project, write_config, subdir):
+    """A notebook under either agent-data tree is the agent's own."""
     write_config()
-    target = project / "var" / "agent_data" / ARTIFACTS_SUBDIR / "run.ipynb"
+    target = project / "var" / "agent_data" / subdir / "run.ipynb"
     target.parent.mkdir(parents=True)
 
     result = run_guard("NotebookEdit", {"notebook_path": str(target)})
@@ -254,10 +272,13 @@ def test_notebookedit_inside_artifacts_is_allowed(run_guard, project, write_conf
 
 
 @pytest.mark.unit
-def test_notebookedit_nested_under_artifacts_is_allowed(run_guard, project, write_config):
-    """The allow is recursive — ``artifacts/**``, not just direct children."""
+@pytest.mark.parametrize("subdir", sorted(NOTEBOOK_SUBDIRS))
+def test_notebookedit_nested_under_an_allowed_subdir_is_allowed(
+    run_guard, project, write_config, subdir
+):
+    """The allow is recursive — ``<subdir>/**``, not just direct children."""
     write_config()
-    target = project / "var" / "agent_data" / ARTIFACTS_SUBDIR / "2026" / "run.ipynb"
+    target = project / "var" / "agent_data" / subdir / "2026" / "run.ipynb"
     target.parent.mkdir(parents=True)
 
     result = run_guard("NotebookEdit", {"notebook_path": str(target)})
@@ -266,7 +287,7 @@ def test_notebookedit_nested_under_artifacts_is_allowed(run_guard, project, writ
 
 
 @pytest.mark.unit
-def test_notebookedit_outside_artifacts_is_denied(run_guard, project, write_config):
+def test_notebookedit_outside_both_subdirs_is_denied(run_guard, project, write_config):
     """A notebook anywhere else is refused — this is the tool's whole gap."""
     write_config()
     target = project / "escape.ipynb"
@@ -288,15 +309,16 @@ def test_notebookedit_into_memory_dir_is_denied(run_guard, project, hook_home, w
 
 
 @pytest.mark.unit
-def test_notebookedit_honours_relocated_agent_data_root(run_guard, project, write_config):
-    """An overridden ``agent_data.base_dir`` moves the allowed directory with it.
+@pytest.mark.parametrize("subdir", sorted(NOTEBOOK_SUBDIRS))
+def test_notebookedit_honours_relocated_agent_data_root(run_guard, project, write_config, subdir):
+    """An overridden ``agent_data.base_dir`` moves both allowed directories with it.
 
-    ``settings.json.j2`` interpolates the same key into its allow rule, so a
-    guard hard-coding the default would refuse the agent its own artifacts on
+    ``settings.json.j2`` interpolates the same key into its allow rules, so a
+    guard hard-coding the default would refuse the agent its own notebooks on
     any project that relocates the root.
     """
     write_config(base_dir="custom_state/agent_data")
-    target = project / "custom_state" / "agent_data" / ARTIFACTS_SUBDIR / "run.ipynb"
+    target = project / "custom_state" / "agent_data" / subdir / "run.ipynb"
     target.parent.mkdir(parents=True)
 
     result = run_guard("NotebookEdit", {"notebook_path": str(target)})
@@ -305,10 +327,13 @@ def test_notebookedit_honours_relocated_agent_data_root(run_guard, project, writ
 
 
 @pytest.mark.unit
-def test_notebookedit_at_default_root_denied_when_root_relocated(run_guard, project, write_config):
+@pytest.mark.parametrize("subdir", sorted(NOTEBOOK_SUBDIRS))
+def test_notebookedit_at_default_root_denied_when_root_relocated(
+    run_guard, project, write_config, subdir
+):
     """Relocating the root also *narrows* the allow — the default no longer counts."""
     write_config(base_dir="custom_state/agent_data")
-    target = project / "var" / "agent_data" / ARTIFACTS_SUBDIR / "run.ipynb"
+    target = project / "var" / "agent_data" / subdir / "run.ipynb"
     target.parent.mkdir(parents=True)
 
     result = run_guard("NotebookEdit", {"notebook_path": str(target)})
@@ -317,12 +342,13 @@ def test_notebookedit_at_default_root_denied_when_root_relocated(run_guard, proj
 
 
 @pytest.mark.unit
-def test_notebookedit_traversal_is_denied(run_guard, project, write_config):
+@pytest.mark.parametrize("subdir", sorted(NOTEBOOK_SUBDIRS))
+def test_notebookedit_traversal_is_denied(run_guard, project, write_config, subdir):
     """``..`` in the raw path is refused even when it resolves back inside."""
     write_config()
-    artifacts = project / "var" / "agent_data" / ARTIFACTS_SUBDIR
-    artifacts.mkdir(parents=True)
-    target = artifacts / "sub" / ".." / "run.ipynb"
+    allowed_dir = project / "var" / "agent_data" / subdir
+    allowed_dir.mkdir(parents=True)
+    target = allowed_dir / "sub" / ".." / "run.ipynb"
 
     result = run_guard("NotebookEdit", {"notebook_path": str(target)})
 
@@ -340,15 +366,16 @@ def test_notebookedit_without_a_path_is_denied(run_guard, write_config):
 
 
 @pytest.mark.unit
-def test_notebookedit_deny_message_names_the_artifacts_directory(run_guard, project, write_config):
-    """The refusal points at the artifact tree, not at the memory directory."""
+def test_notebookedit_deny_message_names_both_allowed_directories(run_guard, project, write_config):
+    """The refusal points at both agent-data trees, not at the memory directory."""
     write_config()
 
     result = run_guard("NotebookEdit", {"notebook_path": str(project / "escape.ipynb")})
 
     reason = result["hookSpecificOutput"]["permissionDecisionReason"]
     assert "NOTEBOOK EDIT DENIED" in reason
-    assert ARTIFACTS_SUBDIR in reason
+    for subdir in NOTEBOOK_SUBDIRS:
+        assert f"/{subdir}/" in reason
 
 
 # -- The original Write contract is unchanged --

--- a/uv.lock
+++ b/uv.lock
@@ -335,12 +335,93 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/43/bb8b6e8708d49a5ab36781333af092d9f483b198a2710d01281204640055/argon2_cffi_bindings-26.1.0.tar.gz", hash = "sha256:63505c71542a44b68b1e38060450fb006404170da375feb31af153e7f9c6205d", size = 1790807, upload-time = "2026-08-20T07:44:22.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/d2/0ae991f1b2181e5be49007c574710a800ad36c2978683addb3e67c474e55/argon2_cffi_bindings-26.1.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:21ca0396fe5ec995dd54431c32698189666f9224810acfa752e50d2bd94d9df2", size = 25521, upload-time = "2026-08-20T07:32:43.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e4/ad91d8297638aa2258aad4501c306aca99480dfe76ccd638173fa3702db9/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78de2d65e0b9ea7ce9d1b1c3e87297b2d7305a02c266ee2a2d6910daddd7ee69", size = 27177, upload-time = "2026-08-20T07:32:44.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/86/5363df11b86d02cf3662208e7406496327649cc90eb365bf6f4e8a54a41f/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27f1821903e2ceadcb88ec2b45ef190897b7682449c772f4d9b53e42c520cf29", size = 26597, upload-time = "2026-08-20T07:32:45.172Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b5/a14dcc592652347dad23ee93b278a4da5d2a25c9ed3ebd10d68eea823a4f/argon2_cffi_bindings-26.1.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d88e5f7e60f28ae0b0cc6b2f16c43e87cd642a196a86f85e0d8bb6fe016fc16d", size = 27403, upload-time = "2026-08-20T07:32:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/b4a20d4902af7f796390bf9245ff83c5217dfa7367efa1d14986956c482b/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:34b7d9c24a4165a2c61cc8ae11d44d48c9ce2830fb536cb7914e11fdd9962728", size = 27132, upload-time = "2026-08-20T07:32:47.13Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/1b/c8de358af07b1c490e0fcb863ef98e46ddb486e45567aca5a60bd68d9daa/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:224865cbbcb7a2bd1356741dff12b0134df726b6d44bb7b500df8e303cbd9e81", size = 27588, upload-time = "2026-08-20T07:32:48.087Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2f/7ee62a6e79f9309f9d9982d301b22a00010adb580c05c8109b94d7b33de0/argon2_cffi_bindings-26.1.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ffff613aaa9ce6236766e2fc6dc560bb5abde7a2e2416e3db1f9ae395a2b4dd4", size = 26785, upload-time = "2026-08-20T07:32:48.977Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/960d0ee93d4897741bcaf4799c697dae2d81499f66fd1ed042a7dd54c1f4/argon2_cffi_bindings-26.1.0-cp310-abi3-win32.whl", hash = "sha256:a86c069c91a747a2c4e5c51473590aeb48172fff9b2130d23729a42d98665ecb", size = 23898, upload-time = "2026-08-20T07:32:50.114Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3a/0cc14a05810e6add9bce5e87693334baa2222de5f647fa31781885b6573f/argon2_cffi_bindings-26.1.0-cp310-abi3-win_amd64.whl", hash = "sha256:2c36ff87b5dfaa477d0bd51e9d7f6abdae7c8955d2983c97419085d842154b3e", size = 25730, upload-time = "2026-08-20T07:32:51.091Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/db/d83cf2af140547f0b9cdaece05b2dc2dcbf991be4667331d073eff771435/argon2_cffi_bindings-26.1.0-cp310-abi3-win_arm64.whl", hash = "sha256:f9c4420a7a864fe1b86ce35befc95b8e39fb852493b81cf798671ddc265de638", size = 24478, upload-time = "2026-08-20T07:32:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/5f/f652055e18d2627e2eed94c7f31a792127cfe38df786635395d742321674/argon2_cffi_bindings-26.1.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:af11ac37a7c53dc16cb7950a6190851b0870fe218b6c60c0bb7ac355234e3083", size = 15434, upload-time = "2026-08-20T07:32:53.143Z" },
+    { url = "https://files.pythonhosted.org/packages/76/38/de696045960f5b846d428c0fb6c130ed3da87aac2af209b05c193815404c/argon2_cffi_bindings-26.1.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:db0fcd827ca61622a01b220aadfbece01939acf53888f2cb98cd93e9b1e2c97e", size = 15449, upload-time = "2026-08-20T07:32:54.075Z" },
+    { url = "https://files.pythonhosted.org/packages/91/0a/c25af768f6b75a5a71e31207f87c540656b2808c015260444a22763221ad/argon2_cffi_bindings-26.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:28524438cd3e723f25412f63d4fd516ff5bae9ae5aa56acbe2a1404398a0cf31", size = 25683, upload-time = "2026-08-20T07:32:55.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7e/be212c751ab0bcea7f646615f933bf262e8e50b3f7bef32f861d0a2d066b/argon2_cffi_bindings-26.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac82fc756a446b6ccd7139ce70efa9d8bbe541e7ad579a12dcb52764b7175c5f", size = 27311, upload-time = "2026-08-20T07:32:56.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ee/f84b28e4afd13d3cac36c1d8fa8c239d2dc2c51cd978d02ee5d5ad98d9bb/argon2_cffi_bindings-26.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6a4e68eed961a8de6928d1c17ff3dc2a547e0e923c17f8f1cd79fb7bc9502f98", size = 26771, upload-time = "2026-08-20T07:32:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/21/c3/95c07a023691ecd529da9cb6a8f0779e13ebc1bdfaa86d145fdc1c6e7e79/argon2_cffi_bindings-26.1.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:151dfaad9de753f4af2a7854e707e4784f2acc434340ade64239c5b104b2d605", size = 27568, upload-time = "2026-08-20T07:32:58.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/31/3a18e31406d8694b4d6a31573c3e572fff6bed318bb744453eb653766d22/argon2_cffi_bindings-26.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:061a6919145bbf282ebf1f9c59d3135d4833c25313c8595c0d68cf7712ddfce2", size = 27280, upload-time = "2026-08-20T07:32:59.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/39/d4be4577e178b2397aa5b5575c8a309bf0da2afe05fe0c72c8f398662d63/argon2_cffi_bindings-26.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:62ff20cd130c956c7c9144d5fe35228f98b51c579b2439e988b27ef93e16c02a", size = 27776, upload-time = "2026-08-20T07:33:00.325Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/78f4dd96f7411339f723b96fe24039c1bd5835102b8a5ba71ac4ec712ac7/argon2_cffi_bindings-26.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:19423e5d7ac1cc354baab59eaabf18db2ec04ef6593b5abe5a34f323c4a8f87a", size = 26932, upload-time = "2026-08-20T07:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/96bfd37434cc0a848a9066c291d84b28846c4c9ea289ed9866b1164d622b/argon2_cffi_bindings-26.1.0-cp314-cp314t-win32.whl", hash = "sha256:4f84cdd868978d7b7350a566c254042d44216d9e37f241f3a6d3b1dfebeede35", size = 24878, upload-time = "2026-08-20T07:33:02.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/42/d8b6810abd9b1bd2f47ebbccf460da59c9f32e94888bea4f7b137d998797/argon2_cffi_bindings-26.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2b741888c93147444fdfc851abd81cc207f37f7f7da42062a00deb3888e57da8", size = 26656, upload-time = "2026-08-20T07:33:03.222Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d1/095d95eaf2ed1d9f77268cf3291bde148c6cd56121f8db2c74c1ba618a0e/argon2_cffi_bindings-26.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6ab674f668d5962a3a4136ae0812519b0f1586874263723a32181d60d64137e1", size = 25378, upload-time = "2026-08-20T07:33:04.332Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cb/214092c39c4dbcb72cf98b12234ddac2221f8fe2c0acf29c6a70fa83be53/argon2_cffi_bindings-26.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:1d98e33bd8bd67d7206c124e200bf2229c4cfa8c9c19f7b44a897f0fc71837eb", size = 25683, upload-time = "2026-08-20T07:33:05.337Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e5/02015b83e9b05ccb85ff2ced424cf6e83a12d3810bc7f66d679a92b69ffb/argon2_cffi_bindings-26.1.0-cp315-cp315t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ccaf0a46cbb380f1fd102a874e32aa629fd3cb0c0e94f4943fa1f6d5edc5dac6", size = 27310, upload-time = "2026-08-20T07:33:06.344Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/4a/85e612787d0796878b3b4f6bd53dcd5484b6fe7b64cc6fc7b6e6a04cf835/argon2_cffi_bindings-26.1.0-cp315-cp315t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0c3103fcff20183e593459cfea6e012281c0e76ae3ed8b5565ad1b92eac3990", size = 26771, upload-time = "2026-08-20T07:33:07.429Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/84/ccb003b6f9969820e87656398f4d49c857def71a85ca1588a0e809afd7ce/argon2_cffi_bindings-26.1.0-cp315-cp315t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c49e853a3bef9dd10329f31f702e7fa9b5c58229ff9c2ff6d069efaf09177c08", size = 27569, upload-time = "2026-08-20T07:33:08.598Z" },
+    { url = "https://files.pythonhosted.org/packages/88/07/c26b76debf0998ee08fbe947ab2058ac5de37d4b9d46b06c17abaa6c4ce9/argon2_cffi_bindings-26.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:6376d4b3aca039375ca8bf92f770da0ec424a1ce3a37077a8d3c557411aa56ca", size = 27279, upload-time = "2026-08-20T07:33:09.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0d/ead6ddc029f91bc9b9390686dad3c808ab08100d348f6266b5f93f8970ee/argon2_cffi_bindings-26.1.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:9bacedc04b0402837586a17f0919e3dfdd95291f441f1f56bd80ec274c2840a1", size = 27774, upload-time = "2026-08-20T07:33:10.728Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/c108530d9eb86036b78d3af4de28b83b4a2d9a70512bd10ff8e59966aab4/argon2_cffi_bindings-26.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:76ae29acace5d33355344612844d588e19deaaba4639d8bb01601e4b1418ef36", size = 26933, upload-time = "2026-08-20T07:33:11.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/0bfc59e781c89acf64c31c388aade9d9d1c1ea38aa1ba1292fe07f607fe9/argon2_cffi_bindings-26.1.0-cp315-cp315t-win32.whl", hash = "sha256:df612391feca41c44d20118f3b88d1b86419465cd1f5496859f715ca60ec2210", size = 24875, upload-time = "2026-08-20T07:33:12.616Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c7/c3e46068cddffccecb8ad94d71135e9bf62bbc789589e7dfadc7c6f59214/argon2_cffi_bindings-26.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:1a0a29ed86960e44eaace7e081bdfab4f08b012fd96ec8edba71e2ad020939e4", size = 26655, upload-time = "2026-08-20T07:33:13.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ca/18b9c8c45fecf34b9100ec6d7946057f14a158f2eaa20ea123a3e82351cb/argon2_cffi_bindings-26.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:d157ddfab1e8b21f2f1dedda9c09645d98b5ed0b667b0626be600a345d426440", size = 25376, upload-time = "2026-08-20T07:33:14.491Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/b9/97f0370f99611b14efd384918613dd5cbda75f28d9bb1b677aacfeaa17df/argon2_cffi_bindings-26.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:19b562b1de4b9052ef1214a2821c44b6e6f22945daa102c32ae4eff929d8b6d8", size = 23055, upload-time = "2026-08-20T07:33:19.716Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/70/7eb3fe7bf00103cbbb569c51aef150661f22b734a782673a600ff0f52309/argon2_cffi_bindings-26.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49d525938467d52c923a890153c99087c9d5a937d1f6b585dbdba34ec82e397a", size = 24869, upload-time = "2026-08-20T07:33:20.671Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4b/9d5919c6cb1f15df7406af0f99b048bd93936f112e3e8f4c8077bc2a9110/argon2_cffi_bindings-26.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b0bcac4d490a237e18cf91f57352920c29f77f2fa39efd0813fb81298bf17ba", size = 24216, upload-time = "2026-08-20T07:33:21.653Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/32109943bace7729233cc4ee78530baa306d8cc3c6501a64ba8cb3b58129/argon2_cffi_bindings-26.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:0cc40f7b4050bb93eb67de95d2d759322fc7ce4930b9d645581ecf4913ec651e", size = 23584, upload-time = "2026-08-20T07:33:22.613Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
 ]
 
 [[package]]
@@ -1795,6 +1876,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2710,6 +2800,18 @@ wheels = [
 ]
 
 [[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2916,6 +3018,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
 name = "jsonasobj2"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2972,6 +3083,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
+]
+
 [[package]]
 name = "jsonschema-path"
 version = "0.3.4"
@@ -2997,6 +3121,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter-builder"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e1/e4ef07e2be228271b59e011a746d97feef69577af1f465b1cff0f1d7c760/jupyter_builder-1.2.2.tar.gz", hash = "sha256:b6cea88f58e44b2c5eba96f28d2e0d16fd453d3ca6dc9c4492ff8a1f2e97f601", size = 981074, upload-time = "2026-08-07T06:47:18.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/3b/920bc7f3c2ad25abc0071ae7ae55789f4b85ecf3e4467f0602a88dc668cb/jupyter_builder-1.2.2-py3-none-any.whl", hash = "sha256:6ebcd4c49daf5df6a18068a74a48010406700ed90a76c189fac43eaf85c60c63", size = 915266, upload-time = "2026-08-07T06:47:16.249Z" },
 ]
 
 [[package]]
@@ -3048,12 +3185,129 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/e0/63b481d5b21f81fe23173dfc9eb25629fa1bc174fdc4a2c19d09c1ff8124/jupyter_server-2.21.0.tar.gz", hash = "sha256:70d9a1883f57d3576ea17f4ce061ec1a7aad7ef388d00428cfb7f5e4f0022271", size = 760357, upload-time = "2026-08-27T16:06:34.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/8a/cb97c2b353cb46cced413be8f742fa8fcd3cb1659524f27314494aa94968/jupyter_server-2.21.0-py3-none-any.whl", hash = "sha256:2ae2e5ce5e97268553e25aebe040197455673d925b5fc7995477153318160cf7", size = 393961, upload-time = "2026-08-27T16:06:31.814Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-builder" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/c0/45934229995d4c6e38192ca118d93185f60808f64157e3df3c5c28f8c5fd/jupyterlab-4.6.3.tar.gz", hash = "sha256:2e3db6e3a12495ebd188276e985bf5ac502fbde3d1e8628819920210008de498", size = 28319771, upload-time = "2026-08-10T18:50:57.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/47/242f46de028074651c9bd6d8000fc340ed0d3cdd1a0eae4387826123413a/jupyterlab-4.6.3-py3-none-any.whl", hash = "sha256:0a1ebc6567186f1eabd99536e94df7ed9e96d1e7c5ddf3e4406ae16e88abacb7", size = 17168312, upload-time = "2026-08-10T18:50:53.044Z" },
+]
+
+[[package]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
 ]
 
 [[package]]
@@ -3171,6 +3425,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/01/a8ea7c5ea32a9b45ceeaee051a04c8ed4320f5add3c51bfa20879b765b70/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85b5352f94e490c028926ea567fc569c52ec79ce131dadb968d3853e809518c2", size = 80281, upload-time = "2025-08-10T21:27:45.369Z" },
     { url = "https://files.pythonhosted.org/packages/da/e3/dbd2ecdce306f1d07a1aaf324817ee993aab7aee9db47ceac757deabafbe/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:464415881e4801295659462c49461a24fb107c140de781d55518c4b80cb6790f", size = 78009, upload-time = "2025-08-10T21:27:46.376Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/0d4add7873a73e462aeb45c036a2dead2562b825aa46ba326727b3f31016/kiwisolver-1.4.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fb940820c63a9590d31d88b815e7a3aa5915cad3ce735ab45f0c730b39547de1", size = 73929, upload-time = "2025-08-10T21:27:48.236Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -4129,6 +4392,18 @@ wheels = [
 ]
 
 [[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4595,9 +4870,12 @@ dependencies = [
     { name = "google-generativeai" },
     { name = "httpx" },
     { name = "idna" },
+    { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
     { name = "litellm" },
     { name = "lume-base" },
     { name = "lume-pyat" },
@@ -4783,9 +5061,12 @@ requires-dist = [
     { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.2.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "idna", specifier = ">=3.18" },
+    { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "jupyter-server", specifier = ">=2.21,<3" },
+    { name = "jupyterlab", specifier = ">=4.6,<5" },
     { name = "linkml-runtime", marker = "extra == 'all'", specifier = ">=1.11.1,<2" },
     { name = "linkml-runtime", marker = "extra == 'dev'", specifier = ">=1.11.1,<2" },
     { name = "linkml-runtime", marker = "extra == 'knowledge'", specifier = ">=1.11.1,<2" },
@@ -4894,6 +5175,15 @@ requires-dist = [
     { name = "websockets", specifier = ">=14" },
 ]
 provides-extras = ["all", "ariel", "ariel-proxy", "dev", "docs", "gchat", "knowledge", "screen-capture-linux", "sheets", "virtual-accelerator"]
+
+[[package]]
+name = "overrides"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+]
 
 [[package]]
 name = "p4p"
@@ -5267,6 +5557,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4d/cf/f588bcdfd2c841839b9d59ce219a46695da56aa2805faff937bbafb9ee2b/prefixmaps-0.2.6.tar.gz", hash = "sha256:7421e1244eea610217fa1ba96c9aebd64e8162a930dc0626207cd8bf62ecf4b9", size = 709899, upload-time = "2024-10-17T16:30:57.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/b2/2b2153173f2819e3d7d1949918612981bc6bd895b75ffa392d63d115f327/prefixmaps-0.2.6-py3-none-any.whl", hash = "sha256:f6cef28a7320fc6337cf411be212948ce570333a0ce958940ef684c7fb192a62", size = 754732, upload-time = "2024-10-17T16:30:55.731Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
 ]
 
 [[package]]
@@ -6115,6 +6414,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/25/5473e46b179f8e8b4ad3aeeb36773d1701b7770eaf5e5bc2025c7303b598/python_json_logger-4.2.0.tar.gz", hash = "sha256:e371ebe22ec01e289850102091a2b1f6fc9e655c7f1f5f29073936756c290afa", size = 18211, upload-time = "2026-08-15T11:36:38.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/55/6467fde553886cb293e41538f3a8b4e4fd4688c6df242cf982162d8367fb/python_json_logger-4.2.0-py3-none-any.whl", hash = "sha256:158a52126fcd6869e09574d2b66272666f3dc8f468c62637ef9a1fa883719cb9", size = 14988, upload-time = "2026-08-15T11:36:36.821Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -6179,6 +6487,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/5c/31feb3dd82d1b33ae0bd09ca601edb993d9da1b7f0226b3336d4b4c39e1e/pywinpty-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda", size = 2092466, upload-time = "2026-06-10T23:44:24.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fe/fe23e2229ffec0c10190cef5964f5c9b2dba179d23b69ae537b7ea90bcab/pywinpty-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:c2406f54f699eab75953fb75ce805f2ae55a33a957cd070890abd454fb4b7680", size = 818395, upload-time = "2026-06-10T23:41:56.93Z" },
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
 ]
 
 [[package]]
@@ -6492,6 +6820,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]
@@ -6962,6 +7323,15 @@ wheels = [
 ]
 
 [[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7296,6 +7666,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
 ]
 
 [[package]]
@@ -7655,6 +8039,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
 name = "uritemplate"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7892,6 +8285,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Runs JupyterLab as a per-terminal sidecar behind the existing panel proxy, reachable
as a **NOTEBOOKS** tab in the web terminal. Notebook kernels carry the same control
target, generation and write posture that an `execute()` child gets, so a cell cannot
reach further into the machine than the chat session it belongs to.

## What this adds

- **Sidecar panel.** `SIDECAR_PANELS` is a new panel class: a process the terminal
  spawns and proxies, rather than a route in the app. The tab retracts if the process
  exits; nothing restarts it.
- **Kernel posture.** A binding file on the shared agent-data root names the most
  recently attached chat session. The kernel launcher reads it and stamps target,
  generation and write posture on the kernel. With no session, it fails closed to a
  sandbox pin — a write is refused with the hint that turns writes on.
- **Confined file access.** The contents API, `/files/` and checkpoints all resolve
  the real path, so a symlink cannot leave the notebook root. Delete-to-trash is off.
- **Agent edits.** Notebooks live on the shared agent-data volume; the memory guard
  allows `NotebookEdit` under `notebooks/`, and edits badge the tab.
- **Preset.** The `control-assistant` family selects the panel by default.

Docs: `docs/source/how-to/web-terminal/notebooks.rst`.

## Worth a reviewer's attention

- **`osprey/runtime/__init__.py` was touched.** One narrowed `except` clause in
  `_run_async` (commit `66b835648`). `ControlTargetChangedError` subclasses
  `RuntimeError`, so the running-loop probe swallowed it and retried — which the
  subprocess executor never hits but a kernel always does. The no-loop path is
  byte-identical.
- **Closing a session tile detaches but does not end the session.** A kernel keeps
  following that session and can still write. Documented as-is; making tile-close
  clear the binding is a session-lifecycle change outside this feature.
- **New CI job `jupyter-panel-e2e`.** The end-to-end suite builds a full deployment,
  so it runs in its own `dockerbuild` job (~10 min cold) rather than the shared lane,
  and is excluded from the model matrix. New wiring — most likely place for a
  first-run surprise.
- **New core dependencies:** `jupyterlab`, `jupyter-server`, `ipykernel`.

## Testing

`pytest` unit lanes, the JS suite, the new browser smoke suite and an 8-case
end-to-end suite against a live deployment all pass locally.

Branch is 7 commits behind `main` at the time of opening.
