### PR TITLE
fix(web-terminal): share the event stream, act once per mode flip, HTTP/2 on TLS

### DIFF
--- a/changelog.d/hub-sse-sharing.fixed.md
+++ b/changelog.d/hub-sse-sharing.fixed.md
@@ -1,0 +1,5 @@
+The web terminal opens one event stream per page instead of three. Every
+module that listened on the file-events stream held its own connection, which
+left a hub tab one short of the browser's six-per-host HTTP/1.1 limit; a second
+tab or one more streaming panel then queued every later request indefinitely.
+The subscribers now share a single connection.

--- a/changelog.d/mode-flip-remount.fixed.md
+++ b/changelog.d/mode-flip-remount.fixed.md
@@ -1,0 +1,3 @@
+Embedded panels no longer re-mount twice on an Expert/Simple flip, or again
+on every tab switch. The hub resends the current mode whenever a panel tab is
+activated; panels now act on it only when the mode actually changed.

--- a/changelog.d/nginx-http2.changed.md
+++ b/changelog.d/nginx-http2.changed.md
@@ -1,0 +1,4 @@
+Deployments with TLS enabled now serve the web terminal over HTTP/2. One
+multiplexed connection replaces the browser's six-per-host HTTP/1.1 limit, so
+open panels and their event streams no longer compete with ordinary requests.
+Plain-HTTP deployments are unchanged.

--- a/src/osprey/interfaces/channel_finder/static/js/app.js
+++ b/src/osprey/interfaces/channel_finder/static/js/app.js
@@ -6,7 +6,7 @@
  */
 
 import { initTheme } from '/design-system/js/theme-manager.js';
-import { applyEmbedded, isEmbedded } from '/design-system/js/frame-params.js';
+import { applyEmbedded, isEmbedded, onModeChange } from '/design-system/js/frame-params.js';
 import { contributeHeader, onHeaderAction } from '/design-system/js/header-contrib.js';
 import '/design-system/js/components/osprey-display-menu.js';
 import { fetchJSON, putJSON } from './api.js';
@@ -29,18 +29,12 @@ applyEmbedded();
 
 // Live Expert<->Simple switch broadcast by the hub's header toggle. The
 // pre-paint rung (mode-boot.js) already set the initial data-ui-mode; this is
-// the runtime flip. Coerce anything non-"simple" to "expert", re-stamp the
-// attribute (CSS deltas key off it), then re-mount the active view so the
+// the runtime flip. frame-params.js's shared receive side normalizes the
+// mode, re-stamps the attribute (CSS deltas key off it) and calls back only
+// on an actual change; the follow-up re-mounts the active view so the
 // in-context renderer repaints its plain cards <-> dense table. Mirrors the
 // ARIEL panel's app.js listener.
-window.addEventListener('message', (e) => {
-  if (e.origin !== window.location.origin) return;
-  if (e.data && e.data.type === 'osprey-mode-change' && e.data.mode) {
-    const mode = e.data.mode === 'simple' ? 'simple' : 'expert';
-    document.documentElement.setAttribute('data-ui-mode', mode);
-    remountCurrentView();
-  }
-});
+onModeChange(() => remountCurrentView());
 
 /** @typedef {{ mount: (container: HTMLElement) => void, unmount: () => void }} ViewModule */
 

--- a/src/osprey/interfaces/design_system/static/js/frame-params.js
+++ b/src/osprey/interfaces/design_system/static/js/frame-params.js
@@ -142,6 +142,19 @@ export function pickUiMode(mode) {
  * fixup, ...). Pages whose Simple/Expert deltas are pure CSS pass no
  * callback.
  *
+ * The callback runs only when the mode actually changed. The hub resends
+ * the current mode to a panel on every tab activation and posts a flip both
+ * as a broadcast and again on activation, so a follower that re-mounted on
+ * every message did so twice per flip and once per tab switch. A repeat of
+ * the mode already on `<html>` (stamped pre-paint by mode-boot.js or by an
+ * earlier message) is not a flip.
+ *
+ * Several callers register on one window (the page itself, every
+ * `<osprey-display-menu>`), and the first listener to see a message is the
+ * one that stamps `<html>`. "Did this message change the mode" is therefore
+ * decided once per message event and shared by every listener, so no later
+ * listener mistakes the stamp its sibling just made for a repeat.
+ *
  * @param {(mode: 'expert'|'simple') => void} [callback]
  * @returns {void}
  */
@@ -150,7 +163,20 @@ export function onModeChange(callback) {
     if (e.origin !== window.location.origin) return;
     if (!e.data || e.data.type !== 'osprey-mode-change' || !e.data.mode) return;
     const mode = e.data.mode === 'simple' ? 'simple' : 'expert';
-    document.documentElement.setAttribute('data-ui-mode', mode);
+    let changed = modeChangeVerdicts.get(e);
+    if (changed === undefined) {
+      changed = document.documentElement.getAttribute('data-ui-mode') !== mode;
+      modeChangeVerdicts.set(e, changed);
+      document.documentElement.setAttribute('data-ui-mode', mode);
+    }
+    if (!changed) return;
     if (callback) callback(mode);
   });
 }
+
+/**
+ * Per-message verdict of {@link onModeChange}: whether the message flipped
+ * the mode. Keyed weakly on the event so entries vanish with it.
+ * @type {WeakMap<MessageEvent, boolean>}
+ */
+const modeChangeVerdicts = new WeakMap();

--- a/src/osprey/interfaces/lattice_dashboard/static/js/app.js
+++ b/src/osprey/interfaces/lattice_dashboard/static/js/app.js
@@ -8,7 +8,7 @@
  */
 
 import { initTheme } from '/design-system/js/theme-manager.js';
-import { applyEmbedded, isEmbedded } from '/design-system/js/frame-params.js';
+import { applyEmbedded, isEmbedded, onModeChange } from '/design-system/js/frame-params.js';
 import '/design-system/js/components/osprey-display-menu.js';
 import { refreshFast, runVerification, createNetClient } from './net.js';
 import {
@@ -122,18 +122,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Live Expert<->Simple switch broadcast by the hub (same-origin
   // postMessage). The pre-paint rung (mode-boot.js) already set the initial
-  // data-ui-mode; this is the runtime flip. The simple layout promotes the
-  // optics figure to fill the canvas, so the visible Plotly figures must be
-  // told to resize — CSS container resizes don't fire Plotly's responsive
-  // handler on their own.
-  window.addEventListener('message', (e) => {
-    if (e.origin !== window.location.origin) return;
-    if (e.data && e.data.type === 'osprey-mode-change' && e.data.mode) {
-      const mode = e.data.mode === 'simple' ? 'simple' : 'expert';
-      document.documentElement.setAttribute('data-ui-mode', mode);
-      // Let the CSS grid/visibility change settle before relaying out.
-      setTimeout(ui.reflowFigures, 60);
-    }
+  // data-ui-mode; this is the runtime flip, and frame-params.js's shared
+  // receive side stamps <html> and calls back only on an actual change. The
+  // simple layout promotes the optics figure to fill the canvas, so the
+  // visible Plotly figures must be told to resize — CSS container resizes
+  // don't fire Plotly's responsive handler on their own.
+  onModeChange(() => {
+    // Let the CSS grid/visibility change settle before relaying out.
+    setTimeout(ui.reflowFigures, 60);
   });
 
   // Load initial state

--- a/src/osprey/interfaces/okf_panel/static/js/app.js
+++ b/src/osprey/interfaces/okf_panel/static/js/app.js
@@ -29,7 +29,7 @@
  */
 
 import { initTheme } from "/design-system/js/theme-manager.js";
-import { applyEmbedded, isEmbedded } from "/design-system/js/frame-params.js";
+import { applyEmbedded, isEmbedded, onModeChange } from "/design-system/js/frame-params.js";
 import { debounce } from "/design-system/js/dom.js";
 import {
   contributeHeader,
@@ -81,18 +81,12 @@ function publishHeaderContribution() {
 // Live Expert<->Simple switch broadcast by the hub (same-origin postMessage),
 // the mode-axis sibling of the osprey-theme-change follower wired by initTheme
 // above. mode-boot.js already stamped the initial data-ui-mode pre-paint; this
-// is the runtime flip. The Simple layout is pure CSS gated on the attribute
-// (see style.css), so stamping <html> covers the body; the tile-bar
+// is the runtime flip. frame-params.js's shared receive side stamps <html> and
+// calls back only on an actual change. The Simple layout is pure CSS gated on
+// the attribute (see style.css), so the stamp covers the body; the tile-bar
 // contribution is mode-dependent, so re-publish it too — that is what moves the
 // search box between the bar and the body on a live flip.
-window.addEventListener("message", (e) => {
-  if (e.origin !== window.location.origin) return;
-  if (e.data && e.data.type === "osprey-mode-change" && e.data.mode) {
-    const mode = e.data.mode === "simple" ? "simple" : "expert";
-    document.documentElement.setAttribute("data-ui-mode", mode);
-    publishHeaderContribution();
-  }
-});
+onModeChange(() => publishHeaderContribution());
 
 applyEmbedded();
 

--- a/src/osprey/interfaces/web_terminal/static/js/api.js
+++ b/src/osprey/interfaces/web_terminal/static/js/api.js
@@ -260,7 +260,25 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
 }
 
 /**
- * Create an EventSource with reconnection.
+ * The live shared streams, keyed by the caller's (unprefixed) URL. One entry
+ * per distinct URL for as long as it has at least one subscriber; the last
+ * `stop()` closes the socket and drops the entry. See createEventSource.
+ * @type {Map<string, {subscribe: (handlers: EventSourceHandlers) => {stop: () => void}}>}
+ */
+const sharedStreams = new Map();
+
+/**
+ * Subscribe to a server-sent event stream, with reconnection.
+ *
+ * One socket per URL, however many subscribers. Browsers cap HTTP/1.1 at six
+ * connections per host across every tab, and an idle EventSource counts the
+ * same as an in-flight fetch. Three hub modules read `/api/files/events` on
+ * one page (panel-sse, the activity strip, the control-target chip); a socket
+ * each left one tab a single connection under the cap, so a second tab — or
+ * one more streaming panel — pushed every later fetch into an indefinite
+ * queue. Subscribers to the same URL now share the socket; each frame is
+ * parsed once and handed to every subscriber's `onMessage` (treat it as
+ * read-only), and the socket closes when the last subscriber stops.
  *
  * The browser's built-in retry covers only network-level failures on a
  * still-live source; a non-2xx response or wrong content type (a proxy 502
@@ -272,11 +290,30 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
  * `onOpen` fires on EVERY open — first connect, browser auto-retry, and this
  * wrapper's own reconnects. SSE has no replay (no event ids are sent), so
  * anything published while disconnected is gone; the hook is the caller's
- * seam for re-fetching authoritative state instead.
+ * seam for re-fetching authoritative state instead. A subscriber that joins
+ * a socket already open gets its `onOpen` immediately, so the resync it
+ * drives happens whether or not this subscriber was the one to connect.
  * @param {string} url
  * @param {EventSourceHandlers} [handlers]
+ * @returns {{stop: () => void}}
  */
 export function createEventSource(url, { onMessage, onError, onOpen } = {}) {
+  let stream = sharedStreams.get(url);
+  if (!stream) {
+    stream = openSharedStream(url);
+    sharedStreams.set(url, stream);
+  }
+  return stream.subscribe({ onMessage, onError, onOpen });
+}
+
+/**
+ * The socket behind createEventSource for one URL: connect, fan out, back
+ * off, close when the last subscriber leaves.
+ * @param {string} url
+ */
+function openSharedStream(url) {
+  /** @type {Set<EventSourceHandlers>} */
+  const subscribers = new Set();
   /** @type {EventSource|null} */
   let es = null;
   let stopped = false;
@@ -295,24 +332,23 @@ export function createEventSource(url, { onMessage, onError, onOpen } = {}) {
       attempt = 0;
       sseState = 'connected';
       notifyStateChange();
-      if (onOpen) onOpen();
+      for (const sub of subscribers) if (sub.onOpen) sub.onOpen();
     };
 
     es.onmessage = (e) => {
-      if (onMessage) {
-        try {
-          const data = JSON.parse(e.data);
-          onMessage(data);
-        } catch {
-          onMessage(e.data);
-        }
+      let data;
+      try {
+        data = JSON.parse(e.data);
+      } catch {
+        data = e.data;
       }
+      for (const sub of subscribers) if (sub.onMessage) sub.onMessage(data);
     };
 
     es.onerror = () => {
       sseState = 'disconnected';
       notifyStateChange();
-      if (onError) onError();
+      for (const sub of subscribers) if (sub.onError) sub.onError();
       // readyState 2 is CLOSED (spec constant): the browser has given up on
       // this source for good, so reconnection is ours from here. While
       // CONNECTING/OPEN the built-in retry is still running — never race it.
@@ -333,8 +369,9 @@ export function createEventSource(url, { onMessage, onError, onOpen } = {}) {
     }, delay);
   }
 
-  function stop() {
+  function close() {
     stopped = true;
+    sharedStreams.delete(url);
     if (reconnectTimer != null) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
@@ -344,8 +381,27 @@ export function createEventSource(url, { onMessage, onError, onOpen } = {}) {
     notifyStateChange();
   }
 
+  /**
+   * @param {EventSourceHandlers} handlers
+   * @returns {{stop: () => void}}
+   */
+  function subscribe(handlers) {
+    subscribers.add(handlers);
+    // readyState 1 is OPEN: the resync hook fires now for a late joiner.
+    if (es && es.readyState === 1 && handlers.onOpen) handlers.onOpen();
+    let active = true;
+    return {
+      stop() {
+        if (!active) return;
+        active = false;
+        subscribers.delete(handlers);
+        if (subscribers.size === 0) close();
+      },
+    };
+  }
+
   connect();
-  return { stop };
+  return { subscribe };
 }
 
 /**

--- a/src/osprey/templates/modules/web_terminals/nginx.conf.j2
+++ b/src/osprey/templates/modules/web_terminals/nginx.conf.j2
@@ -221,7 +221,8 @@
     becomes a redirect-only server and a second `listen <tls_port> ssl` server
     — `tls_port` is 443 unless the deployment set `tls.port`, which is what a
     rootless nginx needs — carrying `ssl_certificate`/`ssl_certificate_key`
-    from the configured paths, becomes the sole content server. The redirect
+    from the configured paths and speaking HTTP/2, becomes the sole content
+    server. The redirect
     names that port too whenever it is not 443. render.py refuses to render at
     all if either path is missing, so this template never has to guard against
     an incoherent pair.
@@ -400,6 +401,12 @@ server {
     listen [::]:{{ tls_port }} ssl;
     ssl_certificate {{ tls_cert }};
     ssl_certificate_key {{ tls_key }};
+    # HTTP/2 rides on the TLS handshake (ALPN), so it exists only here. It
+    # multiplexes every request on one connection, which lifts the browser's
+    # six-connections-per-host HTTP/1.1 cap — a hub tab holds several
+    # long-lived event streams against that budget. WebSockets are unaffected:
+    # the browser opens them on their own HTTP/1.1 connection regardless.
+    http2 on;
 {% else %}
     listen {{ nginx_port }};
     listen [::]:{{ nginx_port }};

--- a/tests/deployment/web_terminals/golden/tls_custom_port/nginx.conf
+++ b/tests/deployment/web_terminals/golden/tls_custom_port/nginx.conf
@@ -100,6 +100,12 @@ server {
     listen [::]:8443 ssl;
     ssl_certificate /etc/nginx/certs/dls.crt;
     ssl_certificate_key /etc/nginx/certs/dls.key;
+    # HTTP/2 rides on the TLS handshake (ALPN), so it exists only here. It
+    # multiplexes every request on one connection, which lifts the browser's
+    # six-connections-per-host HTTP/1.1 cap — a hub tab holds several
+    # long-lived event streams against that budget. WebSockets are unaffected:
+    # the browser opens them on their own HTTP/1.1 connection regardless.
+    http2 on;
 
     server_name _;
 

--- a/tests/deployment/web_terminals/test_auth_tls_seams.py
+++ b/tests/deployment/web_terminals/test_auth_tls_seams.py
@@ -448,6 +448,27 @@ def test_seam_tls_on_a_non_default_port_moves_the_whole_encrypted_seam() -> None
     assert "ssl_certificate_key /etc/nginx/certs/dls.key;" in content
 
 
+def test_seam_tls_content_server_speaks_http2_and_cleartext_servers_do_not() -> None:
+    """SEAM 2 (TLS brings HTTP/2): the encrypted content server enables HTTP/2.
+    Browsers cap HTTP/1.1 at six connections per host, and every hub tab holds
+    several long-lived event streams against that budget; multiplexing removes
+    the ceiling wherever TLS is already terminated here. The redirect-only
+    server has nothing to multiplex, and a plain-http render cannot negotiate
+    HTTP/2 with a browser at all, so neither emits the directive."""
+    # Arrange
+    config = copy.deepcopy(_MULTI_USER_CONFIG)
+    config["modules"]["web_terminals"]["tls"] = copy.deepcopy(_TLS_STANZA)
+
+    # Act
+    redirect, content = _server_blocks(_render_nginx(config))
+    plain = _render_nginx(copy.deepcopy(_MULTI_USER_CONFIG))
+
+    # Assert
+    assert "http2 on;" in content
+    assert "http2" not in redirect
+    assert "http2" not in plain
+
+
 def _nginx_volumes(config: dict) -> list[str]:
     """The rendered nginx service's ``volumes`` list, parsed from the overlay."""
     overlay = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])

--- a/tests/interfaces/design_system/js/frame-params.test.js
+++ b/tests/interfaces/design_system/js/frame-params.test.js
@@ -207,6 +207,52 @@ describe('onModeChange', () => {
 
     expect(document.documentElement.getAttribute('data-ui-mode')).toBe('simple');
   });
+
+  test('a repeat of the mode already stamped invokes no callback', () => {
+    // The hub sends the mode twice on a flip — once as the broadcast, once
+    // again on tab activation — and once more every time a tab is activated.
+    // A follower's callback re-mounts its view or re-fetches, so it must run
+    // only when the mode actually changed.
+    const callback = vi.fn();
+    onModeChange(callback);
+
+    deliverMessage({ type: 'osprey-mode-change', mode: 'simple' });
+    deliverMessage({ type: 'osprey-mode-change', mode: 'simple' });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    deliverMessage({ type: 'osprey-mode-change', mode: 'expert' });
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenLastCalledWith('expert');
+  });
+
+  test('every listener on the window sees one flip, not just the first to stamp', () => {
+    // A page registers its own callback and its <osprey-display-menu>
+    // registers another. The first listener stamps <html>; the second must
+    // not read that stamp as "already this mode" and skip.
+    const page = vi.fn();
+    const menu = vi.fn();
+    onModeChange(page);
+    onModeChange(menu);
+
+    deliverMessage({ type: 'osprey-mode-change', mode: 'simple' });
+
+    expect(page).toHaveBeenCalledWith('simple');
+    expect(menu).toHaveBeenCalledWith('simple');
+  });
+
+  test('a repeat of the mode stamped pre-paint invokes no callback either', () => {
+    // mode-boot.js stamps data-ui-mode before this listener exists; the hub's
+    // activation-time resend of that same mode is not a flip.
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    const callback = vi.fn();
+    onModeChange(callback);
+
+    deliverMessage({ type: 'osprey-mode-change', mode: 'simple' });
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(document.documentElement.getAttribute('data-ui-mode')).toBe('simple');
+  });
 });
 
 describe('pickUiMode', () => {

--- a/tests/interfaces/web_terminal/api.test.mjs
+++ b/tests/interfaces/web_terminal/api.test.mjs
@@ -693,3 +693,178 @@ describe('createEventSource: reconnection and resync hook', () => {
     expect(instances).toHaveLength(1);
   });
 });
+
+describe('createEventSource: one connection per URL, shared by every subscriber', () => {
+  /**
+   * Browsers cap HTTP/1.1 at six connections per host, and an idle SSE socket
+   * counts the same as an in-flight fetch. Three hub modules subscribe to
+   * `/api/files/events` on one page (panel-sse, the activity strip, the
+   * control-target chip); one socket each ate half the budget, and a second
+   * tab pushed every later fetch into an indefinite queue. The helper now
+   * multiplexes: one EventSource per URL, handlers fanned out, the socket
+   * closed by the last unsubscribe.
+   * @returns {any[]}
+   */
+  function stubEventSourceRich() {
+    /** @type {any[]} */
+    const instances = [];
+    vi.stubGlobal(
+      'EventSource',
+      class {
+        /** @param {string} url */
+        constructor(url) {
+          this.url = url;
+          this.readyState = 0;
+          this.closed = false;
+          instances.push(this);
+        }
+        close() {
+          this.closed = true;
+          this.readyState = 2;
+        }
+      }
+    );
+    return instances;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5000', reload: vi.fn() });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('two subscribers to the same URL open a single EventSource', () => {
+    const instances = stubEventSourceRich();
+    api.createEventSource('/api/files/events');
+    api.createEventSource('/api/files/events');
+    expect(instances).toHaveLength(1);
+  });
+
+  test('different URLs still get their own connection', () => {
+    const instances = stubEventSourceRich();
+    api.createEventSource('/api/files/events');
+    api.createEventSource('/api/other/events');
+    expect(instances).toHaveLength(2);
+  });
+
+  test('a frame is fanned out to every subscriber of that URL', () => {
+    const instances = stubEventSourceRich();
+    const a = vi.fn();
+    const b = vi.fn();
+    api.createEventSource('/api/files/events', { onMessage: a });
+    api.createEventSource('/api/files/events', { onMessage: b });
+
+    instances[0].onmessage({ data: JSON.stringify({ type: 'agent_activity', tool: 'x' }) });
+    expect(a).toHaveBeenCalledWith({ type: 'agent_activity', tool: 'x' });
+    expect(b).toHaveBeenCalledWith({ type: 'agent_activity', tool: 'x' });
+  });
+
+  test('a subscriber joining an already-open stream gets its onOpen at once', () => {
+    // panel-sse resyncs authoritative state from onOpen. If the chip opened
+    // the shared socket first, panel-sse's subscription must still see one
+    // open, or it never converges.
+    const instances = stubEventSourceRich();
+    const first = vi.fn();
+    api.createEventSource('/api/files/events', { onOpen: first });
+    instances[0].readyState = 1;
+    instances[0].onopen();
+    expect(first).toHaveBeenCalledTimes(1);
+
+    const late = vi.fn();
+    api.createEventSource('/api/files/events', { onOpen: late });
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledTimes(1);
+  });
+
+  test('a subscriber joining a still-connecting stream waits for the real open', () => {
+    const instances = stubEventSourceRich();
+    api.createEventSource('/api/files/events');
+    const late = vi.fn();
+    api.createEventSource('/api/files/events', { onOpen: late });
+    expect(late).not.toHaveBeenCalled();
+
+    instances[0].readyState = 1;
+    instances[0].onopen();
+    expect(late).toHaveBeenCalledTimes(1);
+  });
+
+  test('a reconnect open reaches every subscriber', () => {
+    const instances = stubEventSourceRich();
+    const a = vi.fn();
+    const b = vi.fn();
+    api.createEventSource('/api/files/events', { onOpen: a });
+    api.createEventSource('/api/files/events', { onOpen: b });
+
+    instances[0].readyState = 2;
+    instances[0].onerror();
+    vi.advanceTimersByTime(1000);
+    expect(instances).toHaveLength(2);
+    instances[1].readyState = 1;
+    instances[1].onopen();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test('a stream error runs the session-expiry probe once, not once per subscriber', () => {
+    const fetchMock = /** @type {import('vitest').Mock} */ (globalThis.fetch);
+    const instances = stubEventSourceRich();
+    api.createEventSource('/api/files/events');
+    api.createEventSource('/api/files/events');
+    api.createEventSource('/api/files/events');
+
+    instances[0].readyState = 2;
+    instances[0].onerror();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('stopping one subscriber keeps the socket alive for the others', () => {
+    const instances = stubEventSourceRich();
+    const a = api.createEventSource('/api/files/events');
+    const b = vi.fn();
+    api.createEventSource('/api/files/events', { onMessage: b });
+
+    a.stop();
+    expect(instances[0].closed).toBe(false);
+    instances[0].onmessage({ data: '{"type":"x"}' });
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test('a stopped subscriber receives nothing more', () => {
+    const instances = stubEventSourceRich();
+    const a = vi.fn();
+    const sub = api.createEventSource('/api/files/events', { onMessage: a });
+    api.createEventSource('/api/files/events');
+
+    sub.stop();
+    instances[0].onmessage({ data: '{"type":"x"}' });
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  test('the last unsubscribe closes the socket, and a later subscribe opens a fresh one', () => {
+    const instances = stubEventSourceRich();
+    const a = api.createEventSource('/api/files/events');
+    const b = api.createEventSource('/api/files/events');
+
+    a.stop();
+    b.stop();
+    expect(instances[0].closed).toBe(true);
+
+    api.createEventSource('/api/files/events');
+    expect(instances).toHaveLength(2);
+    expect(instances[1].closed).toBe(false);
+  });
+
+  test('stop() is idempotent per subscriber (a double stop does not evict a sibling)', () => {
+    const instances = stubEventSourceRich();
+    const a = api.createEventSource('/api/files/events');
+    api.createEventSource('/api/files/events');
+
+    a.stop();
+    a.stop();
+    expect(instances[0].closed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three small connection-budget fixes in the web-terminal hub, found while investigating a Safari "Load failed" on the graph channel-finder panel. The symptom itself turned out to be a stopped stack, but the investigation surfaced structural slack worth closing before the beta.

Browsers cap HTTP/1.1 at six connections per host across all tabs, and an idle event-stream socket counts the same as an in-flight fetch. One hub tab with every panel open held five such sockets, one under the cap; a second persona tab or one more streaming panel pushed every later request into an indefinite queue with no error.

1. **One event stream per page** (`api.js`). Three modules (panel-sse, the activity strip, the control-target chip) each opened their own EventSource to `/api/files/events`. `createEventSource` now multiplexes: one socket per URL, frames and open/error fanned out to every subscriber, a late joiner's `onOpen` fired at once when the socket is already open (the resync contract panel-sse depends on), and the socket closed by the last `stop()`. Callers are unchanged. Side effect: one session-expiry probe per outage instead of three.

2. **Mode messages act only on a real change** (`frame-params.js`). The hub posts `osprey-mode-change` both as the flip broadcast and again on tab activation, and resends the current mode on every later activation; followers that re-mounted on every message did so twice per flip and once per tab switch. The shared receive side now decides once per message event whether the mode on `<html>` changed and shares that verdict with every listener on the window, so a page's own callback and its display menu both see one flip and neither sees a repeat. The channel finder, OKF panel and lattice dashboard drop their hand-rolled listeners for the shared helper.

3. **HTTP/2 on the TLS listener** (`nginx.conf.j2`). The TLS content server listened with `ssl` only, so even a TLS deployment kept the six-connection cap. `http2 on;` (nginx 1.25.1+; the stack pins 1.27) lifts it entirely. Plain-HTTP deployments and the redirect-only server are untouched. The `tls_custom_port` golden is regenerated from the renderer; its delta is exactly the new directive and its comment.

## Test plan

- [x] vitest: 3392 passed (11 new shared-stream tests, 3 new mode-change tests)
- [x] `tsc --noEmit` and `eslint .` clean
- [x] `tests/deployment/web_terminals/`: 1685 passed, including the docker-backed `nginx -t` of the TLS render in `nginx:1.27-alpine`
- [x] Real-browser (`-m browser`) activity and posture-toggle suites: 19 passed in Chromium, exercising the rail badge and header chip on the shared socket
- [x] `scripts/changelog_fragments.py check`: three fragments valid
