### PR TITLE
feat(web-terminal): share one session across both views

### DIFF
--- a/changelog.d/dispatch-mcp-ready.fixed.md
+++ b/changelog.d/dispatch-mcp-ready.fixed.md
@@ -1,0 +1,12 @@
+
+Headless dispatch no longer runs an agent without the MCP tools its trigger
+allow-lists. The agent's toolset is fixed at its first turn, so an MCP server
+that connected later contributed nothing for the rest of the run; on a loaded
+host the workspace server could miss the readiness wait, and the run then
+completed with the report "saved" nowhere. The worker now waits up to 90 s for
+the declared servers (raising the CLI's own 30 s startup limit to match), stops
+waiting for a server the CLI has marked failed, and refuses the run as an
+`infrastructure` error naming the server if one the trigger depends on is still
+not connected. Every run record carries the readiness snapshot (`mcp_servers`:
+status and tool count per server), so a missing tool can be read off the record
+as a server that never connected or one the agent ignored.

--- a/changelog.d/shared-session-handoff.added.md
+++ b/changelog.d/shared-session-handoff.added.md
@@ -1,0 +1,6 @@
+Expert and Simple views are now two windows onto one session: switching view
+hands the conversation over instead of starting a second one, with the same
+transcript, write state and control target. The view you switch to waits for
+the outgoing agent to finish its current turn and offers **Stop and switch
+now**; deployments scaffolded before this release need the `turn-state` hook in
+the profile's `hooks:` list, then a rebuild with `osprey build`.

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -96,6 +96,53 @@ plain Ctrl+C always interrupts the agent. Serve the terminal over HTTPS for
 this to work in every browser — on a plain ``http://`` page copying falls
 back to an older browser mechanism that Safari may refuse.
 
+.. _web-terminal-one-session:
+
+One session, both views
+-----------------------
+
+Expert and Simple are two windows onto the same conversation. Pick the other
+one from the display menu and the agent you were talking to comes with you: the
+terminal and the chat share one session, one write state and one transcript,
+and only the view you are looking at runs the agent.
+
+Handing it over waits for the work in flight. Switch while the agent is
+mid-turn and the view you arrive in reads *Finishing in the other view* with
+the time you have been waiting, and offers **Stop and switch now**. Let it
+finish and the conversation reappears where it left off, with everything said
+so far already in the log. Nothing is ended on a clock: only the turn
+finishing, closing the page, or that button ends it. The button interrupts the
+agent, and stops it outright if it has not yielded within five seconds.
+
+A refusal can meet you instead of the wait. *This session is in use in
+another tab or view.* means another browser tab holds it, so close that tab or
+work there instead. *The previous agent is still shutting down.* is the one
+worth retrying, and the card offers **Retry**.
+
+Running ``/clear`` in the terminal starts a new conversation without starting a
+new session: the write state and the machine you are standing on carry over,
+and the chat shows the cleared conversation too. A prompt you send in the chat
+while a turn is still running waits for that turn rather than being refused,
+and goes as soon as the agent is free.
+
+.. note::
+
+   **Deployments built before this release.** The wait needs the
+   ``turn-state`` hook, which tells the web terminal when a turn starts and
+   ends, and a deployment scaffolded earlier does not have it: add
+   ``turn-state`` to the profile's ``hooks:`` list and run ``osprey build``.
+   Without it, switching away from a terminal that might be working never
+   waits. It says *The other view may still be working.* and offers only
+   **Stop and switch now**, and a terminal that was idle all along can still
+   take the full five seconds to hand over.
+
+One version pin is worth keeping current now that the two views share a
+conversation. The terminal runs the exact agent CLI version
+``claude_code.cli_version`` names, and the chat runs the one the Agent SDK
+bundles, so a pin that has drifted from the bundle makes the same conversation
+behave differently either side of a switch. The server names both versions in
+its log at startup, and warns when they disagree.
+
 .. _web-terminal-session-posture:
 
 The control-target chip
@@ -333,11 +380,15 @@ says nothing about the chip.
    a terminal session. Where they differ is in what the chip can do for them.
 
    A **chat session's write controls work** --- its writes meet the same ceiling
-   and the same locks a terminal's do --- but it is offered no **Switch to**: a
-   chat has no machine connection of its own to move. Know one thing before
-   relying on a chat's write state: the chat page starts a fresh chat every
-   time it loads, so a state you set for it lasts as long as that page does
-   rather than following the conversation.
+   and the same locks a terminal's do --- but **Switch to** comes and goes with
+   the view. While the Expert view holds the session there is a terminal with a
+   machine connection to move, and a row you can switch to offers the button;
+   while Simple holds it there is no such connection, so the button's place on
+   every row is empty. Switch back to Expert and it is there again.
+
+   The write state itself does not come and go. Both views are one session
+   (:ref:`web-terminal-one-session`), so a state you set in either is the state
+   the other finds, and it follows the conversation across the switch.
 
    An **operator websocket session's write controls govern nothing**: the chip
    has no way to hand a write state to that kind of session, so what you set
@@ -426,6 +477,10 @@ you set them in, so a different browser or a different machine starts those
 from the deployment's own defaults. The panel layout is remembered once per
 view: Simple starts from a single panel beside the console and Expert from the
 full workspace, and each keeps the arrangement you make of it.
+
+The view is a preference; the conversation is not tied to it. Switching between
+Expert and Simple hands the same session over rather than starting a second
+one. See :ref:`web-terminal-one-session`.
 
 With nothing saved yet you get the deployment's arrangement, which an operator
 sets with ``web.bar_items``. The keys, and what each one does, are in

--- a/src/osprey/agent_runner/__init__.py
+++ b/src/osprey/agent_runner/__init__.py
@@ -24,12 +24,15 @@ Public surface::
 """
 
 from osprey.agent_runner.primitives import (
+    MCP_READY_TIMEOUT_S,
     SDKWorkflowResult,
     ToolTrace,
     await_mcp_ready,
     build_agent_options,
     combined_text,
     expected_mcp_servers,
+    mcp_servers_connected,
+    mcp_snapshot_summary,
     resolve_default_model,
     sdk_env,
 )
@@ -59,6 +62,9 @@ __all__ = [
     "sdk_env",
     "expected_mcp_servers",
     "await_mcp_ready",
+    "mcp_servers_connected",
+    "mcp_snapshot_summary",
+    "MCP_READY_TIMEOUT_S",
     # runner (single-turn)
     "run_query",
     # session (multi-turn)

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -649,28 +649,47 @@ async def _drain_response(
 # MCP readiness barrier + instrumentation
 # ---------------------------------------------------------------------------
 #
-# OSPREY MCP servers register ASYNCHRONOUSLY: the controls stdio subprocess does
-# heavyweight cold-start work (config prime, connector registration, tool-module
-# imports) and only finishes its MCP handshake ~1–1.5s after the CLI launches —
-# noticeably slower than the python/osprey_workspace servers. If the agent's first
-# turn fires before that handshake completes, the controls tools are simply not in
-# its toolset, and a less-persistent agent reports "no controls server connected"
-# and gives up. That is a cold-start race, NOT a model capability gap — yet it is
-# scored as a failure, and it cannot be distinguished from a genuine model give-up
-# from the persisted transcript (which does not record MCP status).
+# OSPREY MCP servers register ASYNCHRONOUSLY: each stdio subprocess imports the
+# framework and primes its config before it can finish the MCP handshake, so a
+# declared server connects ~1.5–2s after the CLI launches on an idle machine —
+# and the nine servers of a full deployment come up one after another, CPU-bound,
+# so the last one lands several seconds later still. On a loaded host (a cold
+# two-CPU CI runner starting several sessions at once) that tail stretches past
+# a naive "give it a few seconds" wait.
+#
+# The CLI fixes a session's MCP toolset when the FIRST turn is sent and does not
+# revisit it: a server that connects later never contributes its tools to that
+# session (measured — a workspace server connecting 11s after the first turn
+# left the agent calling its tool by exact name and being told no such tool
+# exists, seven turns later). So a turn fired before the servers it needs are
+# connected does not merely start slow; it runs the whole session without those
+# tools, the agent improvises, and the run is scored as a model give-up when it
+# was a cold start. That cannot be told apart from a genuine model give-up from
+# the persisted transcript, which does not record MCP status.
 #
 # Both problems are solved with the SDK's own ``ClaudeSDKClient.get_mcp_status()``:
-#   * READINESS — poll it until the expected servers are ``connected`` before sending
-#     the prompt, so every agent gets a ready toolset (the harness-enforced equivalent
-#     of the CLI's ``WaitForMcpServers`` tool, independent of whether the model thinks
-#     to call it).
-#   * INSTRUMENTATION — persist the final snapshot so a missing tool is provably INFRA
-#     (server never registered) vs MODEL (tool was there, agent ignored it).
+#   * READINESS — poll it until every expected server is terminal (``connected``,
+#     or ``failed`` — a server the CLI has given up on will not connect later)
+#     before sending the prompt, so every agent gets the toolset it can get (the
+#     harness-enforced equivalent of the CLI's ``WaitForMcpServers`` tool,
+#     independent of whether the model thinks to call it).
+#   * INSTRUMENTATION — hand back the final snapshot so a missing tool is provably
+#     INFRA (server never registered) vs MODEL (tool was there, agent ignored it).
 
-# The default ceiling generously covers the measured ~1.5s controls cold start with
-# headroom for a loaded box. Overridable via env for slow CI hosts.
-_MCP_READY_TIMEOUT_S = float(os.environ.get("OSPREY_E2E_MCP_READY_TIMEOUT", "20"))
+# The ceiling only ever costs a run on a host where a server is still pending —
+# the barrier returns the moment every expected server is terminal. It is sized
+# for a cold, oversubscribed CI runner, not for the idle-machine ~2s, because
+# starting early forfeits the late servers for the whole session (see above).
+# Callers that spawn the CLI should hand the same figure to the CLI's own
+# ``MCP_TIMEOUT`` (its stdio-startup limit, 30s by default), or the CLI marks a
+# slow server failed before this barrier would have seen it connect.
+MCP_READY_TIMEOUT_S = float(os.environ.get("OSPREY_E2E_MCP_READY_TIMEOUT", "90"))
+_MCP_READY_TIMEOUT_S = MCP_READY_TIMEOUT_S
 _MCP_READY_POLL_S = 0.3
+
+# ``get_mcp_status()`` statuses that will not change without a reconnect. The
+# barrier stops waiting once every expected server reports one of these.
+_MCP_TERMINAL_STATUSES = frozenset({"connected", "failed"})
 
 
 def expected_mcp_servers(project_dir: Path) -> set[str]:
@@ -690,8 +709,14 @@ async def await_mcp_ready(
     timeout_s: float = _MCP_READY_TIMEOUT_S,
     poll_s: float = _MCP_READY_POLL_S,
 ) -> list[Any]:
-    """Poll ``get_mcp_status()`` until every server in *expected* reports
-    ``connected`` (or *timeout_s* elapses), then return the final snapshot.
+    """Poll ``get_mcp_status()`` until every server in *expected* is terminal —
+    ``connected`` or ``failed`` — or *timeout_s* elapses, then return the final
+    snapshot.
+
+    A ``failed`` server is one the CLI has given up on (spawn error, or its own
+    startup limit — ``MCP_TIMEOUT`` — expired); it will not connect later, so
+    waiting for it only delays the run. It stays in the snapshot with its
+    ``error`` so the caller can name it.
 
     Resilient to ``get_mcp_status()`` raising early in startup (before the stream
     is live). Never raises: on timeout it returns the last snapshot seen so the
@@ -706,9 +731,36 @@ async def await_mcp_ready(
         except Exception:  # noqa: BLE001 — status not queryable yet; keep polling
             servers = servers or []
         if expected:
-            connected = {s.get("name") for s in servers if s.get("status") == "connected"}
-            if expected <= connected:
+            terminal = {s.get("name") for s in servers if s.get("status") in _MCP_TERMINAL_STATUSES}
+            if expected <= terminal:
                 return servers
         if time.monotonic() >= deadline:
             return servers
         await asyncio.sleep(poll_s)
+
+
+def mcp_servers_connected(servers: list[Any]) -> set[str]:
+    """Names of the servers a ``get_mcp_status()`` snapshot reports ``connected``."""
+    return {s.get("name") for s in servers if s.get("status") == "connected"}
+
+
+def mcp_snapshot_summary(servers: list[Any]) -> list[dict[str, Any]]:
+    """Compact, JSON-friendly form of a ``get_mcp_status()`` snapshot.
+
+    One entry per server: ``name``, ``status``, the number of ``tools`` it
+    registered, and its ``error`` (``None`` unless the CLI reported one). This
+    is what a run record persists so a missing tool can be read off the record
+    as INFRA (server not connected) or MODEL (tool registered, agent ignored it).
+    """
+    summary = []
+    for s in servers:
+        tools = s.get("tools") or []
+        summary.append(
+            {
+                "name": s.get("name"),
+                "status": s.get("status"),
+                "tools": len(tools) if isinstance(tools, list) else 0,
+                "error": s.get("error"),
+            }
+        )
+    return summary

--- a/src/osprey/cli/templates/claude_code.py
+++ b/src/osprey/cli/templates/claude_code.py
@@ -1145,7 +1145,7 @@ def _build_framework_hook_rules(
     return [r for _, r in pre_rules], [r for _, r in post_rules]
 
 
-#: Claude Code hook events a profile may declare wiring for. The four events
+#: Claude Code hook events a profile may declare wiring for. The six events
 #: ``settings.json.j2`` renders unconditionally come first; the rest are keys the
 #: template adds only when something declares them.
 CLAUDE_CODE_HOOK_EVENTS: tuple[str, ...] = (
@@ -1153,8 +1153,9 @@ CLAUDE_CODE_HOOK_EVENTS: tuple[str, ...] = (
     "PostToolUse",
     "UserPromptSubmit",
     "SessionStart",
-    "SessionEnd",
     "Stop",
+    "StopFailure",
+    "SessionEnd",
     "SubagentStop",
     "Notification",
     "PreCompact",
@@ -1164,7 +1165,7 @@ CLAUDE_CODE_HOOK_EVENTS: tuple[str, ...] = (
 #: array the template renders regardless. Everything else in
 #: :data:`CLAUDE_CODE_HOOK_EVENTS` becomes a new key when declared.
 FRAMEWORK_WIRED_EVENTS: frozenset[str] = frozenset(
-    {"PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart"}
+    {"PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "Stop", "StopFailure"}
 )
 
 #: Claude Code's own default hook timeout, in seconds. A declaration that says

--- a/src/osprey/interfaces/web_auth.py
+++ b/src/osprey/interfaces/web_auth.py
@@ -1121,9 +1121,10 @@ class Tier(Enum):
 #: The exact ``(method, path)`` pairs an in-process companion may drive with the
 #: panel token alone.
 #:
-#: Every entry is a real route in this tree: the first six live in
-#: :mod:`osprey.interfaces.web_terminal.routes.panels` and
-#: :mod:`osprey.interfaces.web_terminal.routes.agent_activity`, and
+#: Every entry is a real route in this tree: the first seven live in
+#: :mod:`osprey.interfaces.web_terminal.routes.panels`,
+#: :mod:`osprey.interfaces.web_terminal.routes.agent_activity` and
+#: :mod:`osprey.interfaces.web_terminal.routes.agent_turn`, and
 #: ``POST /api/focus`` is the artifacts app's focus setter
 #: (:mod:`osprey.interfaces.artifacts.app`). Because one process serves several
 #: apps and the table is shared by all of them, ``POST /api/focus`` is
@@ -1142,6 +1143,7 @@ PANEL_TIER_ROUTES: frozenset[tuple[str, str]] = frozenset(
         ("POST", "/api/panel-close"),
         ("POST", "/api/panel-arrange"),
         ("POST", "/api/agent-activity"),
+        ("POST", "/api/agent-turn"),
         ("POST", "/api/focus"),
     }
 )

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 import os
+import shlex
 from collections import deque
 from collections.abc import Callable
 from contextlib import asynccontextmanager, suppress
@@ -46,6 +48,7 @@ from osprey.interfaces.web_terminal.ownership import OwnershipStoreError
 from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
 from osprey.interfaces.web_terminal.routes import router
 from osprey.interfaces.web_terminal.routes.agent_activity import ACTIVITY_RING_MAX
+from osprey.interfaces.web_terminal.transcript_map import load as load_transcript_map
 from osprey.port_layout import default_port
 from osprey.profiles.web_panels import (
     BUILTIN_PANELS,
@@ -1753,6 +1756,155 @@ def _load_claude_code_config(config_path: str | Path | None = None) -> dict:
     return _load_config_section("claude_code", config_path)
 
 
+def _log_claude_cli_versions(argv: list[str]) -> None:
+    """Say which Claude Code binary each of the two views will run.
+
+    The expert view spawns the CLI named by ``argv`` in a PTY. The simple view
+    goes through the Agent SDK, which prefers the binary bundled inside its own
+    package over anything on ``PATH``. Those are the same program only by
+    coincidence: a project that pins ``claude_code.cli_version`` runs one build
+    in the terminal and another in the chat, and the difference surfaces much
+    later as a capability or a flag that only one view has.
+
+    So both are named at startup. The pin is read straight out of the argv; the
+    bundle is asked once per process and every failure to ask reads as unknown,
+    because this is diagnostic output and nothing here may hold up a boot. The
+    warning fires only when both versions are known and disagree — an unpinned
+    launch resolves ``claude`` from ``PATH``, whose version this does not probe.
+
+    Args:
+        argv: The argv prefix the PTY will spawn.
+    """
+    from osprey.utils.claude_launcher import argv_cli_version, bundled_cli_version
+
+    bundled = bundled_cli_version()
+    logger.info(
+        "Claude Code CLI — terminal spawns %s; chat uses the Agent SDK bundle (%s)",
+        shlex.join(argv),
+        bundled or "version unknown",
+    )
+    pinned = argv_cli_version(argv)
+    if pinned and bundled and pinned != bundled:
+        logger.warning(
+            "The two views run different Claude Code versions: the terminal is "
+            "pinned to %s by claude_code.cli_version, the chat runs the Agent "
+            "SDK's bundled %s. Behaviour that differs between the views is "
+            "expected until the pin matches the bundle.",
+            pinned,
+            bundled,
+        )
+
+
+#: Basename of the hook that reports the terminal agent's turn edges. The
+#: rendered settings name it inside a shell command, so it is matched as a
+#: substring rather than as a whole command: the interpreter, the project-dir
+#: variable and the fail-open suffix all vary between deployments.
+TURN_STATE_HOOK = "osprey_turn_state.py"
+
+#: The ``SessionStart`` sources the turn hook must be registered for. An entry
+#: without this matcher also runs on ``compact``, which fires inside a running
+#: turn — its idle report would say the process is between turns while it is
+#: mid-answer, so a registration missing the matcher is not turn reporting we
+#: can act on.
+TURN_HOOK_SESSION_START_MATCHER = "startup|resume|clear"
+
+
+def _turn_hook_matchers(settings: dict) -> dict[str, list[str | None]]:
+    """Map each hook event that runs the turn-state hook to its matchers.
+
+    Args:
+        settings: A parsed ``.claude/settings.json``.
+
+    Returns:
+        One entry per event whose registered commands name the turn-state hook,
+        holding the ``matcher`` of each registration — ``None`` for one that
+        carries none, which is how Claude Code spells "every source". Every
+        level is shape-checked: these settings are a rendered artifact a
+        deployment may have edited, and a malformed one must read as "no hook"
+        rather than raise during a boot.
+    """
+    found: dict[str, list[str | None]] = {}
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return found
+    for event, entries in hooks.items():
+        for entry in entries if isinstance(entries, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            registered = entry.get("hooks")
+            for hook in registered if isinstance(registered, list) else []:
+                if isinstance(hook, dict) and TURN_STATE_HOOK in str(hook.get("command", "")):
+                    found.setdefault(event, []).append(entry.get("matcher"))
+    return found
+
+
+def _detect_turn_hook(app: FastAPI) -> None:
+    """Decide whether this project's settings install turn reporting.
+
+    The answer lands on ``app.state.turn_hook_present`` and it is a permission,
+    not a prediction: readers of ``app.state.turn_state`` may wait for an idle
+    edge only where one can actually arrive. A deployment whose settings carry
+    no turn hook — an older render, or a hand-edited one — never sends an edge,
+    and a reader that waited for one would hang instead of falling back to the
+    evidence it can gather itself.
+
+    Two registrations are required. ``Stop`` is the edge that ends a turn, and
+    ``SessionStart`` must carry the matcher that keeps ``compact`` out. A
+    missing ``StopFailure`` is warned about rather than disqualifying: it only
+    reports a turn that errored out, and a CLI build that never emits the event
+    would otherwise make every deployment look broken.
+
+    Args:
+        app: The application, carrying ``state.project_cwd``.
+    """
+    # Established here, not inherited: every early return below documents a
+    # False result, and this function must produce it on its own rather than
+    # leaving whatever a caller happened to set beforehand.
+    app.state.turn_hook_present = False
+
+    settings_path = Path(app.state.project_cwd) / ".claude" / "settings.json"
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.debug("No %s — the terminal reports no turn edges", settings_path)
+        return
+    except (OSError, ValueError):
+        logger.warning(
+            "Could not read %s; assuming the terminal reports no turn edges",
+            settings_path,
+            exc_info=True,
+        )
+        return
+    if not isinstance(settings, dict):
+        return
+
+    events = _turn_hook_matchers(settings)
+    has_stop = "Stop" in events
+    has_session_start = TURN_HOOK_SESSION_START_MATCHER in events.get("SessionStart", [])
+    app.state.turn_hook_present = has_stop and has_session_start
+
+    if not app.state.turn_hook_present:
+        missing = [
+            name for name, ok in (("Stop", has_stop), ("SessionStart", has_session_start)) if not ok
+        ]
+        logger.info(
+            "%s is not wired for %s in %s; view switching will fall back to its "
+            "own idleness evidence",
+            TURN_STATE_HOOK,
+            ", ".join(missing),
+            settings_path,
+        )
+        return
+
+    if "StopFailure" not in events:
+        logger.warning(
+            "%s is wired for Stop but not StopFailure in %s; a turn that ends in "
+            "a failure reports no idle edge",
+            TURN_STATE_HOOK,
+            settings_path,
+        )
+
+
 def _create_lifespan(
     config_path: str | Path | None = None,
     shell_command: list[str] | None = None,
@@ -1782,8 +1934,29 @@ def _create_lifespan(
             app.state.shell_command = build_claude_launch_argv(
                 _load_claude_code_config(config_path)
             )
+        # Which Claude Code build each view runs, named once at startup. Off
+        # the event loop: the probe spawns a large binary, and a boot must not
+        # stall on a diagnostic.
+        await asyncio.to_thread(_log_claude_cli_versions, app.state.shell_command)
+
         max_bg = int(config.get("max_background_sessions", 5))
         app.state.pty_registry = PtyRegistry(max_background=max_bg)
+
+        # Which transcript each session key currently points at, read once so a
+        # recreated container resumes a cleared-and-continued conversation
+        # rather than starting a fresh one under the same key.
+        load_transcript_map(app)
+
+        # What the expert view's Claude Code process last reported it was
+        # doing, keyed by session key (routes/agent_turn.py). Empty at
+        # startup: no report is not a claim of idleness, and every reader
+        # treats a missing entry as "unknown" rather than "free to take over".
+        app.state.turn_state = {}
+        # Whether that reporting is actually installed. Left False here and
+        # decided by the rendered hook settings, so a deployment whose
+        # settings carry no turn-state hook never waits for an edge that
+        # cannot arrive.
+        app.state.turn_hook_present = False
 
         # ── Simple-mode chat pool bounds ──
         # Three knobs bound the operator-chat pool; each fails open to its
@@ -1815,6 +1988,10 @@ def _create_lifespan(
         app.state.project_cwd = str(
             Path(project_dir).resolve() if project_dir else Path.cwd().resolve()
         )
+        # Read once, now that the project the terminal serves is known: the
+        # answer is a property of that project's rendered settings, and nothing
+        # rewrites them while the server runs.
+        _detect_turn_hook(app)
         app.state.broadcaster = FileEventBroadcaster()
         app.state.active_panel = None
         # Bounded history of agent-activity events. The SSE stream only reaches

--- a/src/osprey/interfaces/web_terminal/chat_session_pool.py
+++ b/src/osprey/interfaces/web_terminal/chat_session_pool.py
@@ -52,13 +52,14 @@ class ChatSessionPool:
     """LRU-ordered pool of chat sessions with capacity eviction and idle reaping.
 
     The lock is held only for map inspection/mutation, never across
-    ``session.start()`` or teardown. ``factory(cwd, env)`` returns an unstarted
-    session; the pool starts it outside the lock.
+    ``session.start()`` or teardown. ``factory(cwd, env, session_key)`` returns
+    an unstarted session; the pool starts it outside the lock, naming there the
+    transcript it should resume.
     """
 
     def __init__(
         self,
-        factory: Callable[[str, dict[str, str] | None], OperatorSession],
+        factory: Callable[[str, dict[str, str] | None, str], OperatorSession],
         max_sessions: int = 5,
         idle_seconds: float = 900.0,
     ) -> None:
@@ -67,12 +68,12 @@ class ChatSessionPool:
         self._sessions: OrderedDict[str, OperatorSession] = OrderedDict()
         self._lock = asyncio.Lock()
         self._pending: dict[str, asyncio.Future[OperatorSession]] = {}
-        # Fingerprint of the env each key's child was built from — written when
-        # a creation is registered and kept as that creation becomes a session,
-        # so a pending and a pooled entry answer the same question. See
-        # get_or_create's reuse check. The digest, never the mapping: a chat
-        # child's env carries the panel token.
-        self._env_fingerprints: dict[str, str] = {}
+        # What each key's child was built from — the env digest and the
+        # transcript it resumed — written when a creation is registered and
+        # kept as that creation becomes a session, so a pending and a pooled
+        # entry answer the same question. See get_or_create's reuse check. The
+        # digest, never the mapping: a chat child's env carries the panel token.
+        self._launches: dict[str, tuple[str, str | None]] = {}
         # Creations that a terminate/drain overtook. Keyed on the Future rather
         # than the chat id, so a *later* creation under the same id is not
         # collateral damage of an earlier terminate.
@@ -85,6 +86,8 @@ class ChatSessionPool:
         chat_id: str,
         cwd: str,
         env: dict[str, str] | Callable[[], dict[str, str] | None] | None = None,
+        *,
+        resume_id: str | None = None,
     ) -> tuple[OperatorSession, bool]:
         """Return a live session for ``chat_id``, creating it if needed.
 
@@ -114,6 +117,14 @@ class ChatSessionPool:
         synchronous — the lock is held across the call, so it must not await.
         They are also called on **every** invocation, reuse included, because
         the reuse check below compares against what they produce.
+
+        *resume_id* names the transcript the child continues. Omitted, the
+        child starts a conversation of its own under ``chat_id``. Like the
+        environment it is fixed when the child is spawned, so it is compared
+        alongside the environment below: the same transcript keeps the live
+        child, a different one rebuilds. That comparison is what lets a
+        transcript that moved while another surface held the key reach this
+        one — the key never changes, so nothing else would notice.
 
         **A live entry is only reused when its environment still matches.** A
         child's environment is fixed when it is spawned and cannot be
@@ -149,9 +160,11 @@ class ChatSessionPool:
                 resolved_env = env() if callable(env) else env
             except BaseException as exc:
                 builder_error = exc
-                fingerprint = None
+                launch = None
             else:
-                fingerprint = env_fingerprint(resolved_env)
+                # Everything that is fixed when a child is spawned and cannot
+                # be amended afterwards, in one comparable value.
+                launch = (env_fingerprint(resolved_env), resume_id)
 
             existing = self._sessions.get(chat_id)
             if existing is not None and not existing.is_active:
@@ -160,36 +173,39 @@ class ChatSessionPool:
                 # must not leave this popped-but-unreaped, and a corpse is
                 # nothing to compare an environment against anyway.
                 self._sessions.pop(chat_id, None)
-                self._env_fingerprints.pop(chat_id, None)
+                self._launches.pop(chat_id, None)
                 to_stop.append(existing)
             elif existing is not None and builder_error is None:
-                recorded = self._env_fingerprints.get(chat_id, EMPTY_ENV_FINGERPRINT)
-                if recorded == fingerprint:
+                recorded = self._launches.get(chat_id, (EMPTY_ENV_FINGERPRINT, None))
+                if recorded == launch:
                     self._sessions.move_to_end(chat_id)  # LRU bump
                     return existing, True
-                # The env changed under a live child. A child's environment is
-                # fixed at spawn and cannot be amended, so the only way to
-                # deliver the change is to tear it down and build a new one —
-                # busy or not, exactly as :meth:`terminate` does, because a
-                # turn running under a posture the operator has revoked is the
-                # case this exists for. Values are never logged: the env
-                # carries the panel token.
+                # The env or the transcript changed under a live child.
+                # Both are fixed at spawn and cannot be amended, so the only
+                # way to deliver the change is to tear the child down and build
+                # a new one — busy or not, exactly as :meth:`terminate` does,
+                # because a turn running under a posture the operator has
+                # revoked is the case this exists for. Values are never logged:
+                # the env carries the panel token.
                 logger.info(
-                    "Launch env changed for chat session %r — tearing the warm "
-                    "session down so the new environment reaches a fresh child",
+                    "Launch environment or transcript changed for chat session "
+                    "%r — tearing the warm session down so the new one reaches "
+                    "a fresh child",
                     chat_id,
                 )
                 self._sessions.pop(chat_id, None)
-                self._env_fingerprints.pop(chat_id, None)
+                self._launches.pop(chat_id, None)
                 to_stop.append(existing)
             # A live entry with a builder that raised is left exactly as it is:
             # a failed read of the posture store is no reason to kill a child.
+            # (``launch`` is None exactly when the builder raised.)
 
-            if builder_error is None:
+            if launch is not None:
                 pending = self._pending.get(chat_id)
-                if pending is not None and self._env_fingerprints.get(chat_id) != fingerprint:
+                if pending is not None and self._launches.get(chat_id) != launch:
                     # A creation is in flight that was built from a different
-                    # environment. Joining it would hand this caller the very
+                    # environment or transcript. Joining it would hand this
+                    # caller the very
                     # child the change was meant to replace, so it is overtaken
                     # instead and this call becomes the creator. The marker is
                     # keyed on the Future, so the creation registered below is
@@ -213,7 +229,7 @@ class ChatSessionPool:
                         to_stop.append(victim)
                     pending = asyncio.get_running_loop().create_future()
                     self._pending[chat_id] = pending
-                    self._env_fingerprints[chat_id] = fingerprint
+                    self._launches[chat_id] = launch
                     creator = True
 
         # Teardowns happen outside the lock (never block map access on stop()).
@@ -244,15 +260,15 @@ class ChatSessionPool:
             return session, True
 
         try:
-            session = self._factory(cwd, resolved_env)
-            await session.start()  # deliberately outside the lock
+            session = self._factory(cwd, resolved_env, chat_id)
+            await session.start(resume_id=resume_id)  # deliberately outside the lock
         except BaseException as exc:
             async with self._lock:
                 if self._pending.get(chat_id) is pending:
                     # Ours to clear — and the fingerprint with it. Guarded,
                     # because a later creation may already own both.
                     del self._pending[chat_id]
-                    self._env_fingerprints.pop(chat_id, None)
+                    self._launches.pop(chat_id, None)
                 self._superseded.discard(pending)
             if not pending.done():
                 pending.set_exception(exc)
@@ -271,14 +287,14 @@ class ChatSessionPool:
             superseded = pending in self._superseded
             self._superseded.discard(pending)
             if not superseded:
-                # The fingerprint registered with this creation carries over
-                # unchanged: it already describes the child now landing here.
+                # The launch identity registered with this creation carries
+                # over unchanged: it already describes the child landing here.
                 self._sessions[chat_id] = session
             elif mine:
                 # Nothing of this creation survives, so neither does its
-                # fingerprint — unless a later creation has already claimed
+                # launch identity — unless a later creation has already claimed
                 # the key, which ``mine`` is what tells us.
-                self._env_fingerprints.pop(chat_id, None)
+                self._launches.pop(chat_id, None)
 
         if superseded:
             # A terminate/drain arrived while this session was starting. It had
@@ -330,7 +346,7 @@ class ChatSessionPool:
         """
         return chat_id in self._sessions or chat_id in self._pending
 
-    async def terminate(self, chat_id: str) -> None:
+    async def terminate(self, chat_id: str) -> OperatorSession | None:
         """Evict and tear down a chat session (busy-safe, idempotent).
 
         Eviction is the half that makes a respawn possible: with the entry
@@ -342,13 +358,52 @@ class ChatSessionPool:
         and torn down by its own creator the moment ``start()`` returns (see
         :class:`ChatSessionTerminatedError`). This call does not wait for that:
         a hung ``start()`` must not hang the operator's toggle.
+
+        Returns:
+            The session that was popped and torn down, or ``None`` when the key
+            held nothing poppable. The object outlives the pool entry, and a
+            caller that must know the child is *gone* rather than merely asked
+            to leave reads
+            :attr:`~osprey.interfaces.web_terminal.operator_session.OperatorSession.process_exited`
+            on it. The pool itself keeps no reference.
         """
         async with self._lock:
             session = self._sessions.pop(chat_id, None)
             self._supersede_pending(chat_id)
-            self._env_fingerprints.pop(chat_id, None)
+            self._launches.pop(chat_id, None)
         if session is not None:
             await session.teardown()
+        return session
+
+    async def reinsert(self, chat_id: str, session: OperatorSession) -> bool:
+        """Put a session :meth:`terminate` popped back into the pool.
+
+        The path for a teardown whose child outlived it: a hand-off terminates
+        the entry, then finds
+        :attr:`~osprey.interfaces.web_terminal.operator_session.OperatorSession.process_exited`
+        still False after its death wait. Dropping the object would orphan a
+        running process; putting it back lets the next acquire meet it as an
+        ordinary entry and tear it down again. The session is inactive by
+        then — its client closed, its child not — and every later
+        :meth:`terminate` of it runs ``teardown`` again, which sends the
+        retained child SIGKILL when it still has no return code. The hand-off
+        door tells such a survivor apart from a corpse by ``process_exited``
+        being False and hands it off for that second teardown and death
+        check; :meth:`get_or_create` merely reaps it as a dead entry before
+        creating, which still re-signals the child. No launch identity is
+        recorded, for the same reason.
+
+        Returns:
+            True when the session was put back. False, with the pool left
+            alone, when *chat_id* already holds a session or a creation in
+            flight: something else filled the key in the meantime and the
+            survivor is the caller's to deal with.
+        """
+        async with self._lock:
+            if chat_id in self._sessions or chat_id in self._pending:
+                return False
+            self._sessions[chat_id] = session
+            return True
 
     async def reap_idle(self) -> int:
         """Tear down every idle chat session; return how many were reaped.
@@ -361,7 +416,7 @@ class ChatSessionPool:
             idle_keys = [k for k, s in self._sessions.items() if self._is_idle(s, now)]
             victims = [self._sessions.pop(k) for k in idle_keys]
             for key in idle_keys:
-                self._env_fingerprints.pop(key, None)
+                self._launches.pop(key, None)
         if victims:
             await asyncio.gather(*(s.teardown() for s in victims))
         return len(victims)
@@ -375,7 +430,7 @@ class ChatSessionPool:
             # starting register itself into the drained pool behind us.
             self._superseded.update(self._pending.values())
             self._pending.clear()
-            self._env_fingerprints.clear()
+            self._launches.clear()
         if sessions:
             await asyncio.gather(*(s.teardown() for s in sessions))
 
@@ -408,5 +463,5 @@ class ChatSessionPool:
                 break
         if victim_key is None:
             return None
-        self._env_fingerprints.pop(victim_key, None)
+        self._launches.pop(victim_key, None)
         return self._sessions.pop(victim_key)

--- a/src/osprey/interfaces/web_terminal/operator_session.py
+++ b/src/osprey/interfaces/web_terminal/operator_session.py
@@ -21,6 +21,7 @@ from osprey.agent_runner.sdk_context import build_system_prompt
 from osprey.audit.posture import OSPREY_AGENT_DATA_ROOT
 from osprey.interfaces.web_auth import PANEL_TOKEN_ENV, get_web_credentials
 from osprey.interfaces.web_terminal.chat_session_pool import ChatSessionPool
+from osprey.interfaces.web_terminal.session_key import is_posture_key
 from osprey.utils.config import get_facility_timezone
 
 logger = logging.getLogger(__name__)
@@ -517,12 +518,13 @@ class OperatorSession:
             resume_id: The transcript to continue. Given, the child resumes
                 that conversation (``resume``) and the SDK keeps writing to it;
                 omitted, the child starts a conversation of its own under the
-                session key (``session_id``). The two are mutually exclusive —
-                a resume names the transcript, and naming a session id
-                alongside it would ask the SDK to write one conversation under
-                two identities. Which of the two applies is the caller's
-                decision, taken from the session's transcript state; this seam
-                only offers both shapes.
+                session key (``session_id``), or under an id it mints itself
+                when the key is not one the CLI would accept. Resume and
+                session id are mutually exclusive — a resume names the
+                transcript, and naming a session id alongside it would ask the
+                SDK to write one conversation under two identities. Which
+                applies is the caller's decision, taken from the session's
+                transcript state; this seam only offers the shapes.
         """
         if not CLAUDE_SDK_AVAILABLE:
             raise RuntimeError("claude-agent-sdk is not installed")
@@ -561,12 +563,22 @@ class OperatorSession:
                 resume=resume_id,
             )
         else:
+            # The key names the conversation only where the CLI would accept it
+            # as one. POST /api/chat takes any string for chat_id — an embedder
+            # keying its chats "user-42-chat-3" is a supported caller, and the
+            # posture surface already treats such a key as unaddressable — but
+            # here the key reaches the CLI as `--session-id`, which takes a
+            # canonical UUID and exits non-zero on anything else. The SDK
+            # imposes no format of its own, so an unchecked key would fail the
+            # child on its first prompt rather than at a seam anyone can see.
+            # None omits the flag and the child mints its own id, which is what
+            # this surface did before it could resume at all.
             options = ClaudeAgentOptions(
                 system_prompt=build_system_prompt(get_facility_timezone()),
                 cwd=self._cwd,
                 env=session_env,
                 setting_sources=["project"],
-                session_id=self._session_key,
+                session_id=(self._session_key if is_posture_key(self._session_key) else None),
             )
         self._client = ClaudeSDKClient(options=options)
         await self._client.__aenter__()

--- a/src/osprey/interfaces/web_terminal/operator_session.py
+++ b/src/osprey/interfaces/web_terminal/operator_session.py
@@ -186,6 +186,18 @@ def build_operator_child_env(
     answer. The two are one fact split in half, so they are set together or
     not at all, and a test pins that.
 
+    The same key is also stamped as ``OSPREY_SESSION_ID``, which is what
+    :func:`osprey_connectors.workspace.resolve_agent_data_root` reads to scope
+    a child's execution root to ``sessions/<key>`` — where the python and
+    sandbox executors put their run directories. One key, one root: a
+    conversation is one session whichever view is showing it, so the chat
+    child and the PTY child spawned under the same key work out of the same
+    directory rather than each in a room of its own. Its PTY counterpart
+    stamps the same name from the pool key
+    (:func:`osprey.interfaces.web_terminal.routes.websocket._build_extra_env`).
+    It rides with the audit pair for the same reason the root does — all three
+    describe one session — and never appears without a key to name.
+
     Keeping the stamps here — instead of handing each call site a rule to
     compose — is what stops the two SDK surfaces drifting on what a child is
     told about its own posture, which is the same reason this function exists
@@ -198,9 +210,10 @@ def build_operator_child_env(
         session_key: The identity this session is pooled under — the chat
             pool's ``chat_id`` for ``POST /api/chat``, the minted
             ``operator-<hex8>`` key for ``/ws/operator``. It is the key the
-            posture store is read under. Omitted, the child gets the render's
-            baseline environment and no marker is added — nothing names a
-            session for a reader to look up.
+            posture store is read under and the name the child's execution
+            root is scoped by. Omitted, the child gets the render's baseline
+            environment and no marker is added — nothing names a session for a
+            reader to look up.
         app: The FastAPI app whose agent-data root the child is pointed at
             (:func:`resolve_agent_data_root`). Stamped alongside *session_key*;
             without an app the root falls back to the deployment derivation.
@@ -240,6 +253,7 @@ def build_operator_child_env(
         env[POSTURE_SOURCE_ENV] = posture_source
         env[POSTURE_SESSION_ENV] = session_key
         env[OSPREY_AGENT_DATA_ROOT] = resolve_agent_data_root(app)
+        env["OSPREY_SESSION_ID"] = session_key
 
     return env
 
@@ -330,7 +344,17 @@ def _message_to_events(message: Any) -> list[dict[str, Any]]:
         )
 
     elif isinstance(message, SystemMessage):
-        events.append({"type": "system", "subtype": message.subtype})
+        event: dict[str, Any] = {"type": "system", "subtype": message.subtype}
+        # The init message carries the id of the transcript the child is
+        # actually writing to, which is the only place a resume's real
+        # transcript id can be read back from — a resume may be answered with a
+        # different id than the one asked for. Carried only when the message
+        # has one, so a system message that says nothing about identity does
+        # not look like one reporting a missing id.
+        session_id = (getattr(message, "data", None) or {}).get("session_id")
+        if session_id:
+            event["session_id"] = session_id
+        events.append(event)
 
     # StreamEvent and other unknown types are silently ignored.
     return events
@@ -390,14 +414,39 @@ def is_terminal_event(event: dict[str, Any]) -> bool:
 class OperatorSession:
     """Wraps a ``ClaudeSDKClient`` for operator-mode conversation."""
 
-    def __init__(self, cwd: str, env: dict[str, str] | None = None) -> None:
+    def __init__(
+        self,
+        cwd: str,
+        env: dict[str, str] | None = None,
+        *,
+        session_key: str | None = None,
+    ) -> None:
+        """Build an unstarted session.
+
+        Args:
+            cwd: The project directory the child runs in.
+            env: The child's environment, or ``None`` to inherit the process
+                environment. Fixed at spawn; see
+                :func:`build_operator_child_env`.
+            session_key: The identity this session is pooled and audited
+                under — the shared session key, not a per-child id. It is the
+                telemetry session id, and the SDK session id for a child that
+                starts a conversation of its own. Omitted, one is minted here,
+                so the key is stable for the life of the object rather than
+                re-drawn on every :meth:`start`.
+        """
         self._cwd = cwd
         self._env = env
+        self._session_key = session_key or str(uuid.uuid4())
         self._client: ClaudeSDKClient | None = None
         self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=256)
         self._response_task: asyncio.Task | None = None
         self._quiesce_task: asyncio.Task | None = None
         self._started = False
+        # The child process handle, kept from just before the client is closed
+        # so its death stays observable after teardown has dropped the client.
+        # See :meth:`stop` and :attr:`process_exited`.
+        self._last_process: Any = None
         # Per-turn one-in-flight guard. ``_turn_epoch`` only ever increments and
         # names each turn ever started; ``_active_token`` holds the current
         # turn's epoch or None when idle. Manipulated only by the synchronous,
@@ -461,8 +510,20 @@ class OperatorSession:
         quiesce_running = quiesce is not None and not quiesce.done()
         return handler_running or quiesce_running
 
-    async def start(self) -> None:
-        """Create and connect the SDK client."""
+    async def start(self, *, resume_id: str | None = None) -> None:
+        """Create and connect the SDK client.
+
+        Args:
+            resume_id: The transcript to continue. Given, the child resumes
+                that conversation (``resume``) and the SDK keeps writing to it;
+                omitted, the child starts a conversation of its own under the
+                session key (``session_id``). The two are mutually exclusive —
+                a resume names the transcript, and naming a session id
+                alongside it would ask the SDK to write one conversation under
+                two identities. Which of the two applies is the caller's
+                decision, taken from the session's transcript state; this seam
+                only offers both shapes.
+        """
         if not CLAUDE_SDK_AVAILABLE:
             raise RuntimeError("claude-agent-sdk is not installed")
 
@@ -470,16 +531,16 @@ class OperatorSession:
         for warning in validate_project_directory(self._cwd):
             logger.warning("Operator session: %s (cwd=%s)", warning, self._cwd)
 
-        # Force a known session UUID and hand it to the workspace
-        # provenance_locator tool via env, so a filed issue can point back to
-        # this session's telemetry. The same value is forced onto the SDK
-        # session (session_id below) so the OTEL emitter's session.id matches
-        # what the locator returns. env is a build_clean_env dict in production
-        # (which strips the harness's own CLAUDE_CODE_* id); inject into a copy.
-        telemetry_session_id = str(uuid.uuid4())
+        # Hand the session key to the workspace provenance_locator tool via env,
+        # so a filed issue can point back to this session's telemetry. It is the
+        # key the session is pooled and audited under, never a value minted
+        # here: a telemetry id that changed every time a surface re-acquired the
+        # session would split one conversation's traces across several ids. env
+        # is a build_clean_env dict in production (which strips the harness's own
+        # CLAUDE_CODE_* id); inject into a copy.
         session_env = dict(self._env) if self._env is not None else None
         if session_env is not None:
-            session_env["OSPREY_TELEMETRY_SESSION_ID"] = telemetry_session_id
+            session_env["OSPREY_TELEMETRY_SESSION_ID"] = self._session_key
             session_env["OSPREY_TELEMETRY_SESSION_START"] = datetime.now(UTC).isoformat()
             # Mark the web surface this session serves: the operator chat IS the
             # simple UX. The panels-context SessionStart hook reads this to tell
@@ -487,13 +548,26 @@ class OperatorSession:
             # sets "expert" — see routes/websocket.py's _build_extra_env).
             session_env["OSPREY_WEB_UX"] = "simple"
 
-        options = ClaudeAgentOptions(
-            system_prompt=build_system_prompt(get_facility_timezone()),
-            cwd=self._cwd,
-            env=session_env,
-            setting_sources=["project"],
-            session_id=telemetry_session_id,
-        )
+        # The identity half is spelled out twice rather than assembled, because
+        # the two shapes are mutually exclusive and the SDK's options are a
+        # typed dataclass — an unpacked mapping would hide which of the two a
+        # launch chose behind a name the type checker cannot follow.
+        if resume_id is not None:
+            options = ClaudeAgentOptions(
+                system_prompt=build_system_prompt(get_facility_timezone()),
+                cwd=self._cwd,
+                env=session_env,
+                setting_sources=["project"],
+                resume=resume_id,
+            )
+        else:
+            options = ClaudeAgentOptions(
+                system_prompt=build_system_prompt(get_facility_timezone()),
+                cwd=self._cwd,
+                env=session_env,
+                setting_sources=["project"],
+                session_id=self._session_key,
+            )
         self._client = ClaudeSDKClient(options=options)
         await self._client.__aenter__()
         self._started = True
@@ -693,7 +767,26 @@ class OperatorSession:
         await self.stop()
 
     async def stop(self) -> None:
-        """Disconnect the SDK client and cancel any in-flight response."""
+        """Disconnect the SDK client and cancel any in-flight response.
+
+        Keeps the child's process handle before the client goes away, so a
+        caller that has to wait for the child to be *gone* — not merely asked
+        to leave — can still read :attr:`process_exited` afterwards. Closing
+        the client drops the transport, and with it the only route to that
+        handle. A handle already captured is never overwritten with nothing, so
+        a second ``stop()`` does not erase the first one's answer.
+
+        A child still running once the client is closed is sent SIGKILL
+        (:meth:`_kill_lingering_child`). Closing the client already escalates
+        from stdin EOF through SIGTERM to SIGKILL, each with a bounded wait, so
+        this only matters for a child that outlived that escalation — and it
+        is what makes a second ``stop()`` on a session whose client is already
+        gone kill the child again rather than merely re-read its status.
+        """
+        process = getattr(getattr(self._client, "_transport", None), "_process", None)
+        if process is not None:
+            self._last_process = process
+
         await self.cancel()
 
         if self._client is not None:
@@ -703,12 +796,74 @@ class OperatorSession:
                 pass
             self._client = None
 
+        self._kill_lingering_child()
         self._started = False
         logger.info("OperatorSession stopped")
+
+    def _kill_lingering_child(self) -> None:
+        """Send SIGKILL to the retained child when it has no return code yet.
+
+        Nothing is waited for: :attr:`process_exited` is how a caller sees the
+        signal land. A child that is already gone raises
+        ``ProcessLookupError``, which is the answer wanted.
+        """
+        process = self._last_process
+        if process is None or process.returncode is not None:
+            return
+        try:
+            process.kill()
+        except ProcessLookupError:
+            return
+        except Exception:
+            logger.warning("OperatorSession could not signal its lingering child", exc_info=True)
+            return
+        logger.warning("OperatorSession child outlived its client; sent SIGKILL")
 
     @property
     def is_active(self) -> bool:
         return self._started and self._client is not None
+
+    @property
+    def pid(self) -> int | None:
+        """The pid of this session's child process, or ``None`` when none is running.
+
+        The chat child is what holds a session on the Simple surface, the way
+        a PTY holds one on the Expert surface, so a caller addressing
+        something *to* the process behind a session key has to be able to ask
+        which process that is. The handle is reached through the transport
+        exactly as :meth:`stop` reaches it, falling back to one already
+        retained so a session whose client has been closed still answers
+        while its child is alive.
+
+        ``None`` once the child has a return code, and ``None`` for a session
+        that never started: a pid nothing is running under names no process,
+        and returning one would invite a caller to address it.
+        """
+        process = getattr(getattr(self._client, "_transport", None), "_process", None)
+        if process is None:
+            process = self._last_process
+        if process is None or process.returncode is not None:
+            return None
+        pid = getattr(process, "pid", None)
+        return pid if isinstance(pid, int) and pid > 0 else None
+
+    @property
+    def process_exited(self) -> bool | None:
+        """Whether this session's child process has actually exited.
+
+        ``True`` once the child has a return code, ``False`` while it is still
+        running, and ``None`` when no process handle was ever captured — the
+        session was never started, was closed before :meth:`stop` could reach
+        the transport, or runs against a client that exposes none.
+
+        ``None`` is deliberately not ``False``: a caller sequencing a handover
+        on "the outgoing child is gone" must be able to tell *not exited* from
+        *nothing to observe*, and collapsing the two would make an unanswerable
+        session look like a live one forever.
+        """
+        if self._last_process is None:
+            return None
+        return self._last_process.returncode is not None
 
 
 class OperatorRegistry:
@@ -724,9 +879,15 @@ class OperatorRegistry:
     def __init__(self, chat_max_sessions: int = 5, chat_idle_seconds: float = 900.0) -> None:
         self._sessions: dict[str, OperatorSession] = {}
         # The factory resolves OperatorSession by name at call time, so tests
-        # patching this module's OperatorSession still intercept creation.
+        # patching this module's OperatorSession still intercept creation. The
+        # pool's key IS the session key: a chat child is pooled, audited and
+        # given telemetry under the shared session key, never under an id of
+        # its own. The transcript to resume is not bound here — it is decided
+        # per launch and reaches the child through ``start``.
         self.chats = ChatSessionPool(
-            factory=lambda cwd, env: OperatorSession(cwd=cwd, env=env),
+            factory=lambda cwd, env, session_key: OperatorSession(
+                cwd=cwd, env=env, session_key=session_key
+            ),
             max_sessions=chat_max_sessions,
             idle_seconds=chat_idle_seconds,
         )
@@ -781,6 +942,8 @@ class OperatorRegistry:
         chat_id: str,
         cwd: str,
         env: dict[str, str] | Callable[[], dict[str, str] | None] | None = None,
+        *,
+        resume_id: str | None = None,
     ) -> tuple[OperatorSession, bool]:
         """Pass-through to :meth:`ChatSessionPool.get_or_create`.
 
@@ -788,8 +951,15 @@ class OperatorRegistry:
         keeps a caller's environment read atomic with the pool's registration
         of the creation (``routes/chat.py`` relies on it for the runtime
         posture).
+
+        *resume_id* is the transcript the child should continue — the caller's
+        answer to "what is this key's conversation right now", not something
+        the pool can work out for itself. Omitted, the child starts a
+        conversation of its own under *chat_id*. A live child built from a
+        different transcript is rebuilt, exactly as an environment change
+        rebuilds it.
         """
-        return await self.chats.get_or_create(chat_id, cwd, env)
+        return await self.chats.get_or_create(chat_id, cwd, env, resume_id=resume_id)
 
     def get_chat_session(self, chat_id: str) -> OperatorSession | None:
         return self.chats.get(chat_id)
@@ -804,8 +974,14 @@ class OperatorRegistry:
         """
         return self.chats.has_key(chat_id)
 
-    async def terminate_chat_session(self, chat_id: str) -> None:
-        await self.chats.terminate(chat_id)
+    async def terminate_chat_session(self, chat_id: str) -> OperatorSession | None:
+        """Pass-through to :meth:`ChatSessionPool.terminate`.
+
+        Hands back the torn-down session so a caller can read
+        :attr:`OperatorSession.process_exited` on it; ``None`` when the key held
+        nothing poppable.
+        """
+        return await self.chats.terminate(chat_id)
 
     async def reap_idle_chat_sessions(self) -> int:
         return await self.chats.reap_idle()

--- a/src/osprey/interfaces/web_terminal/pty_manager.py
+++ b/src/osprey/interfaces/web_terminal/pty_manager.py
@@ -115,12 +115,10 @@ def build_pty_env(extra_env: dict[str, str] | None = None) -> dict[str, str]:
 #: connections to the *same pool key*, as built by
 #: :func:`osprey.interfaces.web_terminal.routes.websocket._build_extra_env`:
 #:
-#: * ``OSPREY_SESSION_ID`` — set only when the handler knows the Claude session
-#:   id, and then equal to the pool key itself. A session spawned fresh (id
-#:   dictated on the CLI, ``claude_session_id`` still ``None``) carries no such
-#:   variable; switching back to that same session later resumes it by id and
-#:   does. Absent-or-equal-to-the-key: it names the session the pool already
-#:   keyed on, so it carries no privilege the key does not.
+#: * ``OSPREY_SESSION_ID`` — stamped on every spawn path, always equal to the
+#:   pool key (``claude_session_id or telemetry_session_id``): it names the
+#:   session the pool already keyed on, so it carries no privilege the key
+#:   does not.
 #: * ``OSPREY_TELEMETRY_SESSION_ID`` — same shape. The spawn call site passes a
 #:   telemetry id, the ``switch_session`` call site does not, and when present
 #:   it is also the pool key.
@@ -309,7 +307,18 @@ class PtySession:
         self._last_cols = cols
 
     def terminate(self) -> None:
-        """Terminate the subprocess and close the PTY."""
+        """Terminate the subprocess and close the PTY.
+
+        Blocking, and best-effort: it hangs up the terminal, then escalates
+        SIGTERM to SIGKILL, waiting between steps, so it can occupy the
+        calling thread for about seven seconds. A caller that must not block
+        that long runs it in a worker thread.
+
+        It may also return with the child still running — the SIGKILL wait can
+        expire, which is logged and then let go. Returning is therefore not
+        proof of death: :attr:`is_alive` is, and it is the probe anything that
+        needs to *know* the child is gone must poll.
+        """
         # Close master fd FIRST — the kernel sends SIGHUP to the entire
         # session (all process groups under this session leader), which is the
         # standard Unix mechanism for cleaning up terminal sessions.  Shells
@@ -366,7 +375,11 @@ class PtySession:
 
     @property
     def is_alive(self) -> bool:
-        """Check if the subprocess is still running."""
+        """Whether the subprocess is still running.
+
+        The public death probe: :meth:`terminate` can return with the child
+        alive, so a caller that must observe the process gone polls this.
+        """
         if self._process is None:
             return False
         return self._process.poll() is None
@@ -388,7 +401,16 @@ class PtyRegistry:
 
     def __init__(self, max_background: int = 5) -> None:
         self._sessions: OrderedDict[str, PtySession] = OrderedDict()
-        self._attached: set[str] = set()
+        # Pool key -> the token of the caller currently consuming it. The
+        # token, not the key, is what identifies an attachment: two callers
+        # can meet on one key, and only the one holding the token may release
+        # it. See attach_session().
+        self._attached: dict[str, object] = {}
+        # Pool keys a hand-off in flight will re-fill. Unlike an attachment a
+        # reservation names no owner and grants no exclusivity; it only keeps
+        # the eviction pass off a key whose consumer has left and whose next
+        # consumer has not arrived. See reserve().
+        self._reserved: set[str] = set()
         # Fingerprint of the extra_env each pooled child was spawned with, kept
         # in lockstep with _sessions. Read by get_or_create_session to decide
         # whether a warm entry may be reattached; see env_fingerprint().
@@ -469,7 +491,7 @@ class PtyRegistry:
                 # Dead — remove silently, respawn below
                 self._sessions.pop(session_key, None)
                 self._env_fingerprints.pop(session_key, None)
-                self._attached.discard(session_key)
+                self._attached.pop(session_key, None)
 
         # Evict if at capacity
         self._evict_lru()
@@ -483,26 +505,98 @@ class PtyRegistry:
         self._audit_keys.pop(session_key, None)
         return session, False
 
-    def attach_session(self, session_key: str) -> bool:
-        """Mark session as actively consumed by a WebSocket.
+    def attach_session(self, session_key: str, owner: object) -> bool:
+        """Mark a pooled session as actively consumed by one caller.
 
-        Returns False if already attached or not in pool.
+        One consumer per key: two readers on a single PTY file descriptor
+        split the child's output between them, so a key that is already
+        attached is refused rather than shared. The caller that wins holds the
+        attachment until it releases it with the same token.
+
+        Args:
+            session_key: The pool key to attach.
+            owner: A token identifying the caller — any object, compared by
+                identity. Only the holder of this token can detach the key
+                again, which is what keeps a departing caller from releasing
+                an attachment a newer one has since taken over.
+
+        Returns:
+            True when the attachment was taken. False when the key is not in
+            the pool, or when it is already attached — by another caller or by
+            this one.
         """
         if session_key not in self._sessions:
             return False
         if session_key in self._attached:
             return False
-        self._attached.add(session_key)
+        self._attached[session_key] = owner
         return True
 
-    def detach_session(self, session_key: str) -> None:
-        """Remove from attached set without terminating.
+    def detach_session(self, session_key: str, owner: object) -> None:
+        """Release an attachment without terminating the session.
 
         LRU-bumps the session so it's less likely to be evicted.
+
+        A detach from anyone but the current holder is a no-op — including a
+        detach of a key that is not attached at all. A caller whose session
+        went away and was replaced under the same key therefore tears its own
+        state down without clearing the attachment the replacement holds.
+
+        Args:
+            session_key: The pool key to release.
+            owner: The token :meth:`attach_session` was given for this key.
         """
-        self._attached.discard(session_key)
+        if session_key not in self._attached or self._attached[session_key] is not owner:
+            return
+        del self._attached[session_key]
         if session_key in self._sessions:
             self._sessions.move_to_end(session_key)
+
+    def is_attached(self, session_key: str) -> bool:
+        """Whether some caller currently holds *session_key*.
+
+        The authoritative answer, and the one to ask before evicting or
+        popping a key: :meth:`attached_owner` cannot tell an unattached key
+        from one attached with a falsy token.
+        """
+        return session_key in self._attached
+
+    def reserve(self, session_key: str) -> None:
+        """Hold *session_key* against eviction while a hand-off is in flight.
+
+        A hand-off leaves its key attached to nobody: the outgoing surface
+        releases the key before the incoming one takes it, and in that gap a
+        pooled entry looks exactly like the cold background session the
+        eviction pass exists to reclaim. A reservation says the gap is
+        deliberate and a consumer is on its way, so :meth:`_evict_lru` steps
+        over the key the way it steps over an attached one.
+
+        A reservation is not an attachment. It carries no owner token, grants
+        no exclusive right to read the child, and is taken and dropped by the
+        same hand-off, so reserving a key twice is reserving it once. A key
+        that holds no session may be reserved — a hand-off reserves before it
+        pops, and the entry it protects may not exist yet.
+
+        Every reservation must be released in a ``finally``: a key left
+        reserved is a key the pool can never reclaim.
+        """
+        self._reserved.add(session_key)
+
+    def unreserve(self, session_key: str) -> None:
+        """Release a hand-off reservation.
+
+        A no-op for a key that holds none, so a ``finally`` can call it
+        without knowing whether :meth:`reserve` was reached.
+        """
+        self._reserved.discard(session_key)
+
+    def is_reserved(self, session_key: str) -> bool:
+        """Whether a hand-off currently holds *session_key*."""
+        return session_key in self._reserved
+
+    def attached_owner(self, session_key: str) -> object | None:
+        """The token currently holding *session_key*, or None if it is free."""
+        return self._attached.get(session_key)
 
     def rekey_session(self, old_key: str, new_key: str) -> None:
         """Rename a session entry (e.g. after UUID discovery).
@@ -546,8 +640,7 @@ class PtyRegistry:
         if fingerprint is not None:
             self._env_fingerprints[new_key] = fingerprint
         if old_key in self._attached:
-            self._attached.discard(old_key)
-            self._attached.add(new_key)
+            self._attached[new_key] = self._attached.pop(old_key)
 
         # Chained renames collapse to the FIRST key — that is the one the
         # running child exported. An alias that would name the key itself is
@@ -595,21 +688,39 @@ class PtyRegistry:
         """
         return self._audit_keys.get(session_key, session_key)
 
-    def _evict_lru(self) -> None:
-        """Evict the oldest non-attached session if at capacity."""
+    def pop_lru_victim(self) -> PtySession | None:
+        """Remove and return the session a spawn at capacity would evict, unkilled.
+
+        The selection half of :meth:`_evict_lru`, for a caller on an event
+        loop that is about to call :meth:`get_or_create_session` and cannot
+        afford the blocking kill that eviction performs there: it takes the
+        victim out of the pool here, kills it wherever it likes, and the spawn
+        that follows finds room. Nothing is popped below capacity.
+
+        A key is held either by a consumer reading its child
+        (:meth:`attach_session`) or by a hand-off about to re-fill it
+        (:meth:`reserve`). Both are stepped over, so a pool whose every entry
+        is held grows past ``max_background`` rather than killing a session
+        somebody is using — capacity is a target, not a guarantee.
+
+        Returns:
+            The oldest unheld session, forgotten by the pool exactly as
+            :meth:`pop_session` forgets one, or None when the pool is below
+            capacity or every entry is held.
+        """
         if len(self._sessions) < self._max_background:
-            return
-        # Find oldest non-attached
+            return None
         for key in list(self._sessions):
-            if key not in self._attached:
-                evicted = self._sessions.pop(key)
-                bound_as = self.audit_session_key(key)
-                self._env_fingerprints.pop(key, None)
-                self._audit_keys.pop(key, None)
-                evicted.terminate()
-                _clear_notebook_binding(bound_as)
+            if not self.is_attached(key) and not self.is_reserved(key):
                 logger.info("Evicted LRU session %s", key)
-                return
+                return self.pop_session(key)
+        return None
+
+    def _evict_lru(self) -> None:
+        """Evict the oldest unheld session if at capacity (see :meth:`pop_lru_victim`)."""
+        victim = self.pop_lru_victim()
+        if victim is not None:
+            victim.terminate()
 
     def _spawn_session(
         self,
@@ -655,24 +766,74 @@ class PtyRegistry:
         """Get an existing session by ID."""
         return self._sessions.get(session_id)
 
-    def terminate_session(self, session_id: str) -> None:
-        """Terminate and remove a session.
+    def pop_session(self, session_id: str) -> PtySession | None:
+        """Remove a session from the pool and hand it to the caller, unkilled.
 
-        Drops the entry's recorded env fingerprint and audit alias with it, so
-        the key is fully forgotten and a later spawn under the same key records
-        its own. The notebook session binding goes too, resolved through the
-        audit alias *before* it is dropped — the binding names a session by the
-        key its child stamps, which for a rekeyed session is not the pool key
-        being terminated here.
+        Everything :meth:`terminate_session` does *except* the kill. The pool
+        entry goes, and with it the recorded env fingerprint, the audit alias
+        and any attachment, so the key is fully forgotten and a later spawn
+        under it records its own. The notebook session binding goes too,
+        resolved through the audit alias *before* that alias is dropped — the
+        binding names a session by the key its child stamps, which for a
+        rekeyed session is not the pool key being removed here.
+
+        The split exists because the two halves belong on different threads.
+        The bookkeeping is a handful of dict operations and is safe on an
+        event loop; :meth:`PtySession.terminate` blocks for seconds waiting on
+        signals and is not. Once the entry is out of the pool no new consumer
+        can reach the child, so the caller is free to kill it wherever it
+        likes — and must, since nothing else holds a reference any more.
+
+        Returns:
+            The removed session, or None when *session_id* names no pooled
+            session. The bookkeeping runs either way, which for an unknown key
+            means only clearing a notebook binding that still points at it.
         """
         session = self._sessions.pop(session_id, None)
         bound_as = self.audit_session_key(session_id)
         self._env_fingerprints.pop(session_id, None)
         self._audit_keys.pop(session_id, None)
+        self._attached.pop(session_id, None)
+        _clear_notebook_binding(bound_as)
+        return session
+
+    def reinsert(self, session_id: str, session: PtySession) -> bool:
+        """Put a session :meth:`pop_session` removed back into the pool, unattached.
+
+        The path for a kill that did not take: a hand-off pops the entry,
+        terminates the child, and finds it still alive after the death wait.
+        Dropping the object then would orphan a running process nothing can
+        reach; parking it in a side list would give the pool a second
+        registry to drift from. Putting it back lets the next acquire meet it
+        as an ordinary holder and run the kill again.
+
+        No launch fingerprint is recorded — the pop dropped it and a survivor
+        of a kill is not a child to reattach warm — and no attachment or
+        reservation is taken, so the entry is exactly as evictable as any
+        other background session.
+
+        Returns:
+            True when the session was put back. False, with the pool left
+            alone, when *session_id* is occupied: something else filled the
+            key in the meantime and the survivor is the caller's to deal with.
+        """
+        if session_id in self._sessions:
+            return False
+        self._sessions[session_id] = session
+        return True
+
+    def terminate_session(self, session_id: str) -> None:
+        """Terminate and remove a session.
+
+        The pool bookkeeping is :meth:`pop_session`; the kill that follows
+        blocks the calling thread for as long as the child takes to die, and
+        may return with it still alive (see :meth:`PtySession.terminate`). A
+        caller on an event loop that cannot afford either uses the two halves
+        separately.
+        """
+        session = self.pop_session(session_id)
         if session is not None:
             session.terminate()
-        self._attached.discard(session_id)
-        _clear_notebook_binding(bound_as)
 
     def terminate_session_if_owner(self, session_id: str, owner: PtySession) -> None:
         """Terminate only if the caller still owns the session.
@@ -695,3 +856,4 @@ class PtyRegistry:
         self._env_fingerprints.clear()
         self._audit_keys.clear()
         self._attached.clear()
+        self._reserved.clear()

--- a/src/osprey/interfaces/web_terminal/routes/__init__.py
+++ b/src/osprey/interfaces/web_terminal/routes/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from osprey.interfaces.web_terminal.routes.agent_activity import router as agent_activity_router
+from osprey.interfaces.web_terminal.routes.agent_turn import router as agent_turn_router
 from osprey.interfaces.web_terminal.routes.audit import router as audit_router
 from osprey.interfaces.web_terminal.routes.bar_items import router as bar_items_router
 from osprey.interfaces.web_terminal.routes.chat import router as chat_router
@@ -21,14 +22,19 @@ from osprey.interfaces.web_terminal.routes.panels import router as panels_router
 from osprey.interfaces.web_terminal.routes.proxy import router as proxy_router
 from osprey.interfaces.web_terminal.routes.scaffold import router as scaffold_router
 from osprey.interfaces.web_terminal.routes.session import router as session_router
+from osprey.interfaces.web_terminal.routes.session_handoff import (
+    router as session_handoff_router,
+)
 from osprey.interfaces.web_terminal.routes.websocket import router as websocket_router
 
 router = APIRouter()
 router.include_router(panels_router)
 router.include_router(agent_activity_router)
+router.include_router(agent_turn_router)
 router.include_router(audit_router)
 router.include_router(bar_items_router)
 router.include_router(session_router)
+router.include_router(session_handoff_router)
 router.include_router(config_router)
 router.include_router(files_router)
 router.include_router(feedback_router)

--- a/src/osprey/interfaces/web_terminal/routes/agent_turn.py
+++ b/src/osprey/interfaces/web_terminal/routes/agent_turn.py
@@ -1,0 +1,132 @@
+"""Whether the expert view's Claude Code process is mid-turn.
+
+``POST /api/agent-turn`` is how the terminal's own child process tells the
+server what it is doing. The Claude Code hooks that report it fire on
+``UserPromptSubmit`` (busy), on ``Stop`` and ``StopFailure`` (idle), and on
+``SessionStart`` (idle, plus whichever transcript the session just opened), so
+the server learns of a turn's edges from the process that runs it rather than
+by guessing from terminal output.
+
+The payload shape is a fixed interface contract shared with the hook::
+
+    request:  {"session_id": str, "pool_key": str, "state": "busy"|"idle",
+               "surface": str, "ts": float, "source"?: str}
+    response: {"ok": true, "recorded": bool}
+
+Two identities appear in it and they are not the same thing. ``pool_key`` is
+the session key the browser, the PTY pool and the posture store all use — it
+never changes. ``session_id`` is Claude Code's own session id, which names the
+transcript file and *does* change: a ``/clear`` starts a fresh transcript while
+the key stays put. So a report both marks the key busy or idle and records
+where the key's conversation currently lives, through
+:mod:`osprey.interfaces.web_terminal.transcript_map`.
+
+Both identifiers must be canonical session UUIDs. One becomes a key in a JSON
+store on disk and the other is persisted and later spliced into a resume argv
+and a transcript filename, so the grammar is closed rather than length-bounded
+— the same rule, through the same predicate, that the posture surface applies
+to this class of identifier.
+
+Only the expert surface is recorded. The simple view's chat pool knows its own
+turn boundaries from the SDK client and needs no hook, and a report arriving
+with any other surface — including none, when the environment variable that
+names it is unset — is accepted and dropped rather than refused: a hook cannot
+act on a 4xx, and a refusal would put an error in the operator's terminal for
+something the server deliberately ignores.
+
+Like the panel and agent-activity routes, this endpoint rides the loopback
+baseline plus the panel token (``PANEL_TIER_ROUTES`` in
+:mod:`osprey.interfaces.web_auth`) — the same credential the in-process
+companions already carry.
+
+The recorded entry lives on ``app.state.turn_state``, keyed by session key;
+the store itself, its reader and the reset a PTY spawn or teardown performs
+are :mod:`osprey.interfaces.web_terminal.turn_state`.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Literal
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from osprey.interfaces.web_terminal import transcript_map
+from osprey.interfaces.web_terminal.session_key import is_posture_key
+from osprey.interfaces.web_terminal.turn_state import record_turn_state
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+#: Length bound on the two identifiers and the source label. Session ids are
+#: UUIDs and hook event names are short, so this is generous by an order of
+#: magnitude while keeping an unbounded string out of ``app.state``.
+_MAX_ID_LEN = 256
+
+#: The one surface whose turns are recorded here.
+EXPERT_SURFACE = "expert"
+
+
+class AgentTurnRequest(BaseModel):
+    """Body of ``POST /api/agent-turn``.
+
+    ``session_id`` and ``state`` are the report; the rest is context the hook
+    reads out of its environment. That context is defaulted rather than
+    required because an unset variable must leave the report ignorable, not
+    malformed — a 422 would reach the operator's terminal as hook noise.
+    """
+
+    session_id: str = Field(max_length=_MAX_ID_LEN)
+    state: Literal["busy", "idle"]
+    pool_key: str = Field(default="", max_length=_MAX_ID_LEN)
+    surface: str = Field(default="", max_length=_MAX_ID_LEN)
+    ts: float | None = None
+    source: str | None = Field(default=None, max_length=_MAX_ID_LEN)
+
+
+@router.post("/api/agent-turn")
+async def post_agent_turn(body: AgentTurnRequest, request: Request):
+    """Record a turn edge reported by the expert view's Claude Code process.
+
+    Reports for any other surface are accepted and dropped — see the module
+    docstring for why that is not a 4xx. ``recorded`` in the response says
+    which of the two happened, so a hook author can tell a working install
+    from a silently ignored one without reading the server log.
+
+    The transcript id travels with every recorded report, not only with the
+    ones that move it: writing it unconditionally means a session that returns
+    to its original transcript clears the stale mapping instead of keeping a
+    pointer to a conversation it has left. The map's own write is a no-op when
+    nothing changed, so the per-turn traffic costs no disk writes.
+
+    An id that is not a canonical session UUID is dropped the same way a
+    foreign surface is — silently, with ``recorded`` false — so a malformed
+    identifier can never become a store key, a persisted transcript pointer,
+    or a fragment of a later resume argv.
+    """
+    if body.surface != EXPERT_SURFACE:
+        return {"ok": True, "recorded": False}
+
+    if not is_posture_key(body.session_id) or (body.pool_key and not is_posture_key(body.pool_key)):
+        logger.debug("Ignoring agent-turn report whose identifiers are not session UUIDs")
+        return {"ok": True, "recorded": False}
+
+    app = request.app
+    key = body.pool_key or body.session_id
+    # The hook's clock is the server's clock, so a timestamp ahead of now is a
+    # broken or hostile report rather than a fast one. Later readers let a
+    # newer stored timestamp outrank other evidence of what a session is
+    # doing, and a far-future value would hold that authority forever.
+    now = time.time()
+    record_turn_state(
+        app,
+        key,
+        state=body.state,
+        ts=min(body.ts, now) if body.ts is not None else now,
+        transcript_id=body.session_id,
+    )
+    transcript_map.set(app, key, body.session_id)
+    return {"ok": True, "recorded": True}

--- a/src/osprey/interfaces/web_terminal/routes/chat.py
+++ b/src/osprey/interfaces/web_terminal/routes/chat.py
@@ -17,17 +17,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 from osprey.audit.envelope import POSTURE_SOURCE_PROCESS
-from osprey.interfaces.web_terminal.chat_session_pool import (
-    ChatCapacityError,
-    ChatSessionTerminatedError,
-)
+from osprey.interfaces.web_terminal.chat_session_pool import ChatSessionTerminatedError
 from osprey.interfaces.web_terminal.operator_session import (
     CLAUDE_SDK_AVAILABLE,
     POSTURE_SOURCE_LIVE,
@@ -37,7 +34,16 @@ from osprey.interfaces.web_terminal.operator_session import (
     build_operator_child_env,
     is_terminal_event,
 )
-from osprey.interfaces.web_terminal.routes.websocket import is_posture_key
+from osprey.interfaces.web_terminal.session_handoff import (
+    SURFACE_SIMPLE,
+    ChannelClosed,
+    ChannelToken,
+    HandoffError,
+    HandoffRefused,
+    SpawnRequest,
+    acquire_surface,
+)
+from osprey.interfaces.web_terminal.session_key import is_posture_key
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +65,7 @@ class ChatRequest(BaseModel):
     in-memory dict on this path.
 
     The closed bare-UUID grammar lives on the *posture* surface instead
-    (``_require_session_uuid`` in ``routes/websocket.py``), because that is
+    (:mod:`osprey.interfaces.web_terminal.session_key`), because that is
     where a caller-supplied key becomes a store key on disk that decides a
     child's execution mode. The practical consequence is worth stating: the
     shipped client mints its chat id with ``crypto.randomUUID()``
@@ -113,19 +119,40 @@ def _turn_timeout_s(request: Request) -> float:
 
 
 async def _acquire_chat_turn(request: Request, chat_id: str) -> tuple[OperatorSession, int, bool]:
-    """Get-or-create the chat session and mint its per-turn guard.
+    """Take the session key for the Simple view, then mint this turn's guard.
 
-    Returns ``(session, token, was_reused)``. Maps registry/guard failures to the
-    HTTP contract: :class:`ChatCapacityError` -> 429, :class:`TurnInProgressError`
-    -> 409, :class:`ChatSessionTerminatedError` -> 409, each with a
-    machine-readable body.
+    Every turn goes through :func:`acquire_surface`, because the key may be
+    held by the Expert view's terminal and only the hand-off door can stand
+    that process down before this one starts. A key the chat already holds
+    passes straight through: the pooled child is handed back and the spawn
+    callback below is never called, so the pool's own environment comparison
+    no longer runs per turn. It runs on the one path that still creates a
+    child — this key holding nothing live.
+
+    Returns ``(session, token, fresh_conversation)``. ``fresh_conversation``
+    is True only when the child that will answer this prompt was started with
+    no transcript to resume: the conversation begins here and the client is
+    told so with a ``session_reset`` marker. A resumed child continues a
+    conversation the operator has already seen — in the other view, or in this
+    one before a restart — so it carries no marker.
+
+    Maps every failure to the HTTP contract with a machine-readable ``error``
+    in the body: 409 when another view or connection is consuming the key,
+    when a terminal turn can only be ended by an interrupt
+    (``handoff_needs_interrupt`` — the client offers to stop it and ask
+    again), when the chat was torn down as it started
+    (:class:`ChatSessionTerminatedError`), or when a turn is already in flight
+    (:class:`TurnInProgressError`); 429 when the chat pool is full; 503 when
+    the hand-off's premise vanished under it. :class:`ChannelClosed` is left
+    to the caller — the client that asked for this turn is already gone.
     """
     cwd: str = request.app.state.project_cwd
     registry = request.app.state.operator_registry
 
-    try:
-        session, was_reused = await registry.get_or_create_chat_session(
-            chat_id,
+    async def spawn(spawn_request: SpawnRequest) -> OperatorSession:
+        """Start the chat child the hand-off door asked for, under its key."""
+        session, _created = await registry.get_or_create_chat_session(
+            spawn_request.key,
             cwd,
             # A BUILDER, not a mapping — and that is load-bearing, not style.
             # The chat pool is keyed on chat_id, so that is this surface's
@@ -156,20 +183,38 @@ async def _acquire_chat_turn(request: Request, chat_id: str) -> tuple[OperatorSe
             # ``ChatSessionPool.get_or_create``.
             lambda: build_operator_child_env(
                 cwd,
-                session_key=chat_id,
+                session_key=spawn_request.key,
                 app=request.app,
                 posture_source=(
-                    POSTURE_SOURCE_LIVE if is_posture_key(chat_id) else POSTURE_SOURCE_PROCESS
+                    POSTURE_SOURCE_LIVE
+                    if is_posture_key(spawn_request.key)
+                    else POSTURE_SOURCE_PROCESS
                 ),
             ),
+            resume_id=spawn_request.resume_id,
         )
-    except ChatCapacityError:
+        return cast("OperatorSession", session)
+
+    try:
+        result = await acquire_surface(
+            request.app,
+            chat_id,
+            SURFACE_SIMPLE,
+            ChannelToken(request.is_disconnected),
+            spawn=spawn,
+        )
+    except HandoffRefused as refused:
+        # 409 for a contested key, 429 for a full pool, 503 for an outgoing
+        # process that outlived its kill. The slug is what the client branches
+        # on; the message is for the log and the developer console.
         raise HTTPException(
-            status_code=429,
-            detail={
-                "error": "chat_capacity",
-                "message": "All chat sessions are busy; try again shortly.",
-            },
+            status_code=refused.status,
+            detail={"error": refused.error, "message": str(refused)},
+        ) from None
+    except HandoffError as failed:
+        raise HTTPException(
+            status_code=503,
+            detail={"error": failed.error, "message": str(failed)},
         ) from None
     except ChatSessionTerminatedError:
         # The chat was torn down while this very session was starting — a
@@ -186,9 +231,12 @@ async def _acquire_chat_turn(request: Request, chat_id: str) -> tuple[OperatorSe
             },
         ) from None
 
+    session = cast("OperatorSession", result.session)
     try:
         token = session.acquire_turn()
     except TurnInProgressError:
+        # The backstop behind the hand-off's own wait: a turn that started
+        # between that wait ending and this guard being taken.
         raise HTTPException(
             status_code=409,
             detail={
@@ -197,7 +245,7 @@ async def _acquire_chat_turn(request: Request, chat_id: str) -> tuple[OperatorSe
             },
         ) from None
 
-    return session, token, was_reused
+    return session, token, result.spawned and result.resume_id is None
 
 
 @router.post("/api/chat")
@@ -215,14 +263,20 @@ async def chat(request: Request, body: ChatRequest, stream: bool = True):
     if not prompt:
         raise HTTPException(status_code=422, detail="Prompt must not be empty")
 
-    session, token, was_reused = await _acquire_chat_turn(request, body.chat_id)
+    try:
+        session, token, fresh_conversation = await _acquire_chat_turn(request, body.chat_id)
+    except ChannelClosed:
+        # The client hung up while the session key was being handed over.
+        # Nothing is left holding anything; there is simply nobody to answer.
+        return Response(status_code=204)
+
     turn_timeout_s = _turn_timeout_s(request)
 
     if not stream:
-        return await _buffered_response(session, token, prompt, was_reused, turn_timeout_s)
+        return await _buffered_response(session, token, prompt, fresh_conversation, turn_timeout_s)
 
     return StreamingResponse(
-        _stream_events(session, token, prompt, was_reused, turn_timeout_s),
+        _stream_events(session, token, prompt, fresh_conversation, turn_timeout_s),
         media_type="text/event-stream",
     )
 
@@ -231,7 +285,7 @@ async def _stream_events(
     session: OperatorSession,
     token: int,
     prompt: str,
-    was_reused: bool,
+    fresh_conversation: bool,
     turn_timeout_s: float,
 ):
     """SSE consumer of :meth:`OperatorSession.run_turn` for one turn.
@@ -246,7 +300,7 @@ async def _stream_events(
     synchronous, so the pair cannot be interleaved by another request).
     """
     try:
-        if not was_reused:
+        if fresh_conversation:
             yield _sse(_strip_for_chat({"type": "session_reset"}))
 
         async for event in session.run_turn(
@@ -287,7 +341,7 @@ async def _buffered_response(
     session: OperatorSession,
     token: int,
     prompt: str,
-    was_reused: bool,
+    fresh_conversation: bool,
     turn_timeout_s: float,
 ) -> JSONResponse:
     """Run one turn to completion and return a single reduced JSON response.
@@ -295,8 +349,8 @@ async def _buffered_response(
     Consumes the same :meth:`OperatorSession.run_turn` machine as the SSE
     branch — heartbeat markers are skipped instead of forwarded, and a silence
     timeout maps to 504 instead of an error frame. A ``session_reset`` marker is
-    prepended to ``events`` on a fresh session and ``_strip_for_chat`` applies
-    to every event. The top-level payload is reduced to exactly
+    prepended to ``events`` when the conversation starts with this turn, and
+    ``_strip_for_chat`` applies to every event. The top-level payload is reduced to exactly
     ``{text, events, is_error, error?}`` — cost/duration/turn counts never
     reach the chat client.
     """
@@ -306,7 +360,7 @@ async def _buffered_response(
     error_msg: str | None = None
     status_code = 200
 
-    if not was_reused:
+    if fresh_conversation:
         events.append(_strip_for_chat({"type": "session_reset"}))
 
     try:

--- a/src/osprey/interfaces/web_terminal/routes/session.py
+++ b/src/osprey/interfaces/web_terminal/routes/session.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Request
 
+from osprey.interfaces.web_terminal import transcript_map
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+
+if TYPE_CHECKING:
+    from osprey.mcp_server.workspace.transcript_reader import TranscriptReader
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +27,7 @@ async def list_sessions(request: Request):
     return {"sessions": [asdict(s) for s in sessions]}
 
 
-def _read_session_events(request: Request, reader) -> list[dict]:
+def _read_session_events(request: Request, reader: TranscriptReader) -> list[dict]:
     """Read session events, scoped to a session_id if provided."""
     session_id = request.query_params.get("session_id")
     if session_id:
@@ -180,16 +185,41 @@ async def session_summary(request: Request):
         }
 
 
+#: Values of the ``full`` flag that lift the per-message cap. The browser sends
+#: ``1``; the other spellings are accepted so an operator calling the endpoint
+#: by hand is not handed a silently shortened conversation.
+_FULL_HISTORY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _wants_full_messages(request: Request) -> bool:
+    """Whether the caller asked for whole messages via the ``full`` flag."""
+    return request.query_params.get("full", "").strip().lower() in _FULL_HISTORY_VALUES
+
+
 @router.get("/api/session-chat")
 async def session_chat(request: Request):
-    """Return conversation turns from the current session transcript."""
+    """Return conversation turns from a session's transcript.
+
+    ``session_id`` names a session key, and a key stops naming its transcript
+    the moment a ``/clear`` replaces the conversation, so the key is mapped
+    through :mod:`osprey.interfaces.web_terminal.transcript_map` first: a caller
+    that knows only its key still reads the conversation that key is on.
+
+    ``full=1`` leaves each message whole, which is what replaying a conversation
+    onto another surface needs. Without it the reader's own per-message cap
+    stands, which is what the diagnostics view has always read.
+    """
     try:
         from osprey.mcp_server.workspace.transcript_reader import TranscriptReader
 
         reader = TranscriptReader(request.app.state.project_cwd)
         session_id = request.query_params.get("session_id")
         if session_id:
-            turns = reader.read_chat_history_by_id(session_id)
+            transcript_id = transcript_map.get(request.app, session_id)
+            if _wants_full_messages(request):
+                turns = reader.read_chat_history_by_id(transcript_id, max_chars=None)
+            else:
+                turns = reader.read_chat_history_by_id(transcript_id)
         else:
             turns = reader.read_current_chat_history()
         return {"turns": turns, "count": len(turns)}

--- a/src/osprey/interfaces/web_terminal/routes/session_handoff.py
+++ b/src/osprey/interfaces/web_terminal/routes/session_handoff.py
@@ -1,0 +1,209 @@
+"""Hand a session key to the Simple view.
+
+``POST /api/session/{key}/handoff``
+Body: ``{"to": "simple", "interrupt": false}``
+
+This is the Simple view's half of the one door every surface acquire walks
+through. The Expert view acquires its surface on the ``/ws/terminal``
+handshake, where a refusal is a close code; the Simple view has no long-lived
+socket to refuse on, so it asks here first and only then starts talking to
+``POST /api/chat``. Nothing is prompted: the call returns once the key's
+process is the Simple one, resuming whatever conversation the key is on.
+
+The refusals :func:`~osprey.interfaces.web_terminal.session_handoff.acquire_surface`
+raises are the whole HTTP contract of this route, and every one of them is
+answered with a ``detail.error`` slug the client branches on rather than a
+sentence it would have to match:
+
+===========================================  ======  =============================
+Condition                                    Status  ``detail.error``
+===========================================  ======  =============================
+another connection or view holds the key     409     ``session_attached_elsewhere``
+a terminal holds it and reports no turns     409     ``handoff_needs_interrupt``
+a newer request with interrupt took the key  409     ``handoff_superseded``
+the chat was torn down as it started         409     ``chat_terminated``
+every chat is busy and the pool is full      429     ``chat_capacity``
+the previous agent survived its kill         503     ``outgoing_still_running``
+the hand-off's premise stopped holding       503     ``outgoing_vanished``,
+                                                     ``spawn_not_pooled``
+===========================================  ======  =============================
+
+``handoff_needs_interrupt`` is the one the operator can act on: the terminal
+holding the key has no turn-state hook installed, so nothing can tell when its
+turn ends, and the client offers *Stop and switch now* — the same POST with
+``interrupt: true``, which cuts the running turn short instead of waiting for
+it. That same POST, made while an earlier one for the key is still waiting,
+takes the key over from the earlier one: the waiting request is answered
+``handoff_superseded`` and the interrupting one proceeds, so the operator can
+end a wait from the transitional state without the abandoned request standing
+in the way.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from osprey.interfaces.web_terminal.chat_session_pool import ChatSessionTerminatedError
+from osprey.interfaces.web_terminal.operator_session import (
+    CLAUDE_SDK_AVAILABLE,
+    POSTURE_SOURCE_LIVE,
+    OperatorRegistry,
+    OperatorSession,
+    build_operator_child_env,
+)
+from osprey.interfaces.web_terminal.session_handoff import (
+    SURFACE_SIMPLE,
+    ChannelClosed,
+    ChannelToken,
+    HandoffError,
+    HandoffRefused,
+    SpawnRequest,
+    acquire_surface,
+)
+from osprey.interfaces.web_terminal.session_key import is_posture_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class HandoffRequest(BaseModel):
+    """Body of ``POST /api/session/{key}/handoff``.
+
+    ``to`` is a ``Literal`` rather than a plain string because this route
+    speaks for exactly one surface. The Expert view takes the key on its
+    ``/ws/terminal`` handshake — it needs the socket the refusal closes — so
+    ``{"to": "expert"}`` names a hand-off no HTTP request can carry out, and a
+    422 saying which field is wrong is a better answer than a 200 that did
+    something else.
+
+    ``interrupt`` asks for a running turn on the outgoing surface to be cut
+    short rather than waited for. It defaults to False: the ordinary flip
+    waits, and cutting a turn short is a gesture the operator makes after
+    being told the key is held (``handoff_needs_interrupt``).
+    """
+
+    to: Literal["simple"]
+    interrupt: bool = False
+
+
+@router.post("/api/session/{key}/handoff")
+async def hand_off_session(key: str, body: HandoffRequest, request: Request) -> Response:
+    """Take session *key* for the Simple view and return once its chat is live.
+
+    The chat is resumed onto the key's current transcript, or started fresh
+    under the key when it has none — the acquire decides which from the
+    transcript map and the transcripts on disk, and the spawn callback below
+    only carries out that decision.
+
+    No turn is taken here. The chat this leaves pooled is idle and free of the
+    other surface, and ``POST /api/chat`` mints the per-turn guard when the
+    operator actually says something.
+
+    Returns:
+        200 ``{"state": "simple", "session_id": <key>}``, or 204 with no body
+        when the caller disconnected while the hand-off was waiting.
+
+    Raises:
+        HTTPException: 400 for a key outside the session-UUID grammar, 503
+            when the Agent SDK is not installed, and the refusals listed in
+            the module docstring.
+    """
+    if not is_posture_key(key):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_session_id",
+                "message": "session_id must be a Claude session UUID.",
+            },
+        )
+    if not CLAUDE_SDK_AVAILABLE:
+        # Before the acquire, not after: a hand-off that tears the terminal
+        # down and then finds it has nothing to start would leave the key with
+        # no live process at all.
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "sdk_unavailable",
+                "message": "Claude Agent SDK is not available.",
+            },
+        )
+
+    cwd: str = request.app.state.project_cwd
+    registry: OperatorRegistry = request.app.state.operator_registry
+
+    async def spawn(req: SpawnRequest) -> OperatorSession:
+        """Start the Simple view's chat under the key and hand back the pooled session.
+
+        The environment is built the way ``routes/chat.py`` builds it, with one
+        simplification this route earns: the key has already been held to the
+        posture surface's grammar above, so a store can always answer for it
+        and ``live`` is the honest ``posture_source`` here. The builder form is
+        load-bearing for the same reason it is there — the pool calls it inside
+        the lock hold that registers the creation, so a concurrent posture flip
+        lands wholly before or wholly after this child's environment is read.
+        """
+        session, _ = await registry.get_or_create_chat_session(
+            req.key,
+            cwd,
+            lambda: build_operator_child_env(
+                cwd,
+                session_key=req.key,
+                app=request.app,
+                posture_source=POSTURE_SOURCE_LIVE,
+            ),
+            resume_id=req.resume_id,
+        )
+        return session
+
+    try:
+        # Never under `asyncio.timeout`/`wait_for`/`TaskGroup`: ChannelClosed is
+        # a synthetic cancellation raised from inside the call, and their
+        # uncancel accounting would turn it into a TimeoutError or swallow it.
+        result = await acquire_surface(
+            request.app,
+            key,
+            SURFACE_SIMPLE,
+            ChannelToken(request.is_disconnected),
+            interrupt=body.interrupt,
+            spawn=spawn,
+        )
+    except ChannelClosed:
+        # The operator navigated away or flipped back while the outgoing turn
+        # was still finishing. There is nobody to answer, and the hand-off was
+        # abandoned before anything was torn down or started.
+        logger.info("Hand-off of session %s abandoned; the caller disconnected", key)
+        return Response(status_code=204)
+    except HandoffRefused as refused:
+        raise HTTPException(
+            status_code=refused.status,
+            detail={"error": refused.error, "message": str(refused)},
+        ) from None
+    except HandoffError as failed:
+        raise HTTPException(
+            status_code=503,
+            detail={"error": failed.error, "message": str(failed)},
+        ) from None
+    except ChatSessionTerminatedError:
+        # The chat was torn down while this very hand-off was starting it — a
+        # posture flip or an explicit DELETE. Retrying respawns it under
+        # whatever the store now holds, which is the whole remedy.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "chat_terminated",
+                "message": "This chat was terminated while it was starting; try again.",
+            },
+        ) from None
+
+    logger.info(
+        "Session %s is now on the simple surface (%s)",
+        key,
+        "started" if result.spawned else "already running",
+    )
+    return JSONResponse(content={"state": SURFACE_SIMPLE, "session_id": key})

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -15,7 +15,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import yaml  # type: ignore[import-untyped]
 from fastapi import APIRouter, HTTPException, Request, Response, WebSocket, WebSocketDisconnect
@@ -30,6 +30,7 @@ from osprey.interfaces.common_middleware import (
     session_cookie_name,
 )
 from osprey.interfaces.web_auth import PANEL_TOKEN_ENV, get_web_credentials
+from osprey.interfaces.web_terminal import session_handoff
 from osprey.interfaces.web_terminal.operator_session import (
     POSTURE_SESSION_ENV,
     POSTURE_SOURCE_ENV,
@@ -40,28 +41,30 @@ from osprey.interfaces.web_terminal.operator_session import (
 )
 from osprey.interfaces.web_terminal.session_binding import write_binding
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from osprey.interfaces.web_terminal.session_key import is_posture_key
 from osprey.profiles.web_panels import JUPYTER_PANEL_ID
 from osprey_connectors import session_store
 from osprey_connectors.control_system.base import is_readonly_run
+
+if TYPE_CHECKING:
+    from osprey.interfaces.web_terminal.pty_manager import PtySession
+    from osprey.interfaces.web_terminal.session_handoff import (
+        AcquireResult,
+        SpawnCallback,
+        SpawnRequest,
+    )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# The loose shape check the resume path (``switch_session``) applies to ids
+# Claude itself wrote: any 36 characters drawn from ``[a-f0-9-]``, which is
+# fine for "does this look like a session file stem" and much too wide for a
+# key that is written to a store on disk and later decides a child process's
+# execution mode. The posture surface's *closed* key grammar is
+# :func:`~osprey.interfaces.web_terminal.session_key.is_posture_key`.
 _UUID_RE = re.compile(r"^[a-f0-9-]{36}$")
-
-# The posture surface's *closed* key grammar: a canonical lowercase UUID, and
-# nothing else. ``_UUID_RE`` above is the loose shape check the resume path
-# (``switch_session``) applies to ids Claude itself wrote; it admits any 36
-# characters drawn from ``[a-f0-9-]``, which is fine for "does this look like a
-# session file stem" and much too wide for a key that is written to a store on
-# disk and later decides a child process's execution mode. Both identities the
-# posture route can legitimately name — a discovered PTY session (a Claude
-# session-file stem) and a live chat-pool session (``crypto.randomUUID()`` in
-# ``static/js/chat.js``) — are canonical UUIDs, so nothing shipped loses reach
-# by closing the grammar here. The ``/ws/operator`` pool's minted
-# ``operator-<hex8>`` keys stay unaddressable by design.
-_POSTURE_KEY_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
 # ── Per-(session, target) runtime posture ────────────────────────────────────
 #
@@ -118,19 +121,6 @@ class TargetRequest(BaseModel):
     target: str
 
 
-def is_posture_key(session_id: str) -> bool:
-    """Whether *session_id* matches the posture surface's closed key grammar.
-
-    The public half of :data:`_POSTURE_KEY_RE`, for the one caller outside this
-    module that has to agree with the posture route on what it can address:
-    ``routes/chat.py`` labels a chat child's ``posture_source`` by it, because
-    a key this answers ``False`` for is a key no posture store will ever answer
-    for. Kept as a function rather than an exported pattern so the grammar
-    itself stays private and there is one place to change it.
-    """
-    return bool(_POSTURE_KEY_RE.match(session_id))
-
-
 def _require_session_uuid(session_id: str) -> None:
     """Refuse *session_id* unless it is a canonical, bare session UUID.
 
@@ -138,12 +128,13 @@ def _require_session_uuid(session_id: str) -> None:
     status, the error slug or the sentence. An arbitrary string can never
     become a store key that is then written to disk.
 
-    The grammar is closed (:data:`_POSTURE_KEY_RE`): eight-four-four-four-twelve
-    lowercase hex, no prefix, no suffix. Every key the posture surface can
-    legitimately name is minted that way — a Claude session-file stem or a chat
-    id from ``crypto.randomUUID()`` — so the closed form costs no reach and
-    keeps decorated keys (``operator-<hex8>``) and near-miss strings out of a
-    store that decides a child's execution mode.
+    The grammar is the closed one in
+    :mod:`osprey.interfaces.web_terminal.session_key`: eight-four-four-four-
+    twelve lowercase hex, no prefix, no suffix. Every key the posture surface
+    can legitimately name is minted that way — a Claude session-file stem or a
+    chat id from ``crypto.randomUUID()`` — so the closed form costs no reach
+    and keeps decorated keys (``operator-<hex8>``) and near-miss strings out of
+    a store that decides a child's execution mode.
 
     Raises:
         HTTPException: 400 ``invalid_session_id`` when the shape does not match.
@@ -1014,18 +1005,25 @@ NO_CONVERSATION_MARKER = b"No conversation found with session ID"
 _NO_CONVERSATION_SCAN_LIMIT = 16 * 1024
 
 
-def _transcript_missing(registry, discovery: SessionDiscovery, session_id: str) -> bool:
+def _transcript_missing(app, registry, discovery: SessionDiscovery, session_id: str) -> bool:
     """Whether resuming *session_id* would spawn a child with nothing to resume.
 
-    A pooled PTY that is still alive IS the session — a terminal that was
-    opened and never prompted has one, and no ``.jsonl`` yet, because Claude
-    Code writes the transcript on the first prompt. Only with no live PTY is
-    the transcript directory the authority: ``--resume`` on an id with no
-    file there prints :data:`NO_CONVERSATION_MARKER` and exits, which is the
-    dead PTY the caller refuses to hand the operator.
+    The question is whether the key names a session at all, and three things
+    can answer yes. A pooled PTY that is still alive IS the session — a
+    terminal that was opened and never prompted has one, and no ``.jsonl``
+    yet, because Claude Code writes the transcript on the first prompt. A key
+    the chat pool answers to (:func:`_chat_pool_answers_to`, so a creation
+    still inside ``start()`` counts) is equally a session: both views are
+    windows onto one key, and the conversation the operator started in Simple
+    is the one they are asking for here. Only with none of those is the
+    transcript directory the authority: ``--resume`` on an id with no file
+    there prints :data:`NO_CONVERSATION_MARKER` and exits, which is the dead
+    PTY the caller refuses to hand the operator.
     """
     existing = registry.get_session(session_id)
     if existing is not None and existing.is_alive:
+        return False
+    if _chat_pool_answers_to(app, session_id):
         return False
     return session_id not in discovery.snapshot_session_ids()
 
@@ -1089,10 +1087,20 @@ def _build_extra_env(
     ``telemetry_session_id`` is the session UUID this terminal's ``claude`` is
     forced onto (via ``--session-id``); it is handed to the workspace
     provenance_locator tool so a filed issue can point back to this session's
-    telemetry. Kept separate from ``claude_session_id`` — which drives
-    ``OSPREY_SESSION_ID`` (session-scoped agent-data relocation and artifact
-    session tagging) and stays unset for new sessions — because the telemetry
-    locator must not carry those side effects.
+    telemetry.
+
+    ``OSPREY_SESSION_ID`` is stamped from the **pool key** — the same
+    ``claude_session_id or telemetry_session_id`` the handler keys the pool on
+    — so it is set on every spawn this function serves, the brand-new session
+    included. It scopes the child's execution root
+    (:func:`osprey_connectors.workspace.resolve_agent_data_root` appends
+    ``sessions/<key>``) and tags the artifacts it files. One key, one root: a
+    conversation is one session whichever view is showing it, so the chat
+    child spawned under that key
+    (:func:`~osprey.interfaces.web_terminal.operator_session.build_operator_child_env`)
+    works out of the same directory as this one. The name is in
+    :data:`~osprey.interfaces.web_terminal.pty_manager.POOL_FINGERPRINT_EXCLUDED_ENV`,
+    so stamping it can never make a reattach respawn a live child.
 
     The result also carries the **panel token**, and that is the one place the
     PTY child gets it. :func:`~osprey.interfaces.web_auth._populate` pops the
@@ -1115,8 +1123,9 @@ def _build_extra_env(
     # "simple" in operator_session.py). The panels-context SessionStart hook
     # reads this to tell the agent which UI the operator is looking at.
     extra_env["OSPREY_WEB_UX"] = "expert"
-    if claude_session_id:
-        extra_env["OSPREY_SESSION_ID"] = claude_session_id
+    session_key = claude_session_id or telemetry_session_id
+    if session_key:
+        extra_env["OSPREY_SESSION_ID"] = session_key
     if telemetry_session_id:
         extra_env["OSPREY_TELEMETRY_SESSION_ID"] = telemetry_session_id
         extra_env["OSPREY_TELEMETRY_SESSION_START"] = datetime.now(UTC).isoformat()
@@ -1158,12 +1167,228 @@ def _build_extra_env(
     # authoritative for all of them; a child that held the key without it would
     # be told whose posture to read and left to guess where. Never one without
     # the other, and a test pins that.
-    posture_key = claude_session_id or telemetry_session_id
-    if posture_key:
+    if session_key:
         extra_env[POSTURE_SOURCE_ENV] = POSTURE_SOURCE_LIVE
-        extra_env[POSTURE_SESSION_ENV] = posture_key
+        extra_env[POSTURE_SESSION_ENV] = session_key
         extra_env[OSPREY_AGENT_DATA_ROOT] = resolve_agent_data_root(websocket.app)
     return extra_env
+
+
+#: Query values read as "yes" on ``/ws/terminal?interrupt=``.
+_TRUTHY_QUERY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _query_flag(websocket: WebSocket, name: str) -> bool:
+    """Whether query parameter *name* is set to a truthy value."""
+    return websocket.query_params.get(name, "").strip().lower() in _TRUTHY_QUERY_VALUES
+
+
+class _TerminalChannel:
+    """One terminal socket as the hand-off door sees it, and its single reader.
+
+    ``token`` is this handler's identity for everything that identifies a
+    connection: the channel a pending acquire is registered under, the owner
+    token the PTY is attached with, and the key its 4409 closer is filed
+    under in :attr:`~...session_handoff.HandoffState.closers`. One per
+    socket, kept across a ``switch_session``: the registry checks it before
+    letting a detach release a key, so a handler that has been displaced
+    cannot clear the attachment its successor holds.
+
+    ``closed`` is set the moment the socket's ``websocket.disconnect`` is
+    read — by :meth:`receive` in the main loop or by the side reader
+    :meth:`acquire` runs — and by the closer when phase (c) displaces this
+    handler. The token's closed probe reads it, so a wait inside the door
+    ends as :class:`~...session_handoff.ChannelClosed` instead of running on
+    for a client that is gone.
+
+    Only one ``receive`` may be outstanding on a socket. During an acquire
+    the handler is awaiting the door, so the side reader is that one reader:
+    it records resizes — the size a spawn is started at, or a reused PTY is
+    resized to — drops keystrokes, which have no PTY to go to yet, and keeps
+    every other control message for the main loop, which reads
+    :attr:`deferred` before it reads the socket again.
+
+    The socket read itself is one task that outlives whichever reader awaits
+    it. The side reader is cancelled the moment the door returns, and a
+    frame the transport hands over in that same loop turn is consumed by the
+    cancelled task on transports that deliver straight to a waiting receiver
+    (Starlette's test client does; the ASGI contract promises nothing either
+    way). Cancelling the awaiter leaves the read in flight, so the next
+    :meth:`receive` collects that frame instead of losing it.
+    """
+
+    def __init__(self, websocket: WebSocket) -> None:
+        self.websocket = websocket
+        self.closed = asyncio.Event()
+        self.token = session_handoff.ChannelToken(self.closed.is_set)
+        self.rows = 24
+        self.cols = 80
+        self.deferred: list[Mapping[str, Any]] = []
+        self._read: asyncio.Task[Any] | None = None
+
+    async def receive(self) -> Mapping[str, Any]:
+        """The next message for the main loop: a deferred control message first."""
+        if self.deferred:
+            return self.deferred.pop(0)
+        return await self._read_socket()
+
+    async def _read_socket(self) -> Mapping[str, Any]:
+        """The next message off the socket; a disconnect closes the channel."""
+        if self._read is None:
+            self._read = asyncio.ensure_future(self.websocket.receive())
+        try:
+            message: Mapping[str, Any] = await asyncio.shield(self._read)
+        except asyncio.CancelledError:
+            raise
+        except BaseException:
+            self._read = None
+            raise
+        self._read = None
+        if message.get("type") == "websocket.disconnect":
+            self.closed.set()
+        return message
+
+    def release(self) -> None:
+        """Cancel a read left in flight; the handler is done with the socket."""
+        if self._read is not None:
+            self._read.cancel()
+            self._read = None
+
+    def note_resize(self, msg: Any) -> bool:
+        """Record a ``resize`` control message; False for anything else.
+
+        A malformed resize is recorded as nothing and still answered True:
+        it was a control message, not keystrokes for the PTY.
+        """
+        if not isinstance(msg, dict) or msg.get("type") != "resize":
+            return False
+        try:
+            rows, cols = int(msg["rows"]), int(msg["cols"])
+        except (KeyError, TypeError, ValueError):
+            return True
+        self.rows, self.cols = rows, cols
+        return True
+
+    async def send_text(self, text: str) -> None:
+        """Send a control frame, tolerating a socket that is already gone."""
+        try:
+            await self.websocket.send_text(text)
+        except Exception:
+            pass
+
+    async def send_json(self, frame: dict[str, Any]) -> None:
+        await self.send_text(json.dumps(frame))
+
+    async def close(self, code: int | None = None) -> None:
+        """Close the socket, tolerating one that is already closed."""
+        try:
+            if code is None:
+                await self.websocket.close()
+            else:
+                await self.websocket.close(code=code)
+        except Exception:
+            pass
+
+    async def acquire(
+        self, app: Any, key: str, *, interrupt: bool, spawn: SpawnCallback
+    ) -> AcquireResult:
+        """Take *key* for the Expert surface while reading the socket.
+
+        The acquire runs in the handler's own task — a cancellation delivered
+        while phase (c) runs is then honoured only once the phase is done,
+        which is what lets the handler's teardown detach unconditionally.
+        The side reader is cancelled and reaped before this returns, so the
+        main loop's own ``receive`` never overlaps it.
+        """
+        reader = asyncio.ensure_future(self._read_while_acquiring())
+        try:
+            return await session_handoff.acquire_surface(
+                app,
+                key,
+                session_handoff.SURFACE_EXPERT,
+                self.token,
+                interrupt=interrupt,
+                spawn=spawn,
+            )
+        finally:
+            reader.cancel()
+            with suppress(asyncio.CancelledError):
+                await reader
+
+    async def _read_while_acquiring(self) -> None:
+        while True:
+            try:
+                message = await self._read_socket()
+            except Exception:
+                self.closed.set()
+                return
+            if message.get("type") == "websocket.disconnect":
+                return
+            text = message.get("text")
+            if not text:
+                # Keystrokes are dropped here; the one frame the surviving
+                # socket read holds when the door returns is read by the main
+                # loop instead and reaches the new PTY.
+                continue
+            try:
+                msg = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(msg, dict) and not self.note_resize(msg):
+                self.deferred.append(message)
+
+
+async def _open_surface(
+    channel: _TerminalChannel,
+    app: Any,
+    key: str,
+    *,
+    interrupt: bool,
+    spawn: SpawnCallback,
+) -> AcquireResult | None:
+    """Take *key* for this terminal, answering the client for every way that can end.
+
+    Returns the result on success. Returns None once the client has been
+    answered — a refusal closes the socket with the refusal's close code
+    (4409 attached elsewhere, 4503 the outgoing process survived its kill,
+    which the client offers a retry for); a hand-off error is an ``error``
+    frame and a close; a channel that closed during the wait gets nothing.
+    The ``handoff_pending`` frame goes out first whenever the chat surface
+    holds the key, which is the one case the door waits on a foreign entry
+    for a terminal; the client shows the transitional state until
+    ``session_info`` (or ``error``) replaces it.
+    """
+    if _chat_pool_answers_to(app, key):
+        await channel.send_json({"type": "handoff_pending"})
+    try:
+        return await channel.acquire(app, key, interrupt=interrupt, spawn=spawn)
+    except session_handoff.HandoffRefused as refused:
+        logger.info("Refusing the terminal session %s: %s", key, refused)
+        await channel.close(refused.ws_close_code or session_handoff.WS_CLOSE_SESSION_ATTACHED)
+        return None
+    except session_handoff.ChannelClosed:
+        logger.info("Terminal connection for session %s closed while waiting", key)
+        return None
+    except session_handoff.HandoffError as error:
+        logger.warning("Hand-off to the terminal for session %s failed: %s", key, error)
+        await channel.send_json({"type": "error", "message": str(error)})
+        await channel.close()
+        return None
+
+
+def _write_to_pty(session: PtySession, data: bytes) -> None:
+    """Forward keystrokes; a PTY whose child has gone swallows them."""
+    try:
+        session.write_input(data)
+    except OSError:
+        logger.debug("Dropped terminal input: the PTY is closed", exc_info=True)
+
+
+def _resize_pty(session: PtySession, rows: int, cols: int) -> None:
+    try:
+        session.resize(rows, cols)
+    except OSError:
+        logger.debug("Could not resize the PTY", exc_info=True)
 
 
 @router.websocket("/ws/terminal")
@@ -1178,11 +1403,27 @@ async def terminal_ws(websocket: WebSocket):
     - Server -> Client JSON: {"type": "exit", "code": N}
     - Server -> Client JSON: {"type": "session_switched", "session_id": UUID}
     - Server -> Client JSON: {"type": "session_info", "session_id": UUID}
+    - Server -> Client JSON: {"type": "handoff_pending"}
     - Server -> Client JSON: {"type": "transcript_missing", "session_id": UUID, "code"?: N}
     - Server -> Client JSON: {"type": "error", "message": str}
 
+    Query: ``session_id`` and ``mode=resume`` name the session key to
+    resume; without them a new key is minted. ``interrupt=1`` on a resume
+    cuts short a turn the chat surface is running on that key instead of
+    waiting for it.
+
+    Every PTY this handler serves comes through
+    :func:`~osprey.interfaces.web_terminal.session_handoff.acquire_surface`:
+    the key is one session whichever view shows it, so taking it here hands
+    the conversation off from a chat that holds it (``handoff_pending``
+    while that finishes), takes it over from an older terminal on the same
+    key (closed with 4409), reuses the pooled PTY, or spawns one resuming
+    the key's current transcript. The spawn callback below is the only
+    place the registry's blocking create path is called from.
+
     ``transcript_missing`` answers a resume — the ``mode=resume`` connect or a
-    ``switch_session`` — of an id with no live PTY and no transcript on disk.
+    ``switch_session`` — of an id no surface holds and no transcript on disk
+    names.
     Nothing is spawned for it: on the connect path the socket is then closed,
     on the switch path the current session stays attached. The same frame,
     with the exit ``code``, replaces ``exit`` when a ``--resume`` child prints
@@ -1190,57 +1431,33 @@ async def terminal_ws(websocket: WebSocket):
     """
     await websocket.accept()
 
-    registry = websocket.app.state.pty_registry
-    base_shell_command = websocket.app.state.shell_command
-    discovery = SessionDiscovery(websocket.app.state.project_cwd)
+    app = websocket.app
+    registry = app.state.pty_registry
+    base_shell_command = app.state.shell_command
+    discovery = SessionDiscovery(app.state.project_cwd)
 
     # Parse session params from query string
     req_session_id = websocket.query_params.get("session_id")
     mode = websocket.query_params.get("mode", "new")
+    interrupt = mode == "resume" and _query_flag(websocket, "interrupt")
 
-    effort = _read_effort_level(websocket.app.state.config_path)
+    effort = _read_effort_level(app.state.config_path)
 
-    # Build the command and determine the initial session key.
-    # base_shell_command is list[str] (set by app.lifespan), so unpack with
-    # [*base, ...] — nesting would break PtySession's exec (issue #218).
+    # Pool key: the requested id for resumes, a forced id for new sessions.
+    # A new session's id is dictated on the command line by the spawn below
+    # (``--session-id``), never guessed, so the pool is keyed by the real
+    # session id from the first moment and needs no later rekey. The forced
+    # id is also what the workspace provenance_locator tool hands back (via
+    # OSPREY_TELEMETRY_SESSION_ID) and what the OTEL emitter tags records
+    # with as session.id, so a filed issue's provenance pointer resolves.
     if mode == "resume" and req_session_id:
-        command: list[str] = [*base_shell_command, "--resume", req_session_id]
-        claude_session_id: str | None = req_session_id
-        telemetry_session_id: str = req_session_id
+        current_key: str = req_session_id
     else:
-        # Force a known session UUID so the workspace provenance_locator tool can
-        # hand it back (via OSPREY_TELEMETRY_SESSION_ID, injected below) and it
-        # matches the value the OTEL emitter tags records with as session.id — a
-        # filed issue's provenance pointer then resolves. (Not claude_session_id,
-        # which would set OSPREY_SESSION_ID and relocate session-scoped agent
-        # data — this is the CLI's session id, not an agent-data scope.)
-        telemetry_session_id = str(uuid.uuid4())
-        command = [*base_shell_command, "--session-id", telemetry_session_id]
-        claude_session_id = None
+        current_key = str(uuid.uuid4())
 
-    if effort:
-        command.extend(["--effort", effort])
-
-    # Pool key: the requested id for resumes, the forced id for new sessions.
-    # A new session's id is dictated on the command line above, never guessed,
-    # so the pool is keyed by the real session id from the first moment and
-    # needs no later rekey.
-    current_key = claude_session_id or telemetry_session_id
-
-    # Wait for the client's initial resize message before spawning the PTY.
-    initial_cols, initial_rows = 80, 24
-    try:
-        first = await asyncio.wait_for(websocket.receive(), timeout=5.0)
-        if "text" in first:
-            try:
-                msg = json.loads(first["text"])
-                if msg.get("type") == "resize":
-                    initial_cols = msg["cols"]
-                    initial_rows = msg["rows"]
-            except (json.JSONDecodeError, KeyError):
-                pass
-    except TimeoutError:
-        logger.warning("No initial resize from client within 5s, using defaults")
+    channel = _TerminalChannel(websocket)
+    token = channel.token
+    state = session_handoff.get_state(app)
 
     # The resume boundary. ``--resume`` on an id with no transcript exits at
     # once with "No conversation found", and a PTY that dies on attach is a
@@ -1252,54 +1469,97 @@ async def terminal_ws(websocket: WebSocket):
     if (
         mode == "resume"
         and req_session_id
-        and _transcript_missing(registry, discovery, req_session_id)
+        and _transcript_missing(app, registry, discovery, req_session_id)
     ):
-        logger.info("Refusing to resume %s: no live PTY and no transcript", req_session_id)
-        try:
-            await websocket.send_text(_transcript_missing_frame(req_session_id))
-            await websocket.close()
-        except Exception:
-            pass
+        logger.info(
+            "Refusing to resume %s: no live PTY, no chat session and no transcript",
+            req_session_id,
+        )
+        await channel.send_text(_transcript_missing_frame(req_session_id))
+        await channel.close()
         return
 
-    extra_env = _build_extra_env(websocket, claude_session_id, telemetry_session_id)
-
-    session, was_reused = registry.get_or_create_session(
-        current_key,
-        command,
-        rows=initial_rows,
-        cols=initial_cols,
-        extra_env=extra_env if extra_env else None,
-        cwd=websocket.app.state.project_cwd,
-    )
-    registry.attach_session(current_key)
-    _bind_notebook_session(websocket.app, registry, session, current_key)
-
-    # Confirm the id immediately, whichever path spawned it. A new session's
-    # id is the one this handler put on the CLI's command line; a resume's is
-    # either a warm PTY (the session itself) or an id whose transcript was on
-    # disk a moment ago — the boundary above refused everything else. There is
-    # nothing to wait for and nothing to race.
-    try:
-        await websocket.send_text(json.dumps({"type": "session_info", "session_id": current_key}))
-    except Exception:
-        pass
-
-    # Start output forwarding. A ``--resume`` child this handler spawned is
-    # watched for the CLI's own "no such conversation" verdict.
-    stop_event = asyncio.Event()
-    output_task = asyncio.create_task(
-        _run_output_loop(
-            session,
-            websocket,
-            stop_event,
-            resume_id=req_session_id if mode == "resume" and not was_reused else None,
+    async def spawn(request: SpawnRequest) -> PtySession:
+        # base_shell_command is list[str] (set by app.lifespan), so unpack
+        # with [*base, ...] — nesting would break PtySession's exec (issue
+        # #218). The door decided what to resume: the key's current
+        # transcript when one is on disk, else a fresh session under the key.
+        if request.resume_id:
+            command: list[str] = [*base_shell_command, "--resume", request.resume_id]
+        else:
+            command = [*base_shell_command, "--session-id", request.key]
+        if effort:
+            command.extend(["--effort", effort])
+        extra_env = _build_extra_env(websocket, request.key, request.key)
+        # A full pool evicts its oldest background session first, and the
+        # registry's own eviction kills it on the calling thread. This runs
+        # on the event loop, under the key's hand-off lock, so the victim is
+        # taken out here and killed off the loop instead.
+        victim = registry.pop_lru_victim()
+        if victim is not None:
+            await asyncio.to_thread(victim.terminate)
+        spawned: PtySession
+        spawned, _ = registry.get_or_create_session(
+            request.key,
+            command,
+            rows=channel.rows,
+            cols=channel.cols,
+            extra_env=extra_env if extra_env else None,
+            cwd=app.state.project_cwd,
         )
-    )
+        return spawned
 
+    async def close_displaced() -> None:
+        # A newer terminal on the same key took the PTY over. This handler's
+        # output loop is stopped first: two readers on one PTY descriptor
+        # split the child's output between them, and the close handshake the
+        # main loop waits for is a round trip away (longer for a client that
+        # is gone). The main loop then stops writing to a PTY that is no
+        # longer this handler's. Reads the loop bindings as they are now.
+        stop_event.set()
+        if output_task is not None:
+            output_task.cancel()
+        channel.closed.set()
+        await channel.close(session_handoff.WS_CLOSE_SESSION_ATTACHED)
+
+    state.closers[token] = close_displaced
+
+    # ``session`` is the PTY this handler holds and ``session_key`` the key it
+    # holds it under; ``current_key`` is the key under acquisition, which
+    # differs from ``session_key`` only while a switch is in flight.
+    session: PtySession | None = None
+    session_key = current_key
+    stop_event = asyncio.Event()
+    output_task: asyncio.Task[None] | None = None
     try:
+        result = await _open_surface(channel, app, current_key, interrupt=interrupt, spawn=spawn)
+        if result is None or channel.closed.is_set():
+            return
+        session = cast("PtySession", result.session)
+        # Sized after the door whichever path filled the key: a resize the
+        # side reader recorded after the spawn read the size is applied here
+        # (an unchanged size is a no-op), and a reused PTY is not resized by
+        # the door at all.
+        _resize_pty(session, channel.rows, channel.cols)
+        _bind_notebook_session(app, registry, session, current_key)
+
+        # Confirm the id, whichever path filled the key. A new session's id
+        # is the one the spawn put on the CLI's command line; a resume's is
+        # either a warm PTY (the session itself) or an id whose transcript
+        # was on disk a moment ago — the boundary above refused everything
+        # else. There is nothing to wait for and nothing to race.
+        await channel.send_json({"type": "session_info", "session_id": current_key})
+
+        # Start output forwarding. A ``--resume`` child spawned for this
+        # handler is watched for the CLI's own "no such conversation" verdict.
+        output_task = asyncio.create_task(
+            _run_output_loop(session, websocket, stop_event, resume_id=result.resume_id)
+        )
+
         while True:
-            message = await websocket.receive()
+            message = await channel.receive()
+            if channel.closed.is_set():
+                break
 
             if "text" in message:
                 text = message["text"]
@@ -1309,14 +1569,12 @@ async def terminal_ws(websocket: WebSocket):
                     msg = None
 
                 if isinstance(msg, dict):
-                    msg_type = msg.get("type")
-
-                    if msg_type == "resize":
-                        logger.debug("PTY resize: %dx%d", msg["cols"], msg["rows"])
-                        session.resize(msg["rows"], msg["cols"])
+                    if channel.note_resize(msg):
+                        logger.debug("PTY resize: %dx%d", channel.cols, channel.rows)
+                        _resize_pty(session, channel.rows, channel.cols)
                         continue
 
-                    if msg_type == "switch_session":
+                    if msg.get("type") == "switch_session":
                         target_id = msg.get("session_id", "")
                         if not _UUID_RE.match(target_id):
                             await websocket.send_text(
@@ -1341,105 +1599,94 @@ async def terminal_ws(websocket: WebSocket):
                             )
                             continue
 
-                        if _transcript_missing(registry, discovery, target_id):
+                        if _transcript_missing(app, registry, discovery, target_id):
                             # Nothing to switch to; the operator stays on the
                             # session they are on. Same frame as the connect
                             # path, so the client renders one state.
                             logger.info(
-                                "Refusing to switch to %s: no live PTY and no transcript",
+                                "Refusing to switch to %s: no live PTY, no chat session "
+                                "and no transcript",
                                 target_id,
                             )
                             await websocket.send_text(_transcript_missing_frame(target_id))
                             continue
 
+                        # 1. Stop the current output loop
+                        stop_event.set()
+                        output_task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await output_task
+
+                        # 2. Detach the current session (stays alive in the pool)
+                        registry.detach_session(current_key, token)
+
+                        # 3. Take the target through the door. From here the
+                        #    handler holds nothing, so anything that stops it
+                        #    short of the target ends the connection: the
+                        #    client reconnects on its stored pointer. The
+                        #    target is the key under acquisition from now on,
+                        #    so the teardown detaches it even when a
+                        #    cancellation lands after phase (c) attached it.
+                        current_key = target_id
                         try:
-                            # 1. Stop current output loop
-                            stop_event.set()
-                            output_task.cancel()
-                            try:
-                                await output_task
-                            except asyncio.CancelledError:
-                                pass
-
-                            # 2. Detach current session (stays alive in pool)
-                            registry.detach_session(current_key)
-
-                            # 3. Build command for target — unpack base_shell_command
-                            #    (list[str]) so a pinned ["npx", "-y", "..."] prefix
-                            #    flattens into target_cmd rather than nesting.
-                            target_cmd: list[str] = [
-                                *base_shell_command,
-                                "--resume",
-                                target_id,
-                            ]
-                            if effort:
-                                target_cmd.extend(["--effort", effort])
-                            target_env = _build_extra_env(websocket, target_id)
-
-                            # 4. Get or create target session
-                            session, was_reused = registry.get_or_create_session(
-                                target_id,
-                                target_cmd,
-                                rows=initial_rows,
-                                cols=initial_cols,
-                                extra_env=target_env if target_env else None,
-                                cwd=websocket.app.state.project_cwd,
-                            )
-                            registry.attach_session(target_id)
-                            _bind_notebook_session(websocket.app, registry, session, target_id)
-
-                            # 5. Notify client
-                            await websocket.send_text(
-                                json.dumps(
-                                    {
-                                        "type": "session_switched",
-                                        "session_id": target_id,
-                                    }
-                                )
-                            )
-
-                            # 6. Start new output loop
-                            stop_event = asyncio.Event()
-                            output_task = asyncio.create_task(
-                                _run_output_loop(
-                                    session,
-                                    websocket,
-                                    stop_event,
-                                    resume_id=None if was_reused else target_id,
-                                )
-                            )
-
-                            # 7. Update tracking
-                            current_key = target_id
-
-                            logger.info(
-                                "Session switched to %s (reused=%s)",
-                                target_id,
-                                was_reused,
+                            result = await _open_surface(
+                                channel, app, target_id, interrupt=False, spawn=spawn
                             )
                         except Exception:
-                            logger.exception("Session switch failed")
-                            await websocket.send_text(
-                                json.dumps(
-                                    {
-                                        "type": "error",
-                                        "message": "Session switch failed",
-                                    }
-                                )
+                            logger.exception("Session switch to %s failed", target_id)
+                            await channel.send_json(
+                                {"type": "error", "message": "Session switch failed"}
                             )
+                            await channel.close()
+                            return
+                        if result is None or channel.closed.is_set():
+                            return
+                        session = cast("PtySession", result.session)
+                        session_key = target_id
+                        _resize_pty(session, channel.rows, channel.cols)
+                        _bind_notebook_session(app, registry, session, current_key)
+
+                        # 4. Notify the client
+                        await websocket.send_text(
+                            json.dumps(
+                                {
+                                    "type": "session_switched",
+                                    "session_id": target_id,
+                                }
+                            )
+                        )
+
+                        # 5. Start the new output loop
+                        stop_event = asyncio.Event()
+                        output_task = asyncio.create_task(
+                            _run_output_loop(
+                                session,
+                                websocket,
+                                stop_event,
+                                resume_id=result.resume_id,
+                            )
+                        )
+                        logger.info(
+                            "Session switched to %s (spawned=%s)",
+                            target_id,
+                            result.spawned,
+                        )
                         continue
 
                 # Not a recognized JSON control message — treat as terminal input
-                session.write_input(text.encode("utf-8"))
+                _write_to_pty(session, text.encode("utf-8"))
 
             elif "bytes" in message:
-                session.write_input(message["bytes"])
+                _write_to_pty(session, message["bytes"])
 
     except (WebSocketDisconnect, RuntimeError):
         pass
     finally:
+        state.closers.pop(token, None)
+        channel.release()
         stop_event.set()
-        output_task.cancel()
+        if output_task is not None:
+            output_task.cancel()
         # Detach instead of terminate — keep session alive in the pool.
         # Only terminate if the process has already died.
         #
@@ -1451,11 +1698,24 @@ async def terminal_ws(websocket: WebSocket):
         # dead, and spawn a replacement under the same key. An unguarded
         # teardown would then terminate the live replacement and clear the
         # attachment the newer handler holds, killing a terminal the operator
-        # is looking at.
-        if registry.get_session(current_key) is session:
-            registry.detach_session(current_key)
-        if not session.is_alive:
-            registry.terminate_session_if_owner(current_key, session)
+        # is looking at. The detach carries this handler's attachment token
+        # too, so the registry refuses it from its own side as well — the two
+        # checks cover the same hazard through the two things that can be
+        # compared: which session sits under the key, and who holds it.
+        #
+        # With no session under the key being acquired — the door refused,
+        # or a cancellation landed after phase (c) had already attached this
+        # token — the detach runs unconditionally; it is owner-checked and a
+        # no-op for a token that never attached. A dead PTY is terminated
+        # under the key it was held by.
+        if (
+            session is None
+            or current_key != session_key
+            or registry.get_session(current_key) is session
+        ):
+            registry.detach_session(current_key, token)
+        if session is not None and not session.is_alive:
+            registry.terminate_session_if_owner(session_key, session)
 
 
 # ── Control-target gestures: audit, vocabulary, refusals ─────────────────────

--- a/src/osprey/interfaces/web_terminal/session_handoff.py
+++ b/src/osprey/interfaces/web_terminal/session_handoff.py
@@ -1,0 +1,1615 @@
+"""Hand a session key from one surface to the other, one live process at a time.
+
+The Expert view (a PTY-hosted TUI) and the Simple view (an SDK chat) are two
+windows onto one OSPREY session. Both pools key their entries on the same
+session key ``K``, and the rule that makes them one session is that **at most
+one process is live under ``K`` at any moment**. A view flip therefore hands
+the key over: the surface that holds it lets go, its process is torn down and
+observed dead, and only then does the incoming surface resume the key's
+transcript. :func:`acquire_surface` is the one door every spawn walks through
+— the terminal websocket, the chat route and the hand-off route alike — so the
+rule is enforced in one place.
+
+**State.** Deliberately almost none. Which surface holds ``K`` is read off the
+two pools themselves (``PtyRegistry`` membership, ``ChatSessionPool``
+membership), never mirrored here, so there is no second registry to drift. The
+only state this module adds is :class:`HandoffState` on ``app.state.handoff``:
+one :class:`asyncio.Lock` per key, and one *pending acquire* per key — the
+call that has decided to take the key but has not filled it yet. A survivor of
+a failed kill is put back into its own pool unattached rather than parked in
+an orphan list, so the next acquire meets it as an ordinary holder and re-runs
+the kill.
+
+**Phases.** An acquire runs in three phases; this module lays out all three,
+and the entry point sequences them.
+
+(a) *Under the per-key lock* — :func:`_phase_a`. Inspect both pools and the
+    pending slot, discard a held entry whose process is already dead, and
+    decide what the incoming surface has to do about whatever is live. A
+    chat whose client is closed but whose child still runs — the survivor of
+    a failed kill, put back by (c) — is live in the sense that matters: it
+    is torn down and observed dead again, whichever surface is acquiring. The
+    decision is an :class:`AcquirePlan`. A key that somebody else is actively
+    consuming — an attached PTY when a chat wants it, a pending acquire from
+    another connection, a chat still starting — is a *transient* blocker: it
+    is re-inspected every :data:`ATTACH_POLL_S` seconds for up to
+    :data:`ATTACH_GRACE_S`, with the lock released between looks so the
+    holder can finish, and only then refused with 409. A same-surface Expert
+    connection meeting an attached PTY does not wait: it takes the key over,
+    and the plan names the displaced owner for a 4409 close. A Simple
+    acquire carrying ``interrupt=True`` that meets another Simple acquire's
+    pending wait does not wait for it either: it supersedes it — the waiter's
+    task is cancelled, its wait ends in :class:`HandoffSuperseded`, and the
+    next look finds the slot free — because that wait is the one the
+    operator is asking to end, whether it is their own abandoned request or
+    a second tab's. An Expert acquire never supersedes anything. The phase ends by
+    registering the call as the key's pending acquire and reserving the key in
+    the PTY pool, so the outgoing entry cannot be evicted from under the wait
+    that follows.
+
+(b) *Outside the lock* — :func:`_phase_b`. Wait for the outgoing process to
+    finish its turn. The only cancellable phase, and the only one with no
+    time bound: a turn takes as long as it takes. A chat is idle when its
+    ``is_busy`` drops; a PTY is idle when the turn-state store the TUI's hooks
+    feed says so, or — when the store has nothing newer to say — when the
+    tail of the key's current transcript does. Every :data:`IDLE_POLL_S` the
+    wait also asks the caller's channel whether it is still open and raises
+    :class:`ChannelClosed` when it is not, so a tab that navigates away
+    mid-wait does not leave a hand-off running for nobody. With
+    ``interrupt=True`` the wait is cut short: the PTY is sent Escape and
+    given :data:`INTERRUPT_GRACE_S` to show the interrupt marker or an idle
+    edge, after which it is terminated — the operator asked for exactly that.
+    The phase ends in a :class:`WaitOutcome` naming *why* the wait ended, and
+    that outcome is what (c) is handed.
+
+(c) *Under the lock again, shielded* — :func:`_phase_c`. Tear the outgoing
+    process down, confirm it is dead, spawn the incoming surface's process,
+    and release the pending slot. The whole phase runs as one task behind
+    ``asyncio.shield``: a caller cancelled in the middle of it — a socket that
+    dropped while the new child was starting — gets its cancellation only
+    once the phase has finished, so the pools are never left with a popped
+    entry and no replacement, a spawned child nobody inserted, or a pending
+    slot nobody will release. The outgoing entry is popped from its pool
+    before it is killed and the kill runs off the loop; the child is then
+    *observed* dead (:attr:`PtySession.is_alive`,
+    :attr:`OperatorSession.process_exited`) for up to :data:`DEATH_GRACE_S`.
+    A survivor is put back into its pool unattached and the acquire refused
+    with 503 — the next one meets it as an ordinary holder and kills it
+    again: a PTY survivor is still alive and so still a holder; a chat
+    survivor's client is gone but its child is not, and ``OperatorSession.stop``
+    sends SIGKILL to a retained child that has no return code yet, so the
+    second teardown signals it again before the death check re-runs. Only
+    then is the incoming process started, through the caller's
+    :data:`SpawnCallback`, told which transcript to resume by a fresh look at
+    the transcript map and the transcripts on disk. An Expert caller is
+    attached to the PTY (its channel token is the owner token) before the
+    slot is released, so the eviction pass never sees the entry unheld. The
+    phase ends in an :class:`AcquireResult`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, runtime_checkable
+
+from osprey.interfaces.web_terminal import transcript_map
+from osprey.interfaces.web_terminal.chat_session_pool import ChatCapacityError
+from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from osprey.interfaces.web_terminal.turn_state import IDLE, get_turn_state, reset_turn_state
+from osprey.mcp_server.workspace.transcript_reader import TranscriptReader, tail_state
+
+if TYPE_CHECKING:
+    from osprey.interfaces.web_terminal.chat_session_pool import ChatSessionPool
+    from osprey.interfaces.web_terminal.operator_session import OperatorSession
+    from osprey.interfaces.web_terminal.pty_manager import PtyRegistry, PtySession
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+Surface = Literal["expert", "simple"]
+"""Which view is acquiring: the PTY-hosted TUI or the SDK chat."""
+
+SURFACE_EXPERT: Surface = "expert"
+SURFACE_SIMPLE: Surface = "simple"
+
+AcquireAction = Literal["spawn", "reuse", "takeover", "handoff"]
+"""What phase (c) has to do once phase (b) has let the outgoing entry go idle.
+
+``spawn``
+    Nothing live holds the key. Spawn the incoming surface's process.
+``reuse``
+    The incoming surface already holds the key and nobody else is reading it.
+    No teardown: an Expert reattaches to the pooled PTY, a chat proceeds to
+    the pooled session (or joins the creation still in flight).
+``takeover``
+    An Expert connection met a PTY another Expert connection is attached to.
+    The older owner is closed with 4409 and the newcomer attaches to the same
+    PTY. No teardown.
+``handoff``
+    The key is held by a process the incoming surface cannot use: the other
+    surface's entry, or a chat survivor whose client is already closed. It
+    is torn down once idle and the incoming surface resumes the transcript.
+"""
+
+ACTION_SPAWN: AcquireAction = "spawn"
+ACTION_REUSE: AcquireAction = "reuse"
+ACTION_TAKEOVER: AcquireAction = "takeover"
+ACTION_HANDOFF: AcquireAction = "handoff"
+
+#: How long phase (a) keeps re-inspecting a key somebody else is consuming
+#: before it gives up with 409. Long enough for a tab that closed its socket a
+#: moment ago to be seen detaching; short enough that a key held for real is
+#: refused before the operator wonders what the view is doing.
+ATTACH_GRACE_S = 2.0
+#: How often phase (a) re-inspects during that grace.
+ATTACH_POLL_S = 0.05
+
+#: How often phase (b) looks at the outgoing entry — and, on the same tick, at
+#: the caller's channel. The channel look is what bounds how long a hand-off
+#: can run for a caller that has already gone; it must stay within 0.2 s.
+IDLE_POLL_S = 0.1
+#: How long an interrupted PTY is given to show the interrupt marker or an
+#: idle edge after Escape before phase (b) terminates it outright.
+INTERRUPT_GRACE_S = 5.0
+#: The keystroke that interrupts a running turn in the TUI.
+_INTERRUPT_KEY = b"\x1b"
+
+#: How long phase (c) keeps looking for the outgoing child to be gone after
+#: its kill has returned. ``PtySession.terminate`` has already waited through
+#: its own signal escalation by then and a chat teardown through the SDK's;
+#: this covers the moment between the kill landing and the exit being
+#: collected. A child still alive at the end is a survivor, not a slow one.
+DEATH_GRACE_S = 2.0
+#: How often phase (c) looks during that grace.
+DEATH_POLL_S = 0.05
+
+IdleReason = Literal["none", "idle", "interrupted", "forced", "exited"]
+"""Why phase (b) stopped waiting; see :class:`WaitOutcome`."""
+
+REASON_NONE: IdleReason = "none"
+REASON_IDLE: IdleReason = "idle"
+REASON_INTERRUPTED: IdleReason = "interrupted"
+REASON_FORCED: IdleReason = "forced"
+REASON_EXITED: IdleReason = "exited"
+
+ERROR_SESSION_ATTACHED_ELSEWHERE = "session_attached_elsewhere"
+ERROR_OUTGOING_STILL_RUNNING = "outgoing_still_running"
+ERROR_CHAT_CAPACITY = "chat_capacity"
+ERROR_HANDOFF_NEEDS_INTERRUPT = "handoff_needs_interrupt"
+ERROR_HANDOFF_SUPERSEDED = "handoff_superseded"
+ERROR_OUTGOING_VANISHED = "outgoing_vanished"
+ERROR_SPAWN_NOT_POOLED = "spawn_not_pooled"
+
+#: Websocket close codes for the refusals a terminal socket can meet. The
+#: browser side treats both as terminal (no reconnect); see ``api.js``.
+WS_CLOSE_SESSION_ATTACHED = 4409
+WS_CLOSE_OUTGOING_RUNNING = 4503
+
+_WS_CLOSE_BY_STATUS: dict[int, int] = {
+    409: WS_CLOSE_SESSION_ATTACHED,
+    503: WS_CLOSE_OUTGOING_RUNNING,
+}
+
+
+class HandoffRefused(Exception):
+    """An acquire that must not proceed, with the status each channel reports.
+
+    Routes send ``status`` with a body of ``{"detail": {"error": <error>}}``;
+    the terminal websocket closes with :attr:`ws_close_code`. Every refusal
+    is a classmethod, so a caller never assembles a status/slug pair by hand.
+    """
+
+    def __init__(self, status: int, error: str, message: str | None = None) -> None:
+        super().__init__(message or error)
+        self.status = status
+        self.error = error
+
+    @property
+    def ws_close_code(self) -> int | None:
+        """The websocket close code for this refusal, or ``None`` when the
+        refusal has no websocket form (429 is only ever answered to a POST)."""
+        return _WS_CLOSE_BY_STATUS.get(self.status)
+
+    @classmethod
+    def attached_elsewhere(cls, key: str) -> HandoffRefused:
+        """409 — another connection or view is consuming *key* right now."""
+        return cls(
+            409,
+            ERROR_SESSION_ATTACHED_ELSEWHERE,
+            f"session {key!r} is attached to another connection or view",
+        )
+
+    @classmethod
+    def outgoing_still_running(cls, key: str) -> HandoffRefused:
+        """503 — the outgoing process survived its kill; retry re-runs it."""
+        return cls(
+            503,
+            ERROR_OUTGOING_STILL_RUNNING,
+            f"the previous agent for session {key!r} is still shutting down",
+        )
+
+    @classmethod
+    def chat_capacity(cls, key: str) -> HandoffRefused:
+        """429 — the chat pool is full and every chat is busy."""
+        return cls(
+            429,
+            ERROR_CHAT_CAPACITY,
+            f"no chat capacity to resume session {key!r}",
+        )
+
+    @classmethod
+    def needs_interrupt(cls, key: str) -> HandoffNeedsInterrupt:
+        """409 — a PTY holds *key* and nothing can tell when its turn ends.
+
+        See :class:`HandoffNeedsInterrupt`.
+        """
+        return HandoffNeedsInterrupt(key)
+
+    @classmethod
+    def superseded(cls, key: str) -> HandoffSuperseded:
+        """409 — a newer Simple acquire with an interrupt took *key* over.
+
+        See :class:`HandoffSuperseded`.
+        """
+        return HandoffSuperseded(key)
+
+
+class HandoffNeedsInterrupt(HandoffRefused):
+    """The key is held by a PTY whose turns are invisible; only an interrupt can take it.
+
+    Phase (b) cannot wait for a PTY to go idle without the turn-state hook
+    installed in the TUI (``app.state.turn_hook_present``): the transcript
+    tail alone cannot tell an answered prompt from one still being worked on.
+    So a Simple view acquiring such a key is refused with this, and offers the
+    operator *Stop and switch now* — the same acquire again with
+    ``interrupt=True``, which phase (b) does honour without the hook.
+
+    Only ever answered to a POST: an Expert acquire never waits on a PTY, so
+    the refusal has no websocket form.
+    """
+
+    def __init__(self, key: str) -> None:
+        super().__init__(
+            409,
+            ERROR_HANDOFF_NEEDS_INTERRUPT,
+            f"session {key!r} is held by a terminal whose turn state is not reported",
+        )
+
+    @property
+    def ws_close_code(self) -> int | None:
+        return None
+
+
+class HandoffSuperseded(HandoffRefused):
+    """The wait was ended by a newer Simple acquire of the same key carrying an interrupt.
+
+    The Simple view's *Stop and switch now* is a second request for the key
+    while its first still waits in phase (b) — the browser abandons the first
+    but the server cannot rely on seeing that, and a second tab has no
+    request to abandon at all. Phase (a) therefore lets a Simple acquire with
+    ``interrupt=True`` supersede a pending Simple acquire: the waiter's task
+    is cancelled, its pending slot released, and its wait ends in this
+    refusal, so the route it was made from answers 409 like any other. An
+    abandoned request's answer is discarded by the client that abandoned it;
+    a second tab's shows the operator what happened.
+
+    Only ever answered to a POST: an Expert acquire neither supersedes nor is
+    superseded, so the refusal has no websocket form.
+    """
+
+    def __init__(self, key: str) -> None:
+        super().__init__(
+            409,
+            ERROR_HANDOFF_SUPERSEDED,
+            f"another request took over session {key!r}",
+        )
+
+    @property
+    def ws_close_code(self) -> int | None:
+        return None
+
+
+class HandoffError(Exception):
+    """A hand-off that cannot be carried out because its premise no longer holds.
+
+    Unlike :class:`HandoffRefused` this is not a state the caller can expect
+    and retry against: the outgoing entry phase (a) built the plan around has
+    been replaced in its pool by something other than this hand-off while
+    phase (b) waited on it, or the caller's spawn callback returned a session
+    its pool does not hold under the key. The pending slot and the
+    reservation are released before this reaches the caller.
+    """
+
+    def __init__(self, error: str, message: str) -> None:
+        super().__init__(message)
+        self.error = error
+
+    @classmethod
+    def vanished(cls, key: str, surface: Surface) -> HandoffError:
+        return cls(
+            ERROR_OUTGOING_VANISHED,
+            f"the {surface} entry for session {key!r} left its pool during the hand-off",
+        )
+
+    @classmethod
+    def not_pooled(cls, key: str, surface: Surface) -> HandoffError:
+        return cls(
+            ERROR_SPAWN_NOT_POOLED,
+            f"the {surface} spawn for session {key!r} returned a session its pool does not hold",
+        )
+
+
+class ChannelClosed(asyncio.CancelledError):
+    """The caller's channel closed while phase (b) waited.
+
+    A cancellation like any other — ``except asyncio.CancelledError`` catches
+    it, and the wait releases the pending slot on the way out exactly as it
+    does for a ``task.cancel()`` — but distinguishable, so a route that wants
+    to log *why* its acquire ended can. It is raised from inside the coroutine
+    rather than delivered by ``task.cancel()``, so an acquire must not run
+    under ``asyncio.timeout``, ``wait_for`` or a ``TaskGroup``: their uncancel
+    accounting turns it into a ``TimeoutError`` or drops it silently. Callers
+    catch :class:`ChannelClosed` directly. The reverse hazard exists too: an
+    external ``task.cancel()`` that lands while the wait is suspended inside
+    the channel probe's own cancel scope (Starlette's ``is_disconnected``)
+    can be absorbed by that scope and never thrown — which is why a supersede
+    does not depend on its cancellation but on the mark it leaves on the
+    pending record (see :func:`_raise_if_superseded`).
+    """
+
+
+# ---------------------------------------------------------------------------
+# The caller's channel
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AcquireChannel(Protocol):
+    """What phase (b) asks of the channel token: is the caller still there?
+
+    A channel is any object passed as the ``channel`` argument of
+    :func:`acquire_surface`; it is compared by identity for the pending slot.
+    One that also implements ``is_closed`` is asked, every :data:`IDLE_POLL_S`
+    during the wait, whether the caller has gone away. The answer may be a
+    bool or an awaitable of one — a websocket handler answers from an event
+    its receive loop sets on ``websocket.disconnect``; a POST route answers
+    with ``request.is_disconnected()``. A token without ``is_closed`` never
+    closes.
+    """
+
+    def is_closed(self) -> bool | Awaitable[bool]: ...
+
+
+class ChannelToken:
+    """A channel token with an injectable closed probe.
+
+    The identity phase (a) registers and the probe phase (b) polls, in one
+    object, so a caller need not define its own class::
+
+        ChannelToken(request.is_disconnected)   # POST: awaitable probe
+        ChannelToken(closed_event.is_set)        # websocket: sync probe
+        ChannelToken()                           # never closes
+    """
+
+    def __init__(self, is_closed: Callable[[], bool | Awaitable[bool]] | None = None) -> None:
+        self._probe = is_closed
+
+    def is_closed(self) -> bool | Awaitable[bool]:
+        if self._probe is None:
+            return False
+        return self._probe()
+
+
+async def channel_closed(channel: object) -> bool:
+    """Whether *channel* reports itself closed; False for a token without a probe."""
+    probe = getattr(channel, "is_closed", None)
+    if probe is None:
+        return False
+    answer = probe()
+    if inspect.isawaitable(answer):
+        answer = await answer
+    return bool(answer)
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PendingAcquire:
+    """The one call per key that has decided to take the key and not yet filled it.
+
+    Registered at the end of phase (a), released at the end of phase (c) — or
+    by phase (b) itself when its wait is cancelled, so (c) never runs. Callers
+    never release the slot; the phases own it. While it stands, any other
+    connection's acquire of the same key sees a holder.
+
+    Attributes:
+        channel: The token identifying the connection that made the call —
+            the terminal socket's attach token or a per-request object for a
+            POST. Compared by identity; the same channel re-acquiring replaces
+            its own slot rather than blocking on it.
+        surface: Which surface the call is acquiring for.
+        task: The task running the acquire, so a diagnostic or a shutdown can
+            see what is in flight — and so a superseding acquire can cancel
+            it. ``None`` outside a task.
+        superseded: A newer Simple acquire with an interrupt has cancelled
+            this call's wait. Set before the cancel is delivered, so the
+            waiter can tell it from any other cancellation and end in
+            :class:`HandoffSuperseded`; also what stops a second look from
+            cancelling the same task twice.
+        waiting: The call is still in phase (b), where a cancellation ends a
+            wait and nothing else. Cleared by phase (c) before its shielded
+            task exists, so a supersede never reaches a call that is already
+            carrying the key out: that call is left to finish and answer, and
+            the superseder's next look meets what it pooled.
+    """
+
+    channel: object
+    surface: Surface
+    task: asyncio.Task[Any] | None = None
+    superseded: bool = False
+    waiting: bool = True
+
+
+@dataclass
+class HandoffState:
+    """Everything this module keeps beyond the pools themselves.
+
+    Lives on ``app.state.handoff``; :func:`get_state` builds it lazily so an
+    app assembled without it (tests) still works.
+
+    Attributes:
+        locks: One lock per session key, created on first use and kept for the
+            life of the process. A lock is never removed: a caller that has
+            already looked its lock up and is waiting on it would otherwise be
+            left holding an object nobody else can see, and two acquires of
+            the same key would stop excluding each other. The table is bounded
+            by the number of distinct keys the process has ever seen.
+        pending: The pending acquire per key, if any. See :class:`PendingAcquire`.
+        closers: How to close an attached terminal socket, by its attach
+            token. The terminal handler registers its close coroutine here
+            when it attaches and removes it when it detaches; phase (c) looks
+            a plan's ``displaced_owner`` up here to send the 4409. Absent
+            entries are tolerated — a socket that has already gone away has
+            nothing to close.
+        clock: The monotonic clock the attach grace is measured on.
+        sleep: How phase (a) waits between re-inspections. Both are
+            injectable so the grace can be exercised without spending it.
+    """
+
+    locks: dict[str, asyncio.Lock] = field(default_factory=dict)
+    pending: dict[str, PendingAcquire] = field(default_factory=dict)
+    closers: dict[object, Callable[[], Awaitable[None]]] = field(default_factory=dict)
+    clock: Callable[[], float] = time.monotonic
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep
+
+    def lock_for(self, key: str) -> asyncio.Lock:
+        """The lock serialising every acquire of *key*."""
+        lock = self.locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self.locks[key] = lock
+        return lock
+
+
+def get_state(app: Any) -> HandoffState:
+    """The :class:`HandoffState` on *app*, created on first use."""
+    state = getattr(app.state, "handoff", None)
+    if state is None:
+        state = HandoffState()
+        app.state.handoff = state
+    return state
+
+
+def _pty_registry(app: Any) -> PtyRegistry:
+    registry: PtyRegistry = app.state.pty_registry
+    return registry
+
+
+def _chat_pool(app: Any) -> ChatSessionPool:
+    pool: ChatSessionPool = app.state.operator_registry.chats
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# The contract between the phases
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OutgoingEntry:
+    """The live entry phase (a) found under the key, and which pool it is in."""
+
+    surface: Surface
+    session: PtySession | OperatorSession
+
+
+@dataclass(frozen=True)
+class SpawnRequest:
+    """What phase (c) hands the caller's spawn callback.
+
+    Attributes:
+        key: The session key the new process runs under — its pool key, its
+            ``OSPREY_SESSION_ID``, and its own session id when nothing is
+            resumed.
+        surface: Which surface's process to start.
+        resume_id: The transcript the process continues, or ``None`` when the
+            key has no transcript on disk yet — the process then starts a
+            conversation of its own under *key* (``claude --session-id K``,
+            SDK ``session_id=K``). Chosen at spawn time from the transcript
+            map and the transcripts on disk, so a transcript that moved while
+            the other surface held the key is what the new process opens.
+        transcript_id: The key's current transcript per the map (*key* itself
+            when it never moved), whether or not it is on disk.
+    """
+
+    key: str
+    surface: Surface
+    resume_id: str | None
+    transcript_id: str
+
+
+SpawnCallback = Callable[[SpawnRequest], Awaitable["PtySession | OperatorSession"]]
+"""How the incoming surface starts its process; see :func:`acquire_surface`.
+
+Called by phase (c), inside its shielded task and under the key's lock, once
+the key holds nothing of the other surface. It must start the process *and*
+put it in its pool under ``request.key`` — the terminal handler through
+``PtyRegistry.get_or_create_session`` with the resume argument built from
+``request.resume_id``, the chat route through
+``OperatorRegistry.get_or_create_chat_session(key, cwd, env,
+resume_id=request.resume_id)`` — and return the pooled session. A chat pool
+at capacity may raise ``ChatCapacityError``; phase (c) turns it into the 429
+refusal. Any other exception escapes :func:`acquire_surface` unchanged after
+the pending slot has been released.
+"""
+
+
+@dataclass(frozen=True)
+class AcquirePlan:
+    """What phase (a) decided; the input to phases (b) and (c).
+
+    Attributes:
+        key: The session key being acquired.
+        surface: The surface acquiring it.
+        channel: The caller's channel token, as registered in the pending slot.
+        interrupt: The caller asked for the outgoing turn to be aborted rather
+            than awaited. Carried through for phase (b).
+        action: See :data:`AcquireAction`.
+        outgoing: The live entry the plan is about, or ``None`` when nothing
+            live holds the key (``spawn``), or when a chat creation is still
+            in flight and the incoming chat will join it (``reuse`` for the
+            Simple surface only).
+        teardown: Phase (c) must tear ``outgoing`` down before spawning. True
+            exactly for ``handoff``.
+        wait_for_idle: Phase (b) must wait for ``outgoing`` to finish its
+            turn. True for every ``handoff`` and for a chat reusing a chat —
+            the chat route cannot take a turn on a busy session, so the
+            hand-off is what tells the Simple view when the session is free.
+            False for an Expert reattaching or taking over: a TUI keeps
+            running and the newcomer simply sees its output.
+        displaced_owner: On ``takeover``, the attach token of the Expert
+            connection currently holding the PTY, to be closed with 4409 by
+            phase (c). ``None`` otherwise.
+        spawn: The caller's :data:`SpawnCallback`, carried through for phase
+            (c). ``None`` when the caller has nothing to start — legal only
+            for a plan whose incoming surface's entry is already pooled.
+    """
+
+    key: str
+    surface: Surface
+    channel: object
+    interrupt: bool
+    action: AcquireAction
+    outgoing: OutgoingEntry | None
+    teardown: bool
+    wait_for_idle: bool
+    displaced_owner: object | None = None
+    spawn: SpawnCallback | None = None
+
+
+@dataclass(frozen=True)
+class WaitOutcome:
+    """How phase (b) ended; the second input to phase (c).
+
+    Attributes:
+        reason: Why the wait stopped.
+
+            ``none``
+                There was nothing to wait on: the plan has no outgoing entry,
+                or does not ask for idleness (an Expert reattaching to or
+                taking over a running TUI).
+            ``idle``
+                The outgoing entry was observed idle — a chat's ``is_busy``
+                False, a PTY's turn-state store or transcript tail at rest.
+            ``interrupted``
+                The caller asked for the turn to be aborted. For a PTY, Escape
+                was written and the interrupt marker or an idle edge was seen
+                within :data:`INTERRUPT_GRACE_S`; the turn is over. For a
+                chat, no wait was made and the turn may still be running:
+                ``interrupted`` obliges phase (c) to cancel it — through
+                ``pool.terminate(key)`` when ``plan.teardown`` is True, and
+                through ``await session.cancel()`` on the ``OperatorSession``
+                when the plan is ``reuse`` (``cancel`` interrupts the client
+                and quiesces the reader; ``interrupt`` alone does neither).
+            ``forced``
+                The caller asked for an interrupt and the PTY did not go idle
+                within the grace, so phase (b) has already called its
+                ``terminate`` (off the loop). The entry is still in its pool
+                and ``terminate`` is idempotent, so phase (c) runs its
+                ordinary teardown and death check; it must not expect the
+                child to be gone yet.
+            ``exited``
+                The outgoing process died on its own while still pooled. There
+                is no turn left to wait for; phase (c) discards the corpse.
+    """
+
+    reason: IdleReason
+
+
+@dataclass(frozen=True)
+class AcquireResult:
+    """What :func:`acquire_surface` returns: the key is the caller's.
+
+    Attributes:
+        plan: What phase (a) decided.
+        outcome: How phase (b)'s wait ended.
+        session: The incoming surface's live entry under the key — the
+            ``PtySession`` an Expert caller is now attached to (its channel
+            token is the owner token; it detaches with the same token when it
+            is done), or the ``OperatorSession`` a Simple caller takes its
+            turn on (through ``acquire_turn``, which is where a concurrent
+            turn is still refused).
+        spawned: The spawn callback ran for this acquire. False when the
+            caller was handed the surface's already-pooled entry without a
+            call. True also when the callback joined a chat creation already
+            in flight (the Simple ``reuse`` with no outgoing entry): the
+            callback ran, whether or not it started the process itself.
+        resume_id: What the spawn was asked to resume, ``None`` for a fresh
+            start under the key — and ``None`` whenever nothing was spawned.
+            The terminal handler watches a spawned ``--resume`` child for the
+            CLI's own "no conversation" verdict; this is the id to watch for.
+    """
+
+    plan: AcquirePlan
+    outcome: WaitOutcome
+    session: PtySession | OperatorSession
+    spawned: bool
+    resume_id: str | None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def acquire_surface(
+    app: Any,
+    key: str,
+    surface: Surface,
+    channel: object,
+    *,
+    interrupt: bool = False,
+    spawn: SpawnCallback | None = None,
+) -> AcquireResult:
+    """Take session key *key* for *surface* on behalf of *channel*.
+
+    Runs the three phases and returns once the incoming surface's process is
+    live under the key: for an Expert caller, attached to the returned
+    ``PtySession`` with *channel* as the owner token; for a Simple caller,
+    with the returned ``OperatorSession`` pooled and free of any other
+    surface. The caller never releases the pending slot: the phases own it.
+
+    Raises :class:`HandoffRefused` when the key cannot be taken — 409 when
+    another connection or view is consuming it (or, as
+    :class:`HandoffNeedsInterrupt`, when a hook-less PTY holds it and no
+    interrupt was asked for; or, as :class:`HandoffSuperseded`, when a newer
+    Simple acquire with an interrupt ended this call's wait), 503 when the
+    outgoing process survived its kill, 429 when the chat pool is full; the
+    caller maps ``.status`` and
+    ``.error`` to its channel (HTTP status with a ``detail.error`` body, or
+    ``.ws_close_code``). Raises :class:`ChannelClosed` (a cancellation) when
+    *channel* reports itself closed during the wait: the caller sends
+    nothing and returns. Raises :class:`HandoffError` when the outgoing
+    entry was replaced in its pool mid-wait or the spawn callback returned a
+    session its pool does not hold; the route answers 5xx with its
+    ``.error``. Anything else *spawn* raises escapes unchanged. Because
+    :class:`ChannelClosed` is raised from inside the coroutine, do not run
+    this call under ``asyncio.timeout``, ``wait_for`` or a ``TaskGroup``;
+    catch it directly.
+
+    A cancellation delivered while phase (c) runs is honoured only once the
+    phase has finished; the outgoing process is torn down and the incoming
+    one started, pooled and (Expert) attached regardless. An Expert caller
+    therefore detaches its token in its own cleanup whether or not this call
+    returned — ``detach_session`` is owner-checked and a no-op for a token
+    that never attached.
+
+    Args:
+        app: The application; its ``state`` carries the two pools and the
+            :class:`HandoffState`.
+        key: The session key.
+        surface: ``"expert"`` or ``"simple"``.
+        channel: A token identifying the calling connection, compared by
+            identity. The terminal handler passes its attach token. A token
+            implementing :class:`AcquireChannel` is polled for closure during
+            the wait; see :class:`ChannelToken`.
+        interrupt: Abort the outgoing turn instead of waiting for it.
+        spawn: How the incoming surface starts its process; see
+            :data:`SpawnCallback`. Called only when the key holds no live
+            entry of the incoming surface, so a Simple caller that is merely
+            taking its next turn on its own pooled chat is handed that chat
+            back without a spawn. Omitted, the call can only hand back an
+            entry that is already pooled.
+    """
+    plan = await _phase_a(app, key, surface, channel, interrupt=interrupt, spawn=spawn)
+    outcome = await _phase_b(app, plan)
+    return await _phase_c(app, plan, outcome)
+
+
+def release_pending(app: Any, key: str, channel: object) -> bool:
+    """Drop *channel*'s pending acquire of *key* and the reservation that came with it.
+
+    Owner-checked: a slot held by another channel is left alone, so a caller
+    cleaning up after its own cancelled wait cannot release the acquire that
+    took the key after it. Safe to call when nothing is pending. The phases
+    call it themselves; a caller of :func:`acquire_surface` never has to.
+
+    Returns:
+        True when a slot was released.
+    """
+    state = get_state(app)
+    pending = state.pending.get(key)
+    if pending is None or pending.channel is not channel:
+        return False
+    del state.pending[key]
+    _pty_registry(app).unreserve(key)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Phase (a): inspect, decide, register — under the per-key lock
+# ---------------------------------------------------------------------------
+
+
+class _Blocked(Exception):
+    """Internal: the key is held in a way that may clear within the grace."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+async def _phase_a(
+    app: Any,
+    key: str,
+    surface: Surface,
+    channel: object,
+    *,
+    interrupt: bool,
+    spawn: SpawnCallback | None = None,
+) -> AcquirePlan:
+    """Decide what acquiring *key* for *surface* means right now.
+
+    Each look at the key — inspection, discard of dead entries, decision and
+    registration — happens inside one hold of the key's lock, so two acquires
+    of the same key can never both conclude the key is free. A transient
+    blocker releases the lock, sleeps :data:`ATTACH_POLL_S`, and looks again,
+    until :data:`ATTACH_GRACE_S` has elapsed since the *first* blocked look;
+    time spent waiting for the lock itself is not charged to the grace. The
+    lock is released between looks precisely so the holder (whose own phase
+    (c) needs this lock to release its pending slot) can finish.
+    """
+    state = get_state(app)
+    lock = state.lock_for(key)
+    deadline: float | None = None
+    while True:
+        async with lock:
+            try:
+                return await _inspect_and_register(
+                    app, state, key, surface, channel, interrupt=interrupt, spawn=spawn
+                )
+            except _Blocked as blocked:
+                reason = blocked.reason
+        now = state.clock()
+        if deadline is None:
+            deadline = now + ATTACH_GRACE_S
+        if now >= deadline:
+            logger.info(
+                "Refusing %s acquire of session %s: %s after %.1fs",
+                surface,
+                key,
+                reason,
+                ATTACH_GRACE_S,
+            )
+            raise HandoffRefused.attached_elsewhere(key)
+        await state.sleep(min(ATTACH_POLL_S, deadline - now))
+
+
+async def _inspect_and_register(
+    app: Any,
+    state: HandoffState,
+    key: str,
+    surface: Surface,
+    channel: object,
+    *,
+    interrupt: bool,
+    spawn: SpawnCallback | None = None,
+) -> AcquirePlan:
+    """One look at the key. Caller holds the key's lock.
+
+    Raises :class:`_Blocked` for a holder that may clear within the grace.
+    Returns the plan otherwise, having registered the pending acquire and
+    reserved the key.
+    """
+    registry = _pty_registry(app)
+    pool = _chat_pool(app)
+
+    pending = state.pending.get(key)
+    if pending is not None and pending.channel is not channel:
+        if _supersedes(pending, surface, interrupt=interrupt):
+            _supersede(key, pending)
+            # Blocked for this look only: the cancelled waiter releases the
+            # slot as soon as it runs, and the next look finds the key free.
+            raise _Blocked("a simple acquire from another connection is being superseded")
+        raise _Blocked(f"a {pending.surface} acquire from another connection is pending")
+
+    pty = registry.get_session(key)
+    if pty is not None and not pty.is_alive:
+        # A corpse holds nothing. Pop it on the loop, reap it off the loop —
+        # ``terminate`` on a dead child only closes the fd and collects the
+        # exit status, but it is still the blocking half.
+        registry.pop_session(key)
+        await asyncio.to_thread(pty.terminate)
+        logger.info("Discarded dead PTY under session %s", key)
+        pty = None
+
+    chat = pool.get(key)
+    survivor = chat is not None and _chat_survivor(chat)
+    if chat is not None and not chat.is_active and not survivor:
+        await pool.terminate(key)
+        logger.info("Discarded dead chat session under session %s", key)
+        chat = None
+    chat_starting = chat is None and pool.has_key(key)
+
+    if pty is not None and registry.is_attached(key):
+        if surface != SURFACE_EXPERT:
+            raise _Blocked("the PTY is attached to a terminal connection")
+        # Same surface, live PTY, somebody reading it: the newer connection
+        # wins. The older one is closed with 4409 by phase (c); the PTY is
+        # never torn down for this.
+        plan = AcquirePlan(
+            key=key,
+            surface=surface,
+            channel=channel,
+            interrupt=interrupt,
+            action=ACTION_TAKEOVER,
+            outgoing=OutgoingEntry(SURFACE_EXPERT, pty),
+            teardown=False,
+            wait_for_idle=False,
+            displaced_owner=registry.attached_owner(key),
+            spawn=spawn,
+        )
+        return _register(state, registry, plan)
+
+    if chat_starting:
+        if surface != SURFACE_SIMPLE:
+            raise _Blocked("a chat session is still starting")
+        # The chat route's get_or_create joins the in-flight creation; there
+        # is no session object to wait on yet and nothing to tear down.
+        plan = AcquirePlan(
+            key=key,
+            surface=surface,
+            channel=channel,
+            interrupt=interrupt,
+            action=ACTION_REUSE,
+            outgoing=None,
+            teardown=False,
+            wait_for_idle=False,
+            spawn=spawn,
+        )
+        return _register(state, registry, plan)
+
+    if pty is not None and chat is not None:
+        # Both pools hold a live process under one key — the invariant this
+        # module exists to keep. It cannot arise through this door; it can
+        # through an older spawn path that has not been routed here. The
+        # other surface's entry is the one handed off; the incoming surface's
+        # own entry is what its pool reuses afterwards.
+        logger.warning(
+            "Session %s is live in both pools; handing off the %s entry",
+            key,
+            SURFACE_SIMPLE if surface == SURFACE_EXPERT else SURFACE_EXPERT,
+        )
+
+    outgoing: OutgoingEntry | None = None
+    if surface == SURFACE_EXPERT:
+        if chat is not None:
+            outgoing = OutgoingEntry(SURFACE_SIMPLE, chat)
+        elif pty is not None:
+            outgoing = OutgoingEntry(SURFACE_EXPERT, pty)
+    else:
+        if pty is not None:
+            outgoing = OutgoingEntry(SURFACE_EXPERT, pty)
+        elif chat is not None:
+            outgoing = OutgoingEntry(SURFACE_SIMPLE, chat)
+
+    if outgoing is None:
+        action: AcquireAction = ACTION_SPAWN
+        teardown = False
+        wait_for_idle = False
+    elif outgoing.surface == surface and not survivor:
+        action = ACTION_REUSE
+        teardown = False
+        wait_for_idle = surface == SURFACE_SIMPLE
+    else:
+        # The other surface's entry — or a chat survivor, which no surface
+        # can use: its client is closed, only its child remains to be killed.
+        action = ACTION_HANDOFF
+        teardown = True
+        wait_for_idle = True
+
+    plan = AcquirePlan(
+        key=key,
+        surface=surface,
+        channel=channel,
+        interrupt=interrupt,
+        action=action,
+        outgoing=outgoing,
+        teardown=teardown,
+        wait_for_idle=wait_for_idle,
+        spawn=spawn,
+    )
+    return _register(state, registry, plan)
+
+
+def _chat_survivor(chat: OperatorSession) -> bool:
+    """A chat whose client is closed while its child still runs.
+
+    What phase (c) puts back after a teardown whose death check failed. It
+    is not dead — ``process_exited`` is False, not True or None — and not
+    usable either, so phase (a) hands it off for another teardown instead of
+    discarding it as a corpse or reusing it as a chat.
+    """
+    return not chat.is_active and chat.process_exited is False
+
+
+def _register(state: HandoffState, registry: PtyRegistry, plan: AcquirePlan) -> AcquirePlan:
+    """Record the call as the key's pending acquire and reserve the key.
+
+    Caller holds the key's lock. The reservation keeps the outgoing PTY — now
+    attached to nobody — off the eviction pass for as long as the slot
+    stands; :func:`release_pending` drops both together.
+    """
+    state.pending[plan.key] = PendingAcquire(
+        channel=plan.channel,
+        surface=plan.surface,
+        task=asyncio.current_task(),
+    )
+    registry.reserve(plan.key)
+    return plan
+
+
+def _supersedes(pending: PendingAcquire, surface: Surface, *, interrupt: bool) -> bool:
+    """Whether an acquire for *surface* may end *pending*'s wait instead of waiting on it.
+
+    Only a Simple acquire that asks for an interrupt, meeting a Simple call
+    that is still waiting in phase (b), has a task to cancel and has not been
+    superseded already. A call already in phase (c) is carrying the key out
+    and is left alone: it answers its caller, and the superseder's next look
+    meets the chat it pooled. An Expert acquire never supersedes: its
+    handshake carries no interrupt, and a terminal that wants a key a chat is
+    waiting for is the ordinary blocked case. A pending Expert wait is never
+    superseded either — the interrupt is a gesture at the Simple view's own
+    wait, not at the other view's.
+    """
+    return (
+        interrupt
+        and surface == SURFACE_SIMPLE
+        and pending.surface == SURFACE_SIMPLE
+        and pending.waiting
+        and pending.task is not None
+        and not pending.superseded
+    )
+
+
+def _supersede(key: str, pending: PendingAcquire) -> None:
+    """Cancel *pending*'s wait, marking it so the waiter ends in :class:`HandoffSuperseded`.
+
+    Caller holds the key's lock. The mark lands before the cancel so the
+    waiter, which reads it under no lock, cannot see the cancellation first;
+    the slot itself is released by the waiter's phase (b) on its way out,
+    never here, so the "slot held ⇔ key reserved" invariant is kept by the
+    one owner it has.
+    """
+    assert pending.task is not None
+    pending.superseded = True
+    pending.task.cancel()
+    logger.info("Superseding the pending simple acquire of session %s on an interrupt", key)
+
+
+# ---------------------------------------------------------------------------
+# Phase (b): wait for the outgoing turn to end — outside the lock
+# ---------------------------------------------------------------------------
+
+
+async def _phase_b(app: Any, plan: AcquirePlan) -> WaitOutcome:
+    """Wait until ``plan.outgoing`` is idle, when ``plan.wait_for_idle`` says to.
+
+    The only phase a caller may cancel, and the owner of the pending slot for
+    as long as it runs. Every exit that does not reach phase (c) — a
+    ``task.cancel()``, the caller's channel closing, a refusal, the outgoing
+    entry vanishing — releases the slot and the reservation here, so the key
+    is free for the next acquire and a caller never has to know which of
+    those ended its wait. The wait itself is :func:`_wait_for_idle`.
+
+    One cancellation is not passed on as one: a wait that a newer Simple
+    acquire superseded (see :func:`_supersede`) ends in
+    :class:`HandoffSuperseded` instead, so the route that made it answers a
+    refusal rather than dying cancelled. The mark is read off this call's own
+    pending record before the record is released — a record another channel
+    holds by then says nothing about this wait. The task's cancellation
+    request is withdrawn with ``uncancel`` — safe because an acquire never
+    runs under ``asyncio.timeout``, ``wait_for`` or a ``TaskGroup``, whose
+    accounting the withdrawal would otherwise confuse — unless a further
+    cancellation is outstanding, in which case that one is honoured as
+    usual. A :class:`ChannelClosed` itself is never converted. The
+    cancellation is only the prompt form of the supersede: the wait reads
+    the mark at the start of every look and again before it returns, and
+    ends itself from it (:func:`_raise_if_superseded`), because a cancel
+    landing inside the channel probe's anyio scope can be absorbed there —
+    so a marked call is answered the refusal from the look that finds the
+    mark, whichever of the two exits the cancellation would have taken.
+    """
+    try:
+        return await _wait_for_idle(app, plan)
+    except asyncio.CancelledError as cancelled:
+        superseded = _superseded(get_state(app), plan) and not isinstance(cancelled, ChannelClosed)
+        release_pending(app, plan.key, plan.channel)
+        if superseded and _withdraw_cancellation():
+            logger.info(
+                "The %s acquire of session %s was superseded by a newer request",
+                plan.surface,
+                plan.key,
+            )
+            raise HandoffRefused.superseded(plan.key) from None
+        raise
+    except BaseException:
+        release_pending(app, plan.key, plan.channel)
+        raise
+
+
+def _superseded(state: HandoffState, plan: AcquirePlan) -> bool:
+    """Whether *plan*'s own pending record — still registered — carries the superseded mark."""
+    pending = state.pending.get(plan.key)
+    return pending is not None and pending.channel is plan.channel and pending.superseded
+
+
+def _withdraw_cancellation() -> bool:
+    """Take back the one cancellation a supersede delivered to the current task.
+
+    Returns False — leaving the cancellation to propagate — when there is no
+    task, or when a further cancellation request is still outstanding after
+    the one withdrawn here: that one was somebody else's and is honoured.
+    """
+    task = asyncio.current_task()
+    if task is None:
+        return False
+    task.uncancel()
+    return task.cancelling() == 0
+
+
+async def _wait_for_idle(app: Any, plan: AcquirePlan) -> WaitOutcome:
+    """Block until the outgoing entry has finished its turn, and say how it ended.
+
+    No time bound. Ends when the entry is idle, when the caller's channel
+    closes (:class:`ChannelClosed`), or — with ``plan.interrupt`` — once the
+    turn has been aborted. An entry that leaves its pool while the wait runs
+    is a :class:`HandoffError`; one whose process dies while still pooled ends
+    the wait with ``exited``.
+    """
+    if plan.outgoing is None or not plan.wait_for_idle:
+        return WaitOutcome(REASON_NONE)
+    state = get_state(app)
+    if plan.outgoing.surface == SURFACE_SIMPLE:
+        return await _wait_for_chat_idle(app, state, plan)
+    return await _wait_for_pty_idle(app, state, plan)
+
+
+async def _wait_for_chat_idle(app: Any, state: HandoffState, plan: AcquirePlan) -> WaitOutcome:
+    """A chat is idle when ``is_busy`` is False; no hook is involved.
+
+    With ``plan.interrupt`` nothing is waited for and nothing is cancelled
+    here: the turn is left to phase (c), which on ``interrupted`` must cancel
+    it — ``pool.terminate(key)`` when ``plan.teardown`` is True, ``await
+    session.cancel()`` on the ``OperatorSession`` when the plan is ``reuse``.
+    """
+    assert plan.outgoing is not None
+    session = cast("OperatorSession", plan.outgoing.session)
+    pool = _chat_pool(app)
+    if plan.interrupt:
+        return WaitOutcome(REASON_INTERRUPTED)
+    while True:
+        _raise_if_superseded(state, plan)
+        await _raise_if_channel_closed(plan)
+        if pool.get(plan.key) is not session:
+            raise HandoffError.vanished(plan.key, SURFACE_SIMPLE)
+        if not session.is_active:
+            _raise_if_superseded(state, plan)
+            return WaitOutcome(REASON_EXITED)
+        if not session.is_busy:
+            _raise_if_superseded(state, plan)
+            return WaitOutcome(REASON_IDLE)
+        await state.sleep(IDLE_POLL_S)
+
+
+async def _wait_for_pty_idle(app: Any, state: HandoffState, plan: AcquirePlan) -> WaitOutcome:
+    """A PTY is idle when the turn-state store, or failing that the transcript tail, says so.
+
+    Without the turn-state hook in the TUI the store never speaks and the tail
+    alone cannot tell an answered prompt from one in progress, so a plain wait
+    is refused with :class:`HandoffNeedsInterrupt`. An interrupt is honoured
+    either way: Escape is written once the PTY is seen busy, and the wait
+    then runs for at most :data:`INTERRUPT_GRACE_S` — the interrupt marker in
+    the transcript, or an idle edge, ends it as ``interrupted``; the grace
+    expiring ends it as ``forced`` after ``terminate`` has been called on the
+    PTY in a worker thread. A PTY already idle when an interrupt arrives is
+    not sent anything.
+    """
+    assert plan.outgoing is not None
+    session = cast("PtySession", plan.outgoing.session)
+    registry = _pty_registry(app)
+    if not plan.interrupt and not getattr(app.state, "turn_hook_present", False):
+        raise HandoffRefused.needs_interrupt(plan.key)
+
+    interrupt_sent = False
+    deadline: float | None = None
+    memo = _TailMemo()
+    while True:
+        _raise_if_superseded(state, plan)
+        await _raise_if_channel_closed(plan)
+        if registry.get_session(plan.key) is not session:
+            raise HandoffError.vanished(plan.key, SURFACE_EXPERT)
+        if not session.is_alive:
+            _raise_if_superseded(state, plan)
+            return WaitOutcome(REASON_EXITED)
+        if await _pty_turn_idle(app, plan.key, memo):
+            _raise_if_superseded(state, plan)
+            return WaitOutcome(REASON_INTERRUPTED if interrupt_sent else REASON_IDLE)
+        if plan.interrupt and not interrupt_sent:
+            try:
+                session.write_input(_INTERRUPT_KEY)
+            except OSError as exc:
+                # The master fd went away between the liveness look and the
+                # write: the child is exiting. The next look classifies it.
+                logger.info("Interrupt for session %s not written: %s", plan.key, exc)
+            else:
+                logger.info("Interrupting the terminal turn for session %s", plan.key)
+            interrupt_sent = True
+            deadline = state.clock() + INTERRUPT_GRACE_S
+        elif deadline is not None and state.clock() >= deadline:
+            logger.warning(
+                "Terminal turn for session %s did not end %.0fs after the interrupt; terminating",
+                plan.key,
+                INTERRUPT_GRACE_S,
+            )
+            await asyncio.to_thread(session.terminate)
+            _raise_if_superseded(state, plan)
+            return WaitOutcome(REASON_FORCED)
+        await state.sleep(IDLE_POLL_S)
+
+
+async def _raise_if_channel_closed(plan: AcquirePlan) -> None:
+    if await channel_closed(plan.channel):
+        logger.info("Channel closed during the %s acquire of session %s", plan.surface, plan.key)
+        raise ChannelClosed(f"channel closed during the acquire of session {plan.key!r}")
+
+
+def _raise_if_superseded(state: HandoffState, plan: AcquirePlan) -> None:
+    """End the wait from the superseded mark on its own record, cancellation or not.
+
+    The supersede cancels the waiter's task for promptness, but the mark is
+    what the wait is ended by: a ``task.cancel()`` that lands while the
+    waiter is suspended inside the channel probe's cancel scope (Starlette's
+    ``is_disconnected``) can be absorbed there as if it were the scope's own,
+    and an absorbed cancellation stays counted on the task without ever
+    being thrown again. So every look reads the mark first, and a marked
+    wait ends here — withdrawing whatever cancel requests are still counted,
+    since none of them will be delivered — with the same refusal the
+    delivered cancellation turns into.
+    """
+    if not _superseded(state, plan):
+        return
+    task = asyncio.current_task()
+    if task is not None:
+        while task.cancelling() > 0:
+            task.uncancel()
+    logger.info(
+        "The %s acquire of session %s was superseded by a newer request",
+        plan.surface,
+        plan.key,
+    )
+    raise HandoffRefused.superseded(plan.key)
+
+
+class _TailMemo:
+    """The last tail verdict, kept while the transcript file is unchanged.
+
+    One wait looks at the tail every :data:`IDLE_POLL_S`; a turn that runs
+    for minutes would otherwise re-read the file's last 256 KB hundreds of
+    times for the same answer. The file is still stat'ed on every look — that
+    is what tells the two witnesses apart — and re-read only when its size or
+    modification time moved, or the busy stamp the rule is asked against did.
+    """
+
+    def __init__(self) -> None:
+        self._key: tuple[Path, int, int, float | None] | None = None
+        self._verdict: str = "unknown"
+
+    def verdict(self, path: Path, stat: os.stat_result, busy_since: float | None) -> str:
+        key = (path, stat.st_size, stat.st_mtime_ns, busy_since)
+        if key != self._key:
+            self._verdict = tail_state(path, busy_since)
+            self._key = key
+        return self._verdict
+
+
+async def _pty_turn_idle(app: Any, key: str, memo: _TailMemo | None = None) -> bool:
+    """Whether the PTY under *key* is between turns, judged off the loop.
+
+    The two witnesses are gathered here — the turn-state store entry for the
+    key and the key's *current* transcript — and weighed in a worker thread,
+    since the tail rule reads the transcript file. *memo* is the wait's
+    :class:`_TailMemo`, so an unchanged file is not read twice.
+    """
+    store = get_turn_state(app, key)
+    return await asyncio.to_thread(_judge_pty_idle, app, store, key, memo)
+
+
+def _judge_pty_idle(
+    app: Any,
+    store: dict[str, Any] | None,
+    key: str,
+    memo: _TailMemo | None = None,
+) -> bool:
+    """Weigh the turn-state store against the transcript tail; the newer witness wins.
+
+    Runs in a worker thread: resolving *key* to its current transcript may
+    re-read the transcript map from disk while the map has no settled
+    location, and the tail rule reads the transcript itself.
+
+    The store entry carries the moment it was written; the transcript's
+    modification time is the moment its last entry was appended. Whichever is
+    newer has seen the later event and is believed, ties going to the store.
+    A tail that is newer but says ``unknown`` — an assistant entry, a tool
+    result — carries no evidence and hands the question back to the store.
+    Without a store entry the tail is the only witness, and only an explicit
+    idle shape (the interrupt marker, slash-command output) counts: a key
+    nothing has reported on is not assumed idle.
+    """
+    path = _transcript_path(app, transcript_map.get(app, key))
+    stat: os.stat_result | None = None
+    if path is not None:
+        try:
+            stat = path.stat()
+        except OSError:
+            path = None
+    memo = memo or _TailMemo()
+
+    if store is None:
+        return path is not None and stat is not None and memo.verdict(path, stat, None) == "idle"
+
+    store_idle = store.get("state") == IDLE
+    store_ts = float(store.get("ts") or 0.0)
+    if path is None or stat is None or stat.st_mtime <= store_ts:
+        return store_idle
+    verdict = memo.verdict(path, stat, None if store_idle else store_ts)
+    if verdict == "unknown":
+        return store_idle
+    return verdict == "idle"
+
+
+def _transcript_path(app: Any, transcript_id: str) -> Path | None:
+    """The ``.jsonl`` for *transcript_id* under the app's project, or ``None``."""
+    cwd = getattr(app.state, "project_cwd", None)
+    if not cwd:
+        return None
+    return TranscriptReader(cwd).find_transcript_by_id(transcript_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase (c): tear down, confirm dead, spawn, release — under the lock, shielded
+# ---------------------------------------------------------------------------
+
+
+async def _phase_c(app: Any, plan: AcquirePlan, outcome: WaitOutcome) -> AcquireResult:
+    """Carry the plan out: teardown, death check, spawn, attach, release of the slot.
+
+    *outcome* says how the wait ended — see :class:`WaitOutcome` for what each
+    reason obliges this phase to do. The work runs in its own task behind
+    ``asyncio.shield``, so a cancellation of the caller cannot stop it half
+    way: the caller is made to wait for the task to finish and only then
+    receives its cancellation. The task itself is never cancelled — a pool
+    left with a popped entry and no replacement, or a spawned child nobody
+    inserted, is exactly what the shield exists to make unreachable.
+
+    A failure of the phase after its caller was cancelled reaches nobody, so
+    it is logged from a done-callback on the task rather than by the waiter:
+    a second cancellation can take the waiter away from its
+    ``asyncio.wait``, and the callback is what still retrieves the exception.
+    """
+    # From here the call is carrying the key out, not waiting: a supersede
+    # must not reach it. Cleared before the shielded task exists, in the same
+    # loop step that left phase (b), so no look at the key sees a waiting
+    # record with a phase (c) behind it.
+    pending = get_state(app).pending.get(plan.key)
+    if pending is not None and pending.channel is plan.channel:
+        pending.waiting = False
+    task = asyncio.ensure_future(_carry_out(app, plan, outcome))
+    abandoned = False
+
+    def retrieve(done: asyncio.Future[AcquireResult]) -> None:
+        if done.cancelled():
+            return
+        failure = done.exception()
+        if failure is not None and abandoned:
+            logger.warning(
+                "Hand-off for session %s failed after its caller was cancelled: %s",
+                plan.key,
+                failure,
+            )
+
+    task.add_done_callback(retrieve)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # Let the phase finish. ``asyncio.wait`` does not cancel what it waits
+        # on when the waiter is cancelled, so a second cancellation delivered
+        # here still leaves the task running to its end on its own.
+        abandoned = True
+        await asyncio.wait({task})
+        raise
+
+
+async def _carry_out(app: Any, plan: AcquirePlan, outcome: WaitOutcome) -> AcquireResult:
+    """The body of phase (c), under the key's lock; releases the slot on every exit."""
+    state = get_state(app)
+    async with state.lock_for(plan.key):
+        try:
+            return await _teardown_and_spawn(app, state, plan, outcome)
+        finally:
+            release_pending(app, plan.key, plan.channel)
+
+
+async def _teardown_and_spawn(
+    app: Any, state: HandoffState, plan: AcquirePlan, outcome: WaitOutcome
+) -> AcquireResult:
+    """Clear the key of the other surface, then fill it for the incoming one.
+
+    What clearing means depends on the plan: a ``takeover`` closes the
+    displaced Expert connection and takes its attachment; a ``handoff`` tears
+    the outgoing entry down and confirms its death; a Simple ``reuse`` of a
+    busy chat the caller interrupted cancels that turn, and of a chat that
+    died discards the corpse. Filling the key is the incoming surface's own
+    pooled entry when it has one, else the caller's spawn callback. An Expert
+    caller is attached last, before the slot is released by the caller of
+    this function.
+    """
+    key = plan.key
+    registry = _pty_registry(app)
+    pool = _chat_pool(app)
+    outgoing = plan.outgoing
+
+    if plan.action == ACTION_TAKEOVER:
+        await _displace(state, registry, plan)
+    elif outgoing is not None and plan.teardown:
+        await _tear_down(app, state, plan, outcome)
+    elif outgoing is not None and outgoing.surface == SURFACE_SIMPLE:
+        # A Simple caller on its own chat. The wait left a running turn only
+        # when the caller asked for it to be cut short; a chat that died while
+        # pooled is discarded here so the spawn below replaces it.
+        chat = cast("OperatorSession", outgoing.session)
+        if outcome.reason == REASON_INTERRUPTED:
+            logger.info("Cancelling the chat turn for session %s", key)
+            await chat.cancel()
+        elif outcome.reason == REASON_EXITED and pool.get(key) is chat:
+            await pool.terminate(key)
+            logger.info("Discarded dead chat session under session %s", key)
+
+    if plan.surface == SURFACE_EXPERT:
+        pooled: PtySession | OperatorSession | None = registry.get_session(key)
+    else:
+        pooled = pool.get(key)
+
+    resume_id: str | None = None
+    if pooled is not None:
+        session = pooled
+    else:
+        if plan.spawn is None:
+            raise RuntimeError(
+                f"acquire_surface for session {key!r} was given no spawn callback "
+                f"and nothing of the {plan.surface} surface is pooled"
+            )
+        request = await _spawn_request(app, key, plan.surface)
+        resume_id = request.resume_id
+        logger.info(
+            "Starting the %s process for session %s (%s)",
+            plan.surface,
+            key,
+            f"resuming {resume_id}" if resume_id else "fresh under the key",
+        )
+        try:
+            session = await plan.spawn(request)
+        except ChatCapacityError:
+            raise HandoffRefused.chat_capacity(key) from None
+        now_pooled = registry.get_session(key) if plan.surface == SURFACE_EXPERT else pool.get(key)
+        if now_pooled is not session:
+            raise HandoffError.not_pooled(key, plan.surface)
+        if plan.surface == SURFACE_EXPERT:
+            reset_turn_state(app, key)
+
+    if plan.surface == SURFACE_EXPERT and not registry.attach_session(key, plan.channel):
+        raise HandoffRefused.attached_elsewhere(key)
+
+    return AcquireResult(
+        plan=plan,
+        outcome=outcome,
+        session=session,
+        spawned=pooled is None,
+        resume_id=resume_id,
+    )
+
+
+async def _displace(state: HandoffState, registry: PtyRegistry, plan: AcquirePlan) -> None:
+    """Close the Expert connection holding the PTY and take its attachment.
+
+    The displaced handler registered how to close its socket under its attach
+    token; a token with no closer belongs to a handler already on its way
+    out. The detach here carries the displaced token, so the registry
+    releases the key from its side too, and the handler's own later detach —
+    with a token that no longer holds the key — is a no-op.
+    """
+    owner = plan.displaced_owner
+    closer = state.closers.get(owner) if owner is not None else None
+    if closer is not None:
+        logger.info("Closing the terminal connection displaced from session %s", plan.key)
+        try:
+            await closer()
+        except Exception:
+            logger.warning(
+                "Closing the displaced terminal connection for session %s failed",
+                plan.key,
+                exc_info=True,
+            )
+    if owner is not None:
+        registry.detach_session(plan.key, owner)
+
+
+async def _tear_down(
+    app: Any, state: HandoffState, plan: AcquirePlan, outcome: WaitOutcome
+) -> None:
+    """Pop the outgoing entry, kill it off the loop, and see it dead.
+
+    Whatever phase (b) reported, the same sequence runs: a ``forced`` wait has
+    already called ``terminate`` once but popped nothing and proved nothing;
+    an ``exited`` child still has an exit status to collect. The entry is
+    identity-checked against its pool first — one already gone leaves nothing
+    to do; one replaced by something else is a :class:`HandoffError`. A
+    survivor is put back where it came from, unattached, and the acquire
+    refused with 503.
+    """
+    assert plan.outgoing is not None
+    key = plan.key
+    if plan.outgoing.surface == SURFACE_EXPERT:
+        pty = cast("PtySession", plan.outgoing.session)
+        registry = _pty_registry(app)
+        pooled = registry.get_session(key)
+        if pooled is None:
+            logger.info("Outgoing PTY for session %s already left its pool", key)
+        elif pooled is not pty:
+            raise HandoffError.vanished(key, SURFACE_EXPERT)
+        else:
+            registry.pop_session(key)
+        # ``terminate`` on a dead child only closes the fd and collects the
+        # exit status; on a live one it is the blocking signal escalation.
+        await asyncio.to_thread(pty.terminate)
+        if not await _observed_dead(state, lambda: not pty.is_alive):
+            logger.warning(
+                "PTY for session %s survived its kill; refusing the %s acquire",
+                key,
+                plan.surface,
+            )
+            if not registry.reinsert(key, pty):
+                logger.error("PTY survivor for session %s could not be pooled again", key)
+            raise HandoffRefused.outgoing_still_running(key)
+        reset_turn_state(app, key)
+        logger.info("Terminal for session %s torn down (%s)", key, outcome.reason)
+        return
+
+    chat = cast("OperatorSession", plan.outgoing.session)
+    pool = _chat_pool(app)
+    pooled_chat = pool.get(key)
+    if pooled_chat is None:
+        # Whoever popped it also tore it down; ``teardown`` is idempotent
+        # and re-signals a child that is still running.
+        logger.info("Outgoing chat for session %s already left its pool", key)
+        await chat.teardown()
+    elif pooled_chat is not chat:
+        raise HandoffError.vanished(key, SURFACE_SIMPLE)
+    else:
+        # Pops and tears down; an ``interrupted`` outcome's running turn is
+        # cancelled by the teardown itself.
+        await pool.terminate(key)
+    if chat.process_exited is None:
+        logger.warning(
+            "Chat session %s exposes no process handle; its child cannot be observed dead",
+            key,
+        )
+    elif not await _observed_dead(state, lambda: chat.process_exited is not False):
+        logger.warning(
+            "Chat child for session %s survived its teardown; refusing the %s acquire",
+            key,
+            plan.surface,
+        )
+        if not await pool.reinsert(key, chat):
+            logger.error("Chat survivor for session %s could not be pooled again", key)
+        raise HandoffRefused.outgoing_still_running(key)
+    logger.info("Chat for session %s torn down (%s)", key, outcome.reason)
+
+
+async def _observed_dead(state: HandoffState, dead: Callable[[], bool]) -> bool:
+    """Poll *dead* every :data:`DEATH_POLL_S` for up to :data:`DEATH_GRACE_S`."""
+    deadline = state.clock() + DEATH_GRACE_S
+    while True:
+        if dead():
+            return True
+        now = state.clock()
+        if now >= deadline:
+            return False
+        await state.sleep(min(DEATH_POLL_S, deadline - now))
+
+
+async def _spawn_request(app: Any, key: str, surface: Surface) -> SpawnRequest:
+    """Decide what the new process resumes, from the map and the disk as of now.
+
+    The key's current transcript is resumed when its file exists. A map
+    entry whose file is gone falls back to the key's own transcript when
+    *that* exists — the conversation the key started with is better than
+    none — and a key with no transcript on disk at all starts fresh under
+    the key. The map look-up (a file read when the map is provisional) and
+    the directory listing run off the loop together.
+    """
+    transcript_id, on_disk = await asyncio.to_thread(_transcript_and_disk, app, key)
+    if transcript_id in on_disk:
+        resume_id: str | None = transcript_id
+    elif key in on_disk:
+        resume_id = key
+    else:
+        resume_id = None
+    return SpawnRequest(key=key, surface=surface, resume_id=resume_id, transcript_id=transcript_id)
+
+
+def _transcript_and_disk(app: Any, key: str) -> tuple[str, set[str]]:
+    """The key's current transcript id and the transcripts on disk, as of now."""
+    return transcript_map.get(app, key), _transcripts_on_disk(app)
+
+
+def _transcripts_on_disk(app: Any) -> set[str]:
+    """The ids of every transcript under the app's project; empty without a project."""
+    cwd = getattr(app.state, "project_cwd", None)
+    if not cwd:
+        return set()
+    return SessionDiscovery(cwd).snapshot_session_ids()

--- a/src/osprey/interfaces/web_terminal/session_key.py
+++ b/src/osprey/interfaces/web_terminal/session_key.py
@@ -1,0 +1,36 @@
+"""The closed grammar of a session key.
+
+A session key is the one identity a browser tab keeps for its whole life: the
+same string names the PTY pool entry, the chat pool entry, the posture store
+entry, the transcript map entry and the audit session. It is written to stores
+on disk and later spliced into a ``claude --resume`` argv and a transcript
+filename, so the grammar is closed rather than length-bounded: a canonical
+lowercase UUID — eight-four-four-four-twelve hex, no prefix, no suffix — and
+nothing else.
+
+Every key the web terminal legitimately handles is minted that way — a Claude
+session-file stem, or ``crypto.randomUUID()`` in the browser — so the closed
+form costs no reach while keeping decorated keys (the ``/ws/operator`` pool's
+``operator-<hex8>``) and near-miss strings out of every store that decides a
+child process's execution mode.
+
+The posture routes, the chat route, the hand-off route and the agent-turn
+route all ask :func:`is_posture_key` rather than carrying a pattern of their
+own, so the surfaces cannot drift on what a key is. The pattern itself stays
+private so there is one place to change it.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SESSION_KEY_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+def is_posture_key(session_id: str) -> bool:
+    """Whether *session_id* is a canonical, bare session UUID.
+
+    Named for the surface that first closed the grammar: a key this answers
+    ``False`` for is a key no posture store will ever answer for.
+    """
+    return bool(_SESSION_KEY_RE.match(session_id))

--- a/src/osprey/interfaces/web_terminal/static/css/operator.css
+++ b/src/osprey/interfaces/web_terminal/static/css/operator.css
@@ -96,6 +96,116 @@ html[data-ui-mode="simple"] #operator-container {
   opacity: 0.7;
 }
 
+/* Starts a conversation on a new session key. Pinned to the bar's right edge
+   (`margin-left: auto`) and quiet at rest — it is the one destructive-looking
+   control in the console's chrome, and the log below is where the operator's
+   attention belongs. */
+.op-session-new {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: all var(--wt-transition-fast);
+}
+
+.op-session-new:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--border-accent);
+}
+
+.op-session-new:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+/* ---- Session hand-off overlay ---- */
+
+/* Shown while the session is being handed over from the Expert view, and
+   where a refused hand-off says why. Covers the whole console — including the
+   input row, which takes nothing while the session is still the other view's
+   — and sits above the streaming edge (z-index 3 on .operator-container::after). */
+.op-handoff {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  box-sizing: border-box;
+  background: var(--overlay-black-70);
+}
+
+/* Spelled out because the rule above sets `display` for the UA default to
+   lose against. */
+.op-handoff[hidden] {
+  display: none;
+}
+
+.op-handoff-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  max-width: 320px;
+  padding: var(--space-4);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-dialog);
+  text-align: center;
+}
+
+.op-handoff-message {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--text-secondary);
+}
+
+/* The elapsed wait. Tabular figures so a ticking counter does not reflow the
+   line it sits in. */
+.op-handoff-elapsed {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.op-handoff-action {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  background: var(--accent-tint-08);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: all var(--wt-transition-fast);
+}
+
+.op-handoff-action:hover:not(:disabled) {
+  background: var(--accent-tint-12);
+  border-color: var(--color-accent);
+}
+
+.op-handoff-action:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+/* A refusal with nothing to retry states the fact alone. */
+.op-handoff-action[hidden] {
+  display: none;
+}
+
 /* ---- Messages area (log console) ---- */
 
 .op-messages {

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -2120,3 +2120,89 @@ html[data-ui-mode="simple"] #terminal-container {
   cursor: progress;
   opacity: 0.6;
 }
+
+/* ---- Hand-off overlay ----
+   The transitional state on the terminal card while the session is being
+   handed over from the other view, and where a refused connection says why.
+   Built on demand by terminal.js and removed when it clears, so nothing here
+   applies in the ordinary case. */
+
+.terminal-handoff {
+  position: absolute;
+  inset: 0;
+  /* Above the CRT scanline and bezel layers, which sit at 2 on
+     .terminal-body's own pseudo-elements. */
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  box-sizing: border-box;
+  background: var(--overlay-black-70);
+}
+
+/* The Simple view shows the chat in this same body. Its transitional state is
+   the chat's own; this one would cover it. */
+html[data-ui-mode="simple"] .terminal-handoff {
+  display: none;
+}
+
+.terminal-handoff-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  max-width: 320px;
+  padding: var(--space-4);
+  background: var(--bg-panel);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-dialog);
+  text-align: center;
+}
+
+.terminal-handoff-message {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--text-secondary);
+}
+
+/* The elapsed wait. Tabular figures so a ticking counter does not reflow the
+   line it sits in. */
+.terminal-handoff-elapsed {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.terminal-handoff-action {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  background: var(--accent-tint-08);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-sm);
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: all var(--wt-transition-fast);
+}
+
+.terminal-handoff-action:hover:not(:disabled) {
+  background: var(--accent-tint-12);
+  border-color: var(--color-accent);
+}
+
+.terminal-handoff-action:disabled {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+/* A refusal with nothing to retry states the fact alone. Spelled out because
+   the rule above sets no `display` of its own for the UA default to win with. */
+.terminal-handoff-action[hidden] {
+  display: none;
+}

--- a/src/osprey/interfaces/web_terminal/static/js/api.js
+++ b/src/osprey/interfaces/web_terminal/static/js/api.js
@@ -10,6 +10,7 @@
  * @property {(e: MessageEvent) => void} [onMessage]
  * @property {(e: CloseEvent) => void} [onClose]
  * @property {(e: Event) => void} [onError]
+ * @property {(code: number, reason: string) => void} [onRefused]
  */
 
 /**
@@ -188,11 +189,49 @@ export function wsUrl(path) {
 }
 
 /**
+ * Close code for a socket the server refused because the session is held
+ * elsewhere — another tab, or the other view — and for the older handler a
+ * same-surface takeover displaces. The private range mirrors the HTTP 409 the
+ * same refusal carries on the request routes.
+ */
+export const WS_CLOSE_SESSION_ATTACHED = 4409;
+
+/**
+ * Close code for a refusal because the outgoing agent was still running once
+ * its teardown returned: nothing was started in its place, so a retry is the
+ * next step. Mirrors the HTTP 503 of the same refusal.
+ */
+export const WS_CLOSE_OUTGOING_RUNNING = 4503;
+
+/**
+ * Whether a close code is one of the server's deliberate refusals, which are
+ * final for the connection that received them.
+ *
+ * The distinction the reconnect loop needs is *why* the socket closed. A
+ * dropped link says nothing about the session, so backing off and trying again
+ * is right. A refusal is an answer: the session is demonstrably alive and held
+ * by someone else, or its previous process has not died yet. Reconnecting on
+ * one would fight the holder or hammer an unfinished teardown, so these codes
+ * end the loop and reach the caller instead.
+ * @param {number} code
+ * @returns {boolean}
+ */
+export function isRefusalCloseCode(code) {
+  return code === WS_CLOSE_SESSION_ATTACHED || code === WS_CLOSE_OUTGOING_RUNNING;
+}
+
+/**
  * Create a WebSocket with exponential backoff reconnection.
+ *
+ * Every close reconnects — unless `stop()` has been called, the session has
+ * expired, or the server refused with one of the codes {@link
+ * isRefusalCloseCode} names. A refusal ends this wrapper: `onRefused` fires
+ * with the code and reason so the caller can say which one it was, and a retry
+ * is a new wrapper rather than a resumed loop.
  * @param {string} url
  * @param {WebSocketHandlers} [handlers]
  */
-export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {}) {
+export function createWebSocket(url, { onOpen, onMessage, onClose, onError, onRefused } = {}) {
   /** @type {WebSocket|null} */
   let ws = null;
   let attempt = 0;
@@ -222,6 +261,13 @@ export function createWebSocket(url, { onOpen, onMessage, onClose, onError } = {
       wsState = 'disconnected';
       notifyStateChange();
       if (onClose) onClose(e);
+      if (isRefusalCloseCode(e.code)) {
+        // The session survived — the server said so by refusing — so the
+        // expiry probe has nothing to ask and the backoff nothing to retry.
+        stopped = true;
+        if (onRefused) onRefused(e.code, e.reason);
+        return;
+      }
       scheduleReconnect();
       reloadIfSessionExpired();
     };

--- a/src/osprey/interfaces/web_terminal/static/js/app.js
+++ b/src/osprey/interfaces/web_terminal/static/js/app.js
@@ -1,6 +1,14 @@
 /* OSPREY Web Terminal — Application Entry Point */
 
-import { initTerminal, focusTerminal, pasteToTerminal, getCurrentSessionId, getTerminalInstance } from './terminal.js';
+import {
+  initTerminal,
+  focusTerminal,
+  pasteToTerminal,
+  getCurrentSessionId,
+  getTerminalInstance,
+  startExpert,
+  stopTerminal,
+} from './terminal.js';
 import { logout } from './logout.js';
 import { initPanelManager, broadcastMode, handleUiModeFlip, navigateAndActivatePanel } from './panel-manager.js';
 import '/design-system/js/components/osprey-drawer.js';
@@ -13,7 +21,7 @@ import { initCommandPalette } from './palette-boot.js';
 import { getFamily, initTheme, subscribe as subscribeTheme } from '/design-system/js/theme-manager.js';
 import { onModeChange } from '/design-system/js/frame-params.js';
 import '/design-system/js/components/osprey-display-menu.js';
-import { initChat } from './chat.js';
+import { initChat, enterFromExpert } from './chat.js';
 import { initDockWorkspace, applyDockMode } from './dock-workspace.js';
 import { initHeaderContrib } from './tile-header-contrib.js';
 import { initIdentityMenu } from './identity-menu.js';
@@ -154,10 +162,15 @@ export function initLogoutButton() {
  * `osprey-mode-change` message to this window — and frame-params.js's shared
  * receive side stamps html[data-ui-mode] before handing the mode here. What
  * follows is what only the hub has to do with it: broadcast to the panels,
- * then the dock and panel follow-ups. mode-boot.js already resolved the
- * initial mode pre-paint, so this only ever handles the runtime flip.
+ * the dock and panel follow-ups, then hand the session to the view the
+ * operator flipped to. mode-boot.js already resolved the initial mode
+ * pre-paint, so this only ever handles the runtime flip.
+ *
+ * Exported for testability (see app-mode-flip.test.mjs) — the module's
+ * DOMContentLoaded bootstrap never fires on its own once that event has
+ * already passed, e.g. in a test environment.
  */
-function initUiModeFollowUps() {
+export function initUiModeFollowUps() {
   onModeChange((mode) => {
     // Panels read the current mode off <html>, so broadcast only after the
     // swap (onModeChange stamped it before calling back).
@@ -171,7 +184,61 @@ function initUiModeFollowUps() {
     // and lets the default panel claim a still-empty workspace slot. Runs
     // after applyDockMode so the activation docks into the target layout.
     handleUiModeFlip(mode);
+    // Session half, last: the target view's layout is on screen by now, so
+    // whichever surface has to show a transitional state is the one the
+    // operator is looking at.
+    handOffSession(mode);
   });
+}
+
+/**
+ * The hand-offs of successive flips, chained.
+ *
+ * Both views are windows onto ONE session key, and the server lets exactly one
+ * of them hold it — a second acquire arriving while the first is still pending
+ * is refused outright. A flip is one gesture, so an operator who flips twice
+ * quickly would produce exactly that. Chaining makes the second flip wait for
+ * the first hand-off to settle instead, which is also why the teardown belongs
+ * in here: dropping the terminal ahead of the queue would strand a connection
+ * a queued flip to Expert is about to open.
+ *
+ * The chain covers flips and nothing else. The overlay's own retry and the
+ * session picker take the key over through terminal.js directly, so a flip
+ * that lands between one of those and its answer is still two acquires; both
+ * paths already show the server's refusal where the operator can see it.
+ *
+ * @type {Promise<void>}
+ */
+let sessionHandoff = Promise.resolve();
+
+/**
+ * Move the live agent to *mode*'s view.
+ *
+ * Flipping to Expert resumes the key the tab is pointed at over the terminal
+ * socket, which shows its own overlay while the server tears the chat down.
+ * Flipping to Simple drops that socket first — the server reads the closed
+ * connection as the Expert view letting go — and the console then asks for the
+ * key and replays the transcript into itself. Neither direction reloads.
+ *
+ * Every step answers with a promise and every one of them is awaited. A flip
+ * queued behind an Expert acquire that is still in flight would otherwise drop
+ * the socket before the server had seen it open; and the console would ask for
+ * the key before the dropped socket's close had reached the server, which
+ * reads that close as the Expert view letting go.
+ *
+ * @param {'expert'|'simple'} mode
+ * @returns {void}
+ */
+function handOffSession(mode) {
+  sessionHandoff = sessionHandoff
+    .then(async () => {
+      if (mode === 'expert') return startExpert();
+      await stopTerminal();
+      return enterFromExpert();
+    })
+    .catch((err) => {
+      console.error('Failed to hand the session over:', err);
+    });
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/chat-client.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat-client.js
@@ -1,10 +1,11 @@
 // @ts-check
 /* OSPREY Web Terminal — Chat SSE Transport
  *
- * Browser-side transport for the chat endpoint. Pure networking: it POSTs a
- * prompt, parses the streaming Server-Sent-Events response, and forwards each
- * decoded event to caller-supplied callbacks. It touches no DOM and holds no
- * rendering state, so the whole surface is unit-testable with a mocked `fetch`.
+ * Browser-side transport for the chat endpoint, the session hand-off request,
+ * and the transcript history fetch. Pure networking: it POSTs a prompt, parses
+ * the streaming Server-Sent-Events response, and forwards each decoded event
+ * to caller-supplied callbacks. It touches no DOM and holds no rendering
+ * state, so the whole surface is unit-testable with a mocked `fetch`.
  *
  * SSE wire format (see routes/chat.py `_sse`): each event is one frame
  * `data: {json}\n\n`; heartbeat comments arrive as `: heartbeat` lines. A frame
@@ -17,6 +18,12 @@ import { withPrefix } from './api.js';
 /** Base path for the chat REST + streaming endpoint (prefixed per-call via
  * `withPrefix` so multi-user `/u/<user>/` deployments reach this container). */
 const CHAT_ENDPOINT = '/api/chat';
+
+/** Base path for the per-session routes; `/{key}/handoff` hangs off it. */
+const SESSION_ENDPOINT = '/api/session';
+
+/** Read-only transcript endpoint backing the Simple view's replay. */
+const SESSION_CHAT_ENDPOINT = '/api/session-chat';
 
 /**
  * A single decoded server event. Every event carries a `type`; the remaining
@@ -181,7 +188,9 @@ function reportError(callbacks, err) {
  * POSTs `{prompt, chat_id}` to `/api/chat?stream=true` and parses the SSE body,
  * forwarding events to *callbacks*. Returns synchronously with an abort handle
  * so the caller can cancel before the fetch resolves. The turn always ends with
- * exactly one `onClose()`; a user abort is silent (no `onError`).
+ * exactly one `onClose()`; a user abort is silent (no `onError`). A 204 means
+ * the request was abandoned server-side and carries no events, so the turn ends
+ * the same silent way.
  * @param {string} chatId
  * @param {string} prompt
  * @param {ChatCallbacks} [callbacks]
@@ -207,6 +216,9 @@ export function sendPrompt(chatId, prompt, callbacks = {}) {
         signal: controller.signal,
       });
       if (!res.ok) throw await transportError(res);
+      // 204: the server abandoned the request because this client's channel
+      // closed mid-turn. There is no body to stream, so end quietly.
+      if (res.status === 204) return;
       if (!res.body) throw new Error('Chat response has no readable body');
       reader = res.body.getReader();
       await pump(reader, callbacks);
@@ -249,15 +261,68 @@ export async function interrupt(chatId) {
 }
 
 /**
- * Delete the conversation for *chatId*. Uses `keepalive` so it survives a
- * `pagehide`/`beforeunload` teardown; fire-and-forget by design (the returned
- * promise need not be awaited and is not error-checked).
- * @param {string} chatId
- * @returns {Promise<Response>}
+ * One conversation turn as served by `GET /api/session-chat`. The same shape
+ * the renderer takes, so turns pass straight from here to the replay.
+ *
+ * @typedef {object} ChatTurn
+ * @property {string} role - `user` or `assistant`
+ * @property {string} content - the turn's text; markdown for an agent turn
+ * @property {string} [timestamp] - transcript timestamp
  */
-export function deleteChat(chatId) {
-  return fetch(withPrefix(`${CHAT_ENDPOINT}/${encodeURIComponent(chatId)}`), {
-    method: 'DELETE',
-    keepalive: true,
+
+/**
+ * Ask the server to hand session *key* to the Simple view.
+ *
+ * POSTs to `/api/session/{key}/handoff`. The server tears the outgoing surface
+ * down, waits for it to be observed dead, and answers `{state, session_id}`
+ * once the Simple view may resume the key's transcript. `interrupt` says the
+ * operator chose to cut a turn that was still running rather than wait for it.
+ *
+ * The request is long-lived by design — a busy Expert turn can take minutes to
+ * reach idle — so this adds no timeout of its own; *signal* is the only way to
+ * end it. A rejection carries the endpoint's reason the same way `sendPrompt`'s
+ * does: `err.status` plus `err.slug` from the body's `detail.error` (409 the
+ * key is held elsewhere, 429 `chat_capacity`, 503 the server is shutting down),
+ * so the caller branches on the slug and falls back to the status when a body
+ * carried none.
+ *
+ * Resolves `null` on a 204: the request was abandoned server-side because this
+ * client's channel closed, so no surface was handed over and there is nothing
+ * to resume.
+ * @param {string} key
+ * @param {{ interrupt?: boolean, signal?: AbortSignal }} [options]
+ * @returns {Promise<{ state: string, session_id: string } | null>}
+ */
+export async function requestHandoff(key, options = {}) {
+  const { interrupt: cutRunningTurn = false, signal } = options;
+  const res = await fetch(withPrefix(`${SESSION_ENDPOINT}/${encodeURIComponent(key)}/handoff`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    // `to` is fixed: this module is the Simple view's transport, and the
+    // Expert view acquires its surface over `/ws/terminal` instead.
+    body: JSON.stringify({ to: 'simple', interrupt: cutRunningTurn }),
+    signal,
   });
+  if (!res.ok) throw await transportError(res);
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+/**
+ * Read the conversation behind *key* so the Simple view can replay it.
+ *
+ * `full=1` asks for the whole transcript rather than the trailing window the
+ * session page shows. The response is `{turns, count}`; only the turns are
+ * returned, and a body without them yields an empty list — a key whose
+ * transcript has no turns yet is a normal first flip, not a failure.
+ * `no-store` keeps a flip from replaying a copy cached before the last turn.
+ * @param {string} key
+ * @returns {Promise<ChatTurn[]>}
+ */
+export async function fetchHistory(key) {
+  const url = `${SESSION_CHAT_ENDPOINT}?session_id=${encodeURIComponent(key)}&full=1`;
+  const res = await fetch(withPrefix(url), { cache: 'no-store' });
+  if (!res.ok) throw await transportError(res);
+  const data = await res.json();
+  return Array.isArray(data?.turns) ? data.turns : [];
 }

--- a/src/osprey/interfaces/web_terminal/static/js/chat-render.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat-render.js
@@ -41,6 +41,17 @@
  */
 
 /**
+ * One conversation turn as served by `GET /api/session-chat` (see
+ * workspace/transcript_reader.py `read_chat_history`, which emits text turns
+ * only — tool calls and their results never appear).
+ *
+ * @typedef {object} ChatTurn
+ * @property {string} role - `user` or `assistant`
+ * @property {string} content - the turn's text; markdown for an agent turn
+ * @property {string} [timestamp] - transcript timestamp; not rendered here
+ */
+
+/**
  * @returns {{ DOMPurify: any, hljs: any }} the vendored sanitiser/highlighter
  *   globals, each possibly `undefined`. (`marked` is reached via
  *   {@link chatMarkedParse}, which isolates chat from the shared singleton.)
@@ -433,6 +444,11 @@ export function buildActivityLine(label) {
  * @typedef {object} ChatRenderer
  * @property {(text: string) => HTMLElement} addUserMessage - append an
  *   operator entry and return it
+ * @property {(markdown: string) => HTMLElement} addAgentMessage - append a
+ *   finished agent entry rendered from markdown and return it
+ * @property {(turns: ChatTurn[] | null | undefined) => number} replay - render
+ *   prior conversation turns, leaving the session-reset divider state
+ *   untouched; returns the number of entries rendered
  * @property {(event: ChatEvent) => void} handleEvent - dispatch one SSE event
  * @property {() => void} reset - clear the list and all per-conversation state
  * @property {() => number} messageCount - rendered message entries so far
@@ -542,6 +558,54 @@ export function createChatRenderer(container) {
     return entry;
   }
 
+  /**
+   * Append a finished agent entry rendered from `markdown` in one go — the
+   * whole-message counterpart to the streamed {@link appendAgentText} path,
+   * and through the same sanitising {@link renderMarkdownInto} boundary. Any
+   * in-progress stream is abandoned, so the next `text` event opens a fresh
+   * entry.
+   * @param {string} markdown
+   * @returns {HTMLElement}
+   */
+  function addAgentMessage(markdown) {
+    clearActivity();
+    agentBody = null;
+    agentText = '';
+    const { entry, body } = buildAgentEntry();
+    renderMarkdownInto(body, markdown);
+    count += 1;
+    hasPriorExchange = true;
+    append(entry);
+    return entry;
+  }
+
+  /**
+   * Render prior conversation turns into the log, oldest first.
+   *
+   * Replayed turns are the same conversation continued in another window, not
+   * a completed exchange in this one, so the divider bookkeeping is restored
+   * afterwards: the next stream's frame-0 `session_reset` still draws no
+   * divider above replayed history. Entries are appended — a caller wanting a
+   * clean log calls {@link reset} first.
+   *
+   * @param {ChatTurn[] | null | undefined} turns - as served by
+   *   `GET /api/session-chat`; a missing list renders nothing
+   * @returns {number} entries rendered; a turn with no content is skipped
+   */
+  function replay(turns) {
+    const priorExchange = hasPriorExchange;
+    let rendered = 0;
+    for (const turn of turns ?? []) {
+      const content = turn?.content ?? '';
+      if (!content) continue;
+      if ((turn.role ?? '').toLowerCase() === 'user') addUserMessage(content);
+      else addAgentMessage(content);
+      rendered += 1;
+    }
+    hasPriorExchange = priorExchange;
+    return rendered;
+  }
+
   /** @param {ChatEvent} event */
   function handleEvent(event) {
     switch (event.type) {
@@ -601,6 +665,8 @@ export function createChatRenderer(container) {
 
   return {
     addUserMessage,
+    addAgentMessage,
+    replay,
     handleEvent,
     reset,
     messageCount: () => count,

--- a/src/osprey/interfaces/web_terminal/static/js/chat.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat.js
@@ -3,20 +3,30 @@
  *
  * Thin glue between the SSE transport (chat-client.js) and the message-list
  * renderer (chat-render.js). It builds the operator console DOM inside
- * #operator-container, owns the per-page chat id and the streaming/idle UI
- * state, and turns user intent (submit, stop) into transport calls. All
- * rendering and sanitisation live in the renderer; all networking and SSE
- * parsing live in the client — this file holds no innerHTML and no parsing, so
- * the interesting logic stays in the two unit-tested modules.
+ * #operator-container, binds it to the tab's session pointer, and owns the
+ * streaming/idle UI state, turning user intent (submit, stop, switch view)
+ * into transport calls. All rendering and sanitisation live in the renderer;
+ * all networking and SSE parsing live in the client — this file holds no
+ * innerHTML and no parsing, so the interesting logic stays in the two
+ * unit-tested modules.
+ *
+ * The console does not mint a conversation of its own. Both views are windows
+ * onto one session key, held in the browser by session-pointer.js, and this
+ * console addresses whatever key the pointer names: it replays that key's
+ * transcript when it binds, and a change of pointer rebinds it. Only one view
+ * may run the agent at a time, so arriving from the Expert view is a
+ * negotiation rather than a connect — see {@link enterFromExpert}.
  *
  * Mode visibility is pure CSS: #operator-container is display-gated off
  * html[data-ui-mode] (operator.css), so the console is built once at boot and
  * simply hidden in expert mode — never torn down or toggled from here.
  */
 
-import { sendPrompt, interrupt, deleteChat } from './chat-client.js';
+import { fetchHistory, interrupt, requestHandoff, sendPrompt } from './chat-client.js';
 import { createChatRenderer, elem } from './chat-render.js';
 import { buildEmptyState, onKindChange, onSettled, renderEmptyStateContent } from './first-contact.js';
+import { getPointer, setPointer, subscribe as subscribeToPointer } from './session-pointer.js';
+import { notifySessionChange } from './terminal.js';
 
 /** Max textarea height (px) before it scrolls — matches operator.css. */
 const MAX_INPUT_HEIGHT = 120;
@@ -56,15 +66,77 @@ const TRANSPORT_NOTICES = {
 const TRANSPORT_FALLBACK = 'Connection to the operator agent failed.';
 
 /**
- * Build the operator console interior — session bar, message list, and the
- * command-line input row — and return the handles the controller drives.
+ * What the operator may do about a refused hand-off, keyed on the endpoint's
+ * `detail.error` slug. A refusal is not a transport failure: it is the other
+ * view still holding the session, so it belongs on the overlay that already
+ * has the operator's attention rather than as a line in a log they cannot use.
+ *
+ * `interrupt` re-sends the same request with the operator's consent to cut a
+ * running turn; `retry` re-sends it unchanged; a null action is a refusal
+ * retrying does not change, and states the fact alone.
+ * @type {Record<string, { message: string, action: 'interrupt'|'retry'|null }>}
+ */
+const HANDOFF_REFUSALS = {
+  session_attached_elsewhere: {
+    message: 'This session is in use in another tab or view.',
+    action: null,
+  },
+  handoff_needs_interrupt: {
+    message: 'The other view may still be working.',
+    action: 'interrupt',
+  },
+  handoff_superseded: { message: 'Another request took over this session.', action: 'retry' },
+  outgoing_still_running: {
+    message: 'The previous agent is still shutting down.',
+    action: 'retry',
+  },
+  outgoing_vanished: { message: 'The session changed while switching.', action: 'retry' },
+  spawn_not_pooled: { message: 'The session did not start.', action: 'retry' },
+  chat_capacity: { message: 'No chat capacity right now.', action: 'retry' },
+  sdk_unavailable: { message: 'Operator agent unavailable.', action: null },
+};
+
+// `chat_terminated` is deliberately absent above. This table is consulted
+// before the notice tables, and that slug's one useful answer is the notice
+// it already has: the prompt the operator just sent needs sending again. A
+// hand-off refused with it falls to HANDOFF_FALLBACK, which offers the same
+// retry the overlay would have given it.
+
+/** Overlay copy for a hand-off that failed with no reason this view knows. */
+const HANDOFF_FALLBACK = { message: 'The hand-off failed.', action: /** @type {'retry'} */ ('retry') };
+
+/** Copy shown while the outgoing view finishes the turn it is on. */
+const HANDOFF_PENDING_MESSAGE = 'Finishing in the other view · ';
+
+/**
+ * Build the operator console interior — session bar, message list, hand-off
+ * overlay, and the command-line input row — and return the handles the
+ * controller drives.
  */
 function buildConsole() {
   const bar = elem('div', 'op-session-bar');
   const led = elem('span', 'op-session-led');
-  bar.append(led, elem('span', 'op-session-label', 'Operator'));
+  const newBtn = /** @type {HTMLButtonElement} */ (
+    elem('button', 'op-session-new', 'New conversation')
+  );
+  newBtn.type = 'button';
+  bar.append(led, elem('span', 'op-session-label', 'Operator'), newBtn);
 
   const messages = elem('div', 'op-messages');
+
+  // A state the operator is waiting on rather than one they opened: announced
+  // when it appears, never focus-trapped. Built with the console and hidden,
+  // because a flip has to paint it in the same frame it disables the input.
+  const overlay = elem('div', 'op-handoff');
+  overlay.hidden = true;
+  overlay.setAttribute('role', 'status');
+  overlay.setAttribute('aria-live', 'polite');
+  const overlayMessage = elem('p', 'op-handoff-message');
+  const overlayAction = /** @type {HTMLButtonElement} */ (elem('button', 'op-handoff-action'));
+  overlayAction.type = 'button';
+  const overlayCard = elem('div', 'op-handoff-card');
+  overlayCard.append(overlayMessage, overlayAction);
+  overlay.append(overlayCard);
 
   const textarea = document.createElement('textarea');
   textarea.placeholder = 'Message the operator agent…';
@@ -93,7 +165,19 @@ function buildConsole() {
   const inputArea = elem('div', 'op-input-area');
   inputArea.append(elem('span', 'op-prompt-char', '›'), textarea, controls);
 
-  return { bar, led, messages, inputArea, textarea, sendBtn, stopBtn };
+  return {
+    bar,
+    led,
+    newBtn,
+    messages,
+    overlay,
+    overlayMessage,
+    overlayAction,
+    inputArea,
+    textarea,
+    sendBtn,
+    stopBtn,
+  };
 }
 
 /**
@@ -130,8 +214,45 @@ export function transportNotice(err) {
 }
 
 /**
+ * The hand-off refusal *err* describes, or null when it is an ordinary
+ * transport failure. Slug-only by design: a bare 409 says nothing about who
+ * holds the session, and offering "Stop and switch now" for a rejection that
+ * is not about the other view would cut a turn for no reason.
+ * @param {unknown} err
+ * @returns {{ message: string, action: 'interrupt'|'retry'|null } | null}
+ */
+export function handoffRefusal(err) {
+  const slug = /** @type {{ slug?: unknown }} */ (err ?? {}).slug;
+  if (typeof slug === 'string' && slug in HANDOFF_REFUSALS) return HANDOFF_REFUSALS[slug];
+  return null;
+}
+
+/**
+ * The console's hand-off entry point, bound by {@link initChat}. Module-level
+ * because the flip that calls it (app.js) has no handle on the console.
+ * @type {((options?: { interrupt?: boolean }) => Promise<void>) | null}
+ */
+let enterFromExpertBinding = null;
+
+/**
+ * Take the session over from the Expert view and show it here.
+ *
+ * Shows the transitional state, asks the server to hand the key's transcript
+ * to the Simple view, and replays it once the outgoing agent is dead. `interrupt`
+ * says the operator chose to cut a turn that was still running rather than wait
+ * for it. Resolves when the console is usable, when the refusal is on screen,
+ * or when the server abandoned the request and left the wait as it was; a
+ * console that was never mounted resolves immediately.
+ * @param {{ interrupt?: boolean }} [options]
+ * @returns {Promise<void>}
+ */
+export function enterFromExpert(options = {}) {
+  return enterFromExpertBinding ? enterFromExpertBinding(options) : Promise.resolve();
+}
+
+/**
  * Mount the Simple-mode operator chat into #operator-container. Called once in
- * the boot sequence; mints a single chat id and wires one console. A missing
+ * the boot sequence; binds one console to the tab's session pointer. A missing
  * container is a no-op so the rest of the page still boots.
  * @param {string} [containerId]
  * @returns {void}
@@ -143,25 +264,77 @@ export function initChat(containerId = 'operator-container') {
   // handler closures below, so hand them a statically non-null reference.
   const container = /** @type {HTMLElement} */ (found);
 
-  const chatId = crypto.randomUUID();
-  const { bar, led, messages, inputArea, textarea, sendBtn, stopBtn } = buildConsole();
-  container.append(bar, messages, inputArea);
+  const handles = buildConsole();
+  const { bar, led, newBtn, messages, overlay, overlayMessage, overlayAction } = handles;
+  const { inputArea, textarea, sendBtn, stopBtn } = handles;
+  container.append(bar, messages, overlay, inputArea);
 
   const renderer = createChatRenderer(messages);
 
-  /** In-flight turn handle, or null when idle. Also the streaming/idle flag. */
+  /** In-flight turn handle, or null when idle. */
   let handle = /** @type {import('./chat-client.js').ChatAbortHandle | null} */ (null);
+
+  /** Whether a turn is streaming. */
+  let streaming = false;
+
+  /** Whether a hand-off is in flight or refused — the input stays out of reach. */
+  let transitioning = false;
 
   /** The first-contact block while it is on screen, or null once it is gone. */
   let emptyState = /** @type {HTMLElement | null} */ (null);
+
+  /** Whether first contact has had its moment, so a rebind can re-invite. */
+  let settled = false;
+
+  /**
+   * The session key this tab was already on, or null for a tab that has none.
+   * @type {string|null}
+   */
+  const adopted = getPointer();
+
+  /**
+   * The session key this console is showing. Adopted from the pointer at boot
+   * and minted only for a tab that has none — the Expert view resumes the same
+   * slot, so a second key here would be a second conversation.
+   * @type {string}
+   */
+  let boundKey = adopted ?? crypto.randomUUID();
+  if (!adopted) setPointer(boundKey);
+
+  /** Which hand-off attempt is current; a retry supersedes the one before it. */
+  let handoffGeneration = 0;
+
+  /** The in-flight hand-off request, so a retry can abandon it first. */
+  let handoffAbort = /** @type {AbortController | null} */ (null);
+
+  /** When the current hand-off wait started, or null when none is showing. */
+  let waitStartedAt = /** @type {number | null} */ (null);
+
+  /** The 1 Hz elapsed-time ticker, or null when nothing is counting. */
+  let ticker = /** @type {number | null} */ (null);
+
+  const isSimpleMode = () =>
+    document.documentElement.getAttribute('data-ui-mode') === 'simple';
+
+  const isPinned = () =>
+    messages.scrollHeight - messages.scrollTop - messages.clientHeight < STICK_THRESHOLD;
+  const scrollToBottom = () => {
+    messages.scrollTop = messages.scrollHeight;
+  };
+
+  /** Offer first contact when the log is empty and there is something to say. */
+  function inviteIfEmpty() {
+    if (!settled || emptyState || renderer.messageCount() > 0) return;
+    emptyState = buildEmptyState();
+    messages.prepend(emptyState);
+  }
 
   // First contact, once there is enough known to say something true. A log that
   // already has entries in it is not empty and needs no invitation — a resumed
   // page reaches the settled moment too.
   onSettled(() => {
-    if (renderer.messageCount() > 0) return;
-    emptyState = buildEmptyState();
-    messages.prepend(emptyState);
+    settled = true;
+    inviteIfEmpty();
   });
 
   // A switch changes what the sentence may claim. Rebuilt in place, and only
@@ -170,15 +343,19 @@ export function initChat(containerId = 'operator-container') {
     if (emptyState) renderEmptyStateContent(emptyState);
   });
 
-  const isPinned = () =>
-    messages.scrollHeight - messages.scrollTop - messages.clientHeight < STICK_THRESHOLD;
-  const scrollToBottom = () => {
-    messages.scrollTop = messages.scrollHeight;
-  };
-
   function autoResize() {
     textarea.style.height = 'auto';
     textarea.style.height = `${Math.min(textarea.scrollHeight, MAX_INPUT_HEIGHT)}px`;
+  }
+
+  /** Apply the current streaming/transition state to every control. */
+  function applyControls() {
+    const blocked = streaming || transitioning;
+    textarea.disabled = blocked;
+    sendBtn.disabled = blocked;
+    newBtn.disabled = blocked;
+    stopBtn.hidden = !streaming;
+    stopBtn.disabled = false;
   }
 
   /**
@@ -188,17 +365,25 @@ export function initChat(containerId = 'operator-container') {
    * @param {boolean} on
    */
   function setStreaming(on) {
+    streaming = on;
     container.classList.toggle('streaming', on);
     led.classList.toggle('active', on);
-    textarea.disabled = on;
-    sendBtn.disabled = on;
-    stopBtn.hidden = !on;
-    stopBtn.disabled = false;
+    applyControls();
     // Return focus to the input when a turn ends, but only while the console is
-    // the visible view — focusing a hidden textarea in expert mode is pointless.
-    if (!on && document.documentElement.getAttribute('data-ui-mode') === 'simple') {
-      textarea.focus();
-    }
+    // the visible view and reachable — focusing a hidden or disabled textarea
+    // is pointless.
+    if (!on && !transitioning && isSimpleMode()) textarea.focus();
+  }
+
+  /**
+   * Put the console into (or out of) the hand-off transition, where the input
+   * is out of reach because the session is not this view's yet.
+   * @param {boolean} on
+   */
+  function setTransitioning(on) {
+    transitioning = on;
+    applyControls();
+    if (!on && !streaming && isSimpleMode()) textarea.focus();
   }
 
   /** @param {string} message */
@@ -207,13 +392,195 @@ export function initChat(containerId = 'operator-container') {
     scrollToBottom();
   }
 
+  /** Update the elapsed counter in place. */
+  function renderElapsed() {
+    const elapsed = overlayMessage.querySelector('.op-handoff-elapsed');
+    if (!elapsed || waitStartedAt === null) return;
+    const total = Math.max(0, Math.floor((Date.now() - waitStartedAt) / 1000));
+    elapsed.textContent = `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+  }
+
+  /** Stop the elapsed counter and forget when the wait began. */
+  function stopTicker() {
+    if (ticker !== null) {
+      clearInterval(ticker);
+      ticker = null;
+    }
+    waitStartedAt = null;
+  }
+
+  /**
+   * Write the overlay's one line, optionally with the live counter.
+   * @param {string} text
+   * @param {boolean} withElapsed
+   */
+  function setOverlayMessage(text, withElapsed) {
+    overlayMessage.textContent = text;
+    if (!withElapsed) return;
+    const elapsed = elem('span', 'op-handoff-elapsed');
+    // The card is a polite live region, and a counter inside it would be read
+    // out once a second. The sentence is the announcement; the clock is for
+    // the eye.
+    elapsed.setAttribute('aria-live', 'off');
+    overlayMessage.append(elapsed);
+  }
+
+  /**
+   * Show the overlay's single action, or hide it when there is nothing the
+   * operator can do about the state on screen.
+   * @param {string} label
+   * @param {(() => void) | null} onPress
+   */
+  function setOverlayAction(label, onPress) {
+    overlayAction.textContent = label;
+    overlayAction.hidden = onPress === null;
+    overlayAction.disabled = false;
+    overlayAction.onclick = onPress
+      ? () => {
+        overlayAction.disabled = true;
+        onPress();
+      }
+      : null;
+  }
+
+  /**
+   * Show the transitional state: the other view's agent is finishing its turn
+   * and this one is waiting for it. There is no bound on that wait, so the
+   * elapsed time is the honest thing to show, and the button is the way out.
+   */
+  function showHandoffPending() {
+    // A retry continues the wait the operator is already watching rather than
+    // restarting its clock.
+    if (waitStartedAt === null) waitStartedAt = Date.now();
+    setOverlayMessage(HANDOFF_PENDING_MESSAGE, true);
+    renderElapsed();
+    if (ticker === null) ticker = window.setInterval(renderElapsed, 1000);
+    setOverlayAction('Stop and switch now', () => {
+      void runHandoff(true);
+    });
+    overlay.hidden = false;
+    setTransitioning(true);
+  }
+
+  /**
+   * Show why the server would not hand the session over, and what remains to
+   * be done about it. The input stays out of reach: the session is not this
+   * view's, and a refusal with no action is final for this view.
+   * @param {{ message: string, action: 'interrupt'|'retry'|null }} refusal
+   */
+  function showHandoffRefused(refusal) {
+    stopTicker();
+    setOverlayMessage(refusal.message, false);
+    if (refusal.action === 'interrupt') {
+      setOverlayAction('Stop and switch now', () => {
+        void runHandoff(true);
+      });
+    } else if (refusal.action === 'retry') {
+      setOverlayAction('Retry', () => {
+        void runHandoff(false);
+      });
+    } else {
+      setOverlayAction('', null);
+    }
+    overlay.hidden = false;
+    setTransitioning(true);
+  }
+
+  /** Clear the overlay entirely. */
+  function hideOverlay() {
+    stopTicker();
+    overlay.hidden = true;
+    overlayAction.onclick = null;
+  }
+
+  /** Clear the log and everything the old conversation left behind. */
+  function resetLog() {
+    handle?.abort();
+    handle = null;
+    renderer.reset();
+    emptyState = null;
+    setStreaming(false);
+  }
+
+  /**
+   * Point the console at *key*: clear the log, then replay what the session
+   * has already said so the Simple view opens on the conversation rather than
+   * on an empty console.
+   * @param {string} key
+   * @returns {Promise<void>}
+   */
+  async function bindTo(key) {
+    boundKey = key;
+    resetLog();
+    if (isSimpleMode()) notifySessionChange(key);
+
+    /** @type {import('./chat-client.js').ChatTurn[]} */
+    let turns = [];
+    try {
+      turns = await fetchHistory(key);
+    } catch (err) {
+      if (boundKey === key) showNotice(transportNotice(err));
+      return;
+    }
+    // A newer bind landed while the transcript was in flight; it owns the log.
+    if (boundKey !== key) return;
+    renderer.replay(turns);
+    inviteIfEmpty();
+    scrollToBottom();
+  }
+
+  /**
+   * Ask the server for the session, showing the wait and then either the
+   * conversation or the reason it was refused.
+   * @param {boolean} cutRunningTurn
+   * @returns {Promise<void>}
+   */
+  async function runHandoff(cutRunningTurn) {
+    const generation = ++handoffGeneration;
+    // The server frees a key whose requester disconnects, so abandoning the
+    // wait in flight is what makes room for this one — two live requests for
+    // the same key are two channels, and the second would be refused.
+    handoffAbort?.abort();
+    const controller = new AbortController();
+    handoffAbort = controller;
+
+    const key = boundKey;
+    showHandoffPending();
+    /** @type {{ state: string, session_id: string } | null} */
+    let handed = null;
+    try {
+      handed = await requestHandoff(key, { interrupt: cutRunningTurn, signal: controller.signal });
+    } catch (err) {
+      if (generation !== handoffGeneration) return;
+      handoffAbort = null;
+      const refusal = handoffRefusal(err);
+      showHandoffRefused(refusal ?? HANDOFF_FALLBACK);
+      return;
+    }
+    if (generation !== handoffGeneration) return;
+    // A 204 with no body: the server saw this request's channel close and
+    // abandoned the acquire, so nothing was handed over and nothing failed.
+    // The state on screen is still the true one — a wait the operator can
+    // still cut short — and replacing it with copy about a request that was
+    // never answered would be a claim the server did not make.
+    if (!handed) return;
+    handoffAbort = null;
+    hideOverlay();
+    await bindTo(key);
+    // The replay is awaited, so a retry can start and put its own wait on
+    // screen while this one is still finishing. Enabling the input here would
+    // hand the operator a console over the newer attempt's overlay.
+    if (generation !== handoffGeneration) return;
+    setTransitioning(false);
+  }
+
   /** Submit the current input as a new turn, unless one is already streaming. */
   function submit() {
-    if (handle) return;
+    if (streaming || transitioning) return;
     const prompt = textarea.value.trim();
     if (!prompt) return;
 
-    renderer.addUserMessage(prompt);
+    const entry = renderer.addUserMessage(prompt);
     // The invitation has been taken; the log is the conversation from here.
     emptyState?.remove();
     emptyState = null;
@@ -222,7 +589,7 @@ export function initChat(containerId = 'operator-container') {
     scrollToBottom();
     setStreaming(true);
 
-    handle = sendPrompt(chatId, prompt, {
+    handle = sendPrompt(boundKey, prompt, {
       onEvent: (event) => {
         // Follow the tail only when the operator hasn't scrolled up to read back.
         const pinned = isPinned();
@@ -230,7 +597,18 @@ export function initChat(containerId = 'operator-container') {
         if (pinned) scrollToBottom();
       },
       onError: (err) => {
-        showNotice(transportNotice(err));
+        const refusal = handoffRefusal(err);
+        if (!refusal) {
+          showNotice(transportNotice(err));
+          return;
+        }
+        // The other view holds the session, so the prompt never ran. Take the
+        // bubble back and return the text to the input the operator typed it
+        // in; the overlay carries the one thing left to do.
+        entry.remove();
+        textarea.value = prompt;
+        autoResize();
+        showHandoffRefused(refusal);
       },
       onClose: () => {
         handle = null;
@@ -248,11 +626,27 @@ export function initChat(containerId = 'operator-container') {
     // arrival order is safe server-side; the abort makes the client stop
     // reading immediately. A failed interrupt still falls through to abort.
     try {
-      await interrupt(chatId);
+      await interrupt(boundKey);
     } catch {
       // Non-2xx or network failure — nothing to surface; abort regardless.
     }
     current.abort();
+  }
+
+  /**
+   * Start a conversation on a new session key. The pointer is the shared slot,
+   * so writing it here is what moves both views; the old key's transcript is
+   * left alone — it is a session the operator can still resume.
+   */
+  function newConversation() {
+    const key = crypto.randomUUID();
+    // Claim it before the pointer notifies, so the subscription below sees the
+    // key the console is already on and does not replay an empty transcript.
+    boundKey = key;
+    setPointer(key);
+    resetLog();
+    inviteIfEmpty();
+    if (isSimpleMode()) notifySessionChange(key);
   }
 
   textarea.addEventListener('input', autoResize);
@@ -265,13 +659,25 @@ export function initChat(containerId = 'operator-container') {
   });
   sendBtn.addEventListener('click', submit);
   stopBtn.addEventListener('click', stop);
+  newBtn.addEventListener('click', newConversation);
 
-  // Best-effort server-side cleanup when the page goes away (keepalive DELETE).
-  window.addEventListener('pagehide', () => {
-    try {
-      deleteChat(chatId);
-    } catch {
-      // Fire-and-forget: a teardown-time failure has nowhere to surface.
-    }
+  // The pointer is the tab's session, not this console's: a key chosen
+  // anywhere else (the session picker, another view) moves the log here too. A
+  // cleared pointer means the key is dead for both views and the page is on
+  // its way out — there is no conversation to move to.
+  subscribeToPointer((key) => {
+    if (!key || key === boundKey) return;
+    void bindTo(key);
   });
+
+  enterFromExpertBinding = ({ interrupt: cutRunningTurn = false } = {}) =>
+    runHandoff(cutRunningTurn);
+
+  // A page that opens in Simple mode never went through a flip, so nothing
+  // else replays the key it adopted above — and nothing else tells the panels
+  // which session they are on, because the terminal does not connect here.
+  if (isSimpleMode()) {
+    if (adopted) void bindTo(adopted);
+    else notifySessionChange(boundKey);
+  }
 }

--- a/src/osprey/interfaces/web_terminal/static/js/session-pointer.js
+++ b/src/osprey/interfaces/web_terminal/static/js/session-pointer.js
@@ -1,0 +1,122 @@
+// @ts-check
+/* OSPREY Web Terminal — the browser's session pointer
+ *
+ * One slot, `osprey-pty-session`, holding the session key this tab is on. Both
+ * views read it: the terminal resumes it on page load, and the chat sends it
+ * with every turn, so the two surfaces address the same session rather than
+ * each starting one of their own.
+ *
+ * Per persona, not per origin. localStorage is origin-scoped, so on a
+ * multi-user mount (`/u/alice/`, `/u/bob/`) a bare key would be one shared
+ * pointer — and a session key is not a preference that can be shared:
+ * replaying one persona's key would attach another persona's surface to a
+ * process that is not theirs. Every read, write and clear resolves the key
+ * through pointerKey() below.
+ *
+ * @module session-pointer
+ */
+
+import { scopedStorageKey } from '/design-system/js/storage-scope.js';
+
+const POINTER_KEY_BASE = 'osprey-pty-session';
+
+/**
+ * This document's pointer key. Resolved per call rather than once at module
+ * load: the scope lives on the served document, and reading it at the point of
+ * use is what keeps the key honest.
+ * @returns {string}
+ */
+function pointerKey() {
+  return scopedStorageKey(POINTER_KEY_BASE);
+}
+
+/**
+ * What this module last wrote. Storage can be unavailable (private browsing,
+ * storage disabled), and a pointer that reads back as null there would make
+ * every write look like a change and every read look like "no session". The
+ * mirror keeps both honest for the life of the page.
+ * @type {string|null}
+ */
+let mirror = null;
+
+/**
+ * Listeners for pointer changes, notified with the new value (null on clear).
+ * @type {((sessionId: string|null) => void)[]}
+ */
+const listeners = [];
+
+/**
+ * The session key this tab is on, or null if there is none.
+ * @returns {string|null}
+ */
+export function getPointer() {
+  try {
+    return localStorage.getItem(pointerKey());
+  } catch {
+    return mirror;
+  }
+}
+
+/**
+ * Notify listeners that the pointer settled on `sessionId`. One listener
+ * throwing must not cost the others their notification.
+ * @param {string|null} sessionId
+ */
+function notify(sessionId) {
+  for (const fn of listeners) {
+    try {
+      fn(sessionId);
+    } catch (err) {
+      console.error('osprey web_terminal: a session-pointer listener threw', err);
+    }
+  }
+}
+
+/**
+ * Point this tab at `sessionId`. A write of the key already stored is not a
+ * change and notifies nobody — the same id arrives from several places (a
+ * connect, a confirmation, a chat turn) and each of those is the same fact.
+ * @param {string} sessionId
+ */
+export function setPointer(sessionId) {
+  if (getPointer() === sessionId) return;
+  mirror = sessionId;
+  try {
+    localStorage.setItem(pointerKey(), sessionId);
+  } catch {
+    // Ignore — private browsing / storage disabled. Persistence is a
+    // convenience; both views still work without it, for this page load.
+  }
+  notify(sessionId);
+}
+
+/**
+ * Forget the session key (a dead id, or logout). A clear of an already-empty
+ * pointer notifies nobody, for the same reason a repeated set does not.
+ */
+export function clearPointer() {
+  if (getPointer() === null) return;
+  mirror = null;
+  try {
+    localStorage.removeItem(pointerKey());
+  } catch {
+    // Ignore — see setPointer().
+  }
+  notify(null);
+}
+
+/**
+ * Subscribe to pointer changes. The callback fires for every key the tab
+ * settles on, and with null when the pointer is cleared, but not for the
+ * current value at subscribe time; callers that need it now read
+ * {@link getPointer}. Returns a function that removes the subscription.
+ * @param {(sessionId: string|null) => void} fn
+ * @returns {() => void}
+ */
+export function subscribe(fn) {
+  listeners.push(fn);
+  return () => {
+    const at = listeners.indexOf(fn);
+    if (at !== -1) listeners.splice(at, 1);
+  };
+}

--- a/src/osprey/interfaces/web_terminal/static/js/terminal-handoff.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal-handoff.js
@@ -1,0 +1,201 @@
+/* OSPREY Web Terminal — Session Hand-off Overlay */
+
+import { WS_CLOSE_OUTGOING_RUNNING } from './api.js';
+
+/**
+ * The transitional state shown on the terminal card while the session is
+ * being handed over from the other view, and the place a refused connection
+ * says why.
+ *
+ * Both views are windows onto one session and only one of them may run its
+ * agent at a time, so taking it over is a negotiation rather than a connect:
+ * the outgoing agent finishes the turn it is on — never ended on a clock —
+ * and this is what the operator watches while it does. The overlay is built
+ * on demand and removed when it clears, so the card carries no extra DOM in
+ * the ordinary case.
+ *
+ * The module owns the overlay's DOM, copy and clock, and nothing else:
+ * connecting, retrying and interrupting are the caller's, handed in as
+ * callbacks.
+ */
+const OVERLAY_ID = 'terminal-handoff';
+
+/** When the current hand-off wait started, or null when none is showing. */
+/** @type {number|null} */
+let startedAt = null;
+
+/** The 1 Hz elapsed-time ticker, or null when nothing is counting. */
+/** @type {number|null} */
+let ticker = null;
+
+/**
+ * Elapsed wait as `m:ss`.
+ * @param {number} ms
+ * @returns {string}
+ */
+function formatElapsed(ms) {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+}
+
+/**
+ * The overlay element, building it into the terminal body on first use.
+ * Returns null where there is no terminal body to mount on.
+ * @returns {HTMLElement|null}
+ */
+function ensureOverlay() {
+  const existing = document.getElementById(OVERLAY_ID);
+  if (existing) return existing;
+
+  const body = document.querySelector('.terminal-body');
+  if (!body) return null;
+
+  const overlay = document.createElement('div');
+  overlay.id = OVERLAY_ID;
+  overlay.className = 'terminal-handoff';
+  // A state the operator is waiting on rather than one they opened: announced
+  // when it appears, never focus-trapped.
+  overlay.setAttribute('role', 'status');
+  overlay.setAttribute('aria-live', 'polite');
+
+  const card = document.createElement('div');
+  card.className = 'terminal-handoff-card';
+
+  const message = document.createElement('p');
+  message.className = 'terminal-handoff-message';
+
+  const action = document.createElement('button');
+  action.type = 'button';
+  action.className = 'terminal-handoff-action';
+
+  card.append(message, action);
+  overlay.append(card);
+  body.append(overlay);
+  return overlay;
+}
+
+/**
+ * Write the overlay's one line. `withElapsed` appends the live counter that
+ * {@link renderElapsed} keeps current.
+ * @param {HTMLElement} overlay
+ * @param {string} text
+ * @param {boolean} withElapsed
+ */
+function setMessage(overlay, text, withElapsed) {
+  const message = overlay.querySelector('.terminal-handoff-message');
+  if (!message) return;
+  message.textContent = text;
+  if (!withElapsed) return;
+  const elapsed = document.createElement('span');
+  elapsed.className = 'terminal-handoff-elapsed';
+  // Inside the live region, but not part of what it announces: a counter
+  // ticking once a second would be read out once a second, for as long as the
+  // wait lasts. The sentence around it is the announcement.
+  elapsed.setAttribute('aria-live', 'off');
+  message.append(elapsed);
+}
+
+/** Update the elapsed counter in place. */
+function renderElapsed() {
+  const elapsed = document.querySelector('.terminal-handoff-elapsed');
+  if (!elapsed || startedAt === null) return;
+  elapsed.textContent = formatElapsed(Date.now() - startedAt);
+}
+
+/** The overlay's action button, or null when the overlay is not mounted. */
+function actionButton() {
+  return /** @type {HTMLButtonElement|null} */ (
+    document.querySelector('.terminal-handoff-action')
+  );
+}
+
+/**
+ * Show the transitional state: the other view's agent is finishing its turn
+ * and this connection is waiting for it. There is no bound on that wait, so
+ * the elapsed time is the honest thing to show, and the button is the
+ * operator's way out of it.
+ *
+ * @param {() => void} onInterrupt - "Stop and switch now". The button
+ *   disables itself before this runs, and a later `handoff_pending` re-enables
+ *   it, so one press cannot become two.
+ */
+export function showHandoffPending(onInterrupt) {
+  const overlay = ensureOverlay();
+  if (!overlay) return;
+
+  // A second `handoff_pending` — including the one an interrupt's reconnect
+  // brings back — continues the wait the operator is already watching rather
+  // than restarting its clock.
+  if (startedAt === null) startedAt = Date.now();
+
+  setMessage(overlay, 'Finishing in the other view · ', true);
+  renderElapsed();
+  if (ticker === null) ticker = window.setInterval(renderElapsed, 1000);
+
+  const action = actionButton();
+  if (!action) return;
+  action.textContent = 'Stop and switch now';
+  action.hidden = false;
+  action.disabled = false;
+  action.onclick = () => {
+    action.disabled = true;
+    onInterrupt();
+  };
+  // Moves the caret out of the terminal, which takes no input while the
+  // hand-off is pending.
+  action.focus();
+}
+
+/**
+ * Show why the server refused this connection. Both refusals are final for
+ * the socket that received them (see `isRefusalCloseCode` in api.js): one
+ * says the session is held elsewhere, which retrying does not change, and one
+ * says the outgoing agent had not finished dying, which is exactly what a
+ * retry is for.
+ *
+ * @param {number} code - WebSocket close code.
+ * @param {() => void} onRetry - Runs when the operator retries, which only
+ *   the retryable refusal offers. The overlay clears first.
+ */
+export function showHandoffRefused(code, onRetry) {
+  stopTicker();
+  const overlay = ensureOverlay();
+  if (!overlay) return;
+
+  const retryable = code === WS_CLOSE_OUTGOING_RUNNING;
+  setMessage(
+    overlay,
+    retryable
+      ? 'The previous agent is still shutting down.'
+      : 'This session is in use in another tab or view.',
+    false,
+  );
+
+  const action = actionButton();
+  if (!action) return;
+  action.textContent = 'Retry';
+  action.hidden = !retryable;
+  action.disabled = false;
+  action.onclick = retryable
+    ? () => {
+      hideHandoffOverlay();
+      onRetry();
+    }
+    : null;
+}
+
+/** Stop the elapsed counter and forget when the wait began. */
+function stopTicker() {
+  if (ticker !== null) {
+    clearInterval(ticker);
+    ticker = null;
+  }
+  startedAt = null;
+}
+
+/** Clear the overlay entirely. */
+export function hideHandoffOverlay() {
+  stopTicker();
+  const overlay = document.getElementById(OVERLAY_ID);
+  if (overlay) overlay.remove();
+}

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -1,8 +1,13 @@
 /* OSPREY Web Terminal — Terminal Module */
 
 import { createWebSocket, wsUrl, withPrefix } from './api.js';
+import { clearPointer, getPointer, setPointer } from './session-pointer.js';
+import {
+  hideHandoffOverlay,
+  showHandoffPending,
+  showHandoffRefused,
+} from './terminal-handoff.js';
 import { subscribe, xtermPalette } from '/design-system/js/theme-manager.js';
-import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 
 /** @type {any} */
 let term = null;
@@ -13,28 +18,6 @@ let wsConnection = null;
 let hasConnectedBefore = false;
 /** @type {string|null} */
 let currentSessionId = null;
-
-// localStorage key for persisting the active PTY session ID across page
-// loads, so a kept-warm session survives a logout -> landing page ->
-// return round trip.
-//
-// Per persona, not per origin. localStorage is origin-scoped, so on a
-// multi-user mount (`/u/alice/`, `/u/bob/`) a bare key would be one shared
-// pointer — and a session id is not a preference that can be shared: replaying
-// one persona's id would attach another persona's terminal to a PTY that is
-// not theirs. Every read, write and clear resolves the key through
-// ptySessionStorageKey() below.
-const PTY_SESSION_STORAGE_KEY_BASE = 'osprey-pty-session';
-
-/**
- * This document's PTY-pointer key. Resolved per call rather than once at
- * module load: the scope lives on the served document, and reading it at the
- * point of use is what keeps the key honest.
- * @returns {string}
- */
-function ptySessionStorageKey() {
-  return scopedStorageKey(PTY_SESSION_STORAGE_KEY_BASE);
-}
 
 // Every connection gets a 'session_info' confirmation from
 // routes/websocket.py carrying the id ACTUALLY attached. A resume of an id
@@ -77,43 +60,30 @@ let autoResumeFailoverId = null;
 let freshStartArmed = false;
 
 /**
- * Read the persisted PTY session ID. Returns null if none is stored or if
- * localStorage is unavailable (e.g. private browsing).
+ * Read the tab's session pointer. Returns null if none is stored.
  * @returns {string|null}
  */
 function loadStoredSessionId() {
-  try {
-    return localStorage.getItem(ptySessionStorageKey());
-  } catch {
-    return null;
-  }
+  return getPointer();
 }
 
 /**
- * Persist the active PTY session ID so a later page load can resume it.
+ * Point the tab at the session this terminal is on, so a later page load —
+ * and the chat, which reads the same pointer — resumes it.
  * @param {string} sessionId
  */
 function storeSessionId(sessionId) {
-  try {
-    localStorage.setItem(ptySessionStorageKey(), sessionId);
-  } catch {
-    // Ignore — private browsing / storage disabled. Persistence is a
-    // convenience; the terminal still works without it.
-  }
+  setPointer(sessionId);
 }
 
 /**
- * Clear the persisted PTY session ID (e.g. once a resume attempt turns out
- * to target a dead/expired session, or on logout — see app.js's
+ * Clear the tab's session pointer (e.g. once a resume attempt turns out to
+ * target a dead/expired session, or on logout — see app.js's
  * initLogoutButton, which clears the client's pointer before navigating so
  * the next page load's initTerminal() has nothing to auto-resume).
  */
 export function clearStoredSessionId() {
-  try {
-    localStorage.removeItem(ptySessionStorageKey());
-  } catch {
-    // Ignore — see storeSessionId().
-  }
+  clearPointer();
 }
 
 /**
@@ -304,6 +274,13 @@ export function initTerminal(containerId) {
   });
   resizeObserver.observe(/** @type {Element} */ (container.parentElement));
 
+  // In the Simple view the chat holds the session and the terminal is not on
+  // screen. Only one surface may run the session's agent at a time, so a
+  // hidden terminal that connected here would take the conversation away from
+  // the view the operator is actually looking at. The flip to Expert starts
+  // it instead — see startExpert().
+  if (isSimpleView()) return;
+
   // Start the PTY WebSocket connection. If a session was kept warm from a
   // previous page load (e.g. a logout -> landing page -> return round
   // trip), resume it via the existing server mode=resume path instead of
@@ -323,11 +300,26 @@ export function initTerminal(containerId) {
  *
  * @param {string|null} sessionId - Session UUID to resume. Null for new session.
  * @param {'new'|'resume'} mode - Whether to start a new session or resume.
+ * @param {{ interrupt?: boolean }} [options] - `interrupt` ends the other
+ *   view's running turn instead of waiting for it ("Stop and switch now").
+ *   Only meaningful on a resume.
+ * @returns {Promise<void>} Settles once this attempt has an answer — attached
+ *   (`session_info`), refused, errored, or closed without one — and never
+ *   rejects; a caller sequencing a hand-off awaits it so the next surface
+ *   cannot ask for the session before the server has seen this one let go.
  */
-export function startTerminal(sessionId = null, mode = 'new') {
-  if (wsConnection) return;
-  if (!term) return;
+export function startTerminal(sessionId = null, mode = 'new', { interrupt = false } = {}) {
+  if (wsConnection) return Promise.resolve();
+  if (!term) return Promise.resolve();
   freshStartArmed = false;
+
+  // Resolved by whichever answer arrives first. Resolving is idempotent, so
+  // every settling point below can call it without checking the others.
+  let settle = () => {};
+  /** @type {Promise<void>} */
+  const settled = new Promise((resolve) => {
+    settle = resolve;
+  });
 
   let url = wsUrl('/ws/terminal'); // wsUrl prefixes this internally
   // Is this specifically the page-load auto-resume attempt (as opposed to
@@ -336,6 +328,7 @@ export function startTerminal(sessionId = null, mode = 'new') {
   const isAutoResumeAttempt = mode === 'resume' && sessionId != null && sessionId === autoResumeFailoverId;
   if (mode === 'resume' && sessionId) {
     url += `?session_id=${encodeURIComponent(sessionId)}&mode=resume`;
+    if (interrupt) url += '&interrupt=1';
     currentSessionId = sessionId;
     // Persist optimistically so a reload mid-connect resumes the same id;
     // the server's answer corrects it — 'session_info' with another id, or
@@ -343,7 +336,11 @@ export function startTerminal(sessionId = null, mode = 'new') {
     storeSessionId(sessionId);
   }
 
-  const socket = createWebSocket(url, {
+  // Declared before the call so the handlers below can compare against it;
+  // they only ever run once `createWebSocket` has returned.
+  /** @type {ReturnType<typeof createWebSocket>|null} */
+  let socket = null;
+  socket = createWebSocket(url, {
     onOpen() {
       // On reconnection (server restart), reset terminal to avoid
       // garbled output from old session mixed with new.
@@ -389,6 +386,22 @@ export function startTerminal(sessionId = null, mode = 'new') {
               stopTerminal();
               startTerminal();
             }
+          } else if (msg.type === 'handoff_pending') {
+            // The key is alive in the other view — the server just said so by
+            // negotiating for it — so the page-load failover has its answer
+            // and must not fire. Left armed, the exit that ends the outgoing
+            // agent (or the one an interrupt forces) would read as a dead id
+            // and drop the key both views are on.
+            autoResumeFailoverId = null;
+            // The other view still holds the session and its agent is mid-turn.
+            // The server waits for that turn to end rather than killing it, so
+            // this connection has no bound on how long it sits here — show the
+            // wait, and the way to end it: ask for the same session again with
+            // `interrupt=1`, which ends that turn instead of waiting it out.
+            showHandoffPending(() => {
+              dropConnection();
+              startExpert({ interrupt: true });
+            });
           } else if (msg.type === 'session_info') {
             // On resume, msg.session_id is the id ACTUALLY attached, which
             // may differ from the stale id we asked for (the server
@@ -404,6 +417,10 @@ export function startTerminal(sessionId = null, mode = 'new') {
               mode === 'resume' && sessionId != null && msg.session_id !== sessionId;
             currentSessionId = msg.session_id;
             autoResumeFailoverId = null;
+            // Whatever the connection was waiting on is over: this terminal is
+            // attached to the session.
+            hideHandoffOverlay();
+            settle();
             if (isStaleResumeMismatch) {
               clearStoredSessionId();
             } else {
@@ -420,23 +437,27 @@ export function startTerminal(sessionId = null, mode = 'new') {
             // theirs.
             autoResumeFailoverId = null;
             if (msg.session_id === currentSessionId) {
-              // This connection's own resume. Drop the pointer so no reload
-              // asks for it again, and drop the socket so the wrapper does not
-              // reconnect to the same refused URL.
-              clearStoredSessionId();
+              // This connection's own resume. The pointer is the session key
+              // BOTH views run on, so clearing it says "this conversation is
+              // gone" to the chat as well. Say that only about the key the
+              // pointer actually holds, and only when the chat is not the view
+              // bound to it: in Simple view the terminal is hidden and the chat
+              // is the surface on that key. Drop the socket either way, so the
+              // wrapper does not reconnect to the same refused URL.
+              if (getPointer() === msg.session_id && !isSimpleView()) {
+                clearStoredSessionId();
+              }
+              currentSessionId = null;
               stopTerminal();
               setSessionLabel(null);
-              if (document.documentElement.getAttribute('data-ui-mode') === 'simple') {
-                // Simple view hides the terminal, so writing the state into it
-                // and waiting for Enter asks for a keystroke in a window the
-                // operator cannot see or reach: the chat sits silent until
-                // someone thinks to reload. Nothing about the refusal is
-                // theirs to decide here — the id is already gone from storage
-                // — so make the only remaining move for them.
-                startTerminal();
-              } else {
-                // Expert view can show what happened, so it does, and arms
-                // Enter to make the next move the operator's.
+              // Expert view can show what happened, so it does, and arms Enter
+              // to make the next move the operator's. Simple view hides the
+              // terminal, so both halves of that answer would land in a window
+              // nobody can see or reach — and nothing is started in its place
+              // either: the chat is the surface there, and a hidden terminal
+              // spawning the session's agent would take the conversation away
+              // from it.
+              if (!isSimpleView()) {
                 term.write(
                   `\r\n\x1b[33mThe transcript for session ${msg.session_id} is missing, so it cannot be resumed.\x1b[0m\r\n` +
                   'Press Enter to start a new session.\r\n'
@@ -454,6 +475,10 @@ export function startTerminal(sessionId = null, mode = 'new') {
             term.reset();
             currentSessionId = msg.session_id;
             autoResumeFailoverId = null;
+            // A switch onto a key the chat holds is negotiated like any other
+            // hand-off, and this frame — not `session_info` — is how a switch
+            // reports success. It is the end of the wait either way.
+            hideHandoffOverlay();
             storeSessionId(msg.session_id);
             setSessionLabel(msg.session_id);
             notifySessionChange(msg.session_id);
@@ -464,6 +489,12 @@ export function startTerminal(sessionId = null, mode = 'new') {
               );
             }
           } else if (msg.type === 'error') {
+            // Whatever the connection was waiting on has resolved into this,
+            // so the transitional state goes before the message that replaces
+            // it — an error under a "finishing in the other view" overlay is
+            // unreadable and untrue.
+            hideHandoffOverlay();
+            settle();
             term.write(`\r\n\x1b[31m[Error: ${msg.message}]\x1b[0m\r\n`);
           }
           return;
@@ -477,6 +508,27 @@ export function startTerminal(sessionId = null, mode = 'new') {
     },
     onClose() {
       setConnectionIndicator(false);
+      // A close before any answer is itself the answer: this attempt is over,
+      // whatever the wrapper does about reconnecting.
+      settle();
+      notifyClosed();
+    },
+    onRefused(code) {
+      // The server declined to hand the session over. A refusal that lands
+      // after this socket was abandoned — the operator pressed "Stop and
+      // switch now", and the reconnect is already waiting on its own
+      // hand-off — says nothing about the connection now in place, so it is
+      // dropped rather than allowed to paint over that one's state.
+      if (wsConnection !== socket) return;
+      // This wrapper is spent: it will not reconnect, so the module must stop
+      // holding it or the next start would see a live-looking connection and
+      // return early. Every retry builds a new one — the button below, and
+      // the one the `handoff_pending` branch above wires into startExpert().
+      wsConnection = null;
+      // Stated here rather than left to the close above, so the contract does
+      // not depend on the order api.js fires the two in.
+      settle();
+      showHandoffRefused(code, () => startExpert());
     },
   });
   wsConnection = socket;
@@ -518,6 +570,33 @@ export function startTerminal(sessionId = null, mode = 'new') {
       }
     }, RESUME_FAILOVER_WINDOW_MS);
   }
+
+  return settled;
+}
+
+/**
+ * Take the session over for the Expert view.
+ *
+ * The flip to Expert calls this, and so does everything that retries a
+ * hand-off. It resumes the key the tab is pointed at — the same key the
+ * Simple view was on — so the conversation continues in the terminal rather
+ * than a second one starting beside it. With no key stored there is nothing
+ * to take over, so it starts a session the ordinary way.
+ *
+ * Deliberately not armed for auto-resume failover: the key is shared with the
+ * chat, and an early exit here is a hand-off that did not complete, not a
+ * dead session id to drop.
+ *
+ * @param {{ interrupt?: boolean }} [options] - `interrupt` ends the other
+ *   view's running turn instead of waiting for it.
+ * @returns {Promise<void>} Settles once the Expert acquire has an answer —
+ *   attached, refused, errored, or closed without one — and never rejects.
+ *   A flip chain awaits it so a Simple → Expert → Simple round trip cannot
+ *   ask for the session again before the server has seen this channel go.
+ */
+export function startExpert({ interrupt = false } = {}) {
+  const key = loadStoredSessionId();
+  return key ? startTerminal(key, 'resume', { interrupt }) : startTerminal();
 }
 
 /**
@@ -539,17 +618,80 @@ export async function restartTerminal() {
 }
 
 /**
- * Stop the PTY WebSocket connection.
+ * Drop the PTY WebSocket connection and dim the indicators, leaving any
+ * hand-off overlay standing.
+ *
+ * Split out of {@link stopTerminal} for the one caller that stops the socket
+ * *because* a hand-off is under way ("Stop and switch now"): it reconnects
+ * immediately and the overlay it is watching must not blink out and restart
+ * its clock in between.
  */
-export function stopTerminal() {
+function dropConnection() {
   if (wsConnection) {
     wsConnection.stop();
     wsConnection = null;
   }
 
-  currentSessionId = null;
-
   setConnectionIndicator(false);
+}
+
+// How long a caller sequencing a flip waits for the dropped socket's close
+// event before going on without it. The server holds a short grace for an
+// attached channel to let go, and the next surface asking for the session
+// inside that window is refused with no retry — so waiting for the close is
+// worth doing, and waiting forever on a socket that never reports one is not.
+const CLOSE_ACK_TIMEOUT_MS = 2000;
+
+/** Resolvers waiting for a dropped socket's close event. */
+/** @type {(() => void)[]} */
+let closeWaiters = [];
+
+/** Release everything waiting on a close. */
+function notifyClosed() {
+  const waiting = closeWaiters;
+  closeWaiters = [];
+  for (const resolve of waiting) resolve();
+}
+
+/**
+ * Stop the PTY WebSocket connection.
+ *
+ * This is also the teardown half of a view flip: the session key survives it
+ * (see {@link getCurrentSessionId}), so nothing here touches the pointer.
+ *
+ * The socket is dropped synchronously, as it always was — callers that do not
+ * care may ignore the return value.
+ *
+ * @returns {Promise<void>} Settles when the dropped socket's close event has
+ *   fired, at once when there was nothing open to drop, and after a short
+ *   timeout when the close never arrives; never rejects.
+ */
+export function stopTerminal() {
+  const socket = wsConnection?.ws;
+  // Registered before the drop, because a close can be reported synchronously.
+  const closed = socket && socket.readyState !== WebSocket.CLOSED
+    ? /** @type {Promise<void>} */ (new Promise((resolve) => {
+      const timer = setTimeout(resolve, CLOSE_ACK_TIMEOUT_MS);
+      closeWaiters.push(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    }))
+    : Promise.resolve();
+
+  dropConnection();
+  hideHandoffOverlay();
+  return closed;
+}
+
+/**
+ * Whether this page is currently showing the Simple view. The server stamps
+ * the mode on `<html>` and app.js flips it live, so this is the one question
+ * every "may the terminal act on its own here?" decision asks.
+ * @returns {boolean}
+ */
+function isSimpleView() {
+  return document.documentElement.getAttribute('data-ui-mode') === 'simple';
 }
 
 /**
@@ -595,10 +737,15 @@ export function switchSession(sessionId) {
 }
 
 /**
- * Get the current Claude Code session ID.
+ * The session key this card is on. Tearing the socket down no longer forgets
+ * it: a view flip stops this terminal so the other surface can take the
+ * session over, and the key has to outlive the process that was serving it.
+ * Falls back to the stored pointer for the window between page load and the
+ * first connect, where the chat may ask before any confirmation has arrived.
+ * @returns {string|null}
  */
 export function getCurrentSessionId() {
-  return currentSessionId;
+  return currentSessionId ?? loadStoredSessionId();
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/transcript_map.py
+++ b/src/osprey/interfaces/web_terminal/transcript_map.py
@@ -1,0 +1,174 @@
+"""Which transcript each session key currently points at.
+
+A session key is the one identity a browser tab keeps for its whole life: the
+same string names the PTY pool entry, the chat pool entry, the posture store
+entry and the audit session. The *transcript* is a different thing — the Claude
+Code session id whose ``.jsonl`` holds the conversation — and the two are equal
+only until the conversation is replaced. A ``/clear`` in the terminal starts a
+fresh transcript under a new id while the key stays exactly where it was, so
+after one ``/clear`` the key and the transcript have diverged permanently.
+
+This module holds that divergence, and nothing else:
+
+* :func:`get` answers the transcript a key currently points at, **defaulting to
+  the key itself**. A session that has never cleared has no entry here and
+  needs none, which is why the default is not ``None``: a caller resuming a
+  conversation always has an id to resume, and the absent-entry case is the
+  ordinary one rather than an error to branch on.
+* :func:`set` records a move. It is a no-op when the mapping already says what
+  it is being told — a hook that reports the same transcript on every turn must
+  not fsync a file each time — and an id equal to the key *removes* the entry
+  rather than storing an identity mapping, so the file grows by one line per
+  conversation that actually moved and by nothing per session.
+
+**Where the file lives.** Beside the posture store, under the same one path
+rule (:func:`osprey_connectors.session_store.state_dir`): a deployment that
+resolves one of these two files resolves both, and an operator looking for
+either finds them in one directory. A root that does not resolve is a map with
+no location — every :func:`get` still answers, the process keeps its in-memory
+mapping, and only durability is lost. That is the right degrade: a transcript
+id that survives in memory but not a restart costs the operator the *contents*
+of a cleared-and-continued conversation after a container recreation, whereas
+raising here would take down a view flip over a file nobody can repair from the
+browser.
+
+**Durability is best-effort by design.** Unlike the posture store, whose write
+is a commit point (a narrowing that is not on disk is a lie the badge tells),
+a lost mapping degrades to resuming the key itself — a conversation that reads
+as fresh, not a session that writes when it promised not to. So the write is
+attempted, its failure is logged, and memory keeps the answer.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from osprey.interfaces.web_terminal._json_store import read_json_object, write_json_atomic
+from osprey_connectors import session_store
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["STORE_FILENAME", "get", "load", "set", "store_path"]
+
+#: The document's name, beside ``session-postures.json`` in the same directory.
+STORE_FILENAME = "session-transcripts.json"
+
+
+def store_path() -> Path | None:
+    """Where the map lives, or ``None`` when it has no location.
+
+    Delegates to :func:`osprey_connectors.session_store.state_dir` — the same
+    resolution the posture store uses (env ``OSPREY_AGENT_DATA_ROOT``, else the
+    config derivation), so the two files are co-sited by construction rather
+    than by two rules that agree today. That resolution can raise as well as
+    answer ``None``; both mean the same thing here, a map that is memory-only.
+    """
+    try:
+        directory = session_store.state_dir()
+    except Exception:  # noqa: BLE001 — an unresolvable root is "no file", not a crash
+        logger.warning("The transcript map's location does not resolve", exc_info=True)
+        return None
+    return None if directory is None else directory / STORE_FILENAME
+
+
+def _read(path: Path) -> dict[str, str]:
+    """The persisted mapping at *path*, tolerating every absence.
+
+    :func:`~osprey.interfaces.web_terminal._json_store.read_json_object` already
+    answers ``None`` for a file that is missing, unreadable, not JSON, or not an
+    object. What is added here is the value filter: only string-to-non-empty-
+    string pairs survive, because an entry of any other shape cannot name a
+    transcript to resume and honouring it would send ``--resume`` an argument
+    Claude would reject. A hand-edited or half-migrated file therefore loses the
+    entries nobody could have used and keeps the rest.
+    """
+    document = read_json_object(path) or {}
+    return {
+        key: value
+        for key, value in document.items()
+        if isinstance(key, str) and isinstance(value, str) and value.strip()
+    }
+
+
+def load(app) -> dict[str, str]:
+    """Read the map into ``app.state.transcript_map`` and return it.
+
+    Called once from the lifespan so a restarted container knows where its keys
+    point before it serves anything, and again — lazily, through
+    :func:`_mapping` — only when an earlier load found no location.
+
+    A load taken while the map has **no location** is kept provisional and
+    retried on the next access, and entries recorded during that outage win the
+    merge. Caching a location-less load would let one transient config failure
+    outlive itself: every later read would answer the key itself and silently
+    resume the wrong transcript. The dict is mutated in place because callers
+    hold it.
+    """
+    path = store_path()
+    loaded = _read(path) if path is not None else {}
+
+    mapping: dict[str, str] | None = getattr(app.state, "transcript_map", None)
+    if mapping is None:
+        mapping = loaded
+    else:
+        merged = {**loaded, **mapping}
+        mapping.clear()
+        mapping.update(merged)
+    app.state.transcript_map = mapping
+    app.state.transcript_map_provisional = path is None
+    return mapping
+
+
+def _mapping(app) -> dict[str, str]:
+    """``app.state.transcript_map``, loading it on first use or after an outage."""
+    mapping: dict[str, str] | None = getattr(app.state, "transcript_map", None)
+    if mapping is not None and not getattr(app.state, "transcript_map_provisional", False):
+        return mapping
+    return load(app)
+
+
+def get(app, key: str) -> str:
+    """The transcript *key* currently points at — *key* itself when it has moved nowhere."""
+    return _mapping(app).get(key) or key
+
+
+def set(app, key: str, transcript_id: str) -> None:
+    """Point *key* at *transcript_id*, persisting the change.
+
+    A blank id is ignored: there is no such transcript, and storing it would
+    replace a usable answer with one that cannot be resumed. An id equal to
+    *key* clears the entry, which is the same statement said in the form the
+    file is meant to hold — :func:`get` already answers the key by default.
+
+    Writes only when the mapping actually changes, then only best-effort: a
+    failed write is logged and the in-memory answer stands for the rest of the
+    process's life.
+    """
+    transcript_id = (transcript_id or "").strip()
+    if not transcript_id:
+        return
+
+    mapping = _mapping(app)
+    if transcript_id == key:
+        if mapping.pop(key, None) is None:
+            return
+    else:
+        if mapping.get(key) == transcript_id:
+            return
+        mapping[key] = transcript_id
+
+    path = store_path()
+    if path is None:
+        app.state.transcript_map_provisional = True
+        logger.warning(
+            "This deployment's agent-data root does not resolve, so the transcript for "
+            "session %s is held in memory only and will not survive a restart.",
+            key,
+        )
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_json_atomic(path, dict(mapping))
+    except OSError:
+        logger.warning("Could not persist the transcript map to %s", path, exc_info=True)

--- a/src/osprey/interfaces/web_terminal/turn_state.py
+++ b/src/osprey/interfaces/web_terminal/turn_state.py
@@ -1,0 +1,101 @@
+"""Whether the expert view's Claude Code process is mid-turn, per session key.
+
+The store is one mapping on ``app.state.turn_state``, keyed by session key::
+
+    app.state.turn_state[key] = {"state": ..., "ts": ..., "transcript_id": ...}
+
+Its writers are the ``POST /api/agent-turn`` route in
+:mod:`osprey.interfaces.web_terminal.routes.agent_turn`, which records what the
+process's own hooks report, and :func:`reset_turn_state`, which a PTY spawn or
+teardown calls: a freshly spawned process has no turn in flight, and a
+torn-down one has none either. Its reader is the hand-off door in
+:mod:`osprey.interfaces.web_terminal.session_handoff`, which weighs the entry
+against the transcript's tail before deciding a terminal is idle.
+
+The store lives here rather than in the route module so that the door — a
+core module every route depends on — never imports the ``routes`` package.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from osprey.interfaces.web_terminal import transcript_map
+
+#: The two states a key can be in. ``idle`` is also what a spawn or teardown
+#: resets to, so it is the value :func:`reset_turn_state` writes.
+BUSY = "busy"
+IDLE = "idle"
+
+
+def _store(app) -> dict[str, dict[str, Any]]:
+    """Return ``app.state.turn_state``, creating it when absent.
+
+    Apps that mount the agent-turn router standalone (tests, embedders) never
+    ran the lifespan that installs the store, and a report they receive is
+    still worth keeping — the reader helpers below find it either way.
+    """
+    store = getattr(app.state, "turn_state", None)
+    if store is None:
+        store = {}
+        app.state.turn_state = store
+    return store
+
+
+def get_turn_state(app, key: str) -> dict[str, Any] | None:
+    """Return the last turn reported for a session key, or ``None``.
+
+    ``None`` means nothing has been reported for the key — a process running
+    without the hook installed, or one that has not reached its first turn
+    edge yet. It is not a claim that the key is idle, so a caller waiting for
+    idleness must treat it as "unknown" and fall back to its own evidence.
+
+    Args:
+        app: The FastAPI application carrying ``state.turn_state``.
+        key: The session key (the PTY pool key), not the transcript id.
+
+    Returns:
+        The stored ``{"state", "ts", "transcript_id"}`` mapping, or ``None``.
+    """
+    if not key:
+        return None
+    return _store(app).get(key)
+
+
+def record_turn_state(app, key: str, *, state: str, ts: float, transcript_id: str) -> None:
+    """Store a reported turn edge for a session key.
+
+    Args:
+        app: The FastAPI application carrying ``state.turn_state``.
+        key: The session key the report is about.
+        state: :data:`BUSY` or :data:`IDLE`.
+        ts: When the edge happened, as POSIX seconds on the server's clock.
+        transcript_id: The transcript the key's conversation lives in.
+    """
+    _store(app)[key] = {"state": state, "ts": ts, "transcript_id": transcript_id}
+
+
+def reset_turn_state(app, key: str) -> None:
+    """Record a session key as idle as of now.
+
+    Called on both edges of a PTY's life. A process that has just spawned has
+    no turn in flight, and a process that has just been torn down has none
+    either, so both leave the key idle — and both do so *explicitly*, because
+    the alternative (leaving the previous process's last report in place)
+    would let a key that died mid-turn read as busy forever.
+
+    The transcript id is carried over from the map rather than dropped, so the
+    entry keeps the shape every reader expects. The map defaults an unmapped
+    key to itself, which is the right answer for a session that has never
+    cleared.
+
+    Args:
+        app: The FastAPI application carrying ``state.turn_state``.
+        key: The session key to reset. An empty key is a no-op.
+    """
+    if not key:
+        return
+    record_turn_state(
+        app, key, state=IDLE, ts=time.time(), transcript_id=transcript_map.get(app, key)
+    )

--- a/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
+++ b/src/osprey/mcp_server/dispatch_worker/sdk_runner.py
@@ -19,7 +19,13 @@ from pathlib import Path
 from typing import Any
 
 from osprey.agent_runner.artifact_resolve import deployed_config_path, deployed_render_dir
-from osprey.agent_runner.primitives import await_mcp_ready, expected_mcp_servers
+from osprey.agent_runner.primitives import (
+    MCP_READY_TIMEOUT_S,
+    await_mcp_ready,
+    expected_mcp_servers,
+    mcp_servers_connected,
+    mcp_snapshot_summary,
+)
 from osprey.mcp_server.dispatch_worker import failure_class, run_stats
 
 logger = logging.getLogger("osprey.mcp_server.dispatch_worker.sdk_runner")
@@ -242,31 +248,75 @@ def _assemble_user_content(
     return [*image_blocks, {"type": "text", "text": text}]
 
 
+class McpNotReadyError(RuntimeError):
+    """A server the run's allow-list names was not connected before the first
+    turn, so the run was refused rather than started without its tools."""
+
+
+_MCP_TOOL_PREFIX = "mcp__"
+
+
+def required_mcp_servers(allowed_tools: Iterable[str]) -> set[str]:
+    """The MCP servers a run cannot do without: those its allow-list names.
+
+    Each ``mcp__<server>__<tool>`` entry (or a server-level ``mcp__<server>``)
+    names a server whose tools the trigger was written to use; built-in tools
+    name none. A run whose allow-list names no MCP server needs no server to be
+    up before its first turn.
+    """
+    servers: set[str] = set()
+    for tool in allowed_tools:
+        if not tool.startswith(_MCP_TOOL_PREFIX):
+            continue
+        rest = tool[len(_MCP_TOOL_PREFIX) :]
+        server = rest.split("__", 1)[0]
+        if server:
+            servers.add(server)
+    return servers
+
+
 async def _stream_with_ready_mcp(
     options: Any,
     render_dir: str,
     prompt_stream: Any,
+    *,
+    required_servers: Iterable[str] = (),
+    mcp_snapshot: list[dict[str, Any]] | None = None,
 ) -> Any:
     """Yield the run's messages, holding the first turn until MCP is registered.
 
     The streaming ``ClaudeSDKClient`` rather than the one-shot ``query()``,
     because only the client exposes ``get_mcp_status()``. MCP servers register
-    asynchronously (~1.5s for controls, longer on a loaded host), and a turn
-    that fires before then sees no OSPREY tools: the agent answers "I don't
-    have that tool" and the run is scored as a model give-up when it was a
-    cold start. Polling the status until the project's declared servers report
-    connected gives every dispatch a ready toolset, matching what
+    asynchronously — one after another, CPU-bound, so a full deployment's last
+    server lands seconds after the CLI launches on an idle machine and far
+    later on a loaded one — and the CLI fixes the session's toolset at the
+    first turn: a server that connects after that never contributes its tools
+    to this run. Polling the status until the project's declared servers are
+    terminal gives every dispatch the toolset it can get, matching what
     ``osprey.agent_runner.runner`` already does for interactive runs.
 
-    The barrier is bounded (see ``await_mcp_ready``) and returns the last
-    snapshot on timeout rather than raising, so a server that genuinely never
-    registers still runs — and is logged as such — instead of failing the
-    dispatch outright.
+    The barrier is bounded (see ``await_mcp_ready``). What happens at its exit
+    depends on which servers are still not connected:
+
+    * one the run's allow-list names (``required_servers``) — the run is
+      REFUSED with :class:`McpNotReadyError` before the prompt is sent. Started
+      anyway, the agent would run its whole session without the tool it was
+      dispatched to use, improvise, and report "completed" — a hollow run that
+      nothing downstream can tell from a real one. The refusal is an
+      infrastructure failure (retryable once the host catches up), and it names
+      each server with the status and error the CLI reported;
+    * any other declared server — logged and the run proceeds: the main thread
+      cannot call its tools anyway, so its absence changes nothing the trigger
+      asked for.
+
+    ``mcp_snapshot``, when given, receives the compact snapshot summary (see
+    ``mcp_snapshot_summary``) on both paths so the run record can carry it.
 
     Written as an async generator so the caller keeps driving one object with
     ``__anext__``/``aclose()``: the inactivity watchdog and the cancellation
     path are unchanged, and ``aclose()`` unwinds the client's context manager.
     """
+    required = set(required_servers)
     async with ClaudeSDKClient(options=options) as client:
         # No declared servers — nothing to wait for. Skipped explicitly because
         # ``await_mcp_ready`` polls an empty expectation to its full deadline,
@@ -275,12 +325,34 @@ async def _stream_with_ready_mcp(
         expected = expected_mcp_servers(Path(render_dir))
         if expected:
             servers = await await_mcp_ready(client, expected)
-            connected = {s.get("name") for s in servers if s.get("status") == "connected"}
+            if mcp_snapshot is not None:
+                mcp_snapshot[:] = mcp_snapshot_summary(servers)
+            connected = mcp_servers_connected(servers)
             missing = sorted(expected - connected)
+            missing_required = sorted(required & set(missing))
+            if missing_required:
+                by_name = {s.get("name"): s for s in servers}
+                detail = ", ".join(
+                    f"{name} ({(by_name.get(name) or {}).get('status') or 'not reported'}"
+                    + (
+                        f": {(by_name.get(name) or {}).get('error')}"
+                        if (by_name.get(name) or {}).get("error")
+                        else ""
+                    )
+                    + ")"
+                    for name in missing_required
+                )
+                raise McpNotReadyError(
+                    f"MCP server(s) this trigger's allowed_tools depend on were not "
+                    f"connected within {MCP_READY_TIMEOUT_S:.0f}s of agent start: {detail}. "
+                    "The agent's toolset is fixed at its first turn, so the run was "
+                    "refused rather than started without them."
+                )
             if missing:
                 logger.warning(
                     "MCP servers not connected before first turn: %s (expected %s) — "
-                    "the agent may not see their tools",
+                    "their tools will be absent for this run; none is named by the "
+                    "trigger's allowed_tools",
                     missing,
                     sorted(expected),
                 )
@@ -340,6 +412,12 @@ async def run_dispatch(
                 value the OTEL emitter tags records with as session.id, so a
                 consumer can locate this run's full provenance in the telemetry
                 store (None if the SDK was unavailable and no run started).
+            mcp_servers: the MCP readiness snapshot taken before the first
+                turn — one ``{name, status, tools, error}`` per declared server
+                (``tools`` is a count). Empty when the project declares no
+                servers or the run never reached the barrier. Read it to tell
+                a tool the agent never had (server not ``connected``) from one
+                it had and ignored.
             failure_class: (error results only) the class this failure was
                 stamped with — one of ``failure_class.FAILURE_*``.
             num_tool_calls: (error results only) truthful count of tool calls
@@ -397,6 +475,14 @@ async def run_dispatch(
     # turn, so backgrounding is correct there. Only this single-drain path
     # needs the guard. The cost is that parallel delegations run sequentially.
     sdk_env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] = "1"
+
+    # The CLI abandons a stdio MCP server that has not finished its handshake
+    # within ``MCP_TIMEOUT`` (30s by default) — shorter than the readiness
+    # barrier below, which would then wait on a server the CLI has already
+    # marked failed. One figure drives both, so a slow-but-healthy server on a
+    # loaded host connects instead of being written off. An operator's own
+    # ``MCP_TIMEOUT`` in the worker environment is respected.
+    sdk_env.setdefault("MCP_TIMEOUT", str(int(MCP_READY_TIMEOUT_S * 1000)))
 
     # Point OSPREY config resolution at the render explicitly. ``build_clean_env``
     # carries the worker's own ``CONFIG_FILE`` through, and
@@ -554,8 +640,18 @@ async def run_dispatch(
     async def _prompt_stream():
         yield {"type": "user", "message": {"role": "user", "content": user_content}}
 
+    # Filled by the readiness barrier before the first turn; persisted with the
+    # run on every outcome (see the ``mcp_servers`` result key).
+    mcp_snapshot: list[dict[str, Any]] = []
+
     t0 = time.monotonic()
-    agen = _stream_with_ready_mcp(options, render_dir, _prompt_stream())
+    agen = _stream_with_ready_mcp(
+        options,
+        render_dir,
+        _prompt_stream(),
+        required_servers=required_mcp_servers(effective_tools),
+        mcp_snapshot=mcp_snapshot,
+    )
     try:
         # Drive the generator manually (rather than ``async for``) so each
         # ``__anext__`` is bounded by the inactivity watchdog. A full-window
@@ -613,6 +709,7 @@ async def run_dispatch(
                             "cost_usd": cost_usd,
                             "num_turns": num_turns,
                             "session_id": telemetry_session_id,
+                            "mcp_servers": mcp_snapshot,
                         }
                     ),
                     failure_class.FAILURE_PROVIDER,
@@ -730,6 +827,7 @@ async def run_dispatch(
                         "duration_sec": round(duration_sec, 2),
                         "cost_usd": cost_usd,
                         "num_turns": num_turns,
+                        "mcp_servers": mcp_snapshot,
                     }
                 ),
                 cls,
@@ -753,6 +851,7 @@ async def run_dispatch(
                 "cost_usd": cost_usd,
                 "num_turns": num_turns,
                 "session_id": telemetry_session_id,
+                "mcp_servers": mcp_snapshot,
             }
         )
 
@@ -765,6 +864,32 @@ async def run_dispatch(
         except Exception:
             logger.debug("agen.aclose() raised during cancellation", exc_info=True)
         raise
+    except McpNotReadyError as exc:
+        # The worker's own machinery — the CLI's MCP servers — was not ready
+        # before the run: a known-cause infrastructure fault (retryable once the
+        # host catches up), stamped here rather than routed through the generic
+        # classifier, which reserves that class for call sites that know it.
+        duration_sec = time.monotonic() - t0
+        logger.error("Dispatch refused after %.1fs: %s", duration_sec, exc)
+        await _push({"type": "error", "message": _scrub(str(exc), secret_values)})
+        return failure_class._stamp(
+            _finalize(
+                {
+                    "status": "error",
+                    "text_output": "",
+                    "tool_calls": [],
+                    "error": str(exc),
+                    "stderr": "\n".join(stderr_lines) if stderr_lines else None,
+                    "duration_sec": round(duration_sec, 2),
+                    "cost_usd": None,
+                    "num_turns": None,
+                    "session_id": telemetry_session_id,
+                    "mcp_servers": mcp_snapshot,
+                }
+            ),
+            failure_class.FAILURE_INFRASTRUCTURE,
+            0,
+        )
     except Exception as exc:
         duration_sec = time.monotonic() - t0
         stderr_output = "\n".join(stderr_lines) if stderr_lines else None
@@ -789,6 +914,7 @@ async def run_dispatch(
                     "cost_usd": cost_usd,
                     "num_turns": num_turns,
                     "session_id": telemetry_session_id,
+                    "mcp_servers": mcp_snapshot,
                 }
             ),
             failure_class.classify_exception(exc),

--- a/src/osprey/mcp_server/workspace/transcript_reader.py
+++ b/src/osprey/mcp_server/workspace/transcript_reader.py
@@ -7,7 +7,9 @@ transcripts on demand.
 
 import json
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
 from osprey.agent_runner.project_paths import claude_project_dir
 
@@ -18,6 +20,20 @@ _MCP_TOOL_PREFIX = "mcp__"
 MAX_RESULT_LENGTH = 500
 MAX_ERROR_RESULT_LENGTH = 2000
 MAX_CHAT_MESSAGE_LENGTH = 2000
+
+# Claude Code writes this marker as a synthetic user entry when a turn is
+# cancelled, and wraps slash-command echoes and their captured output in these
+# tags. Both are the TUI's own bookkeeping, not conversation.
+INTERRUPT_MARKER = "[Request interrupted by user"
+COMMAND_NAME_PREFIX = "<command-name>"
+LOCAL_COMMAND_STDOUT_PREFIX = "<local-command-stdout>"
+LOCAL_COMMAND_STDERR_PREFIX = "<local-command-stderr>"
+LOCAL_COMMAND_PREFIXES = (LOCAL_COMMAND_STDOUT_PREFIX, LOCAL_COMMAND_STDERR_PREFIX)
+_BOOKKEEPING_PREFIXES = (COMMAND_NAME_PREFIX, *LOCAL_COMMAND_PREFIXES)
+
+# A transcript grows without bound, but the tail rule only ever looks at its
+# newest message entry, so only this much of the end is read.
+_TAIL_READ_BYTES = 256 * 1024
 
 
 def _is_error_response(result_str: str) -> bool:
@@ -66,6 +82,124 @@ def _split_mcp_tool_name(tool_name: str) -> tuple[str, str, str] | None:
     if not sep or not server or not short_name:
         return None
     return short_name, server, tool_name
+
+
+def _conversation_text(entry: dict) -> str:
+    """Extract only text content blocks from a user or assistant entry."""
+    message = entry.get("message", {})
+    content_blocks = message.get("content", [])
+    if isinstance(content_blocks, str):
+        return content_blocks.strip()
+    parts: list[str] = []
+    for block in content_blocks:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict) and block.get("type") == "text":
+            parts.append(block.get("text", ""))
+    return "\n".join(parts).strip()
+
+
+def is_bookkeeping_entry(entry: dict) -> bool:
+    """Report whether an entry is the TUI's own accounting, not conversation.
+
+    Covers meta entries, the slash-command echo and its captured output, and
+    the marker written when a turn is cancelled. Replaying a conversation onto
+    another surface shows none of these.
+    """
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("isMeta"):
+        return True
+    text = _conversation_text(entry)
+    if not text:
+        return False
+    return text.startswith(INTERRUPT_MARKER) or text.startswith(_BOOKKEEPING_PREFIXES)
+
+
+def _entry_epoch(entry: dict) -> float | None:
+    """Parse an entry's ISO-8601 timestamp into POSIX seconds, or None."""
+    raw = entry.get("timestamp")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        stamp = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    return stamp.timestamp()
+
+
+def _scan_last_message(lines: list[str]) -> dict | None:
+    """Return the newest user or assistant entry among JSONL lines."""
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(entry, dict) and entry.get("type") in ("user", "assistant"):
+            return entry
+    return None
+
+
+def _last_message_entry(path: Path) -> dict | None:
+    """Read a transcript's newest user or assistant entry.
+
+    Only the tail of the file is read; a transcript whose closing entries are
+    all larger than that window falls back to a full read.
+    """
+    try:
+        size = path.stat().st_size
+        truncated = size > _TAIL_READ_BYTES
+        with path.open("rb") as handle:
+            if truncated:
+                handle.seek(size - _TAIL_READ_BYTES)
+                handle.readline()  # discard the partial line the seek landed in
+            chunk = handle.read()
+    except OSError:
+        return None
+
+    entry = _scan_last_message(chunk.decode("utf-8", "replace").splitlines())
+    if entry is None and truncated:
+        try:
+            entry = _scan_last_message(path.read_text().splitlines())
+        except OSError:
+            return None
+    return entry
+
+
+def tail_state(path: Path, busy_since: float | None) -> Literal["busy", "idle", "unknown"]:
+    """Classify a transcript's tail as a turn in flight, at rest, or unreadable.
+
+    A text-bearing user entry at the end of the transcript is a prompt the
+    agent has not answered yet, so the session is ``busy``. Two shapes say the
+    opposite: the interrupt marker, and slash-command output written after
+    ``busy_since`` (the caller's busy stamp, in POSIX seconds; ``None`` when
+    the caller holds no busy stamp at all). Everything else — an assistant
+    entry, a tool-result-only user entry, other bookkeeping — carries no
+    evidence either way and returns ``unknown``, leaving the caller with
+    whatever its own state store says.
+    """
+    entry = _last_message_entry(path)
+    if entry is None or entry.get("type") != "user":
+        return "unknown"
+
+    text = _conversation_text(entry)
+    if not text:
+        return "unknown"
+    if text.startswith(INTERRUPT_MARKER):
+        return "idle"
+    if text.startswith(LOCAL_COMMAND_PREFIXES):
+        if busy_since is None:
+            return "idle"
+        stamp = _entry_epoch(entry)
+        return "idle" if stamp is not None and stamp > busy_since else "unknown"
+    if is_bookkeeping_entry(entry):
+        return "unknown"
+    return "busy"
 
 
 class TranscriptReader:
@@ -334,8 +468,18 @@ class TranscriptReader:
             return []
         return self.read_session(path, **kwargs)
 
-    def read_chat_history_by_id(self, session_id: str) -> list[dict]:
+    def read_chat_history_by_id(
+        self,
+        session_id: str,
+        *,
+        max_chars: int | None = MAX_CHAT_MESSAGE_LENGTH,
+    ) -> list[dict]:
         """Read chat history for a specific session by ID.
+
+        Args:
+            session_id: The Claude Code session UUID.
+            max_chars: Per-message character cap; ``None`` leaves messages
+                whole.
 
         Returns:
             List of conversation turn dicts, or empty list if not found.
@@ -343,7 +487,7 @@ class TranscriptReader:
         path = self.find_transcript_by_id(session_id)
         if not path:
             return []
-        return self.read_chat_history(path)
+        return self.read_chat_history(path, max_chars=max_chars)
 
     def read_agent_timeline(self, agent_id: str, *, session_id: str | None = None) -> list[dict]:
         """Read the full internal timeline of a subagent.
@@ -517,15 +661,22 @@ class TranscriptReader:
 
         return timeline
 
-    def read_chat_history(self, path: Path) -> list[dict]:
+    def read_chat_history(
+        self,
+        path: Path,
+        *,
+        max_chars: int | None = MAX_CHAT_MESSAGE_LENGTH,
+    ) -> list[dict]:
         """Extract conversation turns (user text + assistant text) from a transcript.
 
         Returns a chronologically ordered list of dicts with keys:
         ``role`` ("user" | "assistant"), ``content`` (str), ``timestamp`` (str).
 
         Only text content blocks are captured — tool_use / tool_result blocks
-        are skipped.  Individual messages are truncated to
-        ``MAX_CHAT_MESSAGE_LENGTH`` characters.
+        are skipped, as are the TUI's bookkeeping entries. Individual messages
+        are truncated to ``max_chars`` characters; pass ``None`` to leave them
+        whole, which is what replaying a conversation onto another surface
+        needs.
         """
         if not path.is_file():
             return []
@@ -542,21 +693,21 @@ class TranscriptReader:
                 continue
 
             entry_type = entry.get("type")
-            timestamp = entry.get("timestamp", "")
+            if entry_type not in ("user", "assistant") or is_bookkeeping_entry(entry):
+                continue
 
-            if entry_type == "user":
-                text = self._extract_conversation_text(entry)
-                if text:
-                    if len(text) > MAX_CHAT_MESSAGE_LENGTH:
-                        text = text[:MAX_CHAT_MESSAGE_LENGTH] + "..."
-                    turns.append({"role": "user", "content": text, "timestamp": timestamp})
-
-            elif entry_type == "assistant":
-                text = self._extract_conversation_text(entry)
-                if text:
-                    if len(text) > MAX_CHAT_MESSAGE_LENGTH:
-                        text = text[:MAX_CHAT_MESSAGE_LENGTH] + "..."
-                    turns.append({"role": "assistant", "content": text, "timestamp": timestamp})
+            text = self._extract_conversation_text(entry)
+            if not text:
+                continue
+            if max_chars is not None and len(text) > max_chars:
+                text = text[:max_chars] + "..."
+            turns.append(
+                {
+                    "role": entry_type,
+                    "content": text,
+                    "timestamp": entry.get("timestamp", ""),
+                }
+            )
 
         return turns
 
@@ -574,17 +725,7 @@ class TranscriptReader:
     @staticmethod
     def _extract_conversation_text(entry: dict) -> str:
         """Extract only text content blocks from a user or assistant entry."""
-        message = entry.get("message", {})
-        content_blocks = message.get("content", [])
-        if isinstance(content_blocks, str):
-            return content_blocks.strip()
-        parts: list[str] = []
-        for block in content_blocks:
-            if isinstance(block, str):
-                parts.append(block)
-            elif isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
-        return "\n".join(parts).strip()
+        return _conversation_text(entry)
 
     @staticmethod
     def _collect_task_meta(
@@ -645,6 +786,7 @@ class TranscriptReader:
                 return ""
         except Exception:
             return ""
+        return ""
 
     @staticmethod
     def _match_subagent_to_task(

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -55,6 +55,7 @@ hooks:
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Inject the web terminal panel inventory into agent context
   - workspace-delta   # Report web workspace changes since the agent's last turn
+  - turn-state        # Tell the web terminal when a turn starts and ends
 
 rules:
   - error-handling      # Standard error handling and retry guidance

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -65,6 +65,7 @@ hooks:
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Inject the web terminal panel inventory into agent context
   - workspace-delta   # Report web workspace changes since the agent's last turn
+  - turn-state        # Tell the web terminal when a turn starts and ends
 
 rules:
   - error-handling      # Standard error handling and retry guidance

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -66,6 +66,7 @@ hooks:
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Tell the agent which web terminal panels exist
   - workspace-delta   # Report web workspace changes since the agent's last turn
+  - turn-state        # Tell the web terminal when a turn starts and ends
 
 rules:
   - safety              # Core safety rules: never write without approval

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -63,6 +63,7 @@ hooks:
   - focus-validate # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context # Tell the agent which web terminal panels exist
   - workspace-delta # Report web workspace changes since the agent's last turn
+  - turn-state     # Tell the web terminal when a turn starts and ends
 
 rules:
   - safety          # Core safety rules: never write without approval

--- a/src/osprey/services/build_artifacts/catalog.py
+++ b/src/osprey/services/build_artifacts/catalog.py
@@ -282,6 +282,12 @@ def _get_default_artifacts() -> list[BuildArtifact]:
             output_path=".claude/hooks/osprey_workspace_delta.py",
             description="UserPromptSubmit hook that reports web workspace changes since the agent's last turn",
         ),
+        BuildArtifact(
+            canonical_name="hooks/turn-state",
+            template_path="claude/hooks/osprey_turn_state.py",
+            output_path=".claude/hooks/osprey_turn_state.py",
+            description="Reports the agent's turn edges to the web terminal, so a view switch knows when the process is between turns",
+        ),
         # ── Skills ──────────────────────────────────────────────────
         BuildArtifact(
             canonical_name="skills/session-report",

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_panels_context.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_panels_context.py
@@ -82,9 +82,12 @@ knows the rail but not the tiles, and its report carries a *numeric* age).
 Unknown and empty are different claims, and only one of them is honest.  Both
 hooks apply this rule identically — see :func:`_occupancy_is_known`.
 
-The seed is **unconditional**: SessionStart re-fires on resume and on ``/clear``
-with the same session id, and a stale snapshot would make the first delta line
-of the resumed session describe changes the agent already knows about.  It is
+The seed is **unconditional**: SessionStart re-fires on a resume under the same
+session id, and a snapshot left from before it would make the first delta line
+of the resumed session describe changes the agent already knows about.  A
+``/clear`` is the other case — it opens a *new* Claude Code session id, and so
+a new snapshot path, while the OSPREY session key in the environment stays what
+it was — and seeding there is a first write rather than an overwrite.  It is
 written only when a ``session_id`` is available *and* the live state was
 fetched — with no live state there is nothing honest to record, and the delta
 hook reseeds from a missing snapshot on its own.
@@ -366,9 +369,11 @@ def main():
             state = _workspace_state(data)
             tile_line = _build_tile_line(state)
             if session_id:
-                # Unconditional: SessionStart re-fires on resume and /clear with
-                # the same id, and the delta hook must start from what is on
-                # screen now, not from what was there before the resume.
+                # Unconditional: SessionStart re-fires on a resume under the
+                # same id, and the delta hook must start from what is on screen
+                # now, not from what was there before the resume. A /clear
+                # opens a new id and so a new snapshot, though the OSPREY
+                # session key in the environment is unchanged.
                 _write_snapshot(_snapshot_path(session_id), state)
         except Exception:
             # Web terminal down or unreachable — the surface line (env-only)

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_turn_state.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_turn_state.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+---
+name: Turn State
+description: Reports the terminal agent's turn edges — busy on a submitted prompt, idle when the turn ends — to the web terminal
+summary: The web terminal learns when its own agent is between turns from the process that runs it, instead of guessing from terminal output
+event: UserPromptSubmit, Stop, StopFailure, SessionStart
+---
+
+## Flow
+
+```
+hook fires ──► OSPREY_WEB_PORT and OSPREY_SESSION_ID both set? ──NO──► exit 0, silent
+                    │
+                   YES
+                    │
+                    ▼
+               read stdin JSON
+                    │
+                    ▼
+               hook_event_name ──► busy | idle ──► unrecognised ──► exit 0, silent
+                    │
+                    ▼
+               SessionStart after a compaction? ──YES──► exit 0, silent
+                    │
+                    ▼
+               POST /api/agent-turn {session_id, pool_key, state, surface, ts, source}
+               (2 s, fail-open)
+                    │
+                    ▼
+               exit 0
+```
+
+## Details
+
+The web terminal can show the same conversation in either of two surfaces, and
+only one process may hold it at a time. Moving it means tearing the outgoing
+process down, which is safe *between* turns and destructive in the middle of
+one. This hook is how the server knows which it is: the process reports its own
+turn edges rather than having the server infer them from terminal output.
+
+Four events carry an edge:
+
+* ``UserPromptSubmit`` — the operator submitted a prompt, so a turn starts:
+  **busy**.
+* ``Stop`` — the turn finished: **idle**.
+* ``StopFailure`` — the turn ended in a failure rather than a completion, which
+  is still the end of it: **idle**. Builds that do not emit this event simply
+  never send the report, and the next edge is whatever arrives after it.
+* ``SessionStart`` — a session that has just opened is between turns: **idle**.
+  It also names the transcript the session opened with, which is the other half
+  of what this endpoint records.
+
+## Compaction is not a turn edge
+
+``SessionStart`` fires for four sources — ``startup``, ``resume``, ``clear`` and
+``compact`` — and the last one is not an edge at all. Auto-compaction happens
+*inside* a running turn, so an idle report for it would tell the server the
+process is free at the moment it is busiest, and a view flip would tear down a
+turn in flight. The registered ``matcher`` in ``settings.json.j2`` therefore
+lists only the first three, and this file refuses a ``compact`` payload as well:
+the matcher is the contract, and the check here is what still holds if a
+deployment's ``settings.json`` is edited by hand.
+
+## Two identities
+
+The body carries both, and they are not the same thing:
+
+* ``pool_key`` is ``OSPREY_SESSION_ID`` — the session key the browser, the
+  terminal pool and the posture store all share. It never changes.
+* ``session_id`` is Claude Code's own session id, read from the hook payload. It
+  names the transcript file, and a ``/clear`` moves it while the key stays put.
+
+A payload with no session id is dropped rather than reported with a blank one:
+the server writes the id it receives as the key's current transcript, so an
+empty value would erase a mapping instead of updating it.
+
+``surface`` is ``OSPREY_WEB_UX`` (``expert`` | ``simple``). Only the expert
+surface is recorded — the simple view knows its own turn boundaries — but the
+report is sent either way and the server drops what it does not want. An
+unlaunched-by-the-web-terminal session has neither variable and never sends
+anything.
+
+## Terminal-API authorization
+
+The POST carries ``Authorization: Bearer <OSPREY_PANEL_TOKEN>`` whenever that
+variable holds a non-blank value in the environment the hook inherits — the web
+terminal exports it into the agent it launches. When it is unset, empty or
+whitespace-only the header is omitted entirely rather than sent blank, matching
+how the server-side ``mcp_server.http._panel_auth_headers`` reads the same
+carrier.
+
+Unlike the hooks that fall back to a default port, this one has no fallback:
+without ``OSPREY_WEB_PORT`` there is no web terminal to report to, and a report
+sent to a guessed port would be a report about a session that server has never
+heard of.
+
+stdlib-only — must NOT import osprey, yaml, requests, or any third-party lib.
+Uses only ``json``, ``os``, ``sys``, ``time``, ``urllib.request``. The hook runs
+under ``python3`` (possibly a system Python 3.9, not the venv interpreter), so
+this file must be 3.9-safe.
+
+Fails open on any error — stays silent, writes nothing to stdout, and exits 0.
+Every one of these events would otherwise block the operator's prompt or the end
+of their turn, and a missed report costs a flip its fast path, never the turn.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.request
+
+#: What each hook event says about the process. An event outside this table is
+#: not a turn edge and is not reported.
+_STATE_BY_EVENT = {
+    "UserPromptSubmit": "busy",
+    "Stop": "idle",
+    "StopFailure": "idle",
+    "SessionStart": "idle",
+}
+
+#: The one event whose payload names a source, and so the only one the
+#: compaction backstop below can ask about.
+_SESSION_START = "SessionStart"
+
+#: The ``SessionStart`` source that must never be reported — see the module
+#: docstring. The registered matcher excludes it; this is the backstop.
+_COMPACT_SOURCE = "compact"
+
+#: Seconds the POST may take. Long enough for a loopback call to a busy server,
+#: short enough that a dead one never holds up a prompt or a turn's end.
+_POST_TIMEOUT = 2
+
+
+def _read_payload(stream=None):
+    """Return the hook's stdin payload as a dict, or ``{}``.
+
+    Args:
+        stream: Text stream to read the payload from. Defaults to ``sys.stdin``.
+
+    Returns:
+        The decoded payload when it is a JSON object, and an empty dict for
+        anything else — unreadable stdin, empty input, or a document that is
+        not an object. The caller then finds no event name and reports nothing.
+    """
+    try:
+        raw = (stream if stream is not None else sys.stdin).read()
+    except Exception:
+        return {}
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _turn_request(body, port):
+    """Build the ``POST /api/agent-turn`` request carrying *body*.
+
+    Args:
+        body: The report, already reduced to the endpoint's fixed contract.
+        port: The web terminal's port, from ``OSPREY_WEB_PORT``.
+
+    Returns:
+        A ``urllib.request.Request`` with the JSON body and, when
+        ``OSPREY_PANEL_TOKEN`` holds a non-blank value, a bearer header. A blank
+        one is omitted rather than sent: it would be a credential claim this
+        hook cannot back.
+    """
+    headers = {"Content-Type": "application/json"}
+    token = (os.environ.get("OSPREY_PANEL_TOKEN") or "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/agent-turn",
+        data=json.dumps(body).encode(),
+        headers=headers,
+        method="POST",
+    )
+
+
+def report_turn_state(body, port):
+    """Send one turn report, swallowing every failure.
+
+    A web terminal that is down, refusing the call or slow to answer costs the
+    server one edge, which it recovers from its own evidence. It must never
+    cost the operator the prompt or the turn that triggered the report.
+    """
+    try:
+        urllib.request.urlopen(_turn_request(body, port), timeout=_POST_TIMEOUT).close()
+    except Exception:
+        pass
+
+
+def main():
+    try:
+        port = (os.environ.get("OSPREY_WEB_PORT") or "").strip()
+        pool_key = (os.environ.get("OSPREY_SESSION_ID") or "").strip()
+        if not port or not pool_key:
+            # Not a web-terminal session: nothing to report to.
+            return 0
+
+        payload = _read_payload()
+        event = payload.get("hook_event_name")
+        state = _STATE_BY_EVENT.get(event)
+        if state is None:
+            return 0
+        if event == _SESSION_START and payload.get("source") == _COMPACT_SOURCE:
+            # A compaction is not a turn edge, whatever the matcher allowed.
+            # Only SessionStart carries a source, so the check asks about the
+            # one event where the word means what this backstop reads it as.
+            return 0
+
+        session_id = payload.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            # Without a transcript id the report would blank the one on record.
+            return 0
+
+        report_turn_state(
+            {
+                "session_id": session_id,
+                "pool_key": pool_key,
+                "state": state,
+                "surface": (os.environ.get("OSPREY_WEB_UX") or "").strip(),
+                "ts": time.time(),
+                "source": payload.get("hook_event_name"),
+            },
+            port,
+        )
+        return 0
+    except Exception:
+        # Last-resort fail-open: never block a prompt, a turn or a session start.
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -155,6 +155,23 @@
             "timeout": 5
           }
         ]
+      },
+{#- The only framework entry here that carries a matcher, and it has to. A
+    SessionStart fires for four sources and `compact` is not a turn edge:
+    auto-compaction happens INSIDE a running turn, so an idle report for it
+    would tell the server the process is between turns at the moment it is
+    busiest, and a view flip would tear down a turn in flight. Naming the three
+    real starts is what keeps `compact` out; the hook refuses a compact payload
+    as well, for a settings.json someone edited by hand. #}
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": {{ ('"' ~ current_python_env ~ '" "$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_turn_state.py" 2>/dev/null || true') | tojson }},
+            "timeout": 3
+          }
+        ]
       }{% for rule in declared.get('SessionStart', []) %},{{ declared_entry(rule, current_python_env) }}{% endfor %}
     ],
     "UserPromptSubmit": [
@@ -168,6 +185,11 @@
           {
             "type": "command",
             "command": {{ ('"' ~ current_python_env ~ '" "$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_workspace_delta.py" 2>/dev/null || true') | tojson }},
+            "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": {{ ('"' ~ current_python_env ~ '" "$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_turn_state.py" 2>/dev/null || true') | tojson }},
             "timeout": 3
           }
         ]
@@ -231,9 +253,42 @@
         ]
       }{% if not loop.last %},{% endif %}
 {%- endfor %}
+    ],
+{#- The closing edge of a turn, reported by the same hook that reports the
+    opening one. `Stop` ends a turn that completed and `StopFailure` one that
+    errored out; both leave the process between turns, which is the only state
+    in which the web terminal may move the conversation to its other surface.
+    A CLI build that emits no `StopFailure` simply never runs that entry. -#}
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": {{ ('"' ~ current_python_env ~ '" "$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_turn_state.py" 2>/dev/null || true') | tojson }},
+            "timeout": 3
+          }
+        ]
+      }{% for rule in declared.get('Stop', []) %},{{ declared_entry(rule, current_python_env) }}{% endfor %}
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": {{ ('"' ~ current_python_env ~ '" "$CLAUDE_PROJECT_DIR/.claude/hooks/osprey_turn_state.py" 2>/dev/null || true') | tojson }},
+            "timeout": 3
+          }
+        ]
+      }{% for rule in declared.get('StopFailure', []) %},{{ declared_entry(rule, current_python_env) }}{% endfor %}
     ]
-{#- Events the framework wires nothing on exist as keys only when declared. -#}
-{%- for event in declared_extra_events | default([]) %},
+{#- Events the framework wires nothing on exist as keys only when declared. The
+    two above are now framework-wired and take their declared entries inline,
+    so they are filtered out here: a second key of the same name would be legal
+    JSON whose earlier copy — the framework's — silently loses.
+    `FRAMEWORK_WIRED_EVENTS` in cli/templates/claude_code.py lists both, so this
+    filter normally has nothing left to remove; it stays because the render
+    must not depend on that constant staying in step with this file. -#}
+{%- for event in declared_extra_events | default([]) if event not in ('Stop', 'StopFailure') %},
     "{{ event }}": [
 {%- for rule in declared[event] %}{{ declared_entry(rule, current_python_env) }}{% if not loop.last %},{% endif %}{% endfor %}
     ]

--- a/src/osprey/utils/claude_launcher.py
+++ b/src/osprey/utils/claude_launcher.py
@@ -4,13 +4,41 @@ OSPREY projects can pin a specific Claude Code CLI version via the
 ``claude_code.cli_version`` config field. When set, OSPREY launches Claude
 through ``npx`` rather than the user's global install, insulating projects
 from upstream CC releases that break compatibility (see issue #218).
+
+That pin governs the CLI OSPREY *spawns*. It does not govern the CLI the
+Agent SDK runs, which prefers a binary bundled inside its own package, so a
+pinned project runs two different Claude Code builds side by side. The
+:func:`argv_cli_version` / :func:`bundled_cli_version` pair reads both, which
+is what lets a caller say so out loud instead of leaving the difference to be
+discovered as a behaviour one surface has and the other does not.
 """
 
 from __future__ import annotations
 
+import logging
+import platform
 import re
+import subprocess
+from collections.abc import Sequence
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 _VERSION_RE = re.compile(r"\b(\d+\.\d+\.\d+(?:[-+.][0-9A-Za-z.-]+)?)\b")
+
+#: The npm package a pinned launch runs through ``npx``. Spelled once so the
+#: argv builder and the argv reader below cannot drift apart.
+_CLI_PACKAGE = "@anthropic-ai/claude-code"
+
+#: Directory inside the Agent SDK package that holds its own CLI binary.
+_BUNDLED_DIRNAME = "_bundled"
+
+#: How long the bundled binary gets to answer ``--version``. It is a large
+#: single-file executable and this runs at server startup, so the probe is
+#: bounded rather than allowed to hold a boot open; a timeout reads the same
+#: as a missing bundle.
+_VERSION_PROBE_TIMEOUT_S = 5.0
 
 
 # Restrict Claude Code to project-scope settings files. A user's global
@@ -52,7 +80,7 @@ def build_claude_launch_argv(cc_config: dict, *, no_pin: bool = False) -> list[s
             '(e.g. "2.1.146"); got an empty value.'
         )
     else:
-        base = ["npx", "-y", f"@anthropic-ai/claude-code@{cli_version.strip()}"]
+        base = ["npx", "-y", f"{_CLI_PACKAGE}@{cli_version.strip()}"]
     return base + _SETTING_SOURCES_ARGS
 
 
@@ -65,3 +93,74 @@ def parse_claude_version(version_output: str) -> str | None:
         return None
     match = _VERSION_RE.search(version_output)
     return match.group(1) if match else None
+
+
+def argv_cli_version(argv: Sequence[str]) -> str | None:
+    """Extract the pinned CLI version from a launch argv.
+
+    Args:
+        argv: An argv prefix, normally one :func:`build_claude_launch_argv`
+            returned.
+
+    Returns:
+        The pinned version, or ``None`` when the argv names no pin — an
+        unpinned launch runs whatever ``claude`` PATH resolves to, whose
+        version is not knowable from the argv alone.
+    """
+    prefix = f"{_CLI_PACKAGE}@"
+    for arg in argv:
+        if arg.startswith(prefix):
+            return parse_claude_version(arg[len(prefix) :])
+    return None
+
+
+def bundled_cli_path() -> Path | None:
+    """Return the Claude Code binary bundled inside the Agent SDK, if any.
+
+    The SDK prefers this binary over anything on PATH, so it — not ``claude``
+    — is what the chat surface actually runs. Resolved the same way the SDK
+    resolves it, from the installed package's own location.
+
+    Returns:
+        The binary's path, or ``None`` when the SDK is not installed or ships
+        without a bundle.
+    """
+    try:
+        import claude_agent_sdk
+    except ImportError:
+        return None
+    package_file = getattr(claude_agent_sdk, "__file__", None)
+    if not package_file:
+        return None
+    name = "claude.exe" if platform.system() == "Windows" else "claude"
+    candidate = Path(package_file).resolve().parent / _BUNDLED_DIRNAME / name
+    return candidate if candidate.is_file() else None
+
+
+@lru_cache(maxsize=1)
+def bundled_cli_version() -> str | None:
+    """Return the version of the SDK's bundled CLI, or ``None``.
+
+    Cached for the life of the process: the answer cannot change under a
+    running server, and the probe spawns a large executable. Every failure —
+    no bundle, a binary that will not run, a non-zero exit, a timeout, output
+    with no recognisable version — answers ``None``, because this is
+    diagnostic information and no caller should be denied a start over it.
+    """
+    path = bundled_cli_path()
+    if path is None:
+        return None
+    try:
+        completed = subprocess.run(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_PROBE_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("Could not read the bundled Claude Code version: %s", exc)
+        return None
+    if completed.returncode != 0:
+        return None
+    return parse_claude_version(completed.stdout)

--- a/tests/cli/test_hooks_channel.py
+++ b/tests/cli/test_hooks_channel.py
@@ -383,13 +383,21 @@ def test_a_regex_matcher_survives_the_render_as_valid_json(tmp_path: Path):
     assert _settings(project)["hooks"]["PreToolUse"][-1]["matcher"] == matcher
 
 
-def test_an_event_the_framework_wires_nothing_on_becomes_its_own_key(tmp_path: Path):
-    """Declaring on Stop adds the key; a build that declares nothing has none."""
+def test_a_declaration_on_stop_joins_the_framework_entry(tmp_path: Path):
+    """Declaring on Stop appends beside the framework's own entry, in one key.
+
+    ``Stop`` is framework-wired: the turn-state hook reports the end of a turn
+    there, so the key exists in every build. A declaration therefore extends
+    that array rather than creating a second ``"Stop"`` — which would be legal
+    JSON whose framework half is silently dropped on parse.
+    """
     profile = tmp_path / "profile"
     _write(profile / "hooks" / "facility_guard.py", "print('guard')\n")
 
     plain = _settings(_build(tmp_path, "no-stop", profile))
-    assert "Stop" not in plain["hooks"]
+    framework = [c for c in _hook_commands(plain) if "osprey_turn_state.py" in c]
+    assert framework
+    assert not any("facility_guard.py" in c for c in _hook_commands(plain))
 
     wired = _settings(
         _build(
@@ -399,7 +407,9 @@ def test_an_event_the_framework_wires_nothing_on_becomes_its_own_key(tmp_path: P
             declarations={"claude_code.hooks.Stop": ["hooks/facility_guard.py"]},
         )
     )
-    (entry,) = wired["hooks"]["Stop"]
+    entries = wired["hooks"]["Stop"]
+    assert any("osprey_turn_state.py" in json.dumps(entry) for entry in entries)
+    (entry,) = [e for e in entries if "facility_guard.py" in json.dumps(e)]
     assert "facility_guard.py" in entry["hooks"][0]["command"]
     # No matcher: Stop takes none, and an empty one would match nothing.
     assert "matcher" not in entry

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -27,9 +27,19 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # ARIEL deployment answers structural questions through delegation instead
     # of direct mcp__graph__* calls — so the staleness advisory firing on
     # already-deployed projects is the correct signal.
-    "ariel-standalone": "sha256:ae72c2982cf20738d0d6783531e3619fa4fcccce13199b25056c4db4ce4e51f9",
+    # Moved — and every bundled preset moved with it, which is the signature of
+    # a change to the shared hook list rather than to one tier. `turn-state`
+    # joined every preset's `hooks:`, shipping the reporter that tells the web
+    # terminal when a turn starts and ends. A rebuilt project gains the hook
+    # file in `.claude/hooks/` and four settings.json registrations
+    # (UserPromptSubmit, Stop, StopFailure, and a SessionStart entry matched to
+    # `startup|resume|clear`), which is what lets a view switch wait until the
+    # process is between turns. Deploy-visible, so the staleness advisory
+    # firing on already-deployed projects is the correct signal.
+    "ariel-standalone": "sha256:878c0f09885509f0d7e6866d8603da3f571dfe26ec3aa5293cc437145543136a",
+    # Moved with the shared hook list above: `turn-state`.
     "channel-finder-standalone": (
-        "sha256:71c5399c9ff3f181c1998f2e35d2cdb65a29efc499dcbae73f0d4a0982544f3a"
+        "sha256:ead6c626c7f5a539f21110b827f2eb2e3d15e42522aafb02db0c4c72acc08883"
     ),
     # A digest here is the resolved content of the preset AND of every preset
     # that extends it, so a change in the base moves every control-assistant
@@ -207,7 +217,8 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # already-deployed control-assistant projects is the correct signal. The
     # three standalone digests are unchanged, which is the check that the tab
     # reached the control-assistant family and nothing else.
-    "control-assistant": "sha256:56c00c4b3c1792fc62aa8df77482da07e6b7cfcb530a811c5ff1affae0f3e511",
+    # Moved with the shared hook list above: `turn-state`.
+    "control-assistant": "sha256:1c53e20bcc5d3f5e01048cc7a00e53704957111887dd88197780d837c2dcca4f",
     # Moved with the base above: `live_standin` baseline + strict limits pair.
     # Moved again with the base: permissive `virtual_accelerator` limits block.
     # Moved alone when the admin tier gained the EVENTS/BLUESKY `web_panels`
@@ -221,8 +232,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
+    # Moved with the shared hook list above: `turn-state`.
     "control-assistant-admin": (
-        "sha256:184f6c4f1a377f29007d713aabc3bb24aa7ddda79d48d24b2459d3594d944442"
+        "sha256:3ad2185c2946552f8476ddd5a33b84bfa20432a900d6011a1ce5806c9315e3ae"
     ),
     # Moved with the base above: `live_standin` baseline + strict limits pair.
     # Moved again with the base: permissive `virtual_accelerator` limits block.
@@ -232,8 +244,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
+    # Moved with the shared hook list above: `turn-state`.
     "control-assistant-logbook": (
-        "sha256:aaf0d35ccf2d2c3219d196e2888fcea36450489d197d2412c714197aa6cb82b5"
+        "sha256:1d3091e9a09c4c6d83136ffdc5b4e1553cdbba5d419843c644d4e4dad6650e8d"
     ),
     # New: the second standalone persona. The facility knowledge graph, the
     # graph-mode channel finder and the knowledge bundle behind one shared
@@ -242,8 +255,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # (`draft_concept`) denied.
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
+    # Moved with the shared hook list above: `turn-state`.
     "control-assistant-knowledge": (
-        "sha256:0777311b1d4e018fcb27a8d3c178c7591ef3cee4c94bece650dbb673b78ad96a"
+        "sha256:15fb041fbee6ea3caf8ff83dbfd9a0eb9faa7deb8cc34849ab502fb76b2f3494"
     ),
     # The two operator tiers below moved together, and alone, when each gained
     # the single dotted key `services.graphdb.port_host: 7687` in its `config:`
@@ -307,8 +321,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
+    # Moved with the shared hook list above: `turn-state`.
     "control-assistant-readonly": (
-        "sha256:cfeb9f033ceab1ebf1c9353b681512370ecb89494463738861ace01ab58db36a"
+        "sha256:c1d9905d8ed9de3f522deb60578af0e8fc0f7323f1bb6a2073bc077250c937d6"
     ),
     # Moved with the base above: `live_standin` baseline + strict limits pair.
     # Moved again with the base: permissive `virtual_accelerator` limits block.
@@ -317,8 +332,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
+    # Moved with the shared hook list above: `turn-state`.
     "control-assistant-readwrite": (
-        "sha256:32ccac3d13793f322596f51a440b6e9ce1f93ef3469c35ed4a763f70a334ce40"
+        "sha256:c710eb5ba5717f372d6fe07343d8ea59e714c8dcf1f0d3615496b76961bdd397"
     ),
     # New with per-target write posture, not a moved entry: the rung between
     # the two flat tiers, armed on the virtual accelerator alone. It pins the
@@ -333,8 +349,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: the `knowledge` card joined the roster.
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
+    # Moved with the shared hook list above: `turn-state`.
     "control-assistant-va-readwrite": (
-        "sha256:161d353e06f81965954d1d3c56f98053460ff9af02e1b2519e9f1758690237f9"
+        "sha256:8718753c94636f8ea2f60db58f89a461e0d3ef1a46cdc331e48079ebc830c0b8"
     ),
     # Moved when the onboarding rewrite dropped the `facility` rule. The
     # wholesale comment rewrite that shipped alongside it contributed nothing:
@@ -349,7 +366,8 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved again when the preset gained a live `mcp_servers.example_server`
     # block, so a rebuilt project launches the seeded example MCP server and
     # its `example_status` tool appears in the session.
-    "hello-world": "sha256:fdd41e470ce46d49f206640e558eaab9e909ce034b6bcc456ff50e3edb1e0436",
+    # Moved with the shared hook list above: `turn-state`.
+    "hello-world": "sha256:45fcda3c05242e9728b036caca8226bdd1fea1cfb5053cd497c03ad8ae1d8a2d",
 }
 
 

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -810,6 +810,14 @@ def test_hello_world_renders_no_graph_surface_at_all(built_hello_world_project):
     [
         ("osprey_panels_context.py", "SessionStart"),
         ("osprey_workspace_delta.py", "UserPromptSubmit"),
+        # The turn reporter is the third half of panel awareness: it is what
+        # tells the web terminal whether its own agent is mid-turn. One case
+        # per registered event, because a turn has more than one edge and
+        # losing any single registration is invisible from the others.
+        ("osprey_turn_state.py", "UserPromptSubmit"),
+        ("osprey_turn_state.py", "Stop"),
+        ("osprey_turn_state.py", "StopFailure"),
+        ("osprey_turn_state.py", "SessionStart"),
     ],
 )
 def test_panel_hooks_rendered_and_wired(built_control_assistant_project, hook_file, event):

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -532,6 +532,7 @@ class TestTemplateManifest:
             "osprey_notebook_update.py",
             "osprey_panels_context.py",
             "osprey_target_state.py",
+            "osprey_turn_state.py",
             "osprey_workspace_delta.py",
             "osprey_writes_check.py",
         }

--- a/tests/dispatch_worker/test_run_stats.py
+++ b/tests/dispatch_worker/test_run_stats.py
@@ -117,7 +117,7 @@ def _result_message(cost_usd: float, num_turns: int) -> ResultMessage:
 
 @pytest.mark.asyncio
 async def test_run_dispatch_increments_per_tool_use(monkeypatch, _stub_osprey_helpers):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(
             content=[
                 ToolUseBlock(id="t1", name="Read", input={}),
@@ -145,7 +145,7 @@ async def test_run_dispatch_counts_beyond_retained_cap(monkeypatch, _stub_osprey
     """num_tool_calls stays truthful past the retained tool_calls cap."""
     monkeypatch.setattr(sdk_runner, "_MAX_TOOL_CALLS", 2)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         for i in range(5):
             yield AssistantMessage(
                 content=[ToolUseBlock(id=f"t{i}", name="Read", input={})], model="m"
@@ -165,7 +165,7 @@ async def test_run_dispatch_counts_beyond_retained_cap(monkeypatch, _stub_osprey
 
 @pytest.mark.asyncio
 async def test_run_dispatch_without_run_id_creates_no_entry(monkeypatch, _stub_osprey_helpers):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
 

--- a/tests/dispatch_worker/test_sdk_runner_failure_class.py
+++ b/tests/dispatch_worker/test_sdk_runner_failure_class.py
@@ -90,7 +90,7 @@ async def _drain(queue: asyncio.Queue) -> list[dict]:
 
 @pytest.mark.asyncio
 async def test_success_is_unchanged(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text="hi")], model="m")
         yield _result_message(is_error=False, subtype="success")
 
@@ -115,7 +115,7 @@ async def test_success_is_unchanged(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_budget_cap_subtype_flips_to_run(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
         yield _result_message(
             is_error=True, subtype="error_max_budget_usd", result="Budget exceeded"
@@ -138,7 +138,7 @@ async def test_budget_cap_subtype_flips_to_run(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_max_turns_subtype_flips_to_run(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield _result_message(is_error=True, subtype="error_max_turns", result="Max turns")
 
     monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
@@ -153,7 +153,7 @@ async def test_max_turns_subtype_flips_to_run(monkeypatch):
 async def test_error_result_with_provider_text_is_provider(monkeypatch):
     """A non-budget error whose text reads as a provider fault stays retryable."""
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield _result_message(
             is_error=True,
             subtype="error_during_execution",
@@ -172,7 +172,7 @@ async def test_error_result_with_provider_text_is_provider(monkeypatch):
 async def test_error_result_api_status_folds_into_classification(monkeypatch):
     """api_error_status is appended to the error text and drives classification."""
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield _result_message(
             is_error=True,
             subtype="error_during_execution",
@@ -190,7 +190,7 @@ async def test_error_result_api_status_folds_into_classification(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_error_result_generic_is_run(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield _result_message(
             is_error=True, subtype="error_during_execution", result="a tool crashed mid-run"
         )
@@ -204,7 +204,7 @@ async def test_error_result_generic_is_run(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_error_result_without_text_gets_synthesized_message(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield _result_message(is_error=True, subtype="error_during_execution", result=None)
 
     monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
@@ -224,7 +224,7 @@ async def test_error_result_without_text_gets_synthesized_message(monkeypatch):
 async def test_inactivity_timeout_is_provider(monkeypatch):
     monkeypatch.setattr(sdk_runner, "_INACTIVITY_TIMEOUT_SEC", 0.05)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
         await asyncio.sleep(10)  # provider goes silent -> watchdog trips
         yield _result_message()
@@ -246,7 +246,7 @@ async def test_inactivity_timeout_is_provider(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_generic_exception_run(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[ToolUseBlock(id="t1", name="Read", input={})], model="m")
         raise RuntimeError("something broke")
 
@@ -261,7 +261,7 @@ async def test_generic_exception_run(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_generic_exception_provider_message(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         raise RuntimeError("401 unauthorized: invalid api key")
         yield  # unreachable — makes this an async generator, like the real query
 
@@ -299,7 +299,7 @@ async def test_counter_hook_bumped_on_error(monkeypatch):
     seen: list[str] = []
     failure_class.register_counter_hook(seen.append)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield _result_message(is_error=True, subtype="error_during_execution", result="crash")
 
     monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)

--- a/tests/dispatch_worker/test_sdk_runner_prompt_assembly.py
+++ b/tests/dispatch_worker/test_sdk_runner_prompt_assembly.py
@@ -65,7 +65,7 @@ async def _capture_user_message(monkeypatch, prompt: str, seam: list[dict], run_
     monkeypatch.setattr(dispatch_api, "_run_input_seam", {run_id: seam})
     captured: dict = {}
 
-    async def fake_query(options, project_dir, prompt):  # noqa: A002 - matches SDK signature
+    async def fake_query(options, project_dir, prompt, **_kw):  # noqa: A002 - matches SDK signature
         messages = []
         async for m in prompt:
             messages.append(m)
@@ -286,7 +286,7 @@ def test_prompt_stream_no_run_id_leaves_content_plain(monkeypatch):
     """A run without a run_id has no seam — content is the untouched prompt."""
     captured: dict = {}
 
-    async def fake_query(options, project_dir, prompt):  # noqa: A002
+    async def fake_query(options, project_dir, prompt, **_kw):  # noqa: A002
         async for m in prompt:
             captured.setdefault("messages", []).append(m)
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")

--- a/tests/e2e/test_dispatch_deploy.py
+++ b/tests/e2e/test_dispatch_deploy.py
@@ -482,6 +482,13 @@ def _worker_mcp_surface() -> str:
     tool (model behaviour, which is why this module is marked flaky). An empty
     list alone cannot tell them apart, so probe the container and let the failure
     report the cause it actually hit rather than asserting the likelier guess.
+
+    A third cause — the server was provisioned but not yet connected when the
+    agent's first turn went out, so the tool was never in its toolset — no
+    longer reaches this assertion: the worker refuses such a run as an
+    ``infrastructure`` error (see ``sdk_runner._stream_with_ready_mcp``), which
+    the status assertion above reports with the server named. The persisted run
+    record's ``mcp_servers`` snapshot shows what the barrier saw either way.
     """
     proc = subprocess.run(
         [

--- a/tests/e2e/test_mcp_readiness.py
+++ b/tests/e2e/test_mcp_readiness.py
@@ -151,3 +151,26 @@ def test_repeated_non_delegation_tool_is_not_a_redelegation_loop() -> None:
     wf.tool_traces = [ToolTrace(name="mcp__controls__channel_read", input={"c": "x"})] * 4
     assert wf.has_redelegation_loop is False
     assert wf.repeated_tool_calls  # still surfaced in the digest
+
+
+def test_await_stops_waiting_once_every_expected_server_is_terminal() -> None:
+    """A server the CLI has marked ``failed`` will never become ``connected``,
+    so once every expected server is either connected or failed there is
+    nothing left to wait for: return immediately rather than polling to the
+    deadline. The failed entry (with its error) stays in the snapshot so the
+    caller can name it."""
+    client = _FakeClient(
+        [
+            [_srv("controls", "pending"), _srv("graph", "pending")],
+            [
+                _srv("controls", "connected", ["channel_read"]),
+                {**_srv("graph", "failed"), "error": "spawn failed"},
+            ],
+        ]
+    )
+    servers = asyncio.run(await_mcp_ready(client, {"controls", "graph"}, timeout_s=5, poll_s=0))
+    assert {s["name"]: s["status"] for s in servers} == {
+        "controls": "connected",
+        "graph": "failed",
+    }
+    assert client.calls == 2  # returned on the first fully-terminal snapshot

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -191,6 +191,7 @@ hooks:
   - focus-validate    # Strip stale artifact IDs from focus_state.txt on each prompt
   - panels-context    # Tell the agent which web terminal panels exist
   - workspace-delta   # Report web workspace changes since the agent's last turn
+  - turn-state        # Tell the web terminal when a turn starts and ends
 
 rules:
   - safety              # Core safety rules: never write without approval

--- a/tests/hooks/test_hook_docstring_frontmatter.py
+++ b/tests/hooks/test_hook_docstring_frontmatter.py
@@ -26,6 +26,7 @@ HOOK_FILES = [
     "osprey_focus_validate.py",
     "osprey_panels_context.py",
     "osprey_workspace_delta.py",
+    "osprey_turn_state.py",
     "osprey_cf_feedback_capture.py",
 ]
 
@@ -105,13 +106,26 @@ class TestHookFrontMatter:
         assert not missing, f"Missing required fields: {missing}"
 
     def test_event_is_valid(self, hook_file):
-        """Event field is one of the known Claude Code hook events."""
+        """Every event named is a known Claude Code hook event.
+
+        A hook may name several, comma-separated: one file can be registered on
+        more than one event, and the turn-state reporter is registered on four
+        because a turn has more than one edge.
+        """
         docstring = _load_docstring(hook_file)
         fields, _ = _parse_front_matter(docstring)
 
-        valid_events = {"PreToolUse", "PostToolUse", "SessionStart", "UserPromptSubmit"}
-        assert fields["event"] in valid_events, (
-            f"Invalid event '{fields['event']}', expected one of {valid_events}"
+        valid_events = {
+            "PreToolUse",
+            "PostToolUse",
+            "SessionStart",
+            "UserPromptSubmit",
+            "Stop",
+            "StopFailure",
+        }
+        declared = [event.strip() for event in str(fields["event"]).split(",")]
+        assert declared and all(event in valid_events for event in declared), (
+            f"Invalid event '{fields['event']}', expected one or more of {valid_events}"
         )
 
     def test_has_ascii_diagram(self, hook_file):

--- a/tests/integration/test_input_files_cross_cutting.py
+++ b/tests/integration/test_input_files_cross_cutting.py
@@ -185,7 +185,7 @@ async def test_input_files_content_b64_absent_from_worker_record_and_logs(
     # then return a normal completion.
     captured: dict = {}
 
-    async def fake_query(options, project_dir, prompt):  # noqa: A002 - matches SDK signature
+    async def fake_query(options, project_dir, prompt, **_kw):  # noqa: A002 - matches SDK signature
         messages = []
         async for m in prompt:
             messages.append(m)

--- a/tests/interfaces/test_web_auth.py
+++ b/tests/interfaces/test_web_auth.py
@@ -1231,6 +1231,7 @@ _EXPECTED_PANEL_ROUTES = {
     ("POST", "/api/panel-close"),
     ("POST", "/api/panel-arrange"),
     ("POST", "/api/agent-activity"),
+    ("POST", "/api/agent-turn"),
     ("POST", "/api/focus"),
 }
 

--- a/tests/interfaces/web_terminal/_fakes.py
+++ b/tests/interfaces/web_terminal/_fakes.py
@@ -1,0 +1,136 @@
+"""Fakes shared by the web-terminal session tests.
+
+``FakePtySession`` is the PTY the registry hands out when ``_spawn_session``
+is patched: alive until told otherwise, silent unless ``emit`` queues bytes.
+``FakeClock``, ``FakeChatSession`` and ``FakeChatPool`` are the slice of the
+hand-off door's collaborators that its phase tests drive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class FakePtySession:
+    """Minimal PtySession substitute — alive until told otherwise.
+
+    ``emit`` queues bytes the output loop will forward; ``exit`` ends the
+    child with a code. Queued output is drained before the loop sees the exit,
+    which is what a real PTY does too (:meth:`PtySession.read_output`).
+    """
+
+    def __init__(self):
+        self._alive = True
+        self._exit_code: int | None = None
+        self._chunks: list[bytes] = []
+        self._last_rows = 24
+        self._last_cols = 80
+        self._command_list = ["fake"]
+
+    @property
+    def is_alive(self):
+        return self._alive
+
+    @property
+    def exit_code(self):
+        if self._alive:
+            return None
+        return 0 if self._exit_code is None else self._exit_code
+
+    def start(self, initial_rows=24, initial_cols=80, extra_env=None, cwd=None):
+        self._last_rows = initial_rows
+        self._last_cols = initial_cols
+
+    def resize(self, rows, cols):
+        self._last_rows = rows
+        self._last_cols = cols
+
+    def write_input(self, data):
+        pass
+
+    def terminate(self):
+        self._alive = False
+
+    def emit(self, data: bytes) -> None:
+        self._chunks.append(data)
+
+    def exit(self, code: int) -> None:
+        self._exit_code = code
+        self._alive = False
+
+    async def read_output(self):
+        try:
+            while self._alive or self._chunks:
+                if self._chunks:
+                    yield self._chunks.pop(0)
+                else:
+                    await asyncio.sleep(0.05)
+        except (asyncio.CancelledError, GeneratorExit):
+            return
+
+
+class FakeClock:
+    """A monotonic clock that only moves when ``sleep`` is awaited."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+        self.sleeps: list[float] = []
+        self.on_sleep: list = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+        for hook in list(self.on_sleep):
+            hook(len(self.sleeps))
+        # Yield once so a concurrent task can run between looks.
+        await asyncio.sleep(0)
+
+
+class FakeChatSession:
+    """The slice of ``OperatorSession`` the pools and phase (a) read."""
+
+    def __init__(self, *, active: bool = True, busy: bool = False) -> None:
+        self._active = active
+        self.is_busy = busy
+        self.process_exited: bool | None = None
+        self.teardowns = 0
+
+    @property
+    def is_active(self) -> bool:
+        return self._active
+
+    async def teardown(self) -> None:
+        self.teardowns += 1
+        self._active = False
+        self.process_exited = True
+
+
+class FakeChatPool:
+    """``ChatSessionPool`` as phase (a) sees it: ``get``, ``has_key``, ``terminate``."""
+
+    def __init__(self) -> None:
+        self.sessions: dict[str, FakeChatSession] = {}
+        self.starting: set[str] = set()
+        self.terminated: list[str] = []
+        self.get_calls = 0
+        # When set, ``terminate`` waits on it — used to hold the lock open.
+        self.terminate_gate: asyncio.Event | None = None
+
+    def get(self, chat_id: str) -> FakeChatSession | None:
+        self.get_calls += 1
+        return self.sessions.get(chat_id)
+
+    def has_key(self, chat_id: str) -> bool:
+        return chat_id in self.sessions or chat_id in self.starting
+
+    async def terminate(self, chat_id: str) -> FakeChatSession | None:
+        if self.terminate_gate is not None:
+            await self.terminate_gate.wait()
+        self.terminated.append(chat_id)
+        session = self.sessions.pop(chat_id, None)
+        if session is not None:
+            await session.teardown()
+        return session

--- a/tests/interfaces/web_terminal/api.test.mjs
+++ b/tests/interfaces/web_terminal/api.test.mjs
@@ -19,6 +19,9 @@
  *     definite 401 stops the reconnect loop and reloads -- as a navigation,
  *     which is the request shape both the nginx perimeter (login redirect) and
  *     the app's own gate (an HTML "not signed in" page) answer usefully
+ *   - refusal close codes: 4409 (session held elsewhere) and 4503 (outgoing
+ *     agent still running) end the reconnect loop and reach the caller as
+ *     onRefused; every other close code reconnects exactly as before
  *
  * Module isolation: api.js keeps `wsState`/`sseState`/`stateListeners` as
  * module-private state that no init() resets. `vi.resetModules()` plus a fresh
@@ -560,6 +563,131 @@ describe('reconnect: session-expiry probe (reload-on-401)', () => {
       headers: { Accept: 'application/json' },
     });
     expect(loc.reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWebSocket: refusal close codes are terminal', () => {
+  /**
+   * Stub `WebSocket`, recording every instance so a test can drive `onclose`
+   * by hand and count the reconnect attempts that follow.
+   * @returns {any[]} the constructed instances, in order
+   */
+  function stubWebSocket() {
+    /** @type {any[]} */
+    const instances = [];
+    vi.stubGlobal(
+      'WebSocket',
+      class {
+        constructor() {
+          instances.push(this);
+        }
+        close() {}
+      }
+    );
+    return instances;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('location', { protocol: 'http:', host: 'localhost:5000', reload: vi.fn() });
+    // A refusal must not reach the expiry probe at all; every test here fails
+    // loudly if it does.
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200 })));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('exports the two refusal codes and a predicate that accepts only those', () => {
+    expect(api.WS_CLOSE_SESSION_ATTACHED).toBe(4409);
+    expect(api.WS_CLOSE_OUTGOING_RUNNING).toBe(4503);
+    expect(api.isRefusalCloseCode(4409)).toBe(true);
+    expect(api.isRefusalCloseCode(4503)).toBe(true);
+    // Ordinary closes stay ordinary: an abnormal drop, a clean close, and the
+    // HTTP statuses these codes are named after are all reconnectable.
+    for (const code of [1000, 1001, 1006, 1011, 409, 503, 4000, 4500]) {
+      expect(api.isRefusalCloseCode(code)).toBe(false);
+    }
+  });
+
+  test('a 4409 close reports the refusal and schedules no reconnect', () => {
+    const sockets = stubWebSocket();
+    const onRefused = vi.fn();
+
+    api.createWebSocket('ws://localhost:5000/ws/terminal', { onRefused });
+    sockets[0].onclose({ code: 4409, reason: 'session_attached_elsewhere' });
+
+    expect(onRefused).toHaveBeenCalledTimes(1);
+    expect(onRefused).toHaveBeenCalledWith(4409, 'session_attached_elsewhere');
+    expect(vi.getTimerCount()).toBe(0);
+    // Past the whole backoff ceiling: no further connection is attempted.
+    vi.advanceTimersByTime(60000);
+    expect(sockets).toHaveLength(1);
+  });
+
+  test('a 4503 close reports the refusal and schedules no reconnect', () => {
+    const sockets = stubWebSocket();
+    const onRefused = vi.fn();
+
+    api.createWebSocket('ws://localhost:5000/ws/terminal', { onRefused });
+    sockets[0].onclose({ code: 4503, reason: 'outgoing_still_running' });
+
+    expect(onRefused).toHaveBeenCalledTimes(1);
+    expect(onRefused).toHaveBeenCalledWith(4503, 'outgoing_still_running');
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(60000);
+    expect(sockets).toHaveLength(1);
+  });
+
+  test('a refusal still reaches onClose, and never asks the expiry probe', () => {
+    // The refusal is the server's answer about a session it just confirmed is
+    // alive, so probing /api/session would only add a request. onClose keeps
+    // firing on every close, refusal included: the wrapper's shape is unchanged.
+    const sockets = stubWebSocket();
+    const onClose = vi.fn();
+
+    api.createWebSocket('ws://localhost:5000/ws/terminal', { onClose });
+    sockets[0].onclose({ code: 4409, reason: 'session_attached_elsewhere' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('a refusal without an onRefused callback is still terminal', () => {
+    // The callback is optional; the reconnect decision does not depend on it.
+    const sockets = stubWebSocket();
+
+    api.createWebSocket('ws://localhost:5000/ws/terminal');
+    sockets[0].onclose({ code: 4409, reason: 'session_attached_elsewhere' });
+
+    vi.advanceTimersByTime(60000);
+    expect(sockets).toHaveLength(1);
+  });
+
+  test('an ordinary 1006 close reconnects as before and reports no refusal', () => {
+    const sockets = stubWebSocket();
+    const onRefused = vi.fn();
+
+    api.createWebSocket('ws://localhost:5000/ws/terminal', { onRefused });
+    sockets[0].onclose({ code: 1006, reason: '' });
+
+    expect(onRefused).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(sockets).toHaveLength(2);
+  });
+
+  test('stop() before any close suppresses the reconnect whatever the code', () => {
+    const sockets = stubWebSocket();
+    const onRefused = vi.fn();
+
+    const conn = api.createWebSocket('ws://localhost:5000/ws/terminal', { onRefused });
+    conn.stop();
+    sockets[0].onclose({ code: 1006, reason: '' });
+
+    vi.advanceTimersByTime(60000);
+    expect(sockets).toHaveLength(1);
+    expect(onRefused).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/interfaces/web_terminal/app-mode-flip.test.mjs
+++ b/tests/interfaces/web_terminal/app-mode-flip.test.mjs
@@ -1,0 +1,309 @@
+// @ts-check
+/**
+ * Unit tests for the session half of an Expert/Simple flip (app.js's
+ * `initUiModeFollowUps`):
+ *   ./node_modules/.bin/vitest run tests/interfaces/web_terminal/app-mode-flip.test.mjs
+ *
+ * Both views are windows onto one session key, and the server hands that key
+ * to whichever surface asks for it — so the flip is what moves the live agent.
+ * Flipping to Expert resumes the key over the terminal socket; flipping to
+ * Simple drops that socket and lets the console take the key over. What this
+ * file pins is the order (the view's layout lands before its transitional
+ * state), that neither direction reloads the page, and that two quick flips
+ * produce two hand-offs one after the other rather than two acquires racing
+ * for the same key.
+ *
+ * Seams: terminal.js and chat.js are mocked whole — one wants xterm.js and a
+ * socket, the other a server to hand the key over. panel-manager.js and
+ * dock-workspace.js keep their real modules and lend only the flip's own
+ * follow-up functions to spies, so the dock and panel halves stay under test
+ * alongside the new one. The mode message itself goes through the real
+ * frame-params.js, which is what decides a re-pick of the current mode is not
+ * a flip at all.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+/** Every flip step that ran, in the order it ran. */
+const calls = vi.hoisted(() => /** @type {string[]} */ ([]));
+
+/** Stand-ins for the two surfaces, reachable from the hoisted mock factories. */
+const surfaces = vi.hoisted(() => ({
+  /** Resolves the acquire by default; a test may hold it open. */
+  startExpert: vi.fn(() => {
+    calls.push('startExpert');
+    return Promise.resolve();
+  }),
+  /** Resolves on the dropped socket's close by default; a test may hold it. */
+  stopTerminal: vi.fn(() => {
+    calls.push('stopTerminal');
+    return Promise.resolve();
+  }),
+  /** Resolves the hand-off by default; a test may hold it open. */
+  enterFromExpert: vi.fn(() => {
+    calls.push('enterFromExpert');
+    return Promise.resolve();
+  }),
+}));
+
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js', () => ({
+  initTerminal: vi.fn(),
+  startTerminal: vi.fn(),
+  startExpert: surfaces.startExpert,
+  stopTerminal: surfaces.stopTerminal,
+  restartTerminal: vi.fn(),
+  switchSession: vi.fn(),
+  setSessionLabel: vi.fn(),
+  notifySessionChange: vi.fn(),
+  clearStoredSessionId: vi.fn(),
+  fitTerminal: vi.fn(),
+  getTerminalInstance: () => null,
+  getCurrentSessionId: () => null,
+  focusTerminal: vi.fn(),
+  pasteToTerminal: vi.fn(),
+  onSessionChange: vi.fn(),
+}));
+
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/chat.js', () => ({
+  initChat: vi.fn(),
+  enterFromExpert: surfaces.enterFromExpert,
+  handoffRefusal: vi.fn(() => null),
+  transportNotice: vi.fn(() => ''),
+}));
+
+/** The follow-ups the flip already had, spied on their real modules. */
+const followUps = vi.hoisted(() => ({
+  broadcastMode: vi.fn(() => {
+    calls.push('broadcastMode');
+  }),
+  handleUiModeFlip: vi.fn(() => {
+    calls.push('handleUiModeFlip');
+  }),
+  applyDockMode: vi.fn(() => {
+    calls.push('applyDockMode');
+  }),
+}));
+
+vi.mock(
+  '../../../src/osprey/interfaces/web_terminal/static/js/panel-manager.js',
+  async (importOriginal) => ({
+    .../** @type {object} */ (await importOriginal()),
+    broadcastMode: followUps.broadcastMode,
+    handleUiModeFlip: followUps.handleUiModeFlip,
+  })
+);
+
+vi.mock(
+  '../../../src/osprey/interfaces/web_terminal/static/js/dock-workspace.js',
+  async (importOriginal) => ({
+    .../** @type {object} */ (await importOriginal()),
+    applyDockMode: followUps.applyDockMode,
+  })
+);
+
+import { initUiModeFollowUps } from '../../../src/osprey/interfaces/web_terminal/static/js/app.js';
+
+/**
+ * Flip the view the way the header's View row does: the same-origin
+ * `osprey-mode-change` message frame-params.js listens for.
+ * @param {'expert'|'simple'} mode
+ */
+function flipTo(mode) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type: 'osprey-mode-change', mode },
+      origin: window.location.origin,
+    })
+  );
+}
+
+/** Let the hand-off chain's microtasks (and any queued task) run. */
+function settle() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// Once, as boot does it: the listener is bound to the shared `window` and the
+// flip has no teardown, so re-arming it per test would run every earlier
+// test's copy too.
+beforeAll(() => {
+  initUiModeFollowUps();
+});
+
+beforeEach(() => {
+  calls.length = 0;
+  vi.clearAllMocks();
+  surfaces.startExpert.mockImplementation(() => {
+    calls.push('startExpert');
+    return Promise.resolve();
+  });
+  surfaces.stopTerminal.mockImplementation(() => {
+    calls.push('stopTerminal');
+    return Promise.resolve();
+  });
+  surfaces.enterFromExpert.mockImplementation(() => {
+    calls.push('enterFromExpert');
+    return Promise.resolve();
+  });
+  document.documentElement.setAttribute('data-ui-mode', 'expert');
+});
+
+afterEach(async () => {
+  // Leave no hand-off in flight: the chain is module state shared by the file.
+  await settle();
+  vi.restoreAllMocks();
+});
+
+describe('flip to Simple', () => {
+  test('drops the terminal, then asks the console to take the key over', async () => {
+    flipTo('simple');
+    await settle();
+
+    expect(calls).toEqual([
+      'broadcastMode',
+      'applyDockMode',
+      'handleUiModeFlip',
+      'stopTerminal',
+      'enterFromExpert',
+    ]);
+    expect(surfaces.startExpert).not.toHaveBeenCalled();
+  });
+
+  test('asks for the key with no interrupt: the flip never cuts a running turn', async () => {
+    flipTo('simple');
+    await settle();
+
+    expect(surfaces.enterFromExpert).toHaveBeenCalledTimes(1);
+    expect(surfaces.enterFromExpert).toHaveBeenCalledWith();
+  });
+});
+
+describe('flip to Expert', () => {
+  test('resumes the key over the terminal socket and touches nothing else', async () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+
+    flipTo('expert');
+    await settle();
+
+    expect(calls).toEqual(['broadcastMode', 'applyDockMode', 'handleUiModeFlip', 'startExpert']);
+    expect(surfaces.startExpert).toHaveBeenCalledWith();
+    expect(surfaces.stopTerminal).not.toHaveBeenCalled();
+    expect(surfaces.enterFromExpert).not.toHaveBeenCalled();
+  });
+});
+
+describe('the flip itself', () => {
+  test('reloads nothing in either direction', async () => {
+    const reload = vi.spyOn(window.location, 'reload').mockImplementation(() => {});
+
+    flipTo('simple');
+    await settle();
+    flipTo('expert');
+    await settle();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('a re-pick of the mode already on screen hands nothing over', async () => {
+    flipTo('expert');
+    await settle();
+
+    expect(calls).toEqual([]);
+  });
+
+  test('a second flip waits for the first hand-off instead of racing it', async () => {
+    /** @type {() => void} */
+    let finishHandoff = () => {};
+    surfaces.enterFromExpert.mockImplementation(() => {
+      calls.push('enterFromExpert');
+      return new Promise((resolve) => {
+        finishHandoff = () => resolve(undefined);
+      });
+    });
+
+    flipTo('simple');
+    await settle();
+    expect(calls).toContain('enterFromExpert');
+
+    // The operator flips straight back while the console is still acquiring:
+    // a socket opened now would be a second acquire on the same key, which
+    // the server refuses outright.
+    flipTo('expert');
+    await settle();
+    expect(surfaces.startExpert).not.toHaveBeenCalled();
+
+    finishHandoff();
+    await settle();
+    expect(surfaces.startExpert).toHaveBeenCalledTimes(1);
+    expect(calls[calls.length - 1]).toBe('startExpert');
+  });
+
+  test('the console asks for the key only once the terminal socket has closed', async () => {
+    /** @type {() => void} */
+    let finishClose = () => {};
+    surfaces.stopTerminal.mockImplementation(() => {
+      calls.push('stopTerminal');
+      return new Promise((resolve) => {
+        finishClose = () => resolve(undefined);
+      });
+    });
+
+    flipTo('simple');
+    await settle();
+
+    // The server reads the closed socket as the Expert view letting go, so a
+    // hand-off asked for ahead of it would find the key still held.
+    expect(surfaces.stopTerminal).toHaveBeenCalledTimes(1);
+    expect(surfaces.enterFromExpert).not.toHaveBeenCalled();
+
+    finishClose();
+    await settle();
+    expect(surfaces.enterFromExpert).toHaveBeenCalledTimes(1);
+    expect(calls.slice(-2)).toEqual(['stopTerminal', 'enterFromExpert']);
+  });
+
+  test('a flip back to Simple waits for the Expert acquire it queued behind', async () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    /** @type {() => void} */
+    let finishAcquire = () => {};
+    surfaces.startExpert.mockImplementation(() => {
+      calls.push('startExpert');
+      return new Promise((resolve) => {
+        finishAcquire = () => resolve(undefined);
+      });
+    });
+
+    flipTo('expert');
+    await settle();
+    expect(calls).toContain('startExpert');
+
+    // Dropping the socket now would tear the Expert channel down before the
+    // server had seen it open, and the console's acquire would then arrive to
+    // find the key still held by a view that has already gone.
+    flipTo('simple');
+    await settle();
+    expect(surfaces.stopTerminal).not.toHaveBeenCalled();
+    expect(surfaces.enterFromExpert).not.toHaveBeenCalled();
+
+    finishAcquire();
+    await settle();
+    expect(surfaces.stopTerminal).toHaveBeenCalledTimes(1);
+    expect(surfaces.enterFromExpert).toHaveBeenCalledTimes(1);
+    expect(calls.slice(-2)).toEqual(['stopTerminal', 'enterFromExpert']);
+  });
+
+  test('a failed hand-off is reported and leaves the next flip working', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    surfaces.enterFromExpert.mockImplementation(() => {
+      calls.push('enterFromExpert');
+      return Promise.reject(new Error('server gone'));
+    });
+
+    flipTo('simple');
+    await settle();
+    expect(errSpy).toHaveBeenCalled();
+
+    flipTo('expert');
+    await settle();
+    expect(surfaces.startExpert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/interfaces/web_terminal/chat-client.test.mjs
+++ b/tests/interfaces/web_terminal/chat-client.test.mjs
@@ -26,6 +26,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  delete window.__OSPREY_PREFIX__;
 });
 
 /**
@@ -298,6 +299,22 @@ describe('sendPrompt: transport failures', () => {
     expect(cb.onError.mock.calls[0][0].slug).toBe('');
   });
 
+  test('a 204 closes the turn without reporting an error', async () => {
+    // The server abandoned the request; there is no body to stream, and a
+    // missing body is not the transport failure it would be on a 200.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 204, statusText: 'No Content', body: null }))
+    );
+
+    const cb = collector();
+    chat.sendPrompt('c', 'p', cb.handlers);
+    await vi.waitFor(() => expect(cb.onClose).toHaveBeenCalledTimes(1));
+
+    expect(cb.onError).not.toHaveBeenCalled();
+    expect(cb.events).toEqual([]);
+  });
+
   test('a rejected fetch reports onError and closes', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
 
@@ -382,12 +399,201 @@ describe('interrupt', () => {
   });
 });
 
-describe('deleteChat', () => {
-  test('DELETEs /api/chat/{id} with keepalive and the id encoded', async () => {
-    const fetchMock = vi.fn(async () => ({ ok: true }));
+/**
+ * Build a fake non-streaming `Response` carrying *body* as its JSON.
+ * @param {any} body
+ * @param {{ ok?: boolean, status?: number, statusText?: string }} [opts]
+ */
+function jsonResponse(body, opts = {}) {
+  const { ok = true, status = 200, statusText = 'OK' } = opts;
+  return { ok, status, statusText, json: async () => body };
+}
+
+/** The URL of the first call made to *fetchMock*. */
+function firstUrl(/** @type {any} */ fetchMock) {
+  return fetchMock.mock.calls[0][0];
+}
+
+/** The `init` of the first call made to *fetchMock*. */
+function firstInit(/** @type {any} */ fetchMock) {
+  return fetchMock.mock.calls[0][1];
+}
+
+describe('requestHandoff: request shape', () => {
+  test('POSTs to /api/session/{key}/handoff and resolves the state envelope', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'ready', session_id: 'k-1' }));
     vi.stubGlobal('fetch', fetchMock);
 
-    chat.deleteChat('chat 2');
-    expect(fetchMock).toHaveBeenCalledWith('/api/chat/chat%202', { method: 'DELETE', keepalive: true });
+    const result = await chat.requestHandoff('k-1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(firstUrl(fetchMock)).toBe('/api/session/k-1/handoff');
+    const init = firstInit(fetchMock);
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init.body)).toEqual({ to: 'simple', interrupt: false });
+    expect(result).toEqual({ state: 'ready', session_id: 'k-1' });
+  });
+
+  test('forwards interrupt: true when the operator cuts a running turn', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'ready', session_id: 'k' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await chat.requestHandoff('k', { interrupt: true });
+    expect(JSON.parse(firstInit(fetchMock).body)).toEqual({ to: 'simple', interrupt: true });
+  });
+
+  test('applies the multi-user prefix and encodes the key', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'ready', session_id: 'a/b' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await chat.requestHandoff('a/b');
+    expect(firstUrl(fetchMock)).toBe('/u/alice/api/session/a%2Fb/handoff');
+  });
+
+  test('resolves null on a 204 — the request was abandoned server-side', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 204,
+        statusText: 'No Content',
+        json: async () => {
+          throw new SyntaxError('Unexpected end of JSON input');
+        },
+      }))
+    );
+
+    await expect(chat.requestHandoff('k')).resolves.toBeNull();
+  });
+
+  test('adds no timeout of its own — no signal unless the caller passes one', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'ready', session_id: 'k' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await chat.requestHandoff('k');
+    expect(firstInit(fetchMock).signal).toBeUndefined();
+  });
+});
+
+describe('requestHandoff: abort', () => {
+  test("passes the caller's signal through to fetch", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'ready', session_id: 'k' }));
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+
+    await chat.requestHandoff('k', { signal: controller.signal });
+    expect(firstInit(fetchMock).signal).toBe(controller.signal);
+  });
+
+  test('aborting the signal rejects the pending hand-off', async () => {
+    // A fetch that never settles on its own, mirroring a hand-off waiting on a
+    // long Expert turn: only the signal ends it.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((/** @type {string} */ _url, /** @type {any} */ init) =>
+        new Promise((_resolve, reject) => {
+          /** @type {AbortSignal} */
+          const signal = init.signal;
+          const fail = () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          };
+          if (signal.aborted) fail();
+          else signal.addEventListener('abort', fail);
+        })
+      )
+    );
+    const controller = new AbortController();
+
+    const pending = chat.requestHandoff('k', { signal: controller.signal });
+    controller.abort();
+    await expect(pending).rejects.toThrow('aborted');
+  });
+});
+
+describe('requestHandoff: rejection slugs', () => {
+  test.each([
+    [409, 'Conflict', 'session_attached_elsewhere'],
+    [429, 'Too Many Requests', 'chat_capacity'],
+    [503, 'Service Unavailable', 'shutting_down'],
+  ])('%i carries status and the detail.error slug', async (status, statusText, slug) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => jsonResponse({ detail: { error: slug } }, { ok: false, status, statusText }))
+    );
+
+    const err = await chat.requestHandoff('k').catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(status);
+    expect(err.slug).toBe(slug);
+    expect(err.message).toBe(`HTTP ${status}: ${statusText}`);
+  });
+
+  test('a rejection without a JSON body leaves the slug empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        json: async () => {
+          throw new Error('not JSON');
+        },
+      }))
+    );
+
+    const err = await chat.requestHandoff('k').catch((e) => e);
+    expect(err.status).toBe(503);
+    expect(err.slug).toBe('');
+  });
+});
+
+describe('fetchHistory', () => {
+  test('GETs the full transcript for the key and returns its turns', async () => {
+    const turns = [
+      { role: 'user', content: 'hi', timestamp: '2026-09-05T00:00:00Z' },
+      { role: 'assistant', content: 'hello' },
+    ];
+    const fetchMock = vi.fn(async () => jsonResponse({ turns, count: turns.length }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(chat.fetchHistory('k-1')).resolves.toEqual(turns);
+    expect(fetchMock).toHaveBeenCalledWith('/api/session-chat?session_id=k-1&full=1', {
+      cache: 'no-store',
+    });
+  });
+
+  test('applies the multi-user prefix and encodes the key', async () => {
+    window.__OSPREY_PREFIX__ = '/u/alice';
+    const fetchMock = vi.fn(async () => jsonResponse({ turns: [], count: 0 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await chat.fetchHistory('a/b');
+    expect(firstUrl(fetchMock)).toBe('/u/alice/api/session-chat?session_id=a%2Fb&full=1');
+  });
+
+  test('a body without turns yields an empty list', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ count: 0 })));
+    await expect(chat.fetchHistory('k')).resolves.toEqual([]);
+  });
+
+  test('a non-2xx status rejects with the status and slug', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        jsonResponse({ detail: { error: 'session_unknown' } }, {
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        })
+      )
+    );
+
+    const err = await chat.fetchHistory('k').catch((e) => e);
+    expect(err.status).toBe(404);
+    expect(err.slug).toBe('session_unknown');
   });
 });

--- a/tests/interfaces/web_terminal/chat-render.test.mjs
+++ b/tests/interfaces/web_terminal/chat-render.test.mjs
@@ -11,7 +11,8 @@
  *      keeps an unmapped tool visible.
  *   3. `createChatRenderer` -- the view-model: user/agent entries, streamed
  *      text accumulation, the activity-line state machine, first-turn
- *      session_reset suppression, and error rendering.
+ *      session_reset suppression, error rendering, and the transcript replay
+ *      that repopulates the log after a handoff from the other view.
  *
  * On the XSS tests: the *real* vendored DOMPurify cannot be exercised here --
  * under happy-dom (the vitest env) DOMPurify mis-parses and leaks `<script>`
@@ -526,6 +527,112 @@ describe('createChatRenderer', () => {
     // after reset, a session_reset is again a first-turn (suppressed)
     r.handleEvent({ type: 'session_reset' });
     expect(container.querySelector('.op-system')).toBeNull();
+  });
+
+  describe('replay of prior transcript turns', () => {
+    /** Three turns in the shape `GET /api/session-chat` serves. */
+    const turns = [
+      { role: 'user', content: 'read the beam current', timestamp: '2026-09-05T10:00:00Z' },
+      { role: 'assistant', content: 'The beam current is 500 mA.', timestamp: '2026-09-05T10:00:02Z' },
+      { role: 'user', content: 'and the orbit?', timestamp: '2026-09-05T10:00:09Z' },
+    ];
+
+    test('renders one entry per turn, in order, and returns the count', () => {
+      const r = createChatRenderer(container);
+      expect(r.replay(turns)).toBe(3);
+      expect(r.messageCount()).toBe(3);
+
+      const entries = container.querySelectorAll('.op-entry');
+      expect(entries.length).toBe(3);
+      expect(entries[0].classList.contains('operator')).toBe(true);
+      expect(entries[1].classList.contains('assistant')).toBe(true);
+      expect(entries[2].classList.contains('operator')).toBe(true);
+      expect(entries[1].querySelector('.op-entry-body')?.textContent).toBe(
+        'The beam current is 500 mA.'
+      );
+    });
+
+    test('agent turns go through the sanitising markdown path', () => {
+      vi.stubGlobal('DOMPurify', strippingPurify);
+      const r = createChatRenderer(container);
+      r.replay([
+        {
+          role: 'assistant',
+          content: 'result: <img src=x onerror="steal()"><script>evil()</script>',
+        },
+      ]);
+      const body = qs(container, '.op-entry.assistant .op-entry-body');
+      expect(body.querySelector('script')).toBeNull();
+      expect(body.querySelector('[onerror]')).toBeNull();
+    });
+
+    test('markdown in an agent turn is rendered, not shown as source', () => {
+      vi.stubGlobal('marked', { parse: (/** @type {string} */ t) => `<p><em>${t}</em></p>` });
+      const r = createChatRenderer(container);
+      r.replay([{ role: 'assistant', content: 'orbit corrected' }]);
+      const body = qs(container, '.op-entry.assistant .op-entry-body');
+      expect(body.querySelector('em')?.textContent).toBe('orbit corrected');
+    });
+
+    test('a session_reset after a replay draws no divider', () => {
+      // Replayed turns are the same conversation continued in another window,
+      // so the fresh stream's frame-0 reset is not a boundary worth marking.
+      const r = createChatRenderer(container);
+      r.replay(turns);
+      r.handleEvent({ type: 'session_reset' });
+      expect(container.querySelector('.op-system')).toBeNull();
+      expect(r.messageCount()).toBe(3);
+    });
+
+    test('a reset still earns a divider once a live exchange completes above it', () => {
+      const r = createChatRenderer(container);
+      r.replay(turns);
+      r.handleEvent({ type: 'text', content: 'The orbit is flat.' });
+      r.handleEvent({ type: 'result', is_error: false });
+      r.addUserMessage('thanks');
+      r.handleEvent({ type: 'session_reset' });
+      expect(qs(container, '.op-system').textContent).toBe('session reset');
+    });
+
+    test('a live text event after a replay opens a fresh agent entry', () => {
+      const r = createChatRenderer(container);
+      r.replay([{ role: 'assistant', content: 'replayed' }]);
+      r.handleEvent({ type: 'text', content: 'live' });
+      const agents = container.querySelectorAll('.op-entry.assistant');
+      expect(agents.length).toBe(2);
+      expect(agents[0].querySelector('.op-entry-body')?.textContent).toBe('replayed');
+      expect(agents[1].querySelector('.op-entry-body')?.textContent).toBe('live');
+    });
+
+    test('an empty or missing turn list renders nothing', () => {
+      const r = createChatRenderer(container);
+      expect(r.replay([])).toBe(0);
+      expect(r.replay(undefined)).toBe(0);
+      expect(container.children.length).toBe(0);
+      expect(r.messageCount()).toBe(0);
+    });
+
+    test('a turn with no content is skipped and not counted', () => {
+      const r = createChatRenderer(container);
+      expect(r.replay([{ role: 'user', content: '' }, { role: 'assistant', content: 'hi' }])).toBe(1);
+      expect(r.messageCount()).toBe(1);
+      expect(container.querySelectorAll('.op-entry.operator').length).toBe(0);
+    });
+
+    test('addAgentMessage appends a finished agent entry and marks the exchange', () => {
+      const r = createChatRenderer(container);
+      const entry = r.addAgentMessage('The beam current is 500 mA.');
+      expect(entry.classList.contains('assistant')).toBe(true);
+      expect(qs(container, '.op-entry.assistant .op-entry-body').textContent).toBe(
+        'The beam current is 500 mA.'
+      );
+      expect(r.messageCount()).toBe(1);
+      // Unlike a replay, a directly added agent message is a completed
+      // exchange, so the next reset is worth a divider.
+      r.addUserMessage('and the orbit?');
+      r.handleEvent({ type: 'session_reset' });
+      expect(qs(container, '.op-system').textContent).toBe('session reset');
+    });
   });
 
   test('a hostile tool name reaches the activity line as text, never markup', () => {

--- a/tests/interfaces/web_terminal/chat.test.mjs
+++ b/tests/interfaces/web_terminal/chat.test.mjs
@@ -1,21 +1,65 @@
 // @ts-check
 /**
- * Unit tests for the chat controller's transport-notice mapping (chat.js):
- *   npx vitest run tests/interfaces/web_terminal/chat.test.mjs
+ * Unit tests for the Simple-view chat controller (chat.js):
+ *   ./node_modules/.bin/vitest run tests/interfaces/web_terminal/chat.test.mjs
  *
- * The controller is DOM glue and the interesting decision in it is which
- * sentence an operator reads when the endpoint refuses a turn. That choice is
- * exported as `transportNotice` and tested here directly, because the failure
- * it exists to prevent is not a crash: the endpoint answers 409 both for "a
- * turn is already running" and for "this chat was restarted by your own
- * posture flip", and keying on the status alone told the second operator the
- * first sentence — false, and with no cue to do the one thing that works
- * (send the prompt again).
+ * Two things are worth pinning here.
+ *
+ * The first is which sentence an operator reads when the endpoint refuses a
+ * turn. That choice is exported as `transportNotice`, because the failure it
+ * exists to prevent is not a crash: the endpoint answers 409 both for "a turn
+ * is already running" and for "this chat was restarted by your own posture
+ * flip", and keying on the status alone told the second operator the first
+ * sentence — false, and with no cue to do the one thing that works (send the
+ * prompt again).
+ *
+ * The second is the binding. The console has no conversation of its own: it
+ * addresses the tab's session pointer, replays that key's transcript, and
+ * arrives from the Expert view through a hand-off that the other view can
+ * refuse. Those paths are DOM-and-transport glue, so they are driven here
+ * against a real (happy-dom) container with chat-client.js mocked — what is
+ * asserted is which key was addressed, what reached the log, and which one
+ * action the operator is left with.
+ *
+ * Module isolation: the hand-off entry point is module-level state (app.js has
+ * no handle on the console), so each binding test gets a fresh module instance
+ * via vi.resetModules() + dynamic import, the same pattern as
+ * terminal-resume.test.mjs.
  */
 
-import { test, expect, describe } from 'vitest';
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
 import { transportNotice } from '../../../src/osprey/interfaces/web_terminal/static/js/chat.js';
+
+const CHAT_JS = '../../../src/osprey/interfaces/web_terminal/static/js/chat.js';
+const STORAGE_KEY = 'osprey-pty-session';
+
+/** Transport doubles, re-armed per test by `mountChat`. */
+const transport = {
+  fetchHistory: vi.fn(),
+  sendPrompt: vi.fn(),
+  interrupt: vi.fn(),
+  requestHandoff: vi.fn(),
+};
+
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/chat-client.js', () => ({
+  fetchHistory: (/** @type {any} */ key) => transport.fetchHistory(key),
+  sendPrompt: (/** @type {any} */ key, /** @type {any} */ prompt, /** @type {any} */ cb) =>
+    transport.sendPrompt(key, prompt, cb),
+  interrupt: (/** @type {any} */ key) => transport.interrupt(key),
+  requestHandoff: (/** @type {any} */ key, /** @type {any} */ options) =>
+    transport.requestHandoff(key, options),
+}));
+
+// terminal.js is xterm glue; the console only needs its panel broadcast, and
+// first-contact.js (imported by the console) only needs its session hook.
+const notifySessionChange = vi.fn();
+vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js', () => ({
+  notifySessionChange: (/** @type {any} */ id) => notifySessionChange(id),
+  onSessionChange: () => {},
+  focusTerminal: () => {},
+  pasteToTerminal: () => {},
+}));
 
 /**
  * A transport failure shaped the way chat-client.js builds one.
@@ -78,5 +122,434 @@ describe('transportNotice', () => {
 
   test('a null failure does not throw', () => {
     expect(transportNotice(null)).toBe('Connection to the operator agent failed.');
+  });
+});
+
+// ---- Binding, replay and hand-off ---- //
+
+/** @type {typeof import('../../../src/osprey/interfaces/web_terminal/static/js/chat.js')} */
+let chat;
+
+/** The mounted console's container.
+ * @type {HTMLElement} */
+let container;
+
+/**
+ * Mount a fresh console into a fresh container.
+ * @param {{ mode?: string, pointer?: string|null }} [options]
+ */
+async function mountChat({ mode = 'simple', pointer = null } = {}) {
+  document.documentElement.setAttribute('data-ui-mode', mode);
+  if (pointer) localStorage.setItem(STORAGE_KEY, pointer);
+  container = document.createElement('div');
+  container.id = 'operator-container';
+  document.body.append(container);
+
+  vi.resetModules();
+  chat = await import(CHAT_JS);
+  chat.initChat();
+  // Let the boot-time bind's fetch settle before a test looks at the log.
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/** @param {string} selector */
+const one = (selector) => container.querySelector(selector);
+
+/** @param {string} selector */
+const textOf = (selector) => one(selector)?.textContent ?? '';
+
+/** Every rendered log entry's text, in order. */
+const logEntries = () =>
+  [...container.querySelectorAll('.op-entry-body')].map((el) => el.textContent?.trim());
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.replaceChildren();
+  notifySessionChange.mockReset();
+  transport.fetchHistory.mockReset().mockResolvedValue([]);
+  transport.sendPrompt.mockReset().mockReturnValue({ abort: () => {}, aborted: false });
+  transport.interrupt.mockReset().mockResolvedValue(undefined);
+  transport.requestHandoff.mockReset().mockResolvedValue({ state: 'simple', session_id: 'k' });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.documentElement.removeAttribute('data-ui-mode');
+});
+
+describe('initChat binding', () => {
+  test('a tab with no pointer mints one and stores it', async () => {
+    await mountChat({ mode: 'expert' });
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).toMatch(/^[0-9a-f-]{36}$/);
+    // Nothing to replay on a key that has never existed.
+    expect(transport.fetchHistory).not.toHaveBeenCalled();
+  });
+
+  test('an existing pointer is adopted, never replaced', async () => {
+    await mountChat({ mode: 'expert', pointer: 'key-from-the-terminal' });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('key-from-the-terminal');
+  });
+
+  test('a page that opens in Simple mode replays the pointer it adopted', async () => {
+    transport.fetchHistory.mockResolvedValue([
+      { role: 'user', content: 'status?' },
+      { role: 'assistant', content: 'All quiet.' },
+    ]);
+    await mountChat({ pointer: 'K1' });
+
+    expect(transport.fetchHistory).toHaveBeenCalledWith('K1');
+    expect(logEntries()).toEqual(['status?', 'All quiet.']);
+    expect(notifySessionChange).toHaveBeenCalledWith('K1');
+  });
+
+  test('a prompt is sent under the pointer key, not a minted chat id', async () => {
+    await mountChat({ pointer: 'K1' });
+    const textarea = /** @type {HTMLTextAreaElement} */ (one('textarea'));
+    textarea.value = 'ping';
+    /** @type {HTMLButtonElement} */ (one('.op-send-btn')).click();
+
+    expect(transport.sendPrompt).toHaveBeenCalledWith('K1', 'ping', expect.anything());
+  });
+
+  test('a pointer change rebinds the log to the new key', async () => {
+    transport.fetchHistory.mockResolvedValue([{ role: 'assistant', content: 'from K1' }]);
+    await mountChat({ pointer: 'K1' });
+    expect(logEntries()).toEqual(['from K1']);
+
+    transport.fetchHistory.mockResolvedValue([{ role: 'assistant', content: 'from K2' }]);
+    const pointer = await import(
+      '../../../src/osprey/interfaces/web_terminal/static/js/session-pointer.js'
+    );
+    pointer.setPointer('K2');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Reset then replay: the old key's turns are gone, not appended to.
+    expect(logEntries()).toEqual(['from K2']);
+    expect(notifySessionChange).toHaveBeenLastCalledWith('K2');
+  });
+
+  test('a cleared pointer leaves the log on the key it was bound to', async () => {
+    transport.fetchHistory.mockResolvedValue([{ role: 'assistant', content: 'from K1' }]);
+    await mountChat({ pointer: 'K1' });
+    const pointer = await import(
+      '../../../src/osprey/interfaces/web_terminal/static/js/session-pointer.js'
+    );
+
+    transport.fetchHistory.mockClear();
+    pointer.clearPointer();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A clear says the key is dead for both views, not that this console
+    // moved to another conversation. There is nothing to replay.
+    expect(logEntries()).toEqual(['from K1']);
+    expect(transport.fetchHistory).not.toHaveBeenCalled();
+  });
+
+  test('overlapping pointer changes render only the newer key turns', async () => {
+    await mountChat({ pointer: 'K1' });
+    const pointer = await import(
+      '../../../src/osprey/interfaces/web_terminal/static/js/session-pointer.js'
+    );
+
+    /** @type {((value: any) => void)[]} */
+    const admit = [];
+    transport.fetchHistory.mockImplementation(() => new Promise((resolve) => admit.push(resolve)));
+    pointer.setPointer('K2');
+    pointer.setPointer('K3');
+    // K2's transcript lands after K3 has already claimed the log.
+    admit[1]([{ role: 'assistant', content: 'from K3' }]);
+    admit[0]([{ role: 'assistant', content: 'from K2' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logEntries()).toEqual(['from K3']);
+  });
+
+  test('"New conversation" mints a key, points the tab at it, and clears the log', async () => {
+    transport.fetchHistory.mockResolvedValue([{ role: 'assistant', content: 'old talk' }]);
+    await mountChat({ pointer: 'K1' });
+    expect(logEntries()).toEqual(['old talk']);
+
+    transport.fetchHistory.mockClear();
+    /** @type {HTMLButtonElement} */ (one('.op-session-new')).click();
+    await Promise.resolve();
+
+    const minted = localStorage.getItem(STORAGE_KEY);
+    expect(minted).toMatch(/^[0-9a-f-]{36}$/);
+    expect(minted).not.toBe('K1');
+    expect(logEntries()).toEqual([]);
+    expect(notifySessionChange).toHaveBeenLastCalledWith(minted);
+    // A key minted this instant has no transcript worth asking for.
+    expect(transport.fetchHistory).not.toHaveBeenCalled();
+  });
+});
+
+describe('enterFromExpert', () => {
+  test('shows the transitional state, then the replayed history and a live input', async () => {
+    /** @type {(value: any) => void} */
+    let admit = () => {};
+    transport.requestHandoff.mockReturnValue(
+      new Promise((resolve) => {
+        admit = resolve;
+      })
+    );
+    transport.fetchHistory.mockResolvedValue([{ role: 'assistant', content: 'carried over' }]);
+    await mountChat({ pointer: 'K1' });
+
+    const entered = chat.enterFromExpert();
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(false);
+    expect(textOf('.op-handoff-message')).toContain('Finishing in the other view');
+    expect(textOf('.op-handoff-action')).toBe('Stop and switch now');
+    expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(true);
+
+    admit({ state: 'simple', session_id: 'K1' });
+    await entered;
+
+    expect(transport.requestHandoff).toHaveBeenCalledWith('K1', expect.objectContaining({
+      interrupt: false,
+    }));
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(true);
+    expect(logEntries()).toEqual(['carried over']);
+    expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(false);
+  });
+
+  test('the elapsed counter ticks while the wait runs', async () => {
+    vi.useFakeTimers();
+    transport.requestHandoff.mockReturnValue(new Promise(() => {}));
+    await mountChat({ pointer: 'K1' });
+
+    void chat.enterFromExpert();
+    vi.advanceTimersByTime(62_000);
+    expect(textOf('.op-handoff-elapsed')).toBe('1:02');
+  });
+
+  test('a hook-less refusal offers only the stop, which re-asks with interrupt', async () => {
+    transport.requestHandoff.mockRejectedValueOnce(transportError(409, 'handoff_needs_interrupt'));
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
+    expect(textOf('.op-handoff-message')).toBe('The other view may still be working.');
+    expect(action.hidden).toBe(false);
+    expect(action.textContent).toBe('Stop and switch now');
+    expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(true);
+
+    transport.requestHandoff.mockResolvedValue({ state: 'simple', session_id: 'K1' });
+    action.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.requestHandoff).toHaveBeenLastCalledWith('K1', expect.objectContaining({
+      interrupt: true,
+    }));
+  });
+
+  test('a session held elsewhere states the fact and offers nothing', async () => {
+    transport.requestHandoff.mockRejectedValue(transportError(409, 'session_attached_elsewhere'));
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    expect(textOf('.op-handoff-message')).toBe('This session is in use in another tab or view.');
+    expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).hidden).toBe(true);
+  });
+
+  test('a wait a newer request took over states the fact and offers a retry', async () => {
+    transport.requestHandoff.mockRejectedValueOnce(transportError(409, 'handoff_superseded'));
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
+    expect(textOf('.op-handoff-message')).toBe('Another request took over this session.');
+    expect(action.hidden).toBe(false);
+    expect(action.textContent).toBe('Retry');
+
+    // The retry re-asks without an interrupt: the key's chat is pooled by now.
+    transport.requestHandoff.mockResolvedValue({ state: 'simple', session_id: 'K1' });
+    action.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.requestHandoff).toHaveBeenLastCalledWith('K1', expect.objectContaining({
+      interrupt: false,
+    }));
+  });
+
+  test('a capacity 429 offers a retry that re-asks without interrupting', async () => {
+    transport.requestHandoff.mockRejectedValueOnce(transportError(429, 'chat_capacity'));
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
+    expect(textOf('.op-handoff-message')).toBe('No chat capacity right now.');
+    expect(action.textContent).toBe('Retry');
+
+    transport.requestHandoff.mockResolvedValue({ state: 'simple', session_id: 'K1' });
+    action.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(transport.requestHandoff).toHaveBeenLastCalledWith('K1', expect.objectContaining({
+      interrupt: false,
+    }));
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(true);
+  });
+
+  test('an outgoing agent still shutting down is retryable', async () => {
+    transport.requestHandoff.mockRejectedValue(transportError(503, 'outgoing_still_running'));
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    expect(textOf('.op-handoff-message')).toBe('The previous agent is still shutting down.');
+    expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).textContent).toBe('Retry');
+  });
+
+  test('an abandoned request (204, no body) leaves the wait exactly as it was', async () => {
+    // The server saw this request's channel close and handed nothing over.
+    // Nothing failed, so there is nothing to say — and the wait on screen is
+    // still the true state, with its one action still open.
+    transport.requestHandoff.mockResolvedValue(null);
+    await mountChat({ pointer: 'K1' });
+    transport.fetchHistory.mockClear();
+
+    await chat.enterFromExpert();
+
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(false);
+    expect(textOf('.op-handoff-message')).toContain('Finishing in the other view');
+    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
+    expect(action.textContent).toBe('Stop and switch now');
+    expect(action.hidden).toBe(false);
+    expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(true);
+    // Nothing was handed over, so nothing is replayed.
+    expect(transport.fetchHistory).not.toHaveBeenCalled();
+  });
+
+  test('a superseded attempt finishing last does not open the console over the newer wait', async () => {
+    /** @type {((value: any) => void)[]} */
+    const admit = [];
+    transport.requestHandoff.mockImplementation(
+      () => new Promise((resolve) => admit.push(resolve))
+    );
+    await mountChat({ pointer: 'K1' });
+
+    const first = chat.enterFromExpert();
+    const second = chat.enterFromExpert();
+    // The newer attempt lands first; the older one is still in flight.
+    admit[1]({ state: 'simple', session_id: 'K1' });
+    await second;
+    transport.requestHandoff.mockClear();
+
+    // Nothing is waiting any more, so re-arm the wait the newer attempt would
+    // be showing had the older one not been about to answer.
+    const third = chat.enterFromExpert();
+    admit[0]({ state: 'simple', session_id: 'K1' });
+    await first;
+
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(false);
+    expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(true);
+    admit[2]({ state: 'simple', session_id: 'K1' });
+    await third;
+  });
+
+  test('a failure with no slug says the hand-off failed and offers a retry', async () => {
+    transport.requestHandoff.mockRejectedValue(new Error('network down'));
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    // The in-log transport copy is for the log; the overlay states its own
+    // failure in its own voice.
+    expect(textOf('.op-handoff-message')).toBe('The hand-off failed.');
+    expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).textContent).toBe('Retry');
+  });
+
+  test('the elapsed counter is not announced on every tick', async () => {
+    transport.requestHandoff.mockReturnValue(new Promise(() => {}));
+    await mountChat({ pointer: 'K1' });
+
+    void chat.enterFromExpert();
+    expect(one('.op-handoff')?.getAttribute('aria-live')).toBe('polite');
+    expect(one('.op-handoff-elapsed')?.getAttribute('aria-live')).toBe('off');
+  });
+
+  test('a console that was never mounted resolves rather than throwing', async () => {
+    vi.resetModules();
+    const fresh = await import(CHAT_JS);
+    await expect(fresh.enterFromExpert()).resolves.toBeUndefined();
+  });
+});
+
+describe('a prompt refused by the other view', () => {
+  test('routes through the hand-off overlay and gives the text back', async () => {
+    await mountChat({ pointer: 'K1' });
+    const textarea = /** @type {HTMLTextAreaElement} */ (one('textarea'));
+    textarea.value = 'open the shutter';
+    /** @type {HTMLButtonElement} */ (one('.op-send-btn')).click();
+
+    const callbacks = transport.sendPrompt.mock.calls[0][2];
+    callbacks.onError(transportError(409, 'handoff_needs_interrupt'));
+
+    expect(textOf('.op-handoff-message')).toBe('The other view may still be working.');
+    // The prompt never ran, so neither its bubble nor its text is lost.
+    expect(logEntries()).toEqual([]);
+    expect(textarea.value).toBe('open the shutter');
+  });
+
+  test('a 409 held-elsewhere from the chat endpoint reads exactly as the hand-off one', async () => {
+    await mountChat({ pointer: 'K1' });
+    const textarea = /** @type {HTMLTextAreaElement} */ (one('textarea'));
+    textarea.value = 'status?';
+    /** @type {HTMLButtonElement} */ (one('.op-send-btn')).click();
+
+    const callbacks = transport.sendPrompt.mock.calls[0][2];
+    callbacks.onError(transportError(409, 'session_attached_elsewhere'));
+
+    // One slug, one sentence, whichever endpoint answered it — a prompt
+    // refused because another tab holds the session is the same fact as a
+    // hand-off refused for it, and a second phrasing would read as a second
+    // problem.
+    expect(textOf('.op-handoff-message')).toBe('This session is in use in another tab or view.');
+    expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).hidden).toBe(true);
+    expect(logEntries()).toEqual([]);
+    expect(textarea.value).toBe('status?');
+  });
+
+  test('a terminated chat keeps its resend notice rather than the overlay', async () => {
+    await mountChat({ pointer: 'K1' });
+    const textarea = /** @type {HTMLTextAreaElement} */ (one('textarea'));
+    textarea.value = 'status?';
+    /** @type {HTMLButtonElement} */ (one('.op-send-btn')).click();
+
+    const callbacks = transport.sendPrompt.mock.calls[0][2];
+    callbacks.onError(transportError(409, 'chat_terminated'));
+    callbacks.onClose();
+
+    // The one useful answer to this slug is the notice: send it again. An
+    // overlay would take the console away and offer a retry of the wrong
+    // thing — and it would leave the input disabled, so there would be no
+    // sending it again.
+    expect(textOf('.op-system')).toContain('send your message again');
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(true);
+    expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(false);
+  });
+
+  test('an ordinary transport failure still reads as a system notice', async () => {
+    await mountChat({ pointer: 'K1' });
+    const textarea = /** @type {HTMLTextAreaElement} */ (one('textarea'));
+    textarea.value = 'status?';
+    /** @type {HTMLButtonElement} */ (one('.op-send-btn')).click();
+
+    const callbacks = transport.sendPrompt.mock.calls[0][2];
+    callbacks.onError(new Error('network down'));
+
+    expect(textOf('.op-system')).toBe('Connection to the operator agent failed.');
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(true);
+    expect(logEntries()).toEqual(['status?']);
   });
 });

--- a/tests/interfaces/web_terminal/first-contact.test.mjs
+++ b/tests/interfaces/web_terminal/first-contact.test.mjs
@@ -36,6 +36,12 @@ vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js', () 
   onSessionChange: (fn) => term.listeners.push(fn),
   pasteToTerminal: term.paste,
   focusTerminal: term.focus,
+  // The Simple console tells the panels which session they are on when it
+  // binds in simple mode. Stubbed rather than omitted: a missing export on a
+  // mock throws at the point of use, so leaving it out would make the first
+  // test that mounts the console under data-ui-mode="simple" fail on the mock
+  // rather than on what it is asserting.
+  notifySessionChange: vi.fn(),
 }));
 
 /** Mutable stand-in for the control-target chip, which owns the machine kind. */
@@ -59,7 +65,12 @@ vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/control-target-ch
 const transport = vi.hoisted(() => ({
   sendPrompt: vi.fn(() => ({ abort: vi.fn() })),
   interrupt: vi.fn(),
-  deleteChat: vi.fn(),
+  // The console replays the session pointer's transcript when it binds and
+  // negotiates the hand-off when it is entered from the Expert view. Neither
+  // is reached by the mounts below, but both are named imports: see the note
+  // on notifySessionChange above.
+  fetchHistory: vi.fn(() => Promise.resolve([])),
+  requestHandoff: vi.fn(),
 }));
 
 vi.mock('../../../src/osprey/interfaces/web_terminal/static/js/chat-client.js', () => transport);

--- a/tests/interfaces/web_terminal/session-pointer.test.mjs
+++ b/tests/interfaces/web_terminal/session-pointer.test.mjs
@@ -1,0 +1,210 @@
+// @ts-check
+/**
+ * Unit tests for the browser's session pointer (session-pointer.js):
+ *   npx vitest run tests/interfaces/web_terminal/session-pointer.test.mjs
+ *
+ * The pointer is the one slot both views read to decide which session they
+ * are on, so the contract under test is small and load-bearing: the key is
+ * resolved per persona, a write of an unchanged value is not a change, and
+ * subscribers hear every value the tab settles on — including the null of a
+ * clear, which is how the chat learns the session is gone.
+ *
+ * Module isolation: the listener list and the write mirror are module-private
+ * with no reset API, so each test gets a fresh module instance via
+ * vi.resetModules() + dynamic import (same pattern as terminal-resume.test.mjs).
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+/** @type {typeof import('../../../src/osprey/interfaces/web_terminal/static/js/session-pointer.js')} */
+let pointer;
+
+const STORAGE_KEY = 'osprey-pty-session';
+const SCOPE_ATTR = 'data-osprey-storage-scope';
+
+beforeEach(async () => {
+  vi.resetModules();
+  localStorage.clear();
+  pointer = await import('../../../src/osprey/interfaces/web_terminal/static/js/session-pointer.js');
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute(SCOPE_ATTR);
+  vi.restoreAllMocks();
+});
+
+describe('reading and writing', () => {
+  test('an unset pointer reads null', () => {
+    expect(pointer.getPointer()).toBeNull();
+  });
+
+  test('a set key reads back, and lands in the storage slot both views read', () => {
+    pointer.setPointer('session-k');
+
+    expect(pointer.getPointer()).toBe('session-k');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('session-k');
+  });
+
+  test('a key written by an earlier page load is what the next one reads', () => {
+    localStorage.setItem(STORAGE_KEY, 'session-from-last-load');
+
+    expect(pointer.getPointer()).toBe('session-from-last-load');
+  });
+
+  test('clearing empties the slot', () => {
+    pointer.setPointer('session-k');
+
+    pointer.clearPointer();
+
+    expect(pointer.getPointer()).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('per-persona scope', () => {
+  // On a multi-user mount every `/u/<user>/` shares one origin, so the bare
+  // key is a slot any persona may have written. A session key replayed across
+  // personas would attach one persona's surface to another's process.
+
+  test("bob's write goes to bob's key and leaves the shared slot alone", () => {
+    localStorage.setItem(STORAGE_KEY, 'someone-elses-session');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+    pointer.setPointer('bobs-session');
+
+    expect(localStorage.getItem(`${STORAGE_KEY}--bob`)).toBe('bobs-session');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('someone-elses-session');
+  });
+
+  test("a bare key left by another persona is not bob's pointer", () => {
+    localStorage.setItem(STORAGE_KEY, 'someone-elses-session');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+    expect(pointer.getPointer()).toBeNull();
+  });
+
+  test("clearing removes bob's key only", () => {
+    localStorage.setItem(STORAGE_KEY, 'someone-elses-session');
+    localStorage.setItem(`${STORAGE_KEY}--bob`, 'bobs-session');
+    document.documentElement.setAttribute(SCOPE_ATTR, 'bob');
+
+    pointer.clearPointer();
+
+    expect(localStorage.getItem(`${STORAGE_KEY}--bob`)).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('someone-elses-session');
+  });
+});
+
+describe('subscribers', () => {
+  test('a set notifies with the new key', () => {
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+
+    pointer.setPointer('session-k');
+
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(seen).toHaveBeenCalledWith('session-k');
+  });
+
+  test('a clear notifies with null', () => {
+    pointer.setPointer('session-k');
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+
+    pointer.clearPointer();
+
+    expect(seen).toHaveBeenCalledWith(null);
+  });
+
+  test('re-writing the same key is not a change and notifies nobody', () => {
+    pointer.setPointer('session-k');
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+
+    pointer.setPointer('session-k');
+
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  test('clearing an already-empty pointer notifies nobody', () => {
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+
+    pointer.clearPointer();
+
+    expect(seen).not.toHaveBeenCalled();
+  });
+
+  test('every subscriber hears the change, even when one throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const first = vi.fn(() => { throw new Error('listener blew up'); });
+    const second = vi.fn();
+    pointer.subscribe(first);
+    pointer.subscribe(second);
+
+    pointer.setPointer('session-k');
+
+    expect(first).toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith('session-k');
+  });
+
+  test('unsubscribing stops the notifications', () => {
+    const seen = vi.fn();
+    const unsubscribe = pointer.subscribe(seen);
+
+    unsubscribe();
+    pointer.setPointer('session-k');
+
+    expect(seen).not.toHaveBeenCalled();
+  });
+});
+
+describe('storage unavailable', () => {
+  // Private browsing and disabled storage both throw on access. The pointer
+  // is a convenience there, not a hard dependency: nothing may throw out, and
+  // the value still has to hold for the life of the page so a flip mid-session
+  // does not lose the key.
+
+  /** Make every localStorage access throw, as a locked-down browser does. */
+  function lockStorage() {
+    for (const method of /** @type {const} */ (['getItem', 'setItem', 'removeItem'])) {
+      vi.spyOn(Storage.prototype, method).mockImplementation(() => {
+        throw new Error('storage is not available');
+      });
+    }
+  }
+
+  test('a set still holds for this page, and still notifies', () => {
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+    lockStorage();
+
+    pointer.setPointer('session-k');
+
+    expect(pointer.getPointer()).toBe('session-k');
+    expect(seen).toHaveBeenCalledWith('session-k');
+  });
+
+  test('a clear still empties it, and still notifies', () => {
+    pointer.setPointer('session-k');
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+    lockStorage();
+
+    pointer.clearPointer();
+
+    expect(pointer.getPointer()).toBeNull();
+    expect(seen).toHaveBeenCalledWith(null);
+  });
+
+  test('a repeated set is still not a change', () => {
+    lockStorage();
+    pointer.setPointer('session-k');
+    const seen = vi.fn();
+    pointer.subscribe(seen);
+
+    pointer.setPointer('session-k');
+
+    expect(seen).not.toHaveBeenCalled();
+  });
+});

--- a/tests/interfaces/web_terminal/terminal-handoff.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-handoff.test.mjs
@@ -1,0 +1,691 @@
+// @ts-check
+/**
+ * Unit tests for the Web Terminal's side of the session hand-off (terminal.js):
+ *   npx vitest run tests/interfaces/web_terminal/terminal-handoff.test.mjs
+ *
+ * Both views are windows onto one session, and only one of them may run its
+ * agent at a time. Taking it over is therefore a negotiation rather than a
+ * connect: the server answers `handoff_pending` while the outgoing agent
+ * finishes its turn (never ended on a clock), `session_info` once this
+ * terminal holds it, or a refusal close code when it cannot have it at all.
+ * This file covers what the operator sees for each of those, and the two
+ * places the Simple view changes what the terminal may do on its own.
+ *
+ * Module isolation and the xterm/WebSocket fakes follow terminal-resume.test.mjs
+ * — module-private state has no reset API, so each test gets a fresh instance
+ * via vi.resetModules() + dynamic import.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+/** @type {typeof import('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js')} */
+let terminal;
+
+const STORAGE_KEY = 'osprey-pty-session';
+
+/** Close codes the server refuses a hand-off with (api.js). */
+const WS_CLOSE_SESSION_ATTACHED = 4409;
+const WS_CLOSE_OUTGOING_RUNNING = 4503;
+
+/** Minimal fake xterm.js Terminal -- just enough surface for initTerminal(). */
+class FakeTerminal {
+  constructor() {
+    this.cols = 80;
+    this.rows = 24;
+    this.options = {};
+    /** Everything written to the screen, concatenated. */
+    this.written = '';
+    /** @type {((data: string) => void)|null} */
+    this.dataHandler = null;
+    FakeTerminal.last = this;
+  }
+  loadAddon() {}
+  open() {}
+  /** @param {(data: string) => void} fn */
+  onData(fn) {
+    this.dataHandler = fn;
+  }
+  onResize() {}
+  /** @param {string} text */
+  write(text) {
+    this.written += text;
+  }
+  reset() {}
+  focus() {}
+  attachCustomKeyEventHandler() {}
+}
+/** @type {FakeTerminal|null} */
+FakeTerminal.last = null;
+
+class FakeAddon {
+  fit() {}
+}
+
+/** Minimal fake WebSocket; happy-dom's own implementation dials out for real. */
+class FakeWebSocket {
+  /** @param {string} url */
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    /** @type {any[]} */
+    this.sent = [];
+    /** @type {((ev?: any) => void)|null} */
+    this.onopen = null;
+    /** @type {((ev?: any) => void)|null} */
+    this.onmessage = null;
+    /** @type {((ev?: any) => void)|null} */
+    this.onclose = null;
+    FakeWebSocket.last = this;
+    FakeWebSocket.created += 1;
+  }
+  /** @param {any} data */
+  send(data) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code: 1000, reason: '' });
+  }
+}
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CLOSING = 2;
+FakeWebSocket.CLOSED = 3;
+/** @type {FakeWebSocket|null} */
+FakeWebSocket.last = null;
+/** How many have been constructed — a reconnect is a new one. */
+FakeWebSocket.created = 0;
+
+/** Flip the most recently created fake socket to OPEN and fire its onopen. */
+function openSocket() {
+  const ws = /** @type {FakeWebSocket} */ (FakeWebSocket.last);
+  ws.readyState = FakeWebSocket.OPEN;
+  if (!ws.onopen) throw new Error('onopen handler not set');
+  ws.onopen();
+}
+
+/**
+ * Deliver a JSON control message from the "server" on the current socket.
+ * @param {any} msg
+ */
+function receive(msg) {
+  const ws = /** @type {FakeWebSocket} */ (FakeWebSocket.last);
+  if (!ws.onmessage) throw new Error('onmessage handler not set');
+  ws.onmessage({ data: JSON.stringify(msg) });
+}
+
+/**
+ * Close the current socket the way a server refusal does.
+ * @param {number} code
+ * @param {string} [reason]
+ */
+function refuse(code, reason = '') {
+  const ws = /** @type {FakeWebSocket} */ (FakeWebSocket.last);
+  ws.readyState = FakeWebSocket.CLOSED;
+  if (!ws.onclose) throw new Error('onclose handler not set');
+  ws.onclose({ code, reason });
+}
+
+/** The overlay's single line of copy, or null when no overlay is up. */
+function overlayText() {
+  const message = document.querySelector('.terminal-handoff-message');
+  return message ? message.textContent : null;
+}
+
+/** The overlay's action button, or null when no overlay is up. */
+function overlayAction() {
+  return /** @type {HTMLButtonElement|null} */ (
+    document.querySelector('.terminal-handoff-action')
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  localStorage.clear();
+
+  // The real card: the overlay mounts on `.terminal-body`, which is also the
+  // element initTerminal() observes for resizes.
+  document.body.innerHTML =
+    '<div class="terminal-card"><div class="terminal-body" id="terminal-body">' +
+    '<div id="terminal-container"></div></div></div>';
+  // happy-dom does not implement document.fonts; initTerminal() awaits its
+  // `ready` promise to re-fit after web fonts load.
+  // @ts-expect-error -- test stub, not a full FontFaceSet
+  document.fonts = { ready: Promise.resolve() };
+
+  vi.stubGlobal('Terminal', FakeTerminal);
+  vi.stubGlobal('FitAddon', { FitAddon: FakeAddon });
+  vi.stubGlobal('WebLinksAddon', { WebLinksAddon: class {} });
+  vi.stubGlobal('ClipboardAddon', { ClipboardAddon: class {}, Base64: class {} });
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  // xtermPalette() logs a console.error when the CSS custom properties it
+  // reads are absent, which they are in this bare happy-dom document.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  FakeWebSocket.last = null;
+  FakeWebSocket.created = 0;
+  terminal = await import('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js');
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-ui-mode');
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('the Simple view starts nothing', () => {
+  // One live agent per session. In Simple view the chat is holding it and the
+  // terminal is off screen, so a terminal that connected here would take the
+  // conversation away from the view the operator is looking at.
+
+  test('initTerminal does not open a connection', () => {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+
+    terminal.initTerminal('terminal-container');
+
+    expect(FakeWebSocket.created).toBe(0);
+  });
+
+  test('the terminal itself is still built, so the flip has something to attach', () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+
+    terminal.initTerminal('terminal-container');
+
+    expect(terminal.getTerminalInstance()).not.toBeNull();
+    expect(terminal.getTerminalDimensions()).toEqual({ cols: 80, rows: 24 });
+  });
+
+  test('Expert view still connects on load', () => {
+    document.documentElement.setAttribute('data-ui-mode', 'expert');
+
+    terminal.initTerminal('terminal-container');
+
+    expect(FakeWebSocket.created).toBe(1);
+  });
+});
+
+describe('startExpert: taking the session over', () => {
+  test('resumes the key the tab is pointed at', () => {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    terminal.initTerminal('terminal-container');
+
+    terminal.startExpert();
+
+    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
+    expect(url).toContain('session_id=shared-key');
+    expect(url).toContain('mode=resume');
+    expect(url).not.toContain('interrupt=');
+  });
+
+  test('starts an ordinary session when no key is stored', () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    terminal.initTerminal('terminal-container');
+
+    terminal.startExpert();
+
+    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
+    expect(url).not.toContain('session_id=');
+    expect(url).not.toContain('mode=resume');
+  });
+
+  test('an early exit does not drop the shared key', () => {
+    // The page-load auto-resume treats an early exit as a dead id and forgets
+    // it. A flip must not: the key is the chat's too, and an exit here is a
+    // hand-off that did not complete.
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    terminal.initTerminal('terminal-container');
+    terminal.startExpert();
+    openSocket();
+    const socketsBefore = FakeWebSocket.created;
+
+    receive({ type: 'exit', code: 1 });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('shared-key');
+    expect(FakeWebSocket.created).toBe(socketsBefore);
+  });
+});
+
+describe('startExpert settles when the acquire has an answer', () => {
+  // app.js serialises the flip on this promise: a Simple → Expert → Simple
+  // round trip must not ask for the session again until the server has seen
+  // the Expert channel resolve, one way or the other.
+
+  /** Reach the flip's starting point: Simple view, a key stored, no socket. */
+  function flipToExpert() {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    terminal.initTerminal('terminal-container');
+    return terminal.startExpert();
+  }
+
+  test('a pending hand-off does not settle it', async () => {
+    const settled = flipToExpert();
+    openSocket();
+    receive({ type: 'handoff_pending' });
+
+    const race = await Promise.race([
+      settled.then(() => 'settled'),
+      Promise.resolve('pending'),
+    ]);
+    expect(race).toBe('pending');
+
+    // Leave nothing dangling for the next test.
+    receive({ type: 'session_info', session_id: 'shared-key' });
+    await settled;
+  });
+
+  test('session_info settles it', async () => {
+    const settled = flipToExpert();
+    openSocket();
+    receive({ type: 'session_info', session_id: 'shared-key' });
+
+    await expect(settled).resolves.toBeUndefined();
+  });
+
+  test('a 4409 refusal settles it, with the notice up', async () => {
+    const settled = flipToExpert();
+    openSocket();
+    refuse(WS_CLOSE_SESSION_ATTACHED);
+
+    await expect(settled).resolves.toBeUndefined();
+    expect(overlayText()).toBe('This session is in use in another tab or view.');
+  });
+
+  test('a 4503 refusal settles it', async () => {
+    const settled = flipToExpert();
+    openSocket();
+    refuse(WS_CLOSE_OUTGOING_RUNNING);
+
+    await expect(settled).resolves.toBeUndefined();
+  });
+
+  test('a close with no answer at all settles it', async () => {
+    vi.useFakeTimers();
+    try {
+      const settled = flipToExpert();
+      openSocket();
+      refuse(1006);
+
+      await expect(settled).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('an error frame settles it', async () => {
+    const settled = flipToExpert();
+    openSocket();
+    receive({ type: 'error', message: 'no capacity' });
+
+    await expect(settled).resolves.toBeUndefined();
+  });
+
+  test('a second call while a connection exists settles at once', async () => {
+    const settled = flipToExpert();
+    openSocket();
+    receive({ type: 'session_info', session_id: 'shared-key' });
+    await settled;
+
+    await expect(terminal.startExpert()).resolves.toBeUndefined();
+  });
+
+  test('nothing here ever rejects', async () => {
+    // The flip chain does not catch, so a rejection would break the round
+    // trip rather than the connection.
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    terminal.initTerminal('terminal-container');
+
+    const outcomes = [];
+    for (const answer of [
+      () => receive({ type: 'session_info', session_id: 'shared-key' }),
+      () => refuse(WS_CLOSE_SESSION_ATTACHED),
+      () => receive({ type: 'error', message: 'no capacity' }),
+    ]) {
+      localStorage.setItem(STORAGE_KEY, 'shared-key');
+      const settled = terminal.startExpert();
+      openSocket();
+      answer();
+      outcomes.push(await settled.then(() => 'resolved', () => 'rejected'));
+      terminal.stopTerminal();
+    }
+
+    expect(outcomes).toEqual(['resolved', 'resolved', 'resolved']);
+  });
+});
+
+describe('handoff_pending: the transitional state', () => {
+  /** Flip to Expert on a stored key and reach the pending state. */
+  function pending() {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'handoff_pending' });
+  }
+
+  test('says what is happening and how long it has been', () => {
+    pending();
+
+    expect(overlayText()).toBe('Finishing in the other view · 0:00');
+  });
+
+  test('the elapsed wait counts up', () => {
+    vi.useFakeTimers();
+    try {
+      pending();
+      vi.advanceTimersByTime(65_000);
+
+      expect(overlayText()).toBe('Finishing in the other view · 1:05');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('the ticking counter is not re-announced every second', () => {
+    pending();
+
+    const elapsed = document.querySelector('.terminal-handoff-elapsed');
+    expect(elapsed?.getAttribute('aria-live')).toBe('off');
+  });
+
+  test('the way out of an unbounded wait is offered', () => {
+    pending();
+
+    const action = overlayAction();
+    expect(action).not.toBeNull();
+    expect(action?.hidden).toBe(false);
+    expect(action?.textContent).toBe('Stop and switch now');
+  });
+
+  test('session_info clears it', () => {
+    pending();
+
+    receive({ type: 'session_info', session_id: 'shared-key' });
+
+    expect(document.querySelector('.terminal-handoff')).toBeNull();
+  });
+
+  test('the elapsed timer stops with the overlay', () => {
+    vi.useFakeTimers();
+    try {
+      pending();
+      receive({ type: 'session_info', session_id: 'shared-key' });
+      vi.advanceTimersByTime(60_000);
+
+      expect(document.querySelector('.terminal-handoff')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('flipping back to Simple clears it', () => {
+    pending();
+
+    terminal.stopTerminal();
+
+    expect(document.querySelector('.terminal-handoff')).toBeNull();
+  });
+
+  test('session_switched clears it too, since that is how a switch reports success', () => {
+    // Switching onto a key the chat holds is negotiated like any other
+    // hand-off, but the server answers the completed switch with
+    // `session_switched` rather than `session_info`.
+    pending();
+
+    receive({ type: 'session_switched', session_id: 'other-key' });
+
+    expect(document.querySelector('.terminal-handoff')).toBeNull();
+  });
+
+  test('an error frame replaces it rather than arriving underneath it', () => {
+    pending();
+
+    receive({ type: 'error', message: 'no capacity' });
+
+    expect(document.querySelector('.terminal-handoff')).toBeNull();
+    expect(/** @type {FakeTerminal} */ (FakeTerminal.last).written).toContain('no capacity');
+  });
+
+  test('it disarms the page-load failover, so the outgoing agent\'s exit is not read as a dead key', () => {
+    // This connection IS the page-load auto-resume, so the failover is armed:
+    // an early exit would ordinarily mean "that id is gone". A handoff_pending
+    // says the opposite — the key is alive in the other view — and the exit
+    // that follows is the outgoing agent being handed over, not a dead id.
+    pending();
+    const socketsBefore = FakeWebSocket.created;
+
+    receive({ type: 'exit', code: 0 });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('shared-key');
+    expect(terminal.getCurrentSessionId()).toBe('shared-key');
+    expect(FakeWebSocket.created).toBe(socketsBefore);
+  });
+});
+
+describe('"Stop and switch now"', () => {
+  /** Reach the pending state and press the button. */
+  function interrupt() {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'handoff_pending' });
+    /** @type {HTMLButtonElement} */ (overlayAction()).click();
+  }
+
+  test('asks for the same session again, with the interrupt', () => {
+    interrupt();
+
+    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
+    expect(url).toContain('session_id=shared-key');
+    expect(url).toContain('mode=resume');
+    expect(url).toContain('interrupt=1');
+  });
+
+  test('the refused wrapper is not reused: the retry is a new socket', () => {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'handoff_pending' });
+    const socketsBefore = FakeWebSocket.created;
+
+    /** @type {HTMLButtonElement} */ (overlayAction()).click();
+
+    expect(FakeWebSocket.created).toBe(socketsBefore + 1);
+  });
+
+  test('it cannot be pressed twice while the first attempt is in flight', () => {
+    interrupt();
+
+    expect(overlayAction()?.disabled).toBe(true);
+  });
+
+  test('the wait the operator is watching carries across the reconnect', () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem(STORAGE_KEY, 'shared-key');
+      terminal.initTerminal('terminal-container');
+      openSocket();
+      receive({ type: 'handoff_pending' });
+      vi.advanceTimersByTime(30_000);
+      /** @type {HTMLButtonElement} */ (overlayAction()).click();
+      openSocket();
+      receive({ type: 'handoff_pending' });
+
+      // 0:30 and counting, not back to 0:00.
+      expect(overlayText()).toBe('Finishing in the other view · 0:30');
+      expect(overlayAction()?.disabled).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('stopTerminal reports when the channel is actually gone', () => {
+  // The flip to Simple drops this socket and then asks the server for the
+  // session over HTTP. Asking while the Expert channel is still attached is
+  // refused with the one refusal that has no retry, so the flip waits for the
+  // close rather than racing the server's grace window.
+
+  test('resolves once the dropped socket reports its close', async () => {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+
+    await expect(terminal.stopTerminal()).resolves.toBeUndefined();
+    expect(/** @type {FakeWebSocket} */ (FakeWebSocket.last).readyState).toBe(
+      FakeWebSocket.CLOSED,
+    );
+  });
+
+  test('resolves at once when there is nothing open to drop', async () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    terminal.initTerminal('terminal-container');
+
+    await expect(terminal.stopTerminal()).resolves.toBeUndefined();
+    expect(FakeWebSocket.created).toBe(0);
+  });
+
+  test('a socket that never reports a close cannot hang the flip', async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem(STORAGE_KEY, 'shared-key');
+      terminal.initTerminal('terminal-container');
+      openSocket();
+      // Closing this one is silent: no close event ever arrives.
+      /** @type {FakeWebSocket} */ (FakeWebSocket.last).close = () => {};
+
+      const stopped = terminal.stopTerminal();
+      let settled = false;
+      stopped.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(stopped).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('a refused connection', () => {
+  /**
+   * Flip to Expert on a stored key and have the server refuse.
+   * @param {number} code
+   */
+  function refused(code) {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    refuse(code, 'session_attached_elsewhere');
+  }
+
+  test('4409 says the session is in use elsewhere', () => {
+    refused(WS_CLOSE_SESSION_ATTACHED);
+
+    expect(overlayText()).toBe('This session is in use in another tab or view.');
+  });
+
+  test('4409 offers nothing to retry, because retrying is not the answer', () => {
+    refused(WS_CLOSE_SESSION_ATTACHED);
+
+    expect(overlayAction()?.hidden).toBe(true);
+  });
+
+  test('4503 says the previous agent is still shutting down, and offers the retry', () => {
+    refused(WS_CLOSE_OUTGOING_RUNNING);
+
+    expect(overlayText()).toBe('The previous agent is still shutting down.');
+    const action = overlayAction();
+    expect(action?.hidden).toBe(false);
+    expect(action?.textContent).toBe('Retry');
+  });
+
+  test('the retry builds a new connection and clears the notice', () => {
+    refused(WS_CLOSE_OUTGOING_RUNNING);
+    const socketsBefore = FakeWebSocket.created;
+
+    /** @type {HTMLButtonElement} */ (overlayAction()).click();
+
+    expect(FakeWebSocket.created).toBe(socketsBefore + 1);
+    expect(document.querySelector('.terminal-handoff')).toBeNull();
+    expect(/** @type {FakeWebSocket} */ (FakeWebSocket.last).url).toContain(
+      'session_id=shared-key',
+    );
+  });
+
+  test('the spent wrapper is released, so a later start is not swallowed', () => {
+    // createWebSocket stops reconnecting after a refusal. Holding that dead
+    // wrapper would make every later startTerminal() return early on the
+    // "already connected" guard.
+    refused(WS_CLOSE_SESSION_ATTACHED);
+    const socketsBefore = FakeWebSocket.created;
+
+    terminal.startTerminal();
+
+    expect(FakeWebSocket.created).toBe(socketsBefore + 1);
+  });
+
+  test('the session key survives: the refusal is proof it is alive elsewhere', () => {
+    refused(WS_CLOSE_SESSION_ATTACHED);
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('shared-key');
+    expect(terminal.getCurrentSessionId()).toBe('shared-key');
+  });
+
+  test('a refusal on an abandoned socket does not paint over the live one', () => {
+    // "Stop and switch now" leaves the first socket behind. Its close can
+    // arrive after the reconnect is already waiting on its own hand-off, and
+    // it says nothing about the connection now in place.
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    const abandoned = /** @type {FakeWebSocket} */ (FakeWebSocket.last);
+    openSocket();
+    receive({ type: 'handoff_pending' });
+    /** @type {HTMLButtonElement} */ (overlayAction()).click();
+    openSocket();
+    receive({ type: 'handoff_pending' });
+
+    // The abandoned socket's refusal lands late.
+    /** @type {(ev: any) => void} */ (abandoned.onclose)({
+      code: WS_CLOSE_SESSION_ATTACHED,
+      reason: '',
+    });
+
+    expect(overlayText()).toBe('Finishing in the other view · 0:00');
+  });
+
+  test('a refusal after a pending wait replaces the transitional state', () => {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'handoff_pending' });
+
+    refuse(WS_CLOSE_OUTGOING_RUNNING);
+
+    expect(overlayText()).toBe('The previous agent is still shutting down.');
+  });
+
+  test('an ordinary close is not a refusal and shows nothing', () => {
+    // Fake timers so the backoff reconnect this close schedules — the whole
+    // point of it not being a refusal — is discarded with them.
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem(STORAGE_KEY, 'shared-key');
+      terminal.initTerminal('terminal-container');
+      openSocket();
+
+      refuse(1006);
+
+      expect(document.querySelector('.terminal-handoff')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/interfaces/web_terminal/terminal-resume.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-resume.test.mjs
@@ -192,6 +192,46 @@ describe('per-persona pointer scope', () => {
   });
 });
 
+describe('the session key outlives the connection', () => {
+  // A view flip tears this terminal's socket down so the other surface can
+  // take the session over. Both halves of the pointer have to survive that:
+  // the stored key, so a reload still resumes it, and the answer to "which
+  // session is this card on?", which the chat asks while nothing is attached.
+
+  test('stopTerminal leaves the stored key and the reported id in place', () => {
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'session_info', session_id: 'session-k' });
+
+    terminal.stopTerminal();
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('session-k');
+    expect(terminal.getCurrentSessionId()).toBe('session-k');
+  });
+
+  test('the stored key answers before anything has connected', () => {
+    // Page load with a kept-warm session: the chat can ask for the key before
+    // the terminal's own confirmation has arrived.
+    localStorage.setItem(STORAGE_KEY, 'session-k');
+
+    terminal.initTerminal('terminal-container');
+
+    expect(terminal.getCurrentSessionId()).toBe('session-k');
+  });
+
+  test('a dead key is still forgotten, not kept across the teardown', () => {
+    // The one teardown where the key itself is what failed: the server
+    // refused to resume it, so nothing may report it as the current session.
+    localStorage.setItem(STORAGE_KEY, 'gone-id');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+
+    receive({ type: 'transcript_missing', session_id: 'gone-id' });
+
+    expect(terminal.getCurrentSessionId()).toBeNull();
+  });
+});
+
 describe('resume confirmation: stale id self-correction', () => {
   test('matching confirmed id: storage keeps the resumed id, currentSessionId updates', () => {
     localStorage.setItem(STORAGE_KEY, 'requested-id');
@@ -441,41 +481,59 @@ describe('transcript missing: an explicit state, never a dead PTY', () => {
 describe('a refused own-resume in Simple view', () => {
   // The block above pins the Expert answer to this same frame: say what
   // happened, then wait for Enter. Simple view hides the terminal entirely, so
-  // both halves of that answer land in a window nobody can see or reach, and
-  // the chat would sit silent until someone thought to reload. The stale
-  // pointer is already gone from storage by then, so nothing is left for the
-  // operator to decide and the client makes the only remaining move itself.
+  // both halves of that answer would land in a window nobody can see or reach.
+  // Nor is anything started in its place: the chat is the surface there, it is
+  // bound to the same key, and a hidden terminal spawning the session's agent
+  // would take the conversation away from it. The pointer is that shared key,
+  // so it survives too — clearing it is how this client says "this
+  // conversation is gone", which is not what a terminal that never got to
+  // attach knows.
+  //
+  // The terminal only reaches this state in Simple view by being flipped
+  // mid-connect, so these start it the way the flip does (startExpert), not
+  // through initTerminal — which no longer connects in Simple view at all.
 
-  test('a fresh session is started instead of arming a hidden Enter', () => {
+  test('the shared pointer survives, because the chat is bound to it', () => {
     document.documentElement.setAttribute('data-ui-mode', 'simple');
-    localStorage.setItem(STORAGE_KEY, 'gone-id');
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
     terminal.initTerminal('terminal-container');
+    terminal.startExpert();
+    openSocket();
+
+    receive({ type: 'transcript_missing', session_id: 'shared-key' });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('shared-key');
+    expect(terminal.getCurrentSessionId()).toBe('shared-key');
+  });
+
+  test('nothing is started in the hidden terminal, and nothing is asked of the operator', () => {
+    document.documentElement.setAttribute('data-ui-mode', 'simple');
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    terminal.startExpert();
     openSocket();
     const socketsBefore = FakeWebSocket.created;
 
-    receive({ type: 'transcript_missing', session_id: 'gone-id' });
+    receive({ type: 'transcript_missing', session_id: 'shared-key' });
 
-    expect(FakeWebSocket.created).toBe(socketsBefore + 1);
-    const url = /** @type {FakeWebSocket} */ (FakeWebSocket.last).url;
-    expect(url).not.toContain('session_id=');
-    expect(url).not.toContain('mode=resume');
+    expect(FakeWebSocket.created).toBe(socketsBefore);
     // Nothing was asked of the operator, so nothing claims to have been.
     expect(/** @type {FakeTerminal} */ (FakeTerminal.last).written).not.toMatch(/Press Enter/);
   });
 
-  test('Enter is ordinary input on the session that replaces it', () => {
+  test('a pointer that has moved on is left alone too', () => {
+    // The chat minted a new key while this connect was in flight. The refused
+    // id is not the one in storage, so there is nothing here to correct.
     document.documentElement.setAttribute('data-ui-mode', 'simple');
-    localStorage.setItem(STORAGE_KEY, 'gone-id');
+    localStorage.setItem(STORAGE_KEY, 'old-key');
     terminal.initTerminal('terminal-container');
+    terminal.startExpert();
     openSocket();
-    receive({ type: 'transcript_missing', session_id: 'gone-id' });
-    openSocket();
-    const socketsBefore = FakeWebSocket.created;
+    localStorage.setItem(STORAGE_KEY, 'newer-key');
 
-    press('\r');
+    receive({ type: 'transcript_missing', session_id: 'old-key' });
 
-    expect(FakeWebSocket.created).toBe(socketsBefore);
-    expect(/** @type {FakeWebSocket} */ (FakeWebSocket.last).sent).toContain('\r');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('newer-key');
   });
 
   test('a refused switch is untouched by the mode', () => {
@@ -483,6 +541,7 @@ describe('a refused own-resume in Simple view', () => {
     // live session and there is nothing to start in either view.
     document.documentElement.setAttribute('data-ui-mode', 'simple');
     terminal.initTerminal('terminal-container');
+    terminal.startExpert();
     openSocket();
     receive({ type: 'session_info', session_id: 'live-id' });
     const socketsBefore = FakeWebSocket.created;

--- a/tests/interfaces/web_terminal/test_agent_turn_route.py
+++ b/tests/interfaces/web_terminal/test_agent_turn_route.py
@@ -1,0 +1,381 @@
+"""Tests for the turn-state route (`routes/agent_turn.py`).
+
+``POST /api/agent-turn`` is the Claude Code hook's report of a turn edge::
+
+    request:  {"session_id": str, "pool_key": str, "state": "busy"|"idle",
+               "surface": str, "ts": float, "source"?: str}
+    response: {"ok": true, "recorded": bool}
+
+Two things must come out of an accepted report: the session key's busy/idle
+state on ``app.state.turn_state``, and the transcript the key currently points
+at, recorded in the persisted transcript map. The key is ``pool_key`` — the
+identity that never changes — while ``session_id`` is the transcript, which a
+``/clear`` moves.
+
+Anything reported for another surface is dropped rather than refused, because
+a hook cannot act on a 4xx and a refusal would surface as noise in the
+operator's terminal.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.common_middleware import WebAuthMiddleware
+from osprey.interfaces.web_auth import WebCredentials, reset_web_credentials
+from osprey.interfaces.web_terminal import transcript_map
+from osprey.interfaces.web_terminal.routes.agent_turn import router
+from osprey.interfaces.web_terminal.turn_state import get_turn_state, reset_turn_state
+from osprey_connectors import session_store
+
+#: The session key: the PTY pool key, the posture key, the audit key.
+KEY = "aaaaaaaa-1111-2222-3333-444444444444"
+#: The transcript a ``/clear`` moved that key to — a different id, same key.
+TRANSCRIPT = "cccccccc-1111-2222-3333-444444444444"
+
+PANEL_TOKEN = "panel-token-value"
+OPERATOR_SECRET = "operator-secret-value"
+
+
+@pytest.fixture(autouse=True)
+def shared_root(tmp_path, monkeypatch):
+    """Pin the agent-data root so the transcript map has somewhere to write.
+
+    The same derivation the posture store uses, exercised rather than patched
+    around, so "persisted" in these tests means a file on disk. Autouse
+    because every accepted report touches the map: without a pinned root the
+    resolution walks up to the repository and the suite's leak guard fires.
+    """
+    root = tmp_path / "shared_agent_data"
+    root.mkdir()
+    monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(root))
+    session_store.invalidate_cache()
+    yield root
+    session_store.invalidate_cache()
+
+
+def _make_client() -> TestClient:
+    """A minimal app exposing the turn-state router, with the store installed."""
+    app = FastAPI()
+    app.include_router(router)
+    app.state.turn_state = {}
+    return TestClient(app)
+
+
+def _post(client: TestClient, **overrides) -> dict:
+    """POST a hook-shaped report, returning the parsed body."""
+    body = {
+        "session_id": KEY,
+        "pool_key": KEY,
+        "state": "busy",
+        "surface": "expert",
+        "ts": 1000.0,
+    }
+    body.update(overrides)
+    resp = client.post("/api/agent-turn", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---- The surface filter ----
+
+
+@pytest.mark.parametrize("surface", ["simple", "", "Expert", "unknown"])
+def test_reports_from_other_surfaces_are_dropped_not_refused(surface):
+    """Only ``expert`` is recorded; everything else is a 200 that changed nothing.
+
+    The empty case is the one that actually happens: a hook whose surface
+    environment variable is unset. It must not 4xx into the operator's
+    terminal, and it must not be mistaken for an expert-view report either.
+    """
+    client = _make_client()
+    assert _post(client, surface=surface) == {"ok": True, "recorded": False}
+    assert client.app.state.turn_state == {}
+
+
+def test_expert_reports_are_recorded():
+    """The one accepted surface writes the entry and says so."""
+    client = _make_client()
+    assert _post(client, surface="expert") == {"ok": True, "recorded": True}
+    assert client.app.state.turn_state[KEY]["state"] == "busy"
+
+
+# ---- The two states, including the failure-shaped idle ----
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["Stop", "StopFailure", "SessionStart", None],
+)
+def test_idle_is_recorded_whatever_hook_event_reported_it(source):
+    """A turn that ended badly is still a turn that ended.
+
+    ``StopFailure`` fires where ``Stop`` does not, and the server must read
+    both as idle — a key left busy because its turn failed would never release
+    for the other view. ``source`` is context, never a condition.
+    """
+    client = _make_client()
+    body = {"state": "idle"}
+    if source is not None:
+        body["source"] = source
+    assert _post(client, **body)["recorded"] is True
+    assert client.app.state.turn_state[KEY]["state"] == "idle"
+
+
+def test_an_unknown_state_is_refused():
+    """The one field the hook cannot get wrong quietly."""
+    client = _make_client()
+    resp = client.post(
+        "/api/agent-turn",
+        json={"session_id": KEY, "pool_key": KEY, "state": "thinking", "surface": "expert"},
+    )
+    assert resp.status_code == 422
+    assert client.app.state.turn_state == {}
+
+
+# ---- Keying: the pool key, not the transcript ----
+
+
+def test_entry_is_keyed_on_the_pool_key_not_the_session_id():
+    """A cleared session reports a new transcript under the unchanged key."""
+    client = _make_client()
+    _post(client, session_id=TRANSCRIPT, pool_key=KEY, state="idle", ts=1234.5)
+
+    assert set(client.app.state.turn_state) == {KEY}
+    assert client.app.state.turn_state[KEY] == {
+        "state": "idle",
+        "ts": 1234.5,
+        "transcript_id": TRANSCRIPT,
+    }
+
+
+def test_a_missing_pool_key_falls_back_to_the_session_id():
+    """Before anything has cleared, the two identities are the same string."""
+    client = _make_client()
+    _post(client, session_id=KEY, pool_key="")
+    assert set(client.app.state.turn_state) == {KEY}
+    assert client.app.state.turn_state[KEY]["transcript_id"] == KEY
+
+
+def test_a_report_with_no_identity_at_all_is_dropped():
+    """An empty id is not a session UUID, so there is nothing to record."""
+    client = _make_client()
+    assert _post(client, session_id="", pool_key="") == {"ok": True, "recorded": False}
+    assert client.app.state.turn_state == {}
+
+
+# ---- The identifier grammar ----
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    [
+        "../../etc/passwd",
+        f"../../{KEY}",
+        f"{KEY}/../../etc/passwd",
+        f"{KEY}.jsonl",
+        KEY.upper(),
+        "operator-abcd1234",
+        "not-a-uuid",
+    ],
+)
+def test_a_non_canonical_session_id_is_dropped(session_id):
+    """The transcript id is persisted and later reaches a resume argv and a path.
+
+    A traversal-shaped id must never get that far, and the refusal is a drop
+    rather than a 4xx for the same reason every other drop here is: the hook
+    that sent it cannot act on an error.
+    """
+    client = _make_client()
+    assert _post(client, session_id=session_id, pool_key="") == {"ok": True, "recorded": False}
+    assert client.app.state.turn_state == {}
+    assert transcript_map.store_path().exists() is False
+
+
+def test_a_non_canonical_pool_key_is_dropped():
+    """The key names an entry in a store on disk, so it is closed too."""
+    client = _make_client()
+    assert _post(client, session_id=KEY, pool_key="../../elsewhere") == {
+        "ok": True,
+        "recorded": False,
+    }
+    assert client.app.state.turn_state == {}
+
+
+def test_a_canonical_pair_is_still_recorded():
+    """The grammar closes on malformed ids without costing a legitimate one."""
+    client = _make_client()
+    assert _post(client, session_id=TRANSCRIPT, pool_key=KEY)["recorded"] is True
+    assert client.app.state.turn_state[KEY]["transcript_id"] == TRANSCRIPT
+
+
+def test_a_later_report_replaces_the_entry_for_its_key():
+    """The store holds the latest edge per key, not a history."""
+    client = _make_client()
+    _post(client, state="busy", ts=10.0)
+    _post(client, state="idle", ts=20.0)
+    assert client.app.state.turn_state[KEY] == {
+        "state": "idle",
+        "ts": 20.0,
+        "transcript_id": KEY,
+    }
+
+
+def test_the_server_stamps_the_time_when_the_hook_sends_none():
+    """A hook that omits ``ts`` still produces a fully shaped entry."""
+    client = _make_client()
+    client.post(
+        "/api/agent-turn",
+        json={"session_id": KEY, "pool_key": KEY, "state": "busy", "surface": "expert"},
+    )
+    assert isinstance(client.app.state.turn_state[KEY]["ts"], float)
+
+
+def test_a_future_timestamp_is_clamped_to_now():
+    """A stored timestamp outranks other evidence, so it cannot run ahead.
+
+    The hook shares the server's clock. A ``ts`` in the future is a broken or
+    hostile report, and left as sent it would make this entry permanently the
+    freshest thing any reader has.
+    """
+    before = time.time()
+    client = _make_client()
+    _post(client, state="idle", ts=before + 10_000.0)
+    after = time.time()
+
+    stored = client.app.state.turn_state[KEY]["ts"]
+    assert before <= stored <= after
+
+
+def test_a_past_timestamp_is_kept_as_sent():
+    """Clamping is one-sided: the hook's own reading of when the edge happened."""
+    client = _make_client()
+    _post(client, state="idle", ts=1234.5)
+    assert client.app.state.turn_state[KEY]["ts"] == 1234.5
+
+
+# ---- The transcript id: recorded and persisted ----
+
+
+def test_a_diverged_transcript_is_recorded_and_persisted(shared_root):
+    """``session_id != pool_key`` moves the key's mapping, on disk as well."""
+    client = _make_client()
+    _post(client, session_id=TRANSCRIPT, pool_key=KEY, state="idle")
+
+    assert transcript_map.get(client.app, KEY) == TRANSCRIPT
+    written = json.loads(transcript_map.store_path().read_text(encoding="utf-8"))
+    assert written == {KEY: TRANSCRIPT}
+
+
+def test_a_transcript_equal_to_the_key_clears_a_stale_mapping(shared_root):
+    """Returning to the key's own transcript must not leave the old pointer.
+
+    The map stores only real divergence, so an id equal to the key removes the
+    entry rather than storing an identity mapping.
+    """
+    client = _make_client()
+    _post(client, session_id=TRANSCRIPT, pool_key=KEY, state="idle")
+    _post(client, session_id=KEY, pool_key=KEY, state="idle")
+
+    assert transcript_map.get(client.app, KEY) == KEY
+    assert json.loads(transcript_map.store_path().read_text(encoding="utf-8")) == {}
+
+
+def test_a_dropped_report_never_touches_the_map(shared_root):
+    """The surface filter gates the map write too, not only the state write."""
+    client = _make_client()
+    _post(client, session_id=TRANSCRIPT, pool_key=KEY, surface="simple")
+    assert transcript_map.get(client.app, KEY) == KEY
+
+
+# ---- The helpers spawn and teardown call ----
+
+
+def test_reset_turn_state_marks_a_key_idle():
+    """A key that died mid-turn must not read as busy after a respawn."""
+    app = SimpleNamespace(state=SimpleNamespace(turn_state={}))
+    app.state.turn_state[KEY] = {"state": "busy", "ts": 1.0, "transcript_id": TRANSCRIPT}
+
+    reset_turn_state(app, KEY)
+
+    entry = get_turn_state(app, KEY)
+    assert entry["state"] == "idle"
+    assert isinstance(entry["ts"], float)
+
+
+def test_reset_turn_state_keeps_the_key_pointed_at_its_transcript(shared_root):
+    """The reset clears the turn, not the conversation the key is holding."""
+    app = SimpleNamespace(state=SimpleNamespace())
+    transcript_map.set(app, KEY, TRANSCRIPT)
+
+    reset_turn_state(app, KEY)
+
+    assert get_turn_state(app, KEY)["transcript_id"] == TRANSCRIPT
+
+
+def test_reset_turn_state_ignores_an_empty_key():
+    """Callers hand over whatever key they hold; an absent one is not an entry."""
+    app = SimpleNamespace(state=SimpleNamespace(turn_state={}))
+    reset_turn_state(app, "")
+    assert app.state.turn_state == {}
+
+
+def test_get_turn_state_is_none_when_nothing_was_reported():
+    """Unknown is not idle: a caller waiting for idleness must see the difference."""
+    app = SimpleNamespace(state=SimpleNamespace(turn_state={}))
+    assert get_turn_state(app, KEY) is None
+    assert get_turn_state(app, "") is None
+
+
+# ---- The credential the hook actually carries ----
+
+
+@pytest.fixture
+def panel_token_client(shared_root):
+    """The router behind the real auth middleware, with a known panel token.
+
+    Every test using it carries ``no_auth_seam``: the suite-wide seam injects
+    the operator secret into any client aimed at a gated app, which would admit
+    these requests on a credential the hook does not have.
+    """
+    reset_web_credentials()
+    app = FastAPI()
+    app.include_router(router)
+    app.state.turn_state = {}
+    app.state.web_credentials = WebCredentials(
+        operator_secret=OPERATOR_SECRET, panel_token=PANEL_TOKEN
+    )
+    app.add_middleware(WebAuthMiddleware, cookie_name="osprey_terminal_session_8080")
+    with TestClient(app, client=("127.0.0.1", 54321)) as client:
+        yield client
+    reset_web_credentials()
+
+
+@pytest.mark.no_auth_seam
+def test_the_panel_token_alone_reaches_the_route(panel_token_client):
+    """The hook runs in the agent's own sandbox and carries nothing stronger."""
+    resp = panel_token_client.post(
+        "/api/agent-turn",
+        json={"session_id": KEY, "pool_key": KEY, "state": "idle", "surface": "expert"},
+        headers={"authorization": f"Bearer {PANEL_TOKEN}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "recorded": True}
+
+
+@pytest.mark.no_auth_seam
+def test_a_wrong_panel_token_is_refused(panel_token_client):
+    """The route is panel-tier, not open."""
+    resp = panel_token_client.post(
+        "/api/agent-turn",
+        json={"session_id": KEY, "pool_key": KEY, "state": "idle", "surface": "expert"},
+        headers={"authorization": "Bearer not-the-token"},
+    )
+    assert resp.status_code in (401, 403)
+    assert panel_token_client.app.state.turn_state == {}

--- a/tests/interfaces/web_terminal/test_chat_browser.py
+++ b/tests/interfaces/web_terminal/test_chat_browser.py
@@ -497,9 +497,18 @@ _PROBE_INIT_SCRIPT = """
 """
 
 
+#: Seeded into every page before load: marks the onboarding tour as already
+#: dismissed. Under the default `once` policy the invite card (scrim + modal)
+#: arms itself shortly after boot whenever a tour anchor is on screen by then,
+#: and its veil would intercept the display-menu clicks a flip drives. The tour
+#: has its own dedicated coverage (tour.test.mjs).
+_DISMISS_TOUR = "try { localStorage.setItem('osprey-tour-dismissed-v1', '1') } catch (e) {}"
+
+
 def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
     """Open a fresh page (on a browser or a context) and wait for the console."""
     page: Page = opener.new_page()
+    page.add_init_script(_DISMISS_TOUR)
     page.add_init_script(_PROBE_INIT_SCRIPT)
     page.goto(f"{base_url}{query}", wait_until="domcontentloaded")
     # initChat builds the console on DOMContentLoaded; the input row is the
@@ -511,6 +520,7 @@ def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
 def _open_expert_page(opener, base_url: str, query: str = "") -> Page:
     """Open a fresh page in the Expert view and wait for its terminal to connect."""
     page: Page = opener.new_page()
+    page.add_init_script(_DISMISS_TOUR)
     page.add_init_script(_PROBE_INIT_SCRIPT)
     page.goto(f"{base_url}{query}", wait_until="domcontentloaded")
     expect(page.locator("#terminal-container .xterm")).to_be_visible(timeout=10_000)

--- a/tests/interfaces/web_terminal/test_chat_browser.py
+++ b/tests/interfaces/web_terminal/test_chat_browser.py
@@ -11,8 +11,16 @@ markdown/sanitiser globals and the SSE transport against a live event stream:
   4. Stop mid-stream re-enables the input and the next prompt runs cleanly;
   5. the Expert/Simple toggle swaps the chat card ↔ xterm live, no reload;
   6. hostile model markdown renders inert in the live DOM (no script executes);
-  7. a forced server-side eviction shows the "session reset" divider on the next
-     turn — and NO divider on a fresh page's first turn.
+  7. a re-created chat with nothing to resume shows the "session reset" divider
+     on the next turn — no divider when it resumes, none on a first turn;
+  8. flipping the view hands ONE session between the two surfaces: the Simple
+     view replays the Expert transcript and the Expert view resumes it again,
+     the pointer unchanged and the page never reloaded;
+  9. a flip with no transcript to resume starts the chat under the session key;
+ 10. the view taking the session over shows the transitional state while the
+     outgoing agent finishes: ended by "Stop and switch now" on either side,
+     and by the turn's own idle edge on the Simple side;
+ 11. a second tab holding the session gets the refusal in words.
 
 Harness: the panels-browser ``_live_server`` machinery (a real uvicorn server on
 a background thread, with ``_load_web_config``/``_load_panel_config``/
@@ -23,7 +31,17 @@ objects the ``operator_session`` unit tests use, so the real
 ``_message_to_events`` converter and the real ``routes/chat.py`` SSE branch run
 end to end — only the SDK subprocess is replaced. A handful of ``/__test__/*``
 routes give each scenario a server-loop control channel (release a held turn,
-force an eviction, read turn-guard state) without cross-thread event juggling.
+force an eviction, read turn-guard state and what each SDK client was launched
+with) without cross-thread event juggling.
+
+The Expert half is real: a genuine PTY runs a long-lived child, and the command
+the hand-off door built for it is recorded at the registry seam, so ``--resume
+<transcript>`` versus ``--session-id <key>`` is asserted on the argv the spawn
+actually used. What no fake can produce is the transcript a real Claude child
+writes, so the conversation the Expert view "had" is seeded as a JSONL file in
+the discovery directory — the same file the resume, the replay and the idle
+judgement all read. The project directory, the Claude config root and the
+agent-data root are all under ``tmp_path``, so a run reads no developer state.
 
 Run:
     uv run pytest tests/interfaces/web_terminal/test_chat_browser.py -q
@@ -34,15 +52,20 @@ Skips cleanly when the chromium headless binary is not installed.
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 import re
+import sys
 import time
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 import requests
 from fastapi import Request
 
+from osprey.agent_runner.project_paths import claude_project_dir
 from tests.interfaces._panel_launch import publish_artifact_url
 from tests.interfaces.conftest import _apply_all, _run_app_server
 
@@ -100,12 +123,19 @@ _RELEASE_GATE = asyncio.Event()
 # Default reply for an unregistered prompt: one line of text, then terminate.
 _DEFAULT_PLAN: list[tuple] = [("text", "ok"), ("result",)]
 
+# Every PTY command the hand-off door asked the registry to spawn, in order.
+# Recorded at the registry seam (see _record_pty_spawns) because the identity
+# half of a spawn — ``--resume <transcript>`` or ``--session-id <key>`` — is
+# decided by the door and spelled on the command line, nowhere else.
+_PTY_SPAWNS: list[list[str]] = []
+
 
 def _reset_fake_state() -> None:
     """Clear per-server fake state; called at each server launch (test thread)."""
     global _RELEASE_GATE
     _PLANS.clear()
     _OBSERVED_PROMPTS.clear()
+    _PTY_SPAWNS.clear()
     _RELEASE_GATE = asyncio.Event()
 
 
@@ -124,10 +154,17 @@ class _FakeSDKClient:
       ("hang",)         block until the reader is cancelled (Stop tests)
       ("await_interrupt") block until interrupt() (Stop → clean terminal)
       ("result",)       a terminal ResultMessage
+
+    The options the client was constructed with are kept as ``options``: with
+    ``ClaudeAgentOptions`` faked to a plain mapping, they are what
+    ``OperatorSession.start`` chose between ``resume=<transcript>`` and
+    ``session_id=<key>``, and the ``/__test__/chat-state`` route serves them
+    back per live chat session.
     """
 
     def __init__(self, *args, **kwargs) -> None:
         self._prompts: list[str] = []
+        self.options = kwargs.get("options")
         # Bound to the server loop (constructed inside session.start()).
         self._interrupted = asyncio.Event()
 
@@ -195,11 +232,132 @@ def _install_test_routes(app) -> None:
     async def _chat_state(request: Request):
         registry = request.app.state.operator_registry
         chats = list(registry.chats._sessions.values())
-        return {"n": len(chats), "in_flight": any(s.in_flight for s in chats)}
+        return {
+            "n": len(chats),
+            "in_flight": any(s.in_flight for s in chats),
+            # What each live chat's SDK client was launched with — the identity
+            # half is the whole question a hand-off answers.
+            "options": [getattr(getattr(s, "_client", None), "options", None) for s in chats],
+        }
+
+    async def _pty_spawns(request: Request):  # noqa: ARG001 - Request required by FastAPI
+        return {"commands": [list(command) for command in _PTY_SPAWNS]}
+
+    async def _pty_state(request: Request):
+        registry = request.app.state.pty_registry
+        key = request.query_params.get("session_id", "")
+        session = registry.get_session(key) if key else None
+        return {"live": bool(session is not None and session.is_alive)}
 
     app.add_api_route("/__test__/release", _release, methods=["POST"])
     app.add_api_route("/__test__/evict-all", _evict_all, methods=["POST"])
     app.add_api_route("/__test__/chat-state", _chat_state, methods=["GET"])
+    app.add_api_route("/__test__/pty-spawns", _pty_spawns, methods=["GET"])
+    app.add_api_route("/__test__/pty-state", _pty_state, methods=["GET"])
+
+
+# ---------------------------------------------------------------------------
+# The project the server serves: PTY child, turn hook, transcripts
+# ---------------------------------------------------------------------------
+
+# A PTY command that outlives the test AND tolerates the ``--resume <id>`` /
+# ``--session-id <id>`` (and any ``--effort <level>``) arguments the websocket
+# route appends. ``sleep``/``cat``/``echo`` each exit or error on the extra
+# args, which would trip terminal.js's auto-resume failover and clear the
+# stored pointer mid-test.
+_LONG_LIVED_SHELL = [sys.executable, "-c", "import time; time.sleep(3600)"]
+
+
+def _write_turn_hook_settings(project_dir: Path) -> None:
+    """Render the turn-state hook registrations a deployment's settings carry.
+
+    ``app.state.turn_hook_present`` is read from these settings at startup and
+    is a permission: without it the door refuses a plain hand-off off a PTY
+    (``handoff_needs_interrupt``), because nothing can ever report the idle
+    edge it would wait for. Writing the real registrations — rather than
+    stamping the flag onto ``app.state`` — keeps the suite honest about which
+    deployment it is describing, and runs the detection itself.
+
+    All four events a rendered ``settings.json`` wires are written, the busy
+    edge included, so the stand-in describes the deployment it stands in for
+    rather than only the two registrations the detection happens to read.
+    """
+    from osprey.interfaces.web_terminal.app import (
+        TURN_HOOK_SESSION_START_MATCHER,
+        TURN_STATE_HOOK,
+    )
+
+    command = f"python3 .claude/hooks/{TURN_STATE_HOOK}"
+    entry = [{"hooks": [{"type": "command", "command": command}]}]
+    settings = {
+        "hooks": {
+            "UserPromptSubmit": entry,
+            "Stop": entry,
+            "StopFailure": entry,
+            "SessionStart": [
+                {
+                    "matcher": TURN_HOOK_SESSION_START_MATCHER,
+                    "hooks": [{"type": "command", "command": command}],
+                }
+            ],
+        }
+    }
+    claude_dir = project_dir / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+
+
+def _seed_transcript(project_dir: Path, transcript_id: str, turns) -> Path:
+    """Write the JSONL transcript a Claude child would have left for *transcript_id*.
+
+    A real transcript is written by a real ``claude`` process, which needs the
+    binary and a provider; the conversation is therefore seeded in the shape
+    the readers expect (``<config-dir>/projects/<encoded>/<id>.jsonl``, one
+    entry per line). This single file is what the resume decision, the Simple
+    view's replay and the PTY idle judgement all read.
+
+    Args:
+        project_dir: The project the server serves.
+        transcript_id: The Claude session id the file is named for.
+        turns: ``(role, text)`` pairs, oldest first.
+
+    Returns:
+        The path written.
+    """
+    directory = claude_project_dir(project_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for index, (role, text) in enumerate(turns):
+        content = text if role == "user" else [{"type": "text", "text": text}]
+        lines.append(
+            json.dumps(
+                {
+                    "type": role,
+                    "timestamp": f"2026-01-01T00:00:{index:02d}.000Z",
+                    "sessionId": transcript_id,
+                    "message": {"role": role, "content": content},
+                }
+            )
+        )
+    path: Path = directory / f"{transcript_id}.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _record_pty_spawns(app) -> None:
+    """Record every command the door hands the PTY registry, then spawn it.
+
+    Wraps the live registry rather than the route, so what is recorded is the
+    argv a spawn was actually made with.
+    """
+    registry = app.state.pty_registry
+    inner = registry.get_or_create_session
+
+    def get_or_create_session(session_id, command, **kwargs):
+        _PTY_SPAWNS.append(list(command))
+        return inner(session_id, command, **kwargs)
+
+    registry.get_or_create_session = get_or_create_session
 
 
 # ---------------------------------------------------------------------------
@@ -218,14 +376,31 @@ def _live_chat_server(tmp_path, ui_mode: str = "simple"):
     is applied post-startup (root() re-reads it per request), the same
     app.state seam the ui-mode browser suite uses.
 
+    The project served is a fresh directory under ``tmp_path`` carrying the
+    turn-state hook registrations, and both roots the session machinery writes
+    or reads through — Claude's config directory (transcripts) and the
+    agent-data root (posture and transcript-map stores) — are pinned beside it,
+    so a run neither reads nor writes developer state.
+
     Yields:
-        (base_url, app) — live server address and the FastAPI app.
+        (base_url, app) — live server address and the FastAPI app. The project
+        directory is ``tmp_path / "project"``.
     """
     workspace = tmp_path / "_agent_data"
     workspace.mkdir(exist_ok=True)
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(exist_ok=True)
+    _write_turn_hook_settings(project_dir)
     _reset_fake_state()
 
     patches = [
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_CONFIG_DIR": str(tmp_path / "claude"),
+                "OSPREY_AGENT_DATA_ROOT": str(tmp_path / "agent_data"),
+            },
+        ),
         patch(
             "osprey.interfaces.web_terminal.app._load_web_config",
             return_value={"watch_dir": str(workspace)},
@@ -259,10 +434,11 @@ def _live_chat_server(tmp_path, ui_mode: str = "simple"):
     with _apply_all(patches):
         from osprey.interfaces.web_terminal.app import create_app
 
-        app = create_app(shell_command=["echo", "hello"])
+        app = create_app(shell_command=_LONG_LIVED_SHELL, project_dir=project_dir)
         _install_test_routes(app)
         with _run_app_server(app) as base_url:
             app.state.web_ui_mode = ui_mode
+            _record_pty_spawns(app)
             yield base_url, app
 
 
@@ -271,14 +447,199 @@ def _live_chat_server(tmp_path, ui_mode: str = "simple"):
 # ---------------------------------------------------------------------------
 
 
-def _open_chat_page(browser, base_url: str, query: str = "") -> Page:
-    """Open a fresh page and wait for the console."""
-    page = browser.new_page()
+# Two probes, both installed before any page script runs.
+#
+# The hand-off log answers "was the transitional state on screen?" without
+# racing it. Both overlays are shown by clearing `hidden` (the console builds
+# its card up front) or by being inserted (the terminal builds its own on
+# demand), so a mutation observer sees every appearance no matter how briefly
+# it stands — a poll would not. Its callback runs at the microtask checkpoint,
+# after the synchronous block that wrote the copy.
+#
+# The load counter answers "did the page reload?". A flip is a live swap of two
+# surfaces that are both already in the document; a reload would restart every
+# script, drop the xterm and re-run the boot ladder, and is exactly the
+# implementation this feature must not have. sessionStorage survives a reload,
+# which a window flag would not, so the count is the honest witness — and it is
+# counted for the TOP document only, since the hub's same-origin panel iframes
+# share that storage and would each inflate the count on their own load.
+_PROBE_INIT_SCRIPT = """
+(function () {
+  if (window.top === window) {
+    try {
+      var loads = Number(sessionStorage.getItem('__osprey_loads') || '0') + 1;
+      sessionStorage.setItem('__osprey_loads', String(loads));
+    } catch (e) {}
+  }
+  window.__handoffLog = [];
+  function note() {
+    ['#operator-container .op-handoff', '#terminal-handoff'].forEach(function (selector) {
+      var el = document.querySelector(selector);
+      // `hidden` is how the console toggles its card; offsetParent catches the
+      // CSS side (the terminal overlay is display:none in the Simple view), so
+      // the log records only copy that was actually on screen.
+      if (!el || el.hidden || el.offsetParent === null) return;
+      var text = (el.textContent || '').trim();
+      var log = window.__handoffLog;
+      if (text && text !== log[log.length - 1]) log.push(text);
+    });
+  }
+  // Observed on the document, not the document element: at document-start
+  // `document` always exists but `document.documentElement` may not yet, and
+  // observing null throws out of this whole probe.
+  new MutationObserver(note).observe(document, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['hidden', 'class'],
+  });
+})();
+"""
+
+
+def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
+    """Open a fresh page (on a browser or a context) and wait for the console."""
+    page: Page = opener.new_page()
+    page.add_init_script(_PROBE_INIT_SCRIPT)
     page.goto(f"{base_url}{query}", wait_until="domcontentloaded")
     # initChat builds the console on DOMContentLoaded; the input row is the
     # last thing appended, so its presence means the console is mounted.
     expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_visible(timeout=10_000)
     return page
+
+
+def _open_expert_page(opener, base_url: str, query: str = "") -> Page:
+    """Open a fresh page in the Expert view and wait for its terminal to connect."""
+    page: Page = opener.new_page()
+    page.add_init_script(_PROBE_INIT_SCRIPT)
+    page.goto(f"{base_url}{query}", wait_until="domcontentloaded")
+    expect(page.locator("#terminal-container .xterm")).to_be_visible(timeout=10_000)
+    return page
+
+
+def _click_segment(page: Page, mode: str) -> None:
+    """Pick *mode* in the header's display-menu popover, then close the card."""
+    trigger = page.locator("#display-menu .display-menu-trigger")
+    card = page.locator("#display-menu .display-menu-card")
+    trigger.click()
+    expect(card).to_have_class(re.compile(r"\bopen\b"))
+    page.locator(
+        f'#display-menu .display-menu-view .display-seg-option[data-mode="{mode}"]'
+    ).click()
+    # A mode pick deliberately leaves the card open; close it so the surface
+    # under it is the one the next step interacts with.
+    trigger.click()
+    expect(card).not_to_have_class(re.compile(r"\bopen\b"))
+
+
+def _pointer(page: Page) -> str | None:
+    """The session key this tab is on, read through the pointer module itself."""
+    key: str | None = page.evaluate(
+        "() => import('/static/js/session-pointer.js').then((m) => m.getPointer())"
+    )
+    return key
+
+
+def _wait_for_pointer(page: Page, timeout: float = 15.0) -> str:
+    """Block until the page is on a session key and return it."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        key = _pointer(page)
+        if key:
+            return key
+        page.wait_for_timeout(50)
+    raise AssertionError("the page never stored a session pointer")
+
+
+def _handoff_log(page: Page) -> list[str]:
+    """Every distinct line the hand-off overlays have shown, in order."""
+    lines: list[str] = page.evaluate("() => window.__handoffLog || []")
+    return lines
+
+
+def _page_loads(page: Page) -> int:
+    """How many times this tab has run the boot scripts."""
+    return int(page.evaluate("() => Number(sessionStorage.getItem('__osprey_loads') || '0')"))
+
+
+def _pty_commands(base_url: str) -> list[list[str]]:
+    """Every PTY command the hand-off door has spawned, in order."""
+    resp = requests.get(f"{base_url}/__test__/pty-spawns")
+    resp.raise_for_status()
+    commands: list[list[str]] = resp.json()["commands"]
+    return commands
+
+
+def _chat_options(base_url: str) -> list[dict]:
+    """The SDK options every live chat session was launched with."""
+    resp = requests.get(f"{base_url}/__test__/chat-state")
+    resp.raise_for_status()
+    return [options for options in resp.json()["options"] if options]
+
+
+def _identity_of(command: list[str]) -> tuple[str, str]:
+    """The identity argument pair of a PTY command.
+
+    Asserted rather than a whole-argv comparison because the route appends
+    other arguments (an effort level, say) that this suite is not about.
+    """
+    for flag in ("--resume", "--session-id"):
+        if flag in command:
+            return flag, command[command.index(flag) + 1]
+    raise AssertionError(f"no identity argument in {command}")
+
+
+def _wait_for_pty_spawns(base_url: str, count: int, timeout: float = 20.0) -> list[list[str]]:
+    """Block until the door has spawned *count* PTY children and return them all."""
+    deadline = time.monotonic() + timeout
+    commands: list[list[str]] = []
+    while time.monotonic() < deadline:
+        commands = _pty_commands(base_url)
+        if len(commands) >= count:
+            return commands
+        time.sleep(0.05)
+    raise AssertionError(f"expected {count} PTY spawns, saw {commands}")
+
+
+def _report_turn(base_url: str, key: str, state: str) -> None:
+    """Report a turn edge for *key* the way the terminal's own child process does.
+
+    The real route, not a poke at ``app.state``: it is the interface contract
+    the ``osprey_turn_state`` hook posts on, and going through it runs the
+    identifier grammar and the surface rule that decide whether an edge is
+    recorded at all.
+    """
+    resp = requests.post(
+        f"{base_url}/api/agent-turn",
+        json={
+            "session_id": key,
+            "pool_key": key,
+            "state": state,
+            "surface": "expert",
+            "ts": time.time(),
+            "source": "UserPromptSubmit" if state == "busy" else "Stop",
+        },
+    )
+    resp.raise_for_status()
+    assert resp.json()["recorded"] is True, f"the {state} edge was not recorded: {resp.text}"
+
+
+def _pty_is_live(base_url: str, key: str) -> bool:
+    """Whether a PTY for *key* is still pooled and running."""
+    resp = requests.get(f"{base_url}/__test__/pty-state", params={"session_id": key})
+    resp.raise_for_status()
+    return bool(resp.json()["live"])
+
+
+def _wait_for_chat_options(base_url: str, timeout: float = 20.0) -> list[dict]:
+    """Block until a chat session is live and return what each was launched with."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        options = _chat_options(base_url)
+        if options:
+            return options
+        time.sleep(0.05)
+    raise AssertionError("no chat session was launched")
 
 
 def _send(page: Page, text: str) -> None:
@@ -515,12 +876,7 @@ def test_mode_flip_swaps_chat_and_terminal_live(tmp_path, chromium_browser):
         expect(term).to_be_hidden()
 
         # → Expert: xterm visible, console hidden — no reload, both attached.
-        # (The mode toggle lives inside the display-menu popover — open it once;
-        # a mode pick leaves the card open, so the return trip needs no reopen.)
-        page.locator("#display-menu .display-menu-trigger").click()
-        page.locator(
-            '#display-menu .display-menu-view .display-seg-option[data-mode="expert"]'
-        ).click()
+        _click_segment(page, "expert")
         expect(html).to_have_attribute("data-ui-mode", "expert")
         expect(term).to_be_visible()
         expect(console).to_be_hidden()
@@ -528,9 +884,7 @@ def test_mode_flip_swaps_chat_and_terminal_live(tmp_path, chromium_browser):
         expect(term).to_be_attached()
 
         # → Simple again: the swap is reversible with no teardown.
-        page.locator(
-            '#display-menu .display-menu-view .display-seg-option[data-mode="simple"]'
-        ).click()
+        _click_segment(page, "simple")
         expect(html).to_have_attribute("data-ui-mode", "simple")
         expect(console).to_be_visible()
         expect(term).to_be_hidden()
@@ -578,15 +932,19 @@ def test_hostile_markdown_renders_inert(tmp_path, chromium_browser):
 
 
 # ---------------------------------------------------------------------------
-# 7. Session-expiry divider: shown after a forced eviction, absent on turn 1
+# 7. Session-expiry divider: a conversation that could not be continued
 # ---------------------------------------------------------------------------
 
 
 def test_session_expiry_divider_after_eviction(tmp_path, chromium_browser):
-    """A server-side eviction makes the next turn show the "session reset" divider.
+    """An eviction with nothing to resume makes the next turn show the divider.
 
-    The recreated session re-emits ``session_reset`` while prior turns are on
-    screen, so the renderer marks the boundary with a centred divider.
+    What paints the divider is the conversation ending, not the process dying.
+    The evicted key has no transcript on disk here — the faked SDK writes none
+    — so the re-created session has nothing to continue and starts a
+    conversation of its own, which is what re-emits ``session_reset`` while
+    prior turns are on screen. Its counterpart is the resume below, where the
+    same eviction draws nothing.
     """
     with _live_chat_server(tmp_path) as (base_url, _app):
         _PLANS["turn one"] = [("text", "answer one"), ("result",)]
@@ -605,8 +963,6 @@ def test_session_expiry_divider_after_eviction(tmp_path, chromium_browser):
         divider = page.locator(f"{_OP} .op-system").filter(has_text="session reset")
         before = divider.count()
 
-        # Force a server-side eviction: the next turn creates a brand-new session
-        # (was_reused False), which re-emits session_reset.
         _wait_chat_idle(base_url)
         resp = requests.post(f"{base_url}/__test__/evict-all")
         assert resp.json()["evicted"] >= 1
@@ -615,6 +971,49 @@ def test_session_expiry_divider_after_eviction(tmp_path, chromium_browser):
         # The eviction's session_reset paints a fresh divider (prior turns present).
         expect(divider).to_have_count(before + 1, timeout=10_000)
         expect(page.locator(f"{_OP} .op-entry.assistant").last).to_contain_text("answer two")
+
+        page.close()
+
+
+def test_no_divider_when_the_recreated_session_resumes(tmp_path, chromium_browser):
+    """An eviction the key can be resumed through draws no divider at all.
+
+    The same forced eviction as above, on a key whose transcript is on disk:
+    the re-created session continues that transcript, so the conversation the
+    operator is reading never ended and marking a boundary in it would be a
+    claim the server did not make. The divider is reserved for the case that
+    genuinely lost the thread.
+    """
+    with _live_chat_server(tmp_path) as (base_url, _app):
+        _PLANS["turn one"] = [("text", "answer one"), ("result",)]
+        _PLANS["turn two"] = [("text", "answer two"), ("result",)]
+        page = _open_chat_page(chromium_browser, base_url)
+        key = _wait_for_pointer(page)
+
+        _send(page, "turn one")
+        expect(page.locator(f"{_OP} .op-entry.assistant")).to_contain_text(
+            "answer one", timeout=10_000
+        )
+        expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_enabled()
+
+        # The transcript that turn would have written, so the key has something
+        # to be resumed through.
+        _seed_transcript(
+            tmp_path / "project", key, [("user", "turn one"), ("assistant", "answer one")]
+        )
+
+        _wait_chat_idle(base_url)
+        resp = requests.post(f"{base_url}/__test__/evict-all")
+        assert resp.json()["evicted"] >= 1
+
+        _send(page, "turn two")
+        expect(page.locator(f"{_OP} .op-entry.assistant").last).to_contain_text(
+            "answer two", timeout=10_000
+        )
+        # The re-created session resumed rather than started.
+        options = _wait_for_chat_options(base_url)
+        assert [entry.get("resume") for entry in options] == [key]
+        expect(page.locator(f"{_OP} .op-system").filter(has_text="session reset")).to_have_count(0)
 
         page.close()
 
@@ -639,3 +1038,277 @@ def test_no_session_reset_divider_on_fresh_first_turn(tmp_path, chromium_browser
         expect(page.locator(f"{_OP} .op-system").filter(has_text="session reset")).to_have_count(0)
 
         page.close()
+
+
+# ---------------------------------------------------------------------------
+# 8. A flip hands ONE session over: Simple replays it, Expert resumes it back
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_expert_to_simple_and_back_keeps_one_session(tmp_path, chromium_browser):
+    """Both views are windows onto one session key and one conversation.
+
+    The Expert view starts a child under the key; the flip to Simple shows the
+    transitional state, replays that key's transcript into the console and
+    hands back a usable input, with the chat resuming the transcript rather
+    than opening a second conversation; the flip back spawns a terminal child
+    that resumes the same transcript. Through both flips the browser's pointer
+    is the same string and the page never reloads — the surfaces are swapped
+    live, which is the whole point of the mechanic.
+    """
+    with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
+        _PLANS["and then"] = [("text", "the newer answer"), ("result",)]
+        page = _open_expert_page(chromium_browser, base_url)
+        key = _wait_for_pointer(page)
+
+        # Nothing to resume yet, so the terminal child was started under the key.
+        first = _wait_for_pty_spawns(base_url, 1)[0]
+        assert _identity_of(first) == ("--session-id", key)
+
+        # The conversation that view then had. Seeded, not generated: a real
+        # transcript is written by a real Claude child (see _seed_transcript).
+        _seed_transcript(
+            tmp_path / "project",
+            key,
+            [("user", "what is the beam current"), ("assistant", "the earlier answer")],
+        )
+
+        _click_segment(page, "simple")
+
+        # The transcript is replayed into the console...
+        expect(page.locator(f"{_OP} .op-entry.operator")).to_contain_text(
+            "what is the beam current", timeout=20_000
+        )
+        expect(page.locator(f"{_OP} .op-entry.assistant")).to_contain_text("the earlier answer")
+        # ...the input is usable again...
+        expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_enabled()
+        # ...and the wait was on screen while it happened.
+        assert any("Finishing in the other view" in line for line in _handoff_log(page)), (
+            f"the transitional state was never shown: {_handoff_log(page)}"
+        )
+
+        # The chat continued the transcript rather than starting a conversation
+        # of its own under the key.
+        options = _wait_for_chat_options(base_url)
+        assert [entry.get("resume") for entry in options] == [key]
+        assert all(entry.get("session_id") is None for entry in options)
+
+        # The console is live on that same conversation.
+        _send(page, "and then")
+        expect(page.locator(f"{_OP} .op-entry.assistant").last).to_contain_text(
+            "the newer answer", timeout=10_000
+        )
+
+        _click_segment(page, "expert")
+
+        expect(page.locator("#terminal-container")).to_be_visible()
+        second = _wait_for_pty_spawns(base_url, 2)[1]
+        assert _identity_of(second) == ("--resume", key)
+
+        assert _pointer(page) == key, "the flip moved the tab to another session"
+        assert _page_loads(page) == 1, "the flip reloaded the page"
+
+        page.close()
+
+
+# ---------------------------------------------------------------------------
+# 9. A flip with nothing to resume starts the chat under the session key
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_before_any_prompt_starts_the_chat_under_the_key(tmp_path, chromium_browser):
+    """With no transcript on disk the Simple view opens the key's first conversation.
+
+    The counterpart of the resume above: the same flip, made before anything
+    has been said, must not ask the SDK to continue a transcript that does not
+    exist. It starts one under the session key instead — so the id the child
+    writes its transcript under is the key both views are already on — and the
+    pointer is untouched by the flip.
+    """
+    with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
+        page = _open_expert_page(chromium_browser, base_url)
+        key = _wait_for_pointer(page)
+        first = _wait_for_pty_spawns(base_url, 1)[0]
+        assert _identity_of(first) == ("--session-id", key)
+
+        _click_segment(page, "simple")
+
+        expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_enabled(timeout=20_000)
+        options = _wait_for_chat_options(base_url)
+        assert [entry.get("session_id") for entry in options] == [key]
+        assert all(entry.get("resume") is None for entry in options)
+
+        assert _pointer(page) == key
+        assert _page_loads(page) == 1
+
+        page.close()
+
+
+# ---------------------------------------------------------------------------
+# 10. The Expert side of a flip: the wait, and the way out of it
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_pending_shows_the_wait_and_stop_switches_now(tmp_path, chromium_browser):
+    """A flip to Expert waits out the chat's turn, and one button ends that wait.
+
+    Only one surface may run the session's agent, and the outgoing one is never
+    cut off on a clock — so a flip made mid-turn parks on the terminal card
+    behind a live elapsed counter. "Stop and switch now" is the operator's way
+    out: it asks for the same session again with the interrupt flag, which ends
+    the running turn instead of waiting for it, and the terminal comes up on
+    the key.
+    """
+    with _live_chat_server(tmp_path, ui_mode="simple") as (base_url, _app):
+        # The turn never finishes on its own: the gate is deliberately never
+        # released, so the wait the operator sees is real.
+        _PLANS["hold the line"] = [("text", "working"), ("gate",), ("result",)]
+        page = _open_chat_page(chromium_browser, base_url)
+        key = _wait_for_pointer(page)
+
+        _send(page, "hold the line")
+        expect(page.locator(f"{_OP} .op-entry.assistant")).to_contain_text(
+            "working", timeout=10_000
+        )
+
+        _click_segment(page, "expert")
+
+        overlay = page.locator("#terminal-handoff")
+        expect(overlay).to_be_visible(timeout=10_000)
+        expect(overlay.locator(".terminal-handoff-message")).to_contain_text(
+            "Finishing in the other view", timeout=10_000
+        )
+        # The counter is the honest thing to show for a wait with no bound.
+        expect(overlay.locator(".terminal-handoff-elapsed")).to_have_text(
+            re.compile(r"^\d+:\d{2}$")
+        )
+
+        action = overlay.locator(".terminal-handoff-action")
+        expect(action).to_have_text("Stop and switch now")
+        action.click()
+
+        # The interrupt ends the chat turn, and the terminal takes the key. The
+        # faked SDK writes no transcript, so there is nothing to resume and the
+        # terminal child starts under the key itself.
+        spawned = _wait_for_pty_spawns(base_url, 1)[0]
+        assert _identity_of(spawned) == ("--session-id", key)
+        expect(overlay).to_be_hidden(timeout=15_000)
+        assert _pointer(page) == key
+        assert _page_loads(page) == 1
+
+        page.close()
+
+
+def _flip_into_a_busy_terminal(base_url: str, chromium_browser) -> tuple[Page, str]:
+    """Open Expert, mark the key mid-turn, flip to Simple, and return at the wait.
+
+    Shared by the two cases below because the setup is the whole scenario up to
+    the fork: what the operator does about the wait is what differs.
+    """
+    page = _open_expert_page(chromium_browser, base_url)
+    key = _wait_for_pointer(page)
+    _wait_for_pty_spawns(base_url, 1)
+    assert _pty_is_live(base_url, key)
+
+    # The terminal's own child reports a prompt going in — the hook's busy edge.
+    _report_turn(base_url, key, "busy")
+
+    _click_segment(page, "simple")
+
+    overlay = page.locator(f"{_OP} .op-handoff")
+    expect(overlay).to_be_visible(timeout=10_000)
+    expect(overlay.locator(".op-handoff-message")).to_contain_text("Finishing in the other view")
+    expect(overlay.locator(".op-handoff-elapsed")).to_have_text(re.compile(r"^\d+:\d{2}$"))
+    # The input stays out of reach: the session is not this view's yet.
+    expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_disabled()
+    expect(overlay.locator(".op-handoff-action")).to_have_text("Stop and switch now")
+    return page, key
+
+
+def test_handoff_busy_expert_to_simple_waits_for_the_turn(tmp_path, chromium_browser):
+    """A flip made while the terminal is mid-turn waits, then completes on the idle edge.
+
+    The mirror of the case above, on the surface whose turns are reported by a
+    hook rather than read off an SDK client. The outgoing agent is never ended
+    on a clock, so the console parks behind the transitional state rather than
+    taking the session away mid-answer — and the edge that ends the turn is
+    what releases it. The terminal's process is torn down and the console comes
+    up on the same key.
+    """
+    with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
+        page, key = _flip_into_a_busy_terminal(base_url, chromium_browser)
+
+        # The turn ends: the hook's idle edge is the only thing that says so.
+        assert _pty_is_live(base_url, key), "the wait ended before the turn did"
+        _report_turn(base_url, key, "idle")
+
+        expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_enabled(timeout=20_000)
+        expect(page.locator(f"{_OP} .op-handoff")).to_be_hidden()
+        assert not _pty_is_live(base_url, key), "the terminal kept the session it handed over"
+        assert [entry.get("session_id") for entry in _wait_for_chat_options(base_url)] == [key]
+        assert _pointer(page) == key
+        assert _page_loads(page) == 1
+
+        page.close()
+
+
+def test_handoff_busy_expert_to_simple_waits_then_stops(tmp_path, chromium_browser):
+    """ "Stop and switch now" must end a wait the operator no longer wants.
+
+    The wait on a hooked terminal is unbounded by design, so this button is the
+    only way out of it: it asks for the same session again, this time cutting
+    the running turn short. It must leave the console usable on the key.
+    """
+    with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
+        page, key = _flip_into_a_busy_terminal(base_url, chromium_browser)
+
+        page.locator(f"{_OP} .op-handoff-action").click()
+
+        # The wait ends with the terminal's process gone and the console usable.
+        expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_enabled(timeout=25_000)
+        expect(page.locator(f"{_OP} .op-handoff")).to_be_hidden()
+        assert not _pty_is_live(base_url, key), "the terminal kept the session it handed over"
+        assert [entry.get("session_id") for entry in _wait_for_chat_options(base_url)] == [key]
+
+        page.close()
+
+
+# ---------------------------------------------------------------------------
+# 11. A second tab on the same session is refused, in words
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_refused_while_another_tab_holds_the_session(tmp_path, chromium_browser):
+    """A session already in use elsewhere is refused, and the console says so.
+
+    Two tabs of one browser share the pointer, so both address the same key —
+    and the key can only be in one place. The tab that does not hold it gets
+    the refusal rather than a silent second conversation, and the copy names
+    the situation the operator is actually in.
+    """
+    with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
+        context = chromium_browser.new_context()
+
+        holder = _open_expert_page(context, base_url)
+        key = _wait_for_pointer(holder)
+        _wait_for_pty_spawns(base_url, 1)
+
+        # A second tab, opened in the Simple view on the same pointer.
+        second = _open_chat_page(context, base_url, "/?mode=simple")
+        assert _pointer(second) == key
+
+        _send(second, "are you there")
+
+        overlay = second.locator(f"{_OP} .op-handoff")
+        expect(overlay).to_be_visible(timeout=20_000)
+        expect(overlay.locator(".op-handoff-message")).to_have_text(
+            "This session is in use in another tab or view."
+        )
+        # Nothing this view can do about it, so it is offered nothing.
+        expect(overlay.locator(".op-handoff-action")).to_be_hidden()
+        # The prompt never ran, so the text is back where it was typed.
+        expect(second.locator(f"{_OP} .op-input-area textarea")).to_have_value("are you there")
+
+        second.close()
+        holder.close()
+        context.close()

--- a/tests/interfaces/web_terminal/test_chat_pool_resume.py
+++ b/tests/interfaces/web_terminal/test_chat_pool_resume.py
@@ -1,0 +1,235 @@
+"""The transcript a chat child is launched on, and how the pool compares it.
+
+The chat pool is keyed on the session key, and that key never changes — the
+same key answers for both views, before and after a flip. The *conversation*
+under it can move: a ``/clear`` in the other view starts a new transcript, and
+the child that comes back has to be launched on that one.
+
+So the transcript joins the environment as part of a child's launch identity.
+Both are fixed when the child is spawned and neither can be amended afterwards,
+which makes them the same kind of fact and gives them the same rule: the same
+launch identity reuses the live child, a different one tears it down and builds
+a new one. The environment half is pinned in ``test_terminate_respawn.py``;
+this file pins the transcript half, and the binding that carries the session
+key from the pool's key into the child.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from osprey.interfaces.web_terminal.chat_session_pool import (
+    ChatSessionPool,
+    ChatSessionTerminatedError,
+)
+from osprey.interfaces.web_terminal.operator_session import OperatorRegistry
+
+_SEAM = "osprey.interfaces.web_terminal.operator_session.OperatorSession"
+
+
+class _FakeChatSession:
+    """Lightweight OperatorSession double recording how it was launched.
+
+    Mirrors the double in ``test_terminate_respawn.py`` — the surface the pool
+    drives — and additionally keeps the two launch facts this file is about:
+    the ``session_key`` it was built under and the ``resume_id`` it was started
+    on.
+    """
+
+    def __init__(self, cwd="/tmp", env=None, session_key=None):
+        self.cwd = cwd
+        self.env = env
+        self.session_key = session_key
+        self.resume_id = None
+        self.is_active = True
+        self.is_busy = False
+        self.last_activity = time.monotonic()
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.start_delay = 0.0
+        self.started = asyncio.Event()
+
+    async def start(self, *, resume_id=None):
+        self.resume_id = resume_id
+        self.started.set()
+        if self.start_delay:
+            await asyncio.sleep(self.start_delay)
+        self.start_calls += 1
+
+    async def teardown(self):
+        self.stop_calls += 1
+        self.is_active = False
+
+
+def _pool(start_delay: float = 0.0, **kwargs) -> tuple[ChatSessionPool, list[_FakeChatSession]]:
+    created: list[_FakeChatSession] = []
+
+    def factory(cwd, env, session_key):
+        session = _FakeChatSession(cwd=cwd, env=env, session_key=session_key)
+        session.start_delay = start_delay
+        created.append(session)
+        return session
+
+    return ChatSessionPool(factory=factory, **kwargs), created
+
+
+async def _created_first(created, timeout: float = 1.0):
+    """Wait until the factory has built its first session and entered ``start()``."""
+    deadline = time.monotonic() + timeout
+    while not created:
+        assert time.monotonic() < deadline, "factory never ran"
+        await asyncio.sleep(0)
+    await asyncio.wait_for(created[0].started.wait(), timeout=timeout)
+
+
+class TestTheResumeIdReachesTheChild:
+    @pytest.mark.asyncio
+    async def test_the_transcript_is_named_at_start_not_at_construction(self):
+        """A child is built under the key and started on the transcript.
+
+        The two are different identities and travel separately: the key is what
+        the session is pooled, audited and given telemetry under, the
+        transcript is only which conversation this launch continues.
+        """
+        pool, created = _pool()
+
+        session, was_reused = await pool.get_or_create("K", "/tmp", resume_id="T1")
+
+        assert was_reused is False
+        assert session.session_key == "K"
+        assert session.resume_id == "T1"
+        assert created == [session]
+
+    @pytest.mark.asyncio
+    async def test_without_a_transcript_the_child_starts_its_own(self):
+        """No resume id is the first-launch shape, not an error."""
+        pool, _created = _pool()
+
+        session, _ = await pool.get_or_create("K", "/tmp")
+
+        assert session.session_key == "K"
+        assert session.resume_id is None
+
+
+class TestTheTranscriptJoinsTheReuseCheck:
+    """The transcript half of the launch identity, mirroring the env half.
+
+    ``test_terminate_respawn.TestChatPoolEnvFingerprint`` pins the
+    environment; the transcript is compared in the same place, for the same
+    reason, and these are the same two cases.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_changed_resume_id_rebuilds_instead_of_reusing(self):
+        """The core of it: a different transcript means a different child.
+
+        This is what makes a ``/clear`` in the other view reach this one. The
+        key is unchanged, so nothing else in the pool would notice.
+        """
+        pool, created = _pool()
+
+        first, _ = await pool.get_or_create("K", "/tmp", resume_id="T1")
+        second, was_reused = await pool.get_or_create("K", "/tmp", resume_id="T2")
+
+        assert second is not first
+        assert was_reused is False
+        assert second.resume_id == "T2"
+        assert first.stop_calls == 1
+        assert len(created) == 2
+
+    @pytest.mark.asyncio
+    async def test_an_unchanged_resume_id_still_reuses_the_live_session(self):
+        """The liveness half: a second prompt must not kill the conversation.
+
+        The route hands the key's current transcript over on every turn, so a
+        comparison that fired on an unchanged id would restart the agent under
+        the operator mid-conversation — a worse failure than the one it
+        prevents.
+        """
+        pool, created = _pool()
+
+        first, _ = await pool.get_or_create("K", "/tmp", resume_id="T1")
+        second, was_reused = await pool.get_or_create("K", "/tmp", resume_id="T1")
+
+        assert second is first
+        assert was_reused is True
+        assert first.stop_calls == 0
+        assert first.start_calls == 1
+        assert len(created) == 1
+
+    @pytest.mark.asyncio
+    async def test_dropping_the_resume_id_rebuilds_as_well(self):
+        """An absent transcript is a launch identity of its own, not a wildcard.
+
+        A caller that has stopped naming a transcript is asking for a child
+        that starts a conversation of its own, which the live one is not.
+        """
+        pool, created = _pool()
+
+        first, _ = await pool.get_or_create("K", "/tmp", resume_id="T1")
+        second, was_reused = await pool.get_or_create("K", "/tmp")
+
+        assert second is not first
+        assert was_reused is False
+        assert second.resume_id is None
+        assert first.stop_calls == 1
+        assert len(created) == 2
+
+    @pytest.mark.asyncio
+    async def test_a_creation_on_a_stale_transcript_is_overtaken(self):
+        """A caller must not be joined to a creation it would have replaced.
+
+        The in-flight child is being launched on the transcript the second
+        caller already knows is gone, so joining it would hand back exactly the
+        child the change was meant to replace.
+        """
+        pool, created = _pool(start_delay=0.05)
+        creation = asyncio.create_task(pool.get_or_create("K", "/tmp", resume_id="T1"))
+        await _created_first(created)
+
+        second, was_reused = await pool.get_or_create("K", "/tmp", resume_id="T2")
+
+        with pytest.raises(ChatSessionTerminatedError):
+            await creation
+        assert was_reused is False
+        assert second is created[1]
+        assert second.resume_id == "T2"
+        assert created[0].stop_calls == 1
+        assert pool.get("K") is second
+
+
+class TestTheRegistryBinding:
+    @pytest.mark.asyncio
+    async def test_the_facade_carries_the_key_and_the_transcript_through(self):
+        """The pool's key IS the child's session key, and the resume id rides along.
+
+        The factory bound in ``OperatorRegistry.__init__`` is the only place
+        that turns a pool key into a child identity; a binding that minted an
+        id of its own would split one conversation's audit and telemetry across
+        two.
+        """
+        registry = OperatorRegistry()
+
+        with patch(_SEAM, _FakeChatSession):
+            session, was_reused = await registry.get_or_create_chat_session(
+                "K", cwd="/tmp", resume_id="T1"
+            )
+
+        assert was_reused is False
+        assert session.session_key == "K"
+        assert session.resume_id == "T1"
+        assert registry.get_chat_session("K") is session
+
+    @pytest.mark.asyncio
+    async def test_the_facade_defaults_to_no_transcript(self):
+        """Omitting the transcript reaches the child as omitted, not as a blank."""
+        registry = OperatorRegistry()
+
+        with patch(_SEAM, _FakeChatSession):
+            session, _ = await registry.get_or_create_chat_session("K", cwd="/tmp")
+
+        assert session.resume_id is None

--- a/tests/interfaces/web_terminal/test_chat_routes.py
+++ b/tests/interfaces/web_terminal/test_chat_routes.py
@@ -29,11 +29,13 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 import osprey.interfaces.web_terminal.routes.chat as chat_module
+import osprey.interfaces.web_terminal.session_handoff as handoff_module
 from osprey.interfaces.web_terminal.chat_session_pool import ChatCapacityError
 from osprey.interfaces.web_terminal.operator_session import (
     OperatorRegistry,
     OperatorSession,
 )
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
 from osprey.interfaces.web_terminal.routes.chat import _strip_for_chat
 from tests.interfaces.web_terminal.test_operator_session import (
     FakeAssistantMessage,
@@ -44,6 +46,22 @@ from tests.interfaces.web_terminal.test_operator_session import (
     FakeToolResultBlock,
     FakeToolUseBlock,
 )
+
+
+@pytest.fixture(autouse=True)
+def transcripts_on_disk():
+    """The transcripts the hand-off door believes exist, empty by default.
+
+    Every turn now goes through ``acquire_surface``, which decides what a new
+    child resumes by listing the transcripts under the app's project. These
+    tests run against whatever that project directory really holds, so the
+    listing is pinned here instead. A test that wants a key to resume adds its
+    id to the yielded set.
+    """
+    ids: set[str] = set()
+    with patch.object(handoff_module, "_transcripts_on_disk", lambda app: set(ids)):
+        yield ids
+
 
 # ---- Representative events, one per type `_message_to_events` can emit. ----
 # Each entry: (label, input_event, expected_output_event).
@@ -237,6 +255,9 @@ class _FakeChatSession(OperatorSession):
 
     def __init__(self, events):
         super().__init__(cwd="/tmp")
+        # A session the pools consider live: ``is_active`` is what the
+        # hand-off door reads to tell a pooled chat from a corpse.
+        self._started = True
         self._events = list(events)
         self.quiesce_calls = 0
         self.release_calls = 0
@@ -257,19 +278,50 @@ class _FakeChatSession(OperatorSession):
         return asyncio.get_event_loop().create_task(asyncio.sleep(0))
 
 
+class _FakeChatPool:
+    """The pool face the hand-off door inspects, backed by ``_FakeRegistry``."""
+
+    def __init__(self, registry):
+        self._registry = registry
+
+    def get(self, chat_id):
+        return self._registry.pooled.get(chat_id)
+
+    def has_key(self, chat_id):
+        return chat_id in self._registry.pooled
+
+    async def terminate(self, chat_id):
+        return self._registry.pooled.pop(chat_id, None)
+
+
 class _FakeRegistry:
-    def __init__(self, session=None, was_reused=False, capacity=False):
+    """A chat registry double, plus the pool view ``acquire_surface`` reads.
+
+    ``pooled_key`` seeds the pool with *session* under that key, which is how
+    a test says "this chat is already live": the hand-off hands it back and
+    nothing is spawned. Left unset, the key holds nothing and the route's
+    spawn callback creates the session — the only path that still reaches
+    ``get_or_create_chat_session``.
+    """
+
+    def __init__(self, session=None, pooled_key=None, capacity=False):
         self._session = session
-        self._was_reused = was_reused
         self._capacity = capacity
         self.calls: list[str] = []
         self.terminated: list[str] = []
+        self.resume_ids: list[str | None] = []
+        self.pooled: dict[str, object] = {}
+        if pooled_key is not None:
+            self.pooled[pooled_key] = session
+        self.chats = _FakeChatPool(self)
 
-    async def get_or_create_chat_session(self, chat_id, cwd, env):
+    async def get_or_create_chat_session(self, chat_id, cwd, env, *, resume_id=None):
         self.calls.append(chat_id)
+        self.resume_ids.append(resume_id)
         if self._capacity:
             raise ChatCapacityError("all busy")
-        return self._session, self._was_reused
+        self.pooled[chat_id] = self._session
+        return self._session, False
 
     def get_chat_session(self, chat_id):
         return self._session
@@ -284,7 +336,24 @@ def _make_chat_app(registry, turn_timeout_s=5) -> FastAPI:
     app.state.project_cwd = "/tmp"
     app.state.operator_registry = registry
     app.state.chat_turn_timeout_s = turn_timeout_s
+    _seed_handoff_state(app.state)
     return app
+
+
+def _seed_handoff_state(state) -> None:
+    """The app state ``acquire_surface`` reads beyond the chat pool.
+
+    An empty PTY registry (no terminal holds these keys), and a transcript map
+    that is already loaded so no key resolution reaches the agent-data root.
+    """
+    state.pty_registry = PtyRegistry()
+    state.transcript_map = {}
+    state.transcript_map_provisional = False
+
+
+async def _connected() -> bool:
+    """A client that is still there; the channel probe every request needs."""
+    return False
 
 
 def _data_frames(text: str) -> list[dict]:
@@ -306,7 +375,7 @@ class TestChatStreamRoute:
                 {"type": "result", "is_error": False, "total_cost_usd": 0.1},
             ]
         )
-        registry = _FakeRegistry(session=session, was_reused=False)
+        registry = _FakeRegistry(session=session)
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post("/api/chat", json={"prompt": "hello", "chat_id": "c1"})
@@ -325,7 +394,7 @@ class TestChatStreamRoute:
 
     def test_reused_session_has_no_session_reset(self):
         session = _FakeChatSession([{"type": "result", "is_error": False}])
-        registry = _FakeRegistry(session=session, was_reused=True)
+        registry = _FakeRegistry(session=session, pooled_key="c1")
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post("/api/chat", json={"prompt": "again", "chat_id": "c1"})
@@ -345,7 +414,7 @@ class TestChatStreamRoute:
                 {"type": "result", "is_error": False},
             ]
         )
-        registry = _FakeRegistry(session=session, was_reused=True)
+        registry = _FakeRegistry(session=session, pooled_key="c1")
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"})
@@ -355,7 +424,7 @@ class TestChatStreamRoute:
     def test_turn_in_progress_returns_409(self):
         session = _FakeChatSession([{"type": "result", "is_error": False}])
         session.acquire_turn()  # a turn is already held
-        registry = _FakeRegistry(session=session, was_reused=True)
+        registry = _FakeRegistry(session=session, pooled_key="c1")
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"})
@@ -397,7 +466,7 @@ class TestChatBufferedRoute:
                 {"type": "result", "is_error": False, "total_cost_usd": 0.9, "num_turns": 2},
             ]
         )
-        registry = _FakeRegistry(session=session, was_reused=False)
+        registry = _FakeRegistry(session=session)
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post(
@@ -421,7 +490,7 @@ class TestChatBufferedRoute:
 
     def test_reused_session_omits_session_reset(self):
         session = _FakeChatSession([{"type": "result", "is_error": False}])
-        registry = _FakeRegistry(session=session, was_reused=True)
+        registry = _FakeRegistry(session=session, pooled_key="c1")
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post(
@@ -434,7 +503,7 @@ class TestChatBufferedRoute:
         session = _FakeChatSession(
             [{"type": "error", "message": "boom", "error_type": "ClaudeSDKError"}]
         )
-        registry = _FakeRegistry(session=session, was_reused=True)
+        registry = _FakeRegistry(session=session, pooled_key="c1")
         client = TestClient(_make_chat_app(registry))
 
         resp = client.post(
@@ -445,6 +514,85 @@ class TestChatBufferedRoute:
         assert set(payload) == {"text", "events", "is_error", "error"}
         assert payload["is_error"] is True
         assert payload["error"] == "boom"
+
+
+class TestChatHandoffMapping:
+    """What the hand-off door raises, and what the client is told.
+
+    Every refusal reaches the client as a status plus a machine-readable
+    ``error`` slug, because that slug is what ``chat.js`` branches on to
+    choose its copy and whether to offer a retry.
+    """
+
+    def _refusing_app(self, exc):
+        """A chat app whose acquire always fails with *exc*."""
+        registry = _FakeRegistry(session=_FakeChatSession([]))
+        app = _make_chat_app(registry)
+
+        async def refuse(*args, **kwargs):
+            raise exc
+
+        return app, patch.object(chat_module, "acquire_surface", refuse)
+
+    def test_a_terminal_turn_only_an_interrupt_can_end_is_409_with_its_slug(self):
+        app, patched = self._refusing_app(handoff_module.HandoffRefused.needs_interrupt("c1"))
+        with patched, TestClient(app) as client:
+            resp = client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"})
+
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["error"] == "handoff_needs_interrupt"
+
+    def test_an_outgoing_process_that_outlived_its_kill_is_503_with_its_slug(self):
+        app, patched = self._refusing_app(
+            handoff_module.HandoffRefused.outgoing_still_running("c1")
+        )
+        with patched, TestClient(app) as client:
+            resp = client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"})
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"]["error"] == "outgoing_still_running"
+
+    def test_a_vanished_premise_is_503_with_its_slug(self):
+        app, patched = self._refusing_app(handoff_module.HandoffError.vanished("c1", "expert"))
+        with patched, TestClient(app) as client:
+            resp = client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"})
+
+        assert resp.status_code == 503
+        assert resp.json()["detail"]["error"] == "outgoing_vanished"
+
+    def test_a_client_that_hung_up_gets_no_stream(self):
+        """``ChannelClosed`` is not an error to report — there is nobody to report it to."""
+        app, patched = self._refusing_app(handoff_module.ChannelClosed())
+        with patched, TestClient(app) as client:
+            resp = client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"})
+
+        assert resp.status_code == 204
+        assert resp.content == b""
+
+
+class TestChatResumesTheKeysTranscript:
+    """The transcript the key points at is what the new chat child opens."""
+
+    def test_the_resume_id_reaches_the_pool_and_suppresses_the_reset(self, transcripts_on_disk):
+        transcripts_on_disk.add("c1")
+        session = _FakeChatSession([{"type": "result", "is_error": False}])
+        registry = _FakeRegistry(session=session)
+        client = TestClient(_make_chat_app(registry))
+
+        frames = _data_frames(client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"}).text)
+
+        assert registry.resume_ids == ["c1"]
+        assert all(f.get("type") != "session_reset" for f in frames)
+
+    def test_a_key_with_no_transcript_starts_fresh_under_the_key(self):
+        session = _FakeChatSession([{"type": "result", "is_error": False}])
+        registry = _FakeRegistry(session=session)
+        client = TestClient(_make_chat_app(registry))
+
+        frames = _data_frames(client.post("/api/chat", json={"prompt": "x", "chat_id": "c1"}).text)
+
+        assert registry.resume_ids == [None]
+        assert frames[0] == {"type": "session_reset"}
 
 
 class TestInterruptEndpoint:
@@ -688,7 +836,8 @@ def _req(registry, *, cwd: str = "/tmp", turn_timeout_s: float = 5.0):
     state = SimpleNamespace(
         project_cwd=cwd, operator_registry=registry, chat_turn_timeout_s=turn_timeout_s
     )
-    return SimpleNamespace(app=SimpleNamespace(state=state))
+    _seed_handoff_state(state)
+    return SimpleNamespace(app=SimpleNamespace(state=state), is_disconnected=_connected)
 
 
 async def _collect_sse(resp) -> list[dict]:
@@ -697,6 +846,38 @@ async def _collect_sse(resp) -> list[dict]:
     async for chunk in resp.body_iterator:
         chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
     return _data_frames("".join(chunks))
+
+
+def _fast_handoff_clock(app):
+    """Spend the hand-off's graces in fake time.
+
+    ``HandoffState`` takes its clock and its sleep by injection precisely so a
+    test need not sit out the two-second attach grace for real. Each sleep
+    advances the clock by what it was asked to wait and yields instead.
+    """
+    state = handoff_module.get_state(app)
+    now = [0.0]
+
+    async def sleep(seconds):
+        now[0] += seconds
+        await asyncio.sleep(0)
+
+    state.clock = lambda: now[0]
+    state.sleep = sleep
+
+
+async def _settled(task, *, ticks: int = 60, tick: float = 0.05):
+    """Await *task*, which is expected to finish on its own within the ticks.
+
+    Polls rather than ``wait_for`` so a task that overruns is reported as a
+    failed assertion instead of being cancelled mid hand-off.
+    """
+    for _ in range(ticks):
+        if task.done():
+            break
+        await asyncio.sleep(tick)
+    assert task.done(), "the acquire never completed"
+    return await task
 
 
 async def _inflight_session(req, chat_id: str):
@@ -770,21 +951,74 @@ class TestChatAtomicity:
 
 
 class TestChatStatusMapIntegration:
-    """Matrix 3 & 4: 409 (turn in flight) and 429 (all busy) on real sessions."""
+    """Matrix 3 & 4: the wait on a turn in flight, and 429 (all busy) on real sessions."""
 
-    async def test_second_prompt_while_in_flight_returns_409(self):
+    async def test_second_prompt_waits_for_the_turn_in_flight(self):
+        """The second prompt is queued behind the first, not refused.
+
+        Taking the key for the Simple view when the Simple view already holds
+        it and is working is a wait: the hand-off polls the chat until it is
+        idle and then hands back the very same child. This replaces the
+        immediate 409 the route used to answer — that refusal survives only as
+        the guard's backstop for a turn that starts inside the gap between the
+        wait ending and the guard being taken (``test_turn_in_progress_returns_409``).
+        """
         with _seam(_stall_responder()) as make:
             registry = OperatorRegistry()
             req = _req(registry)
             session, token = await _inflight_session(req, "c")
 
+            second = asyncio.ensure_future(
+                chat_module.chat(req, chat_module.ChatRequest(prompt="second", chat_id="c"))
+            )
+            for _ in range(5):
+                await asyncio.sleep(0.05)
+            assert not second.done()  # still waiting on the turn in flight
+            assert len(make.created) == 1  # and waiting on the pooled chat, not a new one
+
+            # End the parked turn: the guard goes first, so the wait sees idle.
+            session.release_turn(token)
+            session._client.interrupted.set()
+
+            resp = await _settled(second)
+            assert resp.media_type == "text/event-stream"
+            assert len(make.created) == 1  # the same child answers the second prompt
+
+            await registry.cleanup_all()
+
+    async def test_a_third_prompt_arriving_mid_wait_is_refused(self):
+        """Two overlapping acquires of one key: the newcomer is not queued.
+
+        The first prompt is working and the second is inside the hand-off's
+        wait, holding the key's pending slot. A third arrival has no way in —
+        the slot names another connection — so the attach grace runs out and
+        it is refused, rather than stacking a second unbounded wait on one
+        key. The refusal is the same one the terminal answers with a 4409
+        close, so the client already knows the slug.
+        """
+        with _seam(_stall_responder()) as make:
+            registry = OperatorRegistry()
+            req = _req(registry)
+            _fast_handoff_clock(req.app)
+            session, token = await _inflight_session(req, "c")
+
+            waiting = asyncio.ensure_future(
+                chat_module.chat(req, chat_module.ChatRequest(prompt="second", chat_id="c"))
+            )
+            for _ in range(5):  # let the second request register its slot
+                await asyncio.sleep(0)
+            assert not waiting.done()
+
             with pytest.raises(HTTPException) as ei:
-                await chat_module.chat(req, chat_module.ChatRequest(prompt="second", chat_id="c"))
+                await chat_module.chat(req, chat_module.ChatRequest(prompt="third", chat_id="c"))
 
             assert ei.value.status_code == 409
-            assert ei.value.detail["error"] == "turn_in_progress"
-            assert len(make.created) == 1  # no new session for the rejected prompt
+            assert ei.value.detail["error"] == "session_attached_elsewhere"
+            assert len(make.created) == 1  # neither latecomer built anything
 
+            waiting.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await waiting
             session.release_turn(token)
             session._client.interrupted.set()
             await registry.cleanup_all()
@@ -846,6 +1080,7 @@ class TestChatSessionResetContract:
             assert all(e.get("type") != "session_reset" for e in p2["events"])
 
     def test_eviction_makes_a_recreated_chat_fresh_again(self):
+        """A re-create with no transcript to resume starts the conversation over."""
         with _seam(_clean_responder()) as make:
             app = _make_chat_app(OperatorRegistry(chat_max_sessions=1))
             with TestClient(app) as client:
@@ -860,6 +1095,27 @@ class TestChatSessionResetContract:
             assert fA2[0] == {"type": "session_reset"}
             # Three distinct creations: A#1, B, A#2.
             assert len(make.created) == 3
+
+    def test_a_recreated_chat_that_resumes_carries_no_reset(self, transcripts_on_disk):
+        """A child started on an existing transcript continues the conversation.
+
+        The marker says "this conversation starts here", and after a resume it
+        does not: the operator is looking at the same exchange, whether they
+        left it in this view or in the terminal. So the re-created 'A' — a new
+        process by every other measure — sends none.
+        """
+        transcripts_on_disk.add("A")
+        with _seam(_clean_responder()) as make:
+            app = _make_chat_app(OperatorRegistry(chat_max_sessions=1))
+            with TestClient(app) as client:
+                client.post("/api/chat", json={"prompt": "a", "chat_id": "A"})
+                client.post("/api/chat", json={"prompt": "b", "chat_id": "B"})
+                fA2 = _data_frames(
+                    client.post("/api/chat", json={"prompt": "a2", "chat_id": "A"}).text
+                )
+
+            assert all(f.get("type") != "session_reset" for f in fA2)
+            assert len(make.created) == 3  # still a new process, just not a new conversation
 
 
 class TestChatDeleteEndpointIntegration:
@@ -969,7 +1225,7 @@ class TestChatTurnRelease:
             # Drive the real buffered handler as a task, then cancel it mid-turn.
             task = asyncio.create_task(
                 chat_module._buffered_response(
-                    session, token, "p", was_reused=True, turn_timeout_s=30
+                    session, token, "p", fresh_conversation=False, turn_timeout_s=30
                 )
             )
             await asyncio.wait_for(client.reached_hold.wait(), timeout=1.0)
@@ -994,7 +1250,7 @@ class TestChatTurnRelease:
             client.responder = _clean_responder("after-cancel")
             token2 = session.acquire_turn()
             resp = await chat_module._buffered_response(
-                session, token2, "p2", was_reused=True, turn_timeout_s=5
+                session, token2, "p2", fresh_conversation=False, turn_timeout_s=5
             )
             payload = _json.loads(resp.body)
             assert payload["text"] == "after-cancel"

--- a/tests/interfaces/web_terminal/test_child_env_session_id.py
+++ b/tests/interfaces/web_terminal/test_child_env_session_id.py
@@ -1,0 +1,231 @@
+"""One execution root per conversation: ``OSPREY_SESSION_ID`` on every spawn.
+
+Both views are windows onto one session key. The key is the PTY pool key, the
+chat pool key, the posture-store key — and it has to be the execution root too,
+or the two children a flip puts on either side of one conversation work out of
+different directories: the python and sandbox executors put their run
+directories under ``<agent-data root>/sessions/<OSPREY_SESSION_ID>``, so a
+child spawned without the stamp writes to the shared root and a child spawned
+with it writes to a room of its own.
+
+Three spawn paths reach a child, and all three stamp the key:
+
+* the PTY terminal's **new** session, whose key is the id forced onto the CLI
+  with ``--session-id`` (this is the one that used to carry no stamp at all),
+* the PTY terminal's **resume**, connect and ``switch_session`` alike,
+* the SDK child behind ``POST /api/chat`` and ``/ws/operator``.
+
+Pinned here: each path stamps its own pool key, a keyless SDK spawn stamps
+nothing, the PTY and chat envs for ONE key resolve to ONE directory, and the
+name stays outside the pool fingerprint so stamping it can never make a
+reattach kill a live child.
+
+The harness mirrors ``test_agent_data_root_stamp.py``; see its ``shared_root``
+fixture for why the resolver is rebound rather than the variable stamped.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.audit.posture import OSPREY_AGENT_DATA_ROOT
+from osprey.interfaces.web_terminal.app import create_app
+from osprey.interfaces.web_terminal.operator_session import (
+    POSTURE_SOURCE_LIVE,
+    POSTURE_SOURCE_SPAWN,
+    build_operator_child_env,
+)
+from osprey.interfaces.web_terminal.pty_manager import env_fingerprint
+from osprey.interfaces.web_terminal.routes import websocket as websocket_routes
+from osprey_connectors import session_store, workspace
+
+SESSION_ID_ENV = "OSPREY_SESSION_ID"
+
+SESSION_A = "aaaaaaaa-1111-2222-3333-444444444444"
+SESSION_B = "bbbbbbbb-1111-2222-3333-444444444444"
+CHAT_ID = "cccccccc-1111-2222-3333-444444444444"
+OPERATOR_KEY = "operator-deadbeef"
+
+
+# --------------------------------------------------------------------------- #
+# Harness
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def workspace_dir(tmp_path):
+    ws = tmp_path / "_agent_data"
+    ws.mkdir()
+    return ws
+
+
+@pytest.fixture
+def shared_root(tmp_path, monkeypatch):
+    """Stand in for the deployment's shared agent-data root."""
+    root = tmp_path / "shared_agent_data"
+    root.mkdir()
+    monkeypatch.delenv(OSPREY_AGENT_DATA_ROOT, raising=False)
+    monkeypatch.delenv(SESSION_ID_ENV, raising=False)
+    with (
+        patch(
+            "osprey_connectors.workspace.resolve_shared_data_root",
+            return_value=root,
+        ),
+        patch.object(session_store, "resolve_shared_data_root", return_value=root),
+    ):
+        session_store.invalidate_cache()
+        yield root
+        session_store.invalidate_cache()
+
+
+@pytest.fixture
+def client(workspace_dir, shared_root):
+    @contextmanager
+    def _make():
+        with patch(
+            "osprey.interfaces.web_terminal.app._load_web_config",
+            return_value={"watch_dir": str(workspace_dir)},
+        ):
+            app = create_app(shell_command="echo")
+            with TestClient(app) as test_client:
+                yield test_client
+
+    with _make() as c:
+        yield c
+
+
+def _pty_env(client, claude_session_id, telemetry_session_id=None):
+    """The extra env the next PTY spawn for this session would carry."""
+    return websocket_routes._build_extra_env(
+        SimpleNamespace(app=client.app),
+        claude_session_id,
+        telemetry_session_id,
+    )
+
+
+def _sdk_env(client, session_key=None, *, posture_source=POSTURE_SOURCE_LIVE):
+    """The env the next SDK (chat or operator) child would carry."""
+    return build_operator_child_env(
+        client.app.state.project_cwd,
+        session_key=session_key,
+        app=client.app,
+        posture_source=posture_source,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Every spawn path stamps its pool key
+# --------------------------------------------------------------------------- #
+
+
+class TestEverySpawnPathStampsItsKey:
+    @pytest.mark.parametrize(
+        ("claude_session_id", "telemetry_session_id", "pool_key"),
+        [
+            (None, SESSION_A, SESSION_A),  # brand-new session
+            (SESSION_A, SESSION_A, SESSION_A),  # reattach
+            (SESSION_A, None, SESSION_A),  # switch_session
+            (SESSION_A, SESSION_B, SESSION_A),  # resumed under a second telemetry id
+        ],
+        ids=["new", "reattach", "switch", "resumed"],
+    )
+    def test_pty_spawn_stamps_the_pool_key(
+        self, client, claude_session_id, telemetry_session_id, pool_key
+    ):
+        """The stamp is the pool key, on the new-session path as on the rest.
+
+        A new session's id is dictated on the command line, so the handler
+        knows it before the child exists — there is nothing left to discover
+        and no reason for that child to be the one without an execution root
+        of its own.
+        """
+        env = _pty_env(client, claude_session_id, telemetry_session_id)
+        assert env[SESSION_ID_ENV] == pool_key
+
+    def test_chat_spawn_stamps_the_chat_key(self, client):
+        assert _sdk_env(client, CHAT_ID)[SESSION_ID_ENV] == CHAT_ID
+
+    def test_operator_spawn_stamps_its_minted_key(self, client):
+        env = _sdk_env(client, OPERATOR_KEY, posture_source=POSTURE_SOURCE_SPAWN)
+        assert env[SESSION_ID_ENV] == OPERATOR_KEY
+
+    def test_keyless_sdk_spawn_stamps_nothing(self, client):
+        """No key, no scope — the child gets the render's baseline root.
+
+        The same rule the posture pair follows: nothing names a session, so
+        nothing is said about one.
+        """
+        assert SESSION_ID_ENV not in _sdk_env(client, None)
+
+
+# --------------------------------------------------------------------------- #
+# One key, one directory
+# --------------------------------------------------------------------------- #
+
+
+class TestBothSurfacesResolveOneRoot:
+    def test_pty_and_chat_envs_for_one_key_resolve_the_same_root(self, client, tmp_path):
+        """The property the stamp exists for, read through the real resolver.
+
+        A flip tears one child down and starts the other under the same key.
+        Resolved from either child's environment,
+        :func:`osprey_connectors.workspace.resolve_agent_data_root` has to name
+        the same directory, or the conversation's execution artefacts land in
+        two places.
+        """
+        pty = _pty_env(client, None, SESSION_A)
+        chat = _sdk_env(client, SESSION_A)
+
+        roots = [self._resolve_under(env, tmp_path) for env in (pty, chat)]
+
+        assert roots[0] == roots[1]
+        assert roots[0] == tmp_path / "var" / "agent_data" / "sessions" / SESSION_A
+
+    def test_a_child_with_no_stamp_keeps_the_shared_root(self, client, tmp_path):
+        """Absence is the old behaviour, unchanged: no ``sessions/`` segment."""
+        root = self._resolve_under(_sdk_env(client, None), tmp_path)
+        assert root == tmp_path / "var" / "agent_data"
+
+    @staticmethod
+    def _resolve_under(env: dict[str, str], project_root: Path) -> Path:
+        """Resolve the execution root a child holding *env* would see."""
+        with (
+            patch.object(workspace, "load_osprey_config", return_value={}),
+            patch.object(workspace, "resolve_project_root", return_value=project_root),
+            patch.dict(
+                os.environ,
+                {SESSION_ID_ENV: env[SESSION_ID_ENV]} if SESSION_ID_ENV in env else {},
+                clear=False,
+            ),
+        ):
+            if SESSION_ID_ENV not in env:
+                os.environ.pop(SESSION_ID_ENV, None)
+            return workspace.resolve_agent_data_root()
+
+
+# --------------------------------------------------------------------------- #
+# The stamp cannot cost a live child
+# --------------------------------------------------------------------------- #
+
+
+def test_the_stamp_is_outside_the_pool_fingerprint(client):
+    """Adding it to a spawn env respawns nothing.
+
+    ``OSPREY_SESSION_ID`` names the key the pool is already keyed on, so it
+    carries no privilege the key does not — and fingerprinting it would make
+    the first reattach to a session spawned before this stamp kill the running
+    agent. Asserted through :func:`env_fingerprint` rather than against the
+    exclusion set, because the fingerprint is what the registry compares.
+    """
+    stamped = _pty_env(client, SESSION_A, SESSION_A)
+    unstamped = {k: v for k, v in stamped.items() if k != SESSION_ID_ENV}
+
+    assert SESSION_ID_ENV in stamped
+    assert env_fingerprint(stamped) == env_fingerprint(unstamped)

--- a/tests/interfaces/web_terminal/test_cli_version_log.py
+++ b/tests/interfaces/web_terminal/test_cli_version_log.py
@@ -1,0 +1,207 @@
+"""The startup line that names both Claude Code binaries.
+
+A project that pins ``claude_code.cli_version`` runs one CLI in the terminal
+(spawned from the argv :mod:`osprey.utils.claude_launcher` builds) and another
+in the chat (the binary bundled inside the Agent SDK package). The server says
+so at startup rather than leaving the pair to be inferred from a behaviour that
+only one view has.
+
+The bundle is probed by actually running a stand-in binary, not by patching the
+subprocess away: what is being tested is that a real ``--version`` call is made
+once, survives every way it can fail, and is not repeated.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from osprey.interfaces.web_terminal import app as web_app
+from osprey.utils import claude_launcher
+
+#: The bundle's stand-in reports this; the pin below deliberately does not
+#: match it, so the mismatch path is the interesting one.
+BUNDLE_VERSION = "2.1.228"
+PINNED_VERSION = "2.1.146"
+
+LAUNCHER_LOGGER = claude_launcher.logger.name
+APP_LOGGER = web_app.logger.name
+
+#: The stand-in bundle is a shell script, so these need a POSIX shell.
+posix_only = pytest.mark.skipif(os.name != "posix", reason="the stand-in bundle is a shell script")
+
+
+@pytest.fixture(autouse=True)
+def clear_bundle_cache():
+    """Drop the per-process probe cache around every test.
+
+    The cache is the point of the function, so it cannot be disabled — but a
+    value cached by one test would make the next one assert nothing.
+    """
+    claude_launcher.bundled_cli_version.cache_clear()
+    yield
+    claude_launcher.bundled_cli_version.cache_clear()
+
+
+def _fake_bundle(tmp_path, body: str, name: str = "claude"):
+    """Write an executable stand-in for the SDK's bundled binary."""
+    path = tmp_path / name
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _install_bundle(monkeypatch, path) -> None:
+    """Point the launcher's bundle lookup at ``path`` (or nothing)."""
+    monkeypatch.setattr(claude_launcher, "bundled_cli_path", lambda: path)
+
+
+# ---- Reading the bundled version ----
+
+
+@posix_only
+def test_the_bundled_version_is_read_from_the_binary(tmp_path, monkeypatch):
+    """The probe runs the binary and parses the semver out of its output."""
+    _install_bundle(monkeypatch, _fake_bundle(tmp_path, f'echo "{BUNDLE_VERSION} (Claude Code)"'))
+    assert claude_launcher.bundled_cli_version() == BUNDLE_VERSION
+
+
+@posix_only
+def test_the_binary_is_run_once_per_process(tmp_path, monkeypatch):
+    """A second caller gets the cached answer, not a second spawn."""
+    marker = tmp_path / "calls"
+    _install_bundle(
+        monkeypatch,
+        _fake_bundle(tmp_path, f'echo x >> "{marker}"\necho "{BUNDLE_VERSION}"'),
+    )
+
+    assert claude_launcher.bundled_cli_version() == BUNDLE_VERSION
+    assert claude_launcher.bundled_cli_version() == BUNDLE_VERSION
+
+    assert marker.read_text(encoding="utf-8").count("x") == 1
+
+
+def test_no_bundle_is_an_unknown_version_not_an_error(monkeypatch):
+    """An SDK without a bundle leaves the chat's version simply unknown."""
+    _install_bundle(monkeypatch, None)
+    assert claude_launcher.bundled_cli_version() is None
+
+
+@posix_only
+def test_a_binary_that_fails_reports_no_version(tmp_path, monkeypatch):
+    """A non-zero exit is not a version, and is not an exception either."""
+    _install_bundle(monkeypatch, _fake_bundle(tmp_path, "exit 3"))
+    assert claude_launcher.bundled_cli_version() is None
+
+
+@posix_only
+def test_unparseable_output_reports_no_version(tmp_path, monkeypatch):
+    """Output with no semver in it answers ``None`` rather than a fragment."""
+    _install_bundle(monkeypatch, _fake_bundle(tmp_path, 'echo "not a version"'))
+    assert claude_launcher.bundled_cli_version() is None
+
+
+def test_a_missing_binary_reports_no_version(tmp_path, monkeypatch):
+    """A path that does not exist fails at spawn; the caller still gets a start."""
+    _install_bundle(monkeypatch, tmp_path / "does-not-exist")
+    assert claude_launcher.bundled_cli_version() is None
+
+
+def test_the_real_lookup_agrees_with_the_installed_sdk():
+    """The bundle is resolved from the installed package, not a guessed path."""
+    path = claude_launcher.bundled_cli_path()
+    if path is None:
+        pytest.skip("the installed Agent SDK ships no bundled CLI")
+    assert path.is_file()
+    assert path.parent.name == "_bundled"
+
+
+# ---- Reading the pinned version out of the argv ----
+
+
+def test_a_pinned_argv_reports_its_version():
+    """The pin the launcher wrote into the argv is the pin read back out."""
+    argv = claude_launcher.build_claude_launch_argv({"cli_version": PINNED_VERSION})
+    assert claude_launcher.argv_cli_version(argv) == PINNED_VERSION
+
+
+def test_an_unpinned_argv_reports_nothing():
+    """``claude`` off PATH carries no version, and none is invented for it."""
+    argv = claude_launcher.build_claude_launch_argv({})
+    assert claude_launcher.argv_cli_version(argv) is None
+
+
+def test_a_shell_override_reports_nothing():
+    """A configured ``shell`` is not a Claude Code launch at all."""
+    assert claude_launcher.argv_cli_version(["/bin/bash", "-l"]) is None
+
+
+# ---- The startup line ----
+
+
+@posix_only
+def test_both_versions_are_logged(tmp_path, monkeypatch, caplog):
+    """One line names the terminal's argv and the chat's bundled version."""
+    _install_bundle(monkeypatch, _fake_bundle(tmp_path, f'echo "{BUNDLE_VERSION}"'))
+    argv = claude_launcher.build_claude_launch_argv({"cli_version": BUNDLE_VERSION})
+
+    with caplog.at_level(logging.INFO, logger=APP_LOGGER):
+        web_app._log_claude_cli_versions(argv)
+
+    logged = caplog.text
+    assert "npx" in logged
+    assert BUNDLE_VERSION in logged
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+@posix_only
+def test_a_pin_that_differs_from_the_bundle_warns(tmp_path, monkeypatch, caplog):
+    """The whole point: two builds under one server, said out loud."""
+    _install_bundle(monkeypatch, _fake_bundle(tmp_path, f'echo "{BUNDLE_VERSION}"'))
+    argv = claude_launcher.build_claude_launch_argv({"cli_version": PINNED_VERSION})
+
+    with caplog.at_level(logging.INFO, logger=APP_LOGGER):
+        web_app._log_claude_cli_versions(argv)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    assert PINNED_VERSION in warnings[0].getMessage()
+    assert BUNDLE_VERSION in warnings[0].getMessage()
+
+
+@posix_only
+def test_an_unpinned_launch_never_warns(tmp_path, monkeypatch, caplog):
+    """An unprobed PATH ``claude`` is unknown, and unknown is not a mismatch."""
+    _install_bundle(monkeypatch, _fake_bundle(tmp_path, f'echo "{BUNDLE_VERSION}"'))
+    argv = claude_launcher.build_claude_launch_argv({})
+
+    with caplog.at_level(logging.INFO, logger=APP_LOGGER):
+        web_app._log_claude_cli_versions(argv)
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert BUNDLE_VERSION in caplog.text
+
+
+def test_an_unreadable_bundle_still_logs_the_argv(monkeypatch, caplog):
+    """With nothing to compare against, the terminal's argv is still recorded."""
+    _install_bundle(monkeypatch, None)
+    argv = claude_launcher.build_claude_launch_argv({"cli_version": PINNED_VERSION})
+
+    with caplog.at_level(logging.INFO, logger=APP_LOGGER):
+        web_app._log_claude_cli_versions(argv)
+
+    assert PINNED_VERSION in caplog.text
+    assert "unknown" in caplog.text
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_the_probe_failure_path_is_quiet(monkeypatch, caplog, tmp_path):
+    """A bundle that cannot be run is debug noise, never a startup warning."""
+    _install_bundle(monkeypatch, tmp_path / "does-not-exist")
+
+    with caplog.at_level(logging.DEBUG, logger=LAUNCHER_LOGGER):
+        assert claude_launcher.bundled_cli_version() is None
+
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/tests/interfaces/web_terminal/test_handoff_invariants.py
+++ b/tests/interfaces/web_terminal/test_handoff_invariants.py
@@ -1,0 +1,1173 @@
+"""The invariants ``acquire_surface`` keeps, put under adversarial pressure.
+
+The phase suites next to this one each pin one phase's own behaviour. This one
+pins the properties that have to survive *across* the phases, when a caller
+goes away half way, a kill does not take, two connections want the same key at
+once, or the pools are pushed past their capacity while a hand-off is in
+flight:
+
+- **one live process per key** — however the surfaces are interleaved, and
+  whatever the eviction pass and the dead-entry discard do meanwhile, the two
+  pools never both hold a live entry under the key;
+- **pending slot held ⇔ key reserved** — the two are taken together and
+  dropped together, so no look at the key ever sees one without the other;
+- **the slot is released exactly once on every exit path** — a return, each
+  refusal, a channel that closes, a spawn that raises, a cancellation;
+- **attach before release** — an Expert caller owns the PTY before the
+  reservation that protected it is dropped, so the eviction pass never meets
+  the entry unheld;
+- **no spawn after a refusal** — a refused acquire starts no process;
+- **a survivor is re-pooled unattached** — a kill that did not take leaves an
+  ordinary holder the next acquire meets and kills again;
+- **the turn-state store is reset on both PTY edges**, and the resume id is
+  chosen from a snapshot taken at spawn time, not at plan time.
+
+Time is faked through the state's injected ``clock``/``sleep`` as in the phase
+suites, whose fakes this module reuses; the few tests that are about the event
+loop staying responsive spend real milliseconds and say so.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from osprey.interfaces.web_terminal import session_handoff
+from osprey.interfaces.web_terminal.chat_session_pool import ChatSessionPool
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.session_handoff import (
+    ACTION_HANDOFF,
+    ACTION_REUSE,
+    ACTION_SPAWN,
+    ACTION_TAKEOVER,
+    ATTACH_POLL_S,
+    ERROR_HANDOFF_SUPERSEDED,
+    ERROR_OUTGOING_STILL_RUNNING,
+    ERROR_SESSION_ATTACHED_ELSEWHERE,
+    IDLE_POLL_S,
+    REASON_IDLE,
+    REASON_INTERRUPTED,
+    REASON_NONE,
+    ChannelClosed,
+    ChannelToken,
+    HandoffNeedsInterrupt,
+    HandoffRefused,
+    WaitOutcome,
+    acquire_surface,
+    get_state,
+)
+from osprey.interfaces.web_terminal.turn_state import BUSY, IDLE, get_turn_state
+from tests.interfaces.web_terminal.test_handoff_phase_a import KEY, chats, registry
+from tests.interfaces.web_terminal.test_handoff_phase_b import (
+    RecordingPty,
+    assert_held,
+    assert_released,
+    pool_pty,
+    set_store,
+    ticks,
+)
+from tests.interfaces.web_terminal.test_handoff_phase_c import (
+    TRANSCRIPT,
+    Chat,
+    ChatPool,
+    SurvivorPty,
+    chat_spawner,
+    make_app,
+    pty_spawner,
+    wait_returns,
+)
+
+OTHER_KEY = "22222222-3333-4444-5555-666666666666"
+THIRD_KEY = "33333333-4444-5555-6666-777777777777"
+
+
+# ---------------------------------------------------------------------------
+# Fakes and helpers
+# ---------------------------------------------------------------------------
+
+
+class StubbornPty(RecordingPty):
+    """Survives its first kill; the second one takes.
+
+    The shape of a ``terminate`` whose signal escalation ran out before the
+    child was reaped: the acquire is refused with 503 and the next one meets
+    the survivor as an ordinary holder.
+    """
+
+    def terminate(self) -> None:
+        self.terminates += 1
+        if self.terminates > 1:
+            self._alive = False
+
+
+class TransportChat:
+    """A chat whose ``process_exited`` reads a fake transport's return code.
+
+    ``OperatorSession`` answers ``process_exited`` from the return code of the
+    child handle it captured: False while the child is still running, True once
+    it has exited, and None for the whole object when no handle was ever
+    captured. This fake is those three answers under the test's control.
+    """
+
+    def __init__(self, returncode: int | None, *, has_handle: bool = True) -> None:
+        self._returncode = returncode
+        self._has_handle = has_handle
+        self._active = True
+        self.is_busy = False
+        self.teardowns = 0
+        self.cancels = 0
+
+    @property
+    def is_active(self) -> bool:
+        return self._active
+
+    @property
+    def process_exited(self) -> bool | None:
+        if not self._has_handle:
+            return None
+        return self._returncode is not None
+
+    async def teardown(self) -> None:
+        self.teardowns += 1
+        self._active = False
+
+    async def cancel(self) -> None:
+        self.cancels += 1
+        self.is_busy = False
+
+
+class PoolChatSession:
+    """An ``OperatorSession`` double the *real* ``ChatSessionPool`` can drive.
+
+    The surface of the double in ``test_chat_pool_resume.py`` — which is what
+    the pool itself asks for — plus the ``process_exited`` the hand-off's death
+    check reads, and the two launch facts worth asserting: the ``session_key``
+    it was built under and the ``resume_id`` it was started on.
+    """
+
+    def __init__(self, cwd: str = "/tmp", env=None, session_key: str | None = None) -> None:
+        self.cwd = cwd
+        self.env = env
+        self.session_key = session_key
+        self.resume_id: str | None = None
+        self.is_active = True
+        self.is_busy = False
+        self.last_activity = time.monotonic()
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.process_exited: bool | None = False
+
+    async def start(self, *, resume_id: str | None = None) -> None:
+        self.resume_id = resume_id
+        self.start_calls += 1
+
+    async def teardown(self) -> None:
+        self.stop_calls += 1
+        self.is_active = False
+        self.process_exited = True
+
+
+class SlowChatPool(ChatPool):
+    """A chat pool whose teardown takes real time, so a caller can vanish during it."""
+
+    def __init__(self, delay: float = 0.3) -> None:
+        super().__init__()
+        self.delay = delay
+        self.entered = asyncio.Event()
+
+    async def terminate(self, chat_id: str):
+        self.entered.set()
+        await asyncio.sleep(self.delay)
+        return await super().terminate(chat_id)
+
+
+@pytest.fixture
+def disk():
+    """The transcripts on disk, as the spawn request sees them; tests add ids."""
+    ids: set[str] = set()
+    with patch.object(session_handoff, "_transcripts_on_disk", lambda _app: ids):
+        yield ids
+
+
+def live_entries(app: SimpleNamespace, key: str = KEY) -> int:
+    """How many pools hold a live entry under *key* — the number this module guards."""
+    pty = registry(app).get_session(key)
+    chat = chats(app).get(key)
+    return int(pty is not None) + int(chat is not None)
+
+
+def pool_pty_under(app: SimpleNamespace, key: str, pty: RecordingPty) -> RecordingPty:
+    """``pool_pty`` for a key other than the one under test."""
+    reg = registry(app)
+    with patch.object(reg, "_spawn_session", return_value=pty):
+        session, reused = reg.get_or_create_session(key, ["fake"])
+    assert session is pty and not reused
+    return pty
+
+
+def watch_slot_invariant(app: SimpleNamespace) -> list[str]:
+    """Check "slot held ⇔ key reserved" on every look the fake clock takes."""
+    seen: list[str] = []
+
+    def probe(_count: int) -> None:
+        pending = KEY in get_state(app).pending
+        reserved = registry(app).is_reserved(KEY)
+        if pending != reserved:
+            seen.append(f"pending={pending} reserved={reserved}")
+
+    app.clock.on_sleep.append(probe)
+    return seen
+
+
+def watch_attach(app: SimpleNamespace) -> list[bool]:
+    """Whether the pending slot still stood at each ``attach_session``."""
+    reg = registry(app)
+    real = reg.attach_session
+    held: list[bool] = []
+
+    def attach(key: str, owner: object) -> bool:
+        held.append(key in get_state(app).pending)
+        return real(key, owner)
+
+    reg.attach_session = attach  # type: ignore[method-assign]
+    return held
+
+
+@contextlib.contextmanager
+def releases():
+    """Collect the keys whose pending slot was actually released."""
+    real = session_handoff.release_pending
+    taken: list[str] = []
+
+    def release(app, key: str, channel: object) -> bool:
+        done = real(app, key, channel)
+        if done:
+            taken.append(key)
+        return done
+
+    with patch.object(session_handoff, "release_pending", release):
+        yield taken
+
+
+def real_chat_pool(app: SimpleNamespace) -> tuple[ChatSessionPool, list[PoolChatSession]]:
+    """Put a real ``ChatSessionPool`` on *app*, over a fake session factory."""
+    created: list[PoolChatSession] = []
+
+    def factory(cwd: str, env, session_key: str) -> PoolChatSession:
+        session = PoolChatSession(cwd=cwd, env=env, session_key=session_key)
+        created.append(session)
+        return session
+
+    pool = ChatSessionPool(factory=factory, max_sessions=5)
+    app.state.operator_registry.chats = pool
+    return pool, created
+
+
+def turn_state(app: SimpleNamespace) -> dict | None:
+    return get_turn_state(app, KEY)
+
+
+# ---------------------------------------------------------------------------
+# One live process per key
+# ---------------------------------------------------------------------------
+
+
+async def test_interleaved_acquires_never_leave_two_live_entries(disk):
+    """Six flips in a row, on a key whose transcript a ``/clear`` already moved."""
+    app = make_app()
+    app.state.transcript_map[KEY] = TRANSCRIPT
+    disk.add(TRANSCRIPT)
+    pty_spawn = pty_spawner(app)
+    chat_spawn = chat_spawner(app)
+    flips = [
+        ("expert", pty_spawn),
+        ("simple", chat_spawn),
+        ("simple", chat_spawn),
+        ("expert", pty_spawn),
+        ("expert", pty_spawn),
+        ("simple", chat_spawn),
+    ]
+
+    spawned: list[bool] = []
+    for surface, spawn in flips:
+        channel = object()
+        result = await acquire_surface(app, KEY, surface, channel, spawn=spawn)
+        assert live_entries(app) == 1
+        assert_released(app)
+        spawned.append(result.spawned)
+        if surface == "expert":
+            # What a terminal handler does in its own cleanup.
+            registry(app).detach_session(KEY, channel)
+
+    assert spawned == [True, True, False, True, False, True]
+    # Every spawn resumed the key's current transcript, not the key itself.
+    assert {call.resume_id for call in pty_spawn.calls} == {TRANSCRIPT}
+    assert {call.resume_id for call in chat_spawn.calls} == {TRANSCRIPT}
+    assert {call.transcript_id for call in chat_spawn.calls} == {TRANSCRIPT}
+
+
+async def test_a_dead_entry_is_reaped_rather_than_handed_off(disk):
+    app = make_app()
+    corpse = pool_pty(app)
+    corpse.exit(1)
+    spawn = chat_spawner(app)
+
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert corpse.terminates == 1
+    assert result.plan.outgoing is None
+    assert chats(app).get(KEY) is result.session
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_a_key_live_in_both_pools_is_reduced_to_one(disk):
+    """The state this module exists to make unreachable, met head on."""
+    app = make_app()
+    pty = pool_pty(app)
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+    set_store(app, IDLE, 1.0)
+    assert live_entries(app) == 2
+
+    result = await acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+
+    assert result.plan.action == ACTION_HANDOFF
+    assert chat.teardowns == 1 and chats(app).get(KEY) is None
+    assert result.session is pty and result.spawned is False
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Slot held ⇔ key reserved, and the eviction pass
+# ---------------------------------------------------------------------------
+
+
+async def test_the_slot_and_the_reservation_are_taken_and_dropped_together(disk):
+    app = make_app()
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    violations = watch_slot_invariant(app)
+    channel = object()
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel, spawn=pty_spawner(app)))
+    await ticks(app, 10)
+    assert_held(app, channel)
+    chat.is_busy = False
+    await task
+
+    assert violations == []
+    assert_released(app)
+
+
+async def test_the_eviction_pass_steps_over_the_key_a_handoff_reserved(disk):
+    app = make_app()
+    app.state.pty_registry = PtyRegistry(max_background=2)
+    outgoing = pool_pty(app)
+    spare = pool_pty_under(app, OTHER_KEY, RecordingPty())
+    set_store(app, BUSY, 1.0)
+
+    task = asyncio.create_task(
+        acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+    )
+    await ticks(app, 3)
+    assert registry(app).is_reserved(KEY)
+
+    # A third session takes the pool past capacity while the wait runs.
+    pool_pty_under(app, THIRD_KEY, RecordingPty())
+    assert registry(app).get_session(KEY) is outgoing
+    assert outgoing.terminates == 0
+    assert registry(app).get_session(OTHER_KEY) is None
+    assert spare.terminates == 1
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Every exit path releases the slot exactly once
+# ---------------------------------------------------------------------------
+
+
+async def _exit_returns(app: SimpleNamespace) -> None:
+    chats(app).sessions[KEY] = Chat(busy=False)
+    await acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+
+
+async def _exit_refused_409(app: SimpleNamespace) -> None:
+    pool_pty(app)
+    registry(app).attach_session(KEY, object())
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+    assert refused.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+
+
+async def _exit_refused_503(app: SimpleNamespace) -> None:
+    pool_pty(app, SurvivorPty())
+    set_store(app, IDLE, 1.0)
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+    assert refused.value.error == ERROR_OUTGOING_STILL_RUNNING
+
+
+async def _exit_needs_interrupt(app: SimpleNamespace) -> None:
+    pool_pty(app)
+    with pytest.raises(HandoffNeedsInterrupt):
+        await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+
+
+async def _exit_channel_closed(app: SimpleNamespace) -> None:
+    chats(app).sessions[KEY] = Chat(busy=True)
+    closed = asyncio.Event()
+    token = ChannelToken(closed.is_set)
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", token, spawn=pty_spawner(app)))
+    await ticks(app, 3)
+    closed.set()
+    with pytest.raises(ChannelClosed):
+        await task
+
+
+async def _exit_cancelled(app: SimpleNamespace) -> None:
+    chats(app).sessions[KEY] = Chat(busy=True)
+    task = asyncio.create_task(
+        acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+    )
+    await ticks(app, 3)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def _exit_spawn_raised(app: SimpleNamespace) -> None:
+    chats(app).sessions[KEY] = Chat(busy=False)
+
+    async def spawn(_request):
+        raise OSError("fork failed")
+
+    with pytest.raises(OSError, match="fork failed"):
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+
+
+#: Each exit path and how many slots it should release. One, for every exit
+#: that got as far as taking the slot — and none for the 409 the attach grace
+#: ends in, which is refused before phase (a) registers anything at all.
+EXIT_PATHS = {
+    "returns": (_exit_returns, 1),
+    "refused_409": (_exit_refused_409, 0),
+    "refused_503": (_exit_refused_503, 1),
+    "needs_interrupt": (_exit_needs_interrupt, 1),
+    "channel_closed": (_exit_channel_closed, 1),
+    "cancelled": (_exit_cancelled, 1),
+    "spawn_raised": (_exit_spawn_raised, 1),
+}
+
+
+@pytest.mark.parametrize("name", list(EXIT_PATHS))
+async def test_the_pending_slot_is_released_exactly_once_on_every_exit(disk, name):
+    run, expected = EXIT_PATHS[name]
+    app = make_app(hook=name != "needs_interrupt")
+    violations = watch_slot_invariant(app)
+    with releases() as taken:
+        await run(app)
+    assert taken == [KEY] * expected
+    assert violations == []
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# No spawn after a refusal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["refused_409", "refused_503", "needs_interrupt"])
+async def test_a_refused_acquire_starts_no_process(disk, name):
+    app = make_app(hook=name != "needs_interrupt")
+    if name == "refused_409":
+        pool_pty(app)
+        registry(app).attach_session(KEY, object())
+    elif name == "refused_503":
+        pool_pty(app, SurvivorPty())
+        set_store(app, IDLE, 1.0)
+    else:
+        pool_pty(app)
+    spawn = chat_spawner(app)
+
+    with pytest.raises(HandoffRefused):
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert spawn.calls == []
+    assert chats(app).get(KEY) is None
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# A kill that did not take
+# ---------------------------------------------------------------------------
+
+
+async def test_a_pty_that_survives_once_is_repooled_and_the_retry_leaves_one_child(disk):
+    app = make_app()
+    pty = pool_pty(app, StubbornPty())
+    set_store(app, IDLE, 1.0)
+    spawn = chat_spawner(app)
+
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    assert refused.value.status == 503
+    assert registry(app).get_session(KEY) is pty
+    assert not registry(app).is_attached(KEY)
+    assert not registry(app).is_reserved(KEY)
+    assert spawn.calls == []
+
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert pty.terminates == 2
+    assert not pty.is_alive
+    assert len(spawn.calls) == 1
+    assert chats(app).get(KEY) is result.session
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+@pytest.mark.parametrize(
+    ("returncode", "has_handle", "spawns"),
+    [(None, True, False), (0, True, True), (None, False, True)],
+)
+async def test_the_chat_child_must_be_seen_gone_before_anything_is_spawned(
+    disk, returncode, has_handle, spawns
+):
+    """A transport still holding a live child is a survivor, not a slow exit."""
+    app = make_app()
+    chat = TransportChat(returncode, has_handle=has_handle)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+
+    if spawns:
+        result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+        assert result.spawned is True
+        assert registry(app).get_session(KEY) is result.session
+    else:
+        with pytest.raises(HandoffRefused) as refused:
+            await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+        assert refused.value.error == ERROR_OUTGOING_STILL_RUNNING
+        assert spawn.calls == []
+        assert chats(app).get(KEY) is chat
+        assert registry(app).get_session(KEY) is None
+
+    assert chat.teardowns == 1
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_the_spawn_waits_for_the_kill_to_return_and_the_child_to_be_gone(disk):
+    """The order a hand-off depends on: pop, kill, see it dead, only then spawn."""
+    app = make_app()
+    order: list[str] = []
+    pty = SurvivorPty()
+    pool_pty(app, pty)
+    set_store(app, IDLE, 1.0)
+    real_terminate = pty.terminate
+
+    def terminate() -> None:
+        order.append("terminate")
+        real_terminate()
+
+    pty.terminate = terminate  # type: ignore[method-assign]
+
+    def maybe_die(count: int) -> None:
+        if count >= 3 and pty.is_alive:
+            order.append("dead")
+            pty.die()
+
+    app.clock.on_sleep.append(maybe_die)
+
+    async def spawn(request):
+        order.append("spawn")
+        assert registry(app).get_session(request.key) is None
+        assert not pty.is_alive
+        session = Chat(busy=False)
+        chats(app).sessions[request.key] = session
+        return session
+
+    await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert order == ["terminate", "dead", "spawn"]
+
+
+# ---------------------------------------------------------------------------
+# Attachment: cleared, never cleared, and taken over
+# ---------------------------------------------------------------------------
+
+
+async def test_an_attachment_that_clears_within_the_grace_becomes_a_handoff(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    owner = object()
+    assert registry(app).attach_session(KEY, owner)
+    set_store(app, IDLE, 1.0)
+    spawn = chat_spawner(app)
+
+    # Six looks at 50 ms is the 300 ms a socket takes to notice it has gone.
+    def detach_on_the_sixth_look(count: int) -> None:
+        if count == 6:
+            registry(app).detach_session(KEY, owner)
+
+    app.clock.on_sleep.append(detach_on_the_sixth_look)
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    # Six polls of the grace, and nothing else: the key was idle by then.
+    assert app.clock.sleeps == [ATTACH_POLL_S] * 6
+    assert result.plan.action == ACTION_HANDOFF
+    assert pty.terminates == 1
+    assert chats(app).get(KEY) is result.session
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_an_attachment_that_never_clears_is_the_409_for_the_other_surface(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    assert registry(app).attach_session(KEY, object())
+    set_store(app, IDLE, 1.0)
+    spawn = chat_spawner(app)
+
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert refused.value.status == 409
+    assert refused.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+    assert pty.terminates == 0
+    assert spawn.calls == []
+    assert registry(app).get_session(KEY) is pty
+    assert_released(app)
+
+
+async def test_the_same_surface_takes_the_attachment_over_without_waiting(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    older, newer = object(), object()
+    assert registry(app).attach_session(KEY, older)
+    spawn = pty_spawner(app)
+
+    result = await acquire_surface(app, KEY, "expert", newer, spawn=spawn)
+
+    assert result.plan.action == ACTION_TAKEOVER
+    assert app.clock.sleeps == []
+    assert result.session is pty and result.spawned is False
+    assert pty.terminates == 0
+    assert registry(app).attached_owner(KEY) is newer
+    assert spawn.calls == []
+    assert_released(app)
+
+
+async def test_the_expert_owns_the_pty_before_the_reservation_is_dropped(disk):
+    app = make_app()
+    chats(app).sessions[KEY] = Chat(busy=False)
+    held = watch_attach(app)
+    channel = object()
+
+    result = await acquire_surface(app, KEY, "expert", channel, spawn=pty_spawner(app))
+
+    assert held == [True]
+    assert registry(app).attached_owner(KEY) is channel
+    assert result.spawned is True
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# The same surface already holds the key
+# ---------------------------------------------------------------------------
+
+
+async def test_a_chat_held_key_is_handed_back_to_the_simple_view_untouched(disk):
+    app = make_app()
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+    spawn = chat_spawner(app)
+
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert result.plan.action == ACTION_REUSE
+    assert result.outcome == WaitOutcome(REASON_IDLE)
+    assert result.session is chat and result.spawned is False
+    assert chat.teardowns == 0 and chat.cancels == 0
+    assert chats(app).terminated == []
+    assert spawn.calls == []
+    assert_released(app)
+
+
+async def test_a_hookless_deployment_still_waits_on_a_busy_chat_for_the_expert(disk):
+    """The hook only speaks for a PTY; ``is_busy`` needs no hook at all."""
+    app = make_app(hook=False)
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", object(), spawn=spawn))
+    await ticks(app, 20)
+    assert not task.done()
+    assert chat.teardowns == 0 and spawn.calls == []
+    assert set(app.clock.sleeps) == {IDLE_POLL_S}
+
+    chat.is_busy = False
+    result = await task
+
+    assert result.plan.action == ACTION_HANDOFF
+    assert chat.teardowns == 1 and result.spawned is True
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# A turn that never ends, and a caller that goes away
+# ---------------------------------------------------------------------------
+
+
+async def test_a_never_idle_pty_is_never_terminated_by_a_plain_acquire(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, BUSY, 1.0)
+    channel = object()
+    spawn = chat_spawner(app)
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "simple", channel, spawn=spawn))
+    await ticks(app, 40)
+    assert not task.done()
+    assert pty.terminates == 0 and pty.writes == []
+    assert registry(app).get_session(KEY) is pty
+    assert spawn.calls == []
+    assert_held(app, channel)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert pty.terminates == 0
+    assert registry(app).get_session(KEY) is pty
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_a_channel_that_closes_mid_wait_tears_nothing_down(disk):
+    app = make_app()
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    closed = asyncio.Event()
+    token = ChannelToken(closed.is_set)
+    spawn = pty_spawner(app)
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", token, spawn=spawn))
+    await ticks(app, 5)
+    closed.set()
+    with pytest.raises(ChannelClosed):
+        await task
+
+    assert chat.teardowns == 0 and chat.cancels == 0
+    assert chats(app).terminated == []
+    assert spawn.calls == []
+    assert chats(app).get(KEY) is chat
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_a_disconnect_during_the_teardown_still_leaves_the_key_usable(disk):
+    """The caller goes while the outgoing chat is being torn down (300 ms).
+
+    The shield carries the phase to its end: the PTY is spawned, pooled and
+    attached to the token that asked for it. The handler's own cleanup then
+    detaches, and the key is an ordinary PTY-held key the Simple view can take.
+    """
+    app = make_app()
+    app.state.operator_registry.chats = SlowChatPool()
+    pool = chats(app)
+    pool.sessions[KEY] = Chat(busy=False)
+    set_store(app, IDLE, 1.0)
+    channel = object()
+    spawn = pty_spawner(app)
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel, spawn=spawn))
+    await pool.entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pty = registry(app).get_session(KEY)
+    assert pty is not None and len(spawn.calls) == 1
+    assert registry(app).attached_owner(KEY) is channel
+    assert pool.get(KEY) is None
+    assert live_entries(app) == 1
+    assert_released(app)
+
+    # What the terminal handler does in its ``finally``, whatever ended it.
+    registry(app).detach_session(KEY, channel)
+    assert not registry(app).is_attached(KEY)
+
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+
+    assert result.plan.action == ACTION_HANDOFF
+    assert pty.terminates == 1
+    assert live_entries(app) == 1
+
+
+async def test_the_loop_stays_responsive_while_a_kill_blocks_its_thread(disk):
+    """A concurrent request must complete while ``terminate`` blocks for 300 ms."""
+    app = make_app()
+    pool_pty(app, RecordingPty(terminate_blocks_s=0.3))
+    set_store(app, IDLE, 1.0)
+    served = 0
+
+    async def serve_requests() -> None:
+        nonlocal served
+        while True:
+            await asyncio.sleep(0.01)
+            served += 1
+
+    requests = asyncio.create_task(serve_requests())
+    try:
+        result = await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+    finally:
+        requests.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await requests
+
+    assert result.spawned is True
+    assert served >= 5
+
+
+# ---------------------------------------------------------------------------
+# The turn-state store and the resume id
+# ---------------------------------------------------------------------------
+
+
+async def test_both_pty_edges_reset_the_turn_state_under_the_moved_transcript(disk):
+    app = make_app()
+    app.state.transcript_map[KEY] = TRANSCRIPT
+    disk.add(TRANSCRIPT)
+
+    # Spawn edge: a fresh TUI has no turn in flight.
+    channel = object()
+    await acquire_surface(app, KEY, "expert", channel, spawn=pty_spawner(app))
+    spawned = turn_state(app)
+    assert spawned is not None
+    assert spawned["state"] == IDLE and spawned["transcript_id"] == TRANSCRIPT
+    registry(app).detach_session(KEY, channel)
+
+    # The TUI runs a turn, then the Simple view takes the key.
+    set_store(app, BUSY, spawned["ts"] + 1.0)
+    with wait_returns(REASON_IDLE):
+        await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawner(app))
+
+    torn_down = turn_state(app)
+    assert torn_down is not None
+    assert torn_down["state"] == IDLE and torn_down["transcript_id"] == TRANSCRIPT
+
+
+async def test_the_resume_id_comes_from_a_snapshot_taken_at_spawn_time(disk):
+    """A ``/clear`` that lands while the wait runs is what the new process opens."""
+    app = make_app()
+    chats(app).sessions[KEY] = Chat(busy=False)
+    disk.add(KEY)
+
+    def clears():
+        app.state.transcript_map[KEY] = TRANSCRIPT
+        disk.add(TRANSCRIPT)
+
+    spawn = pty_spawner(app)
+    with wait_returns(REASON_IDLE, before=clears):
+        result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+
+    assert result.resume_id == TRANSCRIPT
+    assert spawn.calls[0].transcript_id == TRANSCRIPT
+
+
+# ---------------------------------------------------------------------------
+# Through the real chat pool
+# ---------------------------------------------------------------------------
+
+
+async def test_a_simple_round_trip_through_the_real_chat_pool(disk):
+    """The Simple side end to end: the acquire door onto the real pool.
+
+    Everything else here drives a fake pool, so the seam between the two — the
+    spawn callback handing ``request.resume_id`` to
+    ``ChatSessionPool.get_or_create`` and returning what the pool then holds —
+    is only exercised by this test. The child under it is a fake; the pool,
+    its reuse check and its teardown are the real ones.
+    """
+    app = make_app()
+    pool, created = real_chat_pool(app)
+    app.state.transcript_map[KEY] = TRANSCRIPT
+    disk.add(TRANSCRIPT)
+    spawns: list[str | None] = []
+
+    async def spawn(request):
+        spawns.append(request.resume_id)
+        session, _reused = await pool.get_or_create(
+            request.key, "/tmp", resume_id=request.resume_id
+        )
+        return session
+
+    first = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    chat = first.session
+
+    assert first.plan.action == ACTION_SPAWN
+    assert first.spawned is True and first.resume_id == TRANSCRIPT
+    assert spawns == [TRANSCRIPT]
+    assert pool.get(KEY) is chat
+    # The key is what the child is pooled and audited under; the transcript is
+    # only which conversation it continues.
+    assert chat.session_key == KEY
+    assert chat.resume_id == TRANSCRIPT
+    assert created == [chat]
+    assert_released(app)
+
+    # The next turn is handed the same child, and the pool is never asked.
+    second = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert second.session is chat
+    assert second.spawned is False and second.resume_id is None
+    assert second.outcome == WaitOutcome(REASON_IDLE)
+    assert spawns == [TRANSCRIPT]
+    assert chat.start_calls == 1 and chat.stop_calls == 0
+    assert len(created) == 1
+    assert_released(app)
+
+    # The Expert view takes the key: the real pool tears the child down.
+    third = await acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+
+    assert third.plan.action == ACTION_HANDOFF
+    assert chat.stop_calls == 1 and chat.process_exited is True
+    assert pool.get(KEY) is None and not pool.has_key(KEY)
+    assert registry(app).get_session(KEY) is third.session
+    assert third.resume_id == TRANSCRIPT
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Property-style: two acquirers, and a cancel at every await point
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("stagger", range(6))
+async def test_two_expert_acquirers_leave_one_child_and_one_owner(disk, stagger):
+    app = make_app()
+    spawn = pty_spawner(app)
+    first, second = object(), object()
+
+    one = asyncio.create_task(acquire_surface(app, KEY, "expert", first, spawn=spawn))
+    for _ in range(stagger):
+        await asyncio.sleep(0)
+    two = asyncio.create_task(acquire_surface(app, KEY, "expert", second, spawn=spawn))
+    results = await asyncio.gather(one, two)
+
+    # One child was started, both callers were handed it, and the attachment
+    # belongs to whichever of them looked at the key last.
+    assert len(spawn.calls) == 1
+    assert live_entries(app) == 1
+    assert {r.session for r in results} == {registry(app).get_session(KEY)}
+    assert sum(r.spawned for r in results) == 1
+    assert registry(app).attached_owner(KEY) in (first, second)
+    assert [r.plan.action for r in results].count(ACTION_TAKEOVER) == 1
+    assert_released(app)
+
+
+@pytest.mark.parametrize("yields", range(26))
+async def test_a_cancel_at_any_point_leaves_the_key_consistent(disk, yields):
+    app = make_app()
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+    channel = object()
+    spawn = pty_spawner(app)
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel, spawn=spawn))
+    for _ in range(yields):
+        await asyncio.sleep(0)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert_released(app)
+    assert live_entries(app) <= 1
+    # The outgoing chat is never torn down without a replacement in the key.
+    if chat.teardowns:
+        assert registry(app).get_session(KEY) is not None
+        assert registry(app).attached_owner(KEY) is channel
+    else:
+        assert chats(app).get(KEY) is chat
+    # Nothing was started that the pool does not hold.
+    assert len(spawn.calls) == int(registry(app).get_session(KEY) is not None)
+
+
+async def test_a_cancelled_acquire_leaves_the_key_free_for_the_next_one(disk):
+    app = make_app()
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    doomed = asyncio.create_task(
+        acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+    )
+    await ticks(app, 3)
+    doomed.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await doomed
+
+    chat.is_busy = False
+    result = await acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+
+    assert result.plan.action == ACTION_HANDOFF
+    assert result.outcome == WaitOutcome(REASON_IDLE)
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_a_second_acquire_of_a_free_key_spawns_nothing_new(disk):
+    """The plain case the property loops are measured against."""
+    app = make_app()
+    spawn = chat_spawner(app)
+
+    first = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    second = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert first.session is second.session
+    assert first.spawned is True and second.spawned is False
+    assert second.outcome == WaitOutcome(REASON_IDLE)
+    assert len(spawn.calls) == 1
+    assert live_entries(app) == 1
+    assert_released(app)
+
+
+async def test_an_expert_reattach_does_not_wait_on_a_running_turn(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, BUSY, 1.0)
+    channel = object()
+
+    result = await acquire_surface(app, KEY, "expert", channel, spawn=pty_spawner(app))
+
+    assert result.plan.action == ACTION_REUSE
+    assert result.outcome == WaitOutcome(REASON_NONE)
+    assert app.clock.sleeps == []
+    assert result.session is pty and result.spawned is False
+    assert registry(app).attached_owner(KEY) is channel
+    # A reattach is not a spawn edge: the running turn's report stands.
+    state = turn_state(app)
+    assert state is not None and state["state"] == BUSY
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# A Simple interrupt supersedes the Simple wait ahead of it
+# ---------------------------------------------------------------------------
+
+
+async def test_a_simple_interrupt_supersedes_the_pending_simple_wait_and_lands(disk):
+    """The wait the operator wants to end is ended; the interrupt's own acquire completes.
+
+    Through the real phase (c): the superseded wait releases its slot exactly
+    once and starts nothing, the superseding acquire cuts the turn short,
+    tears the terminal down and spawns the chat, and at no look are there two
+    pending records or two live entries under the key.
+    """
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, BUSY, 1.0)
+    violations = watch_slot_invariant(app)
+    slots: list[int] = []
+    entries: list[int] = []
+
+    def count(_n: int) -> None:
+        slots.append(len(get_state(app).pending))
+        entries.append(live_entries(app))
+        if pty.writes:
+            set_store(app, IDLE, 2.0)
+
+    app.clock.on_sleep.append(count)
+    first_channel, second_channel = ChannelToken(), ChannelToken()
+    first_spawn, second_spawn = chat_spawner(app), chat_spawner(app)
+
+    with releases() as taken:
+        first = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", first_channel, spawn=first_spawn)
+        )
+        await ticks(app, 5)
+        assert_held(app, first_channel)
+        second = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", second_channel, interrupt=True, spawn=second_spawn)
+        )
+        with pytest.raises(HandoffRefused) as refused:
+            await first
+        assert refused.value.error == ERROR_HANDOFF_SUPERSEDED
+        assert first_spawn.calls == []
+        result = await second
+
+    assert result.spawned and result.plan.interrupt
+    assert result.outcome.reason == REASON_INTERRUPTED
+    assert len(second_spawn.calls) == 1
+    assert pty.writes == [b"\x1b"]
+    assert pty.terminates == 1
+    assert registry(app).get_session(KEY) is None
+    assert chats(app).get(KEY) is result.session
+    assert live_entries(app) == 1
+    assert taken == [KEY, KEY]
+    assert violations == []
+    assert max(slots) <= 1
+    assert max(entries) <= 1
+    assert_released(app)
+
+
+async def test_a_supersede_arriving_during_phase_c_leaves_the_carrier_to_answer(disk):
+    """A call already carrying the key out is not cancelled; the interrupt reuses what it pooled.
+
+    The first acquire has left its wait and is spawning the chat when the
+    interrupt looks at the key — the look lands in the step between phase
+    (b) returning and the shielded phase (c) task taking the lock. It is
+    plainly blocked, not a supersede: the first caller is answered, the
+    second finds the pooled idle chat once the lock is free and is handed it
+    back without a spawn of its own.
+    """
+    app = make_app()
+    violations = watch_slot_invariant(app)
+    gate = asyncio.Event()
+    first_channel, second_channel = ChannelToken(), ChannelToken()
+    first_spawn = chat_spawner(app, gate=gate)
+    second_spawn = chat_spawner(app)
+
+    with releases() as taken:
+        first = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", first_channel, spawn=first_spawn)
+        )
+        second = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", second_channel, interrupt=True, spawn=second_spawn)
+        )
+        # One step: the first is at its shield, the spawn is waiting on the
+        # gate, and the second has looked — and found a record it may not touch.
+        await asyncio.sleep(0)
+        pending = get_state(app).pending[KEY]
+        assert pending.channel is first_channel
+        assert not pending.waiting
+        assert not pending.superseded
+        assert not first.done() and not second.done()
+
+        gate.set()
+        landed = await first
+        reused = await second
+
+    assert landed.spawned and landed.resume_id is None
+    assert not reused.spawned
+    assert reused.session is landed.session
+    assert reused.plan.action == ACTION_REUSE
+    assert len(first_spawn.calls) == 1 and second_spawn.calls == []
+    assert chats(app).get(KEY) is landed.session
+    assert live_entries(app) == 1
+    assert taken == [KEY, KEY]
+    assert violations == []
+    assert_released(app)

--- a/tests/interfaces/web_terminal/test_handoff_phase_a.py
+++ b/tests/interfaces/web_terminal/test_handoff_phase_a.py
@@ -1,0 +1,656 @@
+"""Phase (a) of a surface acquire: inspect, decide, register.
+
+``acquire_surface`` is the one door every spawn walks through, and phase (a)
+is where it reads the two pools and the pending slot under the per-key lock
+and decides what the incoming surface has to do. These tests pin that
+decision table and the two invariants around it:
+
+- one look at a key is atomic (the lock serialises concurrent acquires), and
+- a key somebody else is consuming is re-inspected for the attach grace with
+  the lock *released* between looks, then refused with 409.
+
+Time is faked: the state's ``clock``/``sleep`` are injected, so the two-second
+grace is exercised without being spent. The PTY pool is a real
+``PtyRegistry`` holding the fake PTY from ``test_ws_resume_confirm``; the chat
+pool is a fake that answers the three questions phase (a) asks it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from osprey.interfaces.web_terminal import session_handoff
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.session_handoff import (
+    ACTION_HANDOFF,
+    ACTION_REUSE,
+    ACTION_SPAWN,
+    ACTION_TAKEOVER,
+    ATTACH_GRACE_S,
+    ATTACH_POLL_S,
+    ERROR_SESSION_ATTACHED_ELSEWHERE,
+    REASON_NONE,
+    WS_CLOSE_OUTGOING_RUNNING,
+    WS_CLOSE_SESSION_ATTACHED,
+    AcquirePlan,
+    HandoffRefused,
+    HandoffState,
+    WaitOutcome,
+    acquire_surface,
+    get_state,
+    release_pending,
+)
+from tests.interfaces.web_terminal._fakes import (
+    FakeChatPool,
+    FakeChatSession,
+    FakeClock,
+    FakePtySession,
+)
+
+KEY = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture(autouse=True)
+def _phase_b_does_not_wait():
+    """These tests are about the decision; the wait it leads to is phase (b)'s own suite.
+
+    Several plans here name a busy outgoing entry — a real phase (b) would wait
+    on it — so the wait is stubbed out to return at once. A test that needs a
+    particular wait patches ``_wait_for_idle`` itself inside this stub.
+    """
+
+    async def no_wait(_app, _plan):
+        return WaitOutcome(REASON_NONE)
+
+    with patch.object(session_handoff, "_wait_for_idle", no_wait):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _phase_c_hands_the_plan_back():
+    """Phase (c) would carry the plan out — spawn, attach, release the slot.
+
+    These tests assert on the plan and on what phase (a) registered, so (c)
+    is stubbed to hand the plan straight back and leave the slot standing.
+    Its own suite exercises the real thing.
+    """
+
+    async def hand_back(_app, plan, _outcome):
+        return plan
+
+    with patch.object(session_handoff, "_phase_c", hand_back):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def make_app(clock: FakeClock | None = None) -> SimpleNamespace:
+    clock = clock or FakeClock()
+    state = HandoffState(clock=clock, sleep=clock.sleep)
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            pty_registry=PtyRegistry(max_background=5),
+            operator_registry=SimpleNamespace(chats=FakeChatPool()),
+            handoff=state,
+        ),
+        clock=clock,
+    )
+
+
+def pool_pty(app: SimpleNamespace, key: str = KEY) -> FakePtySession:
+    """Put a live fake PTY into the registry under *key* through the pool path."""
+    fake = FakePtySession()
+    registry: PtyRegistry = app.state.pty_registry
+    with patch.object(registry, "_spawn_session", return_value=fake):
+        session, reused = registry.get_or_create_session(key, ["fake"])
+    assert session is fake and not reused
+    return fake
+
+
+def chats(app: SimpleNamespace) -> FakeChatPool:
+    return app.state.operator_registry.chats
+
+
+def registry(app: SimpleNamespace) -> PtyRegistry:
+    return app.state.pty_registry
+
+
+def assert_registered(app: SimpleNamespace, plan: AcquirePlan, channel: object) -> None:
+    """The pending slot and the reservation an accepted plan leaves behind."""
+    pending = get_state(app).pending[plan.key]
+    assert pending.channel is channel
+    assert pending.surface == plan.surface
+    assert pending.task is not None
+    assert registry(app).is_reserved(plan.key)
+    assert plan.channel is channel
+
+
+# ---------------------------------------------------------------------------
+# Nothing held
+# ---------------------------------------------------------------------------
+
+
+async def test_a_free_key_is_a_spawn_for_either_surface():
+    for surface in ("expert", "simple"):
+        app = make_app()
+        channel = object()
+        plan = await acquire_surface(app, KEY, surface, channel)
+        assert plan.action == ACTION_SPAWN
+        assert plan.outgoing is None
+        assert plan.teardown is False
+        assert plan.wait_for_idle is False
+        assert plan.displaced_owner is None
+        assert plan.surface == surface
+        assert plan.interrupt is False
+        assert_registered(app, plan, channel)
+        assert app.clock.sleeps == []
+
+
+async def test_interrupt_is_carried_into_the_plan():
+    app = make_app()
+    plan = await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+    assert plan.interrupt is True
+
+
+async def test_state_is_created_on_first_use():
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            pty_registry=PtyRegistry(max_background=5),
+            operator_registry=SimpleNamespace(chats=FakeChatPool()),
+        )
+    )
+    state = get_state(app)
+    assert isinstance(state, HandoffState)
+    assert get_state(app) is state
+    assert app.state.handoff is state
+    assert state.lock_for(KEY) is state.lock_for(KEY)
+
+
+# ---------------------------------------------------------------------------
+# Dead entries are discarded, not handed off
+# ---------------------------------------------------------------------------
+
+
+async def test_a_dead_pty_is_popped_and_reaped_and_the_key_is_free():
+    app = make_app()
+    fake = pool_pty(app)
+    fake.exit(1)
+    terminated = []
+    fake.terminate = lambda: terminated.append(True)  # type: ignore[method-assign]
+
+    plan = await acquire_surface(app, KEY, "simple", object())
+
+    assert plan.action == ACTION_SPAWN
+    assert plan.outgoing is None
+    assert registry(app).get_session(KEY) is None
+    assert terminated == [True]
+
+
+async def test_a_dead_pty_that_is_still_attached_is_discarded_too():
+    """A socket that has not yet noticed its child died holds nothing."""
+    app = make_app()
+    fake = pool_pty(app)
+    stale_token = object()
+    assert registry(app).attach_session(KEY, stale_token)
+    fake.exit(0)
+
+    plan = await acquire_surface(app, KEY, "simple", object())
+
+    assert plan.action == ACTION_SPAWN
+    assert not registry(app).is_attached(KEY)
+    assert app.clock.sleeps == []
+
+
+async def test_a_dead_chat_is_terminated_and_the_key_is_free():
+    app = make_app()
+    dead = FakeChatSession(active=False)
+    chats(app).sessions[KEY] = dead
+
+    plan = await acquire_surface(app, KEY, "expert", object())
+
+    assert plan.action == ACTION_SPAWN
+    assert chats(app).terminated == [KEY]
+    assert dead.teardowns == 1
+    assert chats(app).get(KEY) is None
+
+
+# ---------------------------------------------------------------------------
+# Live entries: the decision table
+# ---------------------------------------------------------------------------
+
+
+async def test_a_live_unattached_pty_is_the_outgoing_entry_for_a_chat():
+    app = make_app()
+    fake = pool_pty(app)
+    channel = object()
+
+    plan = await acquire_surface(app, KEY, "simple", channel)
+
+    assert plan.action == ACTION_HANDOFF
+    assert plan.outgoing is not None
+    assert plan.outgoing.surface == "expert"
+    assert plan.outgoing.session is fake
+    assert plan.teardown is True
+    assert plan.wait_for_idle is True
+    assert plan.displaced_owner is None
+    # Phase (a) never touches the outgoing entry: still pooled, still alive.
+    assert registry(app).get_session(KEY) is fake
+    assert fake.is_alive
+    assert_registered(app, plan, channel)
+
+
+async def test_a_live_chat_is_the_outgoing_entry_for_an_expert():
+    app = make_app()
+    live = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = live
+
+    plan = await acquire_surface(app, KEY, "expert", object())
+
+    assert plan.action == ACTION_HANDOFF
+    assert plan.outgoing is not None
+    assert plan.outgoing.surface == "simple"
+    assert plan.outgoing.session is live
+    assert plan.teardown is True
+    assert plan.wait_for_idle is True
+    assert chats(app).terminated == []
+    assert live.teardowns == 0
+
+
+async def test_an_expert_reattaching_to_a_free_pty_reuses_it_without_waiting():
+    app = make_app()
+    fake = pool_pty(app)
+
+    plan = await acquire_surface(app, KEY, "expert", object())
+
+    assert plan.action == ACTION_REUSE
+    assert plan.outgoing is not None
+    assert plan.outgoing.session is fake
+    assert plan.teardown is False
+    assert plan.wait_for_idle is False
+    assert plan.displaced_owner is None
+
+
+async def test_a_chat_acquiring_a_chat_held_key_is_ready_with_no_teardown():
+    app = make_app()
+    live = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = live
+
+    plan = await acquire_surface(app, KEY, "simple", object())
+
+    assert plan.action == ACTION_REUSE
+    assert plan.outgoing is not None
+    assert plan.outgoing.surface == "simple"
+    assert plan.outgoing.session is live
+    assert plan.teardown is False
+    # The chat route cannot take a turn on a busy session, so (b) waits.
+    assert plan.wait_for_idle is True
+    assert chats(app).terminated == []
+
+
+async def test_a_chat_joins_a_chat_creation_still_in_flight():
+    app = make_app()
+    chats(app).starting.add(KEY)
+
+    plan = await acquire_surface(app, KEY, "simple", object())
+
+    assert plan.action == ACTION_REUSE
+    assert plan.outgoing is None
+    assert plan.teardown is False
+    assert plan.wait_for_idle is False
+    assert app.clock.sleeps == []
+
+
+async def test_an_expert_waits_for_a_chat_creation_to_land_then_hands_off():
+    app = make_app()
+    chats(app).starting.add(KEY)
+    landed = FakeChatSession()
+
+    def land(nth_sleep: int) -> None:
+        if nth_sleep == 3:
+            chats(app).starting.discard(KEY)
+            chats(app).sessions[KEY] = landed
+
+    app.clock.on_sleep.append(land)
+
+    plan = await acquire_surface(app, KEY, "expert", object())
+
+    assert plan.action == ACTION_HANDOFF
+    assert plan.outgoing is not None and plan.outgoing.session is landed
+    assert len(app.clock.sleeps) == 3
+
+
+async def test_an_expert_is_refused_while_a_chat_creation_never_lands():
+    """A creation still in flight for the whole grace is a holder, not a gap."""
+    app = make_app()
+    chats(app).starting.add(KEY)
+
+    with pytest.raises(HandoffRefused) as excinfo:
+        await acquire_surface(app, KEY, "expert", object())
+
+    assert excinfo.value.status == 409
+    assert excinfo.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+    assert sum(app.clock.sleeps) == pytest.approx(ATTACH_GRACE_S)
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+    # The creation itself is left to its creator.
+    assert chats(app).terminated == []
+    assert KEY in chats(app).starting
+
+
+async def test_a_refusal_after_a_dead_discard_leaves_the_key_clean():
+    """The discard in a look stands even when that look ends in a refusal."""
+    app = make_app()
+    dead = pool_pty(app)
+    dead.exit(1)
+    chats(app).starting.add(KEY)  # blocks an Expert for the whole grace
+
+    with pytest.raises(HandoffRefused) as excinfo:
+        await acquire_surface(app, KEY, "expert", object())
+
+    assert excinfo.value.status == 409
+    # The corpse was popped and reaped in the first look, not left for later.
+    assert registry(app).get_session(KEY) is None
+    assert not registry(app).is_attached(KEY)
+    assert not dead.is_alive
+    # Nothing of the refused call remains.
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+
+
+async def test_both_pools_live_hands_off_the_other_surface(caplog):
+    app = make_app()
+    fake = pool_pty(app)
+    live = FakeChatSession()
+    chats(app).sessions[KEY] = live
+
+    with caplog.at_level("WARNING"):
+        as_expert = await acquire_surface(app, KEY, "expert", object())
+    assert as_expert.action == ACTION_HANDOFF
+    assert as_expert.outgoing is not None and as_expert.outgoing.session is live
+    assert "live in both pools" in caplog.text
+
+    release_pending(app, KEY, as_expert.channel)
+    as_chat = await acquire_surface(app, KEY, "simple", object())
+    assert as_chat.action == ACTION_HANDOFF
+    assert as_chat.outgoing is not None and as_chat.outgoing.session is fake
+
+
+# ---------------------------------------------------------------------------
+# Attached PTY: takeover for an Expert, grace-then-409 for a chat
+# ---------------------------------------------------------------------------
+
+
+async def test_same_surface_expert_takes_over_an_attached_pty():
+    app = make_app()
+    fake = pool_pty(app)
+    older = object()
+    assert registry(app).attach_session(KEY, older)
+    newer = object()
+
+    plan = await acquire_surface(app, KEY, "expert", newer)
+
+    assert plan.action == ACTION_TAKEOVER
+    assert plan.displaced_owner is older
+    assert plan.outgoing is not None and plan.outgoing.session is fake
+    assert plan.teardown is False
+    assert plan.wait_for_idle is False
+    # Immediate: a takeover is not a wait for the older owner to leave.
+    assert app.clock.sleeps == []
+    # Phase (a) marks; phase (c) closes. The attachment is still the older one's.
+    assert registry(app).attached_owner(KEY) is older
+    assert fake.is_alive
+    assert_registered(app, plan, newer)
+
+
+async def test_a_chat_polls_an_attached_pty_every_50ms_for_2s_then_409():
+    app = make_app()
+    pool_pty(app)
+    assert registry(app).attach_session(KEY, object())
+
+    with pytest.raises(HandoffRefused) as excinfo:
+        await acquire_surface(app, KEY, "simple", object())
+
+    refused = excinfo.value
+    assert refused.status == 409
+    assert refused.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+    assert refused.ws_close_code == WS_CLOSE_SESSION_ATTACHED
+    sleeps = app.clock.sleeps
+    assert sum(sleeps) == pytest.approx(ATTACH_GRACE_S)
+    assert all(0 < s <= ATTACH_POLL_S for s in sleeps)
+    assert len(sleeps) >= round(ATTACH_GRACE_S / ATTACH_POLL_S)
+    # Refused means nothing was registered.
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+
+
+async def test_a_chat_proceeds_when_the_pty_detaches_within_the_grace():
+    app = make_app()
+    fake = pool_pty(app)
+    token = object()
+    assert registry(app).attach_session(KEY, token)
+
+    def detach(nth_sleep: int) -> None:
+        if nth_sleep == 5:
+            registry(app).detach_session(KEY, token)
+
+    app.clock.on_sleep.append(detach)
+
+    plan = await acquire_surface(app, KEY, "simple", object())
+
+    assert plan.action == ACTION_HANDOFF
+    assert plan.outgoing is not None and plan.outgoing.session is fake
+    assert len(app.clock.sleeps) == 5
+    assert app.clock.now == pytest.approx(1000.0 + 5 * ATTACH_POLL_S)
+
+
+# ---------------------------------------------------------------------------
+# The pending slot
+# ---------------------------------------------------------------------------
+
+
+async def test_a_pending_acquire_from_another_connection_is_a_holder():
+    app = make_app()
+    first = object()
+    await acquire_surface(app, KEY, "simple", first)
+
+    with pytest.raises(HandoffRefused) as excinfo:
+        await acquire_surface(app, KEY, "expert", object())
+
+    assert excinfo.value.status == 409
+    assert excinfo.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+    assert sum(app.clock.sleeps) == pytest.approx(ATTACH_GRACE_S)
+    # The first call's slot survives the refusal untouched.
+    assert get_state(app).pending[KEY].channel is first
+    assert registry(app).is_reserved(KEY)
+
+
+async def test_a_second_connection_proceeds_once_the_pending_slot_is_released():
+    app = make_app()
+    first = object()
+    await acquire_surface(app, KEY, "simple", first)
+    second = object()
+
+    def finish_first(nth_sleep: int) -> None:
+        if nth_sleep == 2:
+            assert release_pending(app, KEY, first)
+
+    app.clock.on_sleep.append(finish_first)
+
+    plan = await acquire_surface(app, KEY, "expert", second)
+
+    assert plan.action == ACTION_SPAWN
+    assert len(app.clock.sleeps) == 2
+    assert_registered(app, plan, second)
+
+
+async def test_the_same_connection_replaces_its_own_pending_slot():
+    app = make_app()
+    channel = object()
+    await acquire_surface(app, KEY, "simple", channel)
+
+    plan = await acquire_surface(app, KEY, "expert", channel)
+
+    assert plan.action == ACTION_SPAWN
+    assert app.clock.sleeps == []
+    pending = get_state(app).pending[KEY]
+    assert pending.channel is channel
+    assert pending.surface == "expert"
+
+
+async def test_release_pending_is_owner_checked_and_drops_the_reservation():
+    app = make_app()
+    owner = object()
+    await acquire_surface(app, KEY, "simple", owner)
+    assert registry(app).is_reserved(KEY)
+
+    assert release_pending(app, KEY, object()) is False
+    assert KEY in get_state(app).pending
+    assert registry(app).is_reserved(KEY)
+
+    assert release_pending(app, KEY, owner) is True
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+
+    assert release_pending(app, KEY, owner) is False
+
+
+async def test_cancelling_the_phase_b_wait_releases_the_slot_and_reservation():
+    """Phase (b) owns the pending slot while it waits: cancelled, it lets go."""
+    app = make_app()
+    pool_pty(app)
+    channel = object()
+    entered = asyncio.Event()
+
+    async def wait_forever(_app, _plan):
+        entered.set()
+        await asyncio.Event().wait()
+
+    with patch.object(session_handoff, "_wait_for_idle", wait_forever):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", channel))
+        await entered.wait()
+        # Phase (a) is done: slot and reservation stand.
+        assert get_state(app).pending[KEY].channel is channel
+        assert registry(app).is_reserved(KEY)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+    # The key is free for the next acquire.
+    plan = await acquire_surface(app, KEY, "expert", object())
+    assert plan.action == ACTION_REUSE
+
+
+async def test_waiting_for_the_lock_is_not_charged_to_the_attach_grace():
+    """The grace starts at the first blocked look, not at the call."""
+    app = make_app()
+    pool_pty(app)
+    assert registry(app).attach_session(KEY, object())
+    lock = get_state(app).lock_for(KEY)
+
+    await lock.acquire()
+    task = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert app.clock.sleeps == []
+    # Far longer than the grace passes while the acquire waits for the lock.
+    app.clock.now += 5 * ATTACH_GRACE_S
+    lock.release()
+
+    with pytest.raises(HandoffRefused) as excinfo:
+        await task
+    assert excinfo.value.status == 409
+    # The full grace was still granted after the lock was obtained.
+    assert sum(app.clock.sleeps) == pytest.approx(ATTACH_GRACE_S)
+    assert len(app.clock.sleeps) >= round(ATTACH_GRACE_S / ATTACH_POLL_S)
+
+
+# ---------------------------------------------------------------------------
+# The per-key lock
+# ---------------------------------------------------------------------------
+
+
+async def test_the_per_key_lock_serialises_concurrent_inspections():
+    """While one acquire is inside its look at the key, another cannot look.
+
+    The first acquire finds a dead chat and awaits its teardown under the
+    lock; the second must not read the pools until that hold ends.
+    """
+    app = make_app()
+    chats(app).sessions[KEY] = FakeChatSession(active=False)
+    gate = asyncio.Event()
+    chats(app).terminate_gate = gate
+
+    first = asyncio.create_task(acquire_surface(app, KEY, "expert", object()))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert get_state(app).lock_for(KEY).locked()
+    assert chats(app).get_calls == 1
+
+    second = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert chats(app).get_calls == 1, "second acquire inspected under the first's hold"
+    assert not second.done()
+
+    gate.set()
+    first_plan = await first
+    assert first_plan.action == ACTION_SPAWN
+
+    # The second now sees the first's pending slot (checked before the pools
+    # are read), waits its grace, and is refused — never having looked while
+    # the first was inside the lock.
+    with pytest.raises(HandoffRefused):
+        await second
+    assert get_state(app).pending[KEY].channel is first_plan.channel
+
+
+async def test_locks_are_per_key():
+    app = make_app()
+    other = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    chats(app).sessions[KEY] = FakeChatSession(active=False)
+    gate = asyncio.Event()
+    chats(app).terminate_gate = gate
+
+    blocked = asyncio.create_task(acquire_surface(app, KEY, "expert", object()))
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    plan = await acquire_surface(app, other, "simple", object())
+    assert plan.action == ACTION_SPAWN
+
+    gate.set()
+    await blocked
+    state = get_state(app)
+    assert state.lock_for(KEY) is not state.lock_for(other)
+
+
+# ---------------------------------------------------------------------------
+# The refusal type
+# ---------------------------------------------------------------------------
+
+
+def test_refusals_carry_status_slug_and_close_code():
+    attached = HandoffRefused.attached_elsewhere(KEY)
+    assert (attached.status, attached.error) == (409, "session_attached_elsewhere")
+    assert attached.ws_close_code == WS_CLOSE_SESSION_ATTACHED == 4409
+
+    running = HandoffRefused.outgoing_still_running(KEY)
+    assert (running.status, running.error) == (503, "outgoing_still_running")
+    assert running.ws_close_code == WS_CLOSE_OUTGOING_RUNNING == 4503
+
+    capacity = HandoffRefused.chat_capacity(KEY)
+    assert (capacity.status, capacity.error) == (429, "chat_capacity")
+    assert capacity.ws_close_code is None
+
+    assert issubclass(HandoffRefused, Exception)
+    assert session_handoff.ERROR_CHAT_CAPACITY == "chat_capacity"

--- a/tests/interfaces/web_terminal/test_handoff_phase_b.py
+++ b/tests/interfaces/web_terminal/test_handoff_phase_b.py
@@ -1,0 +1,1293 @@
+"""Phase (b) of a surface acquire: the wait for the outgoing turn to end.
+
+Phase (b) runs outside the per-key lock and is the only cancellable phase. It
+waits — without a time bound — for the entry phase (a) found under the key to
+finish its turn, and ends in a ``WaitOutcome`` that phase (c) is handed. These
+tests pin the invariants around that wait:
+
+- a running turn is never torn down, however long it runs, while the caller
+  is still there;
+- the caller's channel is polled on every tick, and its closing cancels the
+  wait, releasing the pending slot and the reservation with no teardown;
+- an interrupt is Escape, a bounded grace, then ``terminate`` — and the
+  terminate runs off the loop;
+- a PTY whose turns are invisible (no turn-state hook) is refused unless the
+  caller interrupts;
+- of the turn-state store and the transcript tail, the newer witness wins;
+- an entry that leaves its pool mid-wait is an error, not a spawn.
+
+Time is faked through the state's injected ``clock``/``sleep``, as in the
+phase (a) tests, whose fakes this module reuses. The PTY is a recording fake
+so writes and terminates can be asserted; transcripts are real files under
+``tmp_path`` with their modification time set by hand.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import anyio
+import pytest
+
+from osprey.interfaces.web_terminal import session_handoff
+from osprey.interfaces.web_terminal.session_handoff import (
+    ACTION_HANDOFF,
+    ACTION_REUSE,
+    ATTACH_POLL_S,
+    ERROR_HANDOFF_NEEDS_INTERRUPT,
+    ERROR_HANDOFF_SUPERSEDED,
+    ERROR_OUTGOING_VANISHED,
+    ERROR_SESSION_ATTACHED_ELSEWHERE,
+    IDLE_POLL_S,
+    INTERRUPT_GRACE_S,
+    REASON_EXITED,
+    REASON_FORCED,
+    REASON_IDLE,
+    REASON_INTERRUPTED,
+    REASON_NONE,
+    AcquireChannel,
+    AcquirePlan,
+    ChannelClosed,
+    ChannelToken,
+    HandoffError,
+    HandoffNeedsInterrupt,
+    HandoffRefused,
+    HandoffSuperseded,
+    WaitOutcome,
+    acquire_surface,
+    channel_closed,
+    get_state,
+)
+from tests.interfaces.web_terminal._fakes import FakeChatSession, FakeClock, FakePtySession
+from tests.interfaces.web_terminal.test_handoff_phase_a import KEY, chats, make_app, registry
+
+ESC = b"\x1b"
+
+
+# ---------------------------------------------------------------------------
+# Fakes and helpers
+# ---------------------------------------------------------------------------
+
+
+class RecordingPty(FakePtySession):
+    """The phase (a) fake PTY, remembering what phase (b) does to it."""
+
+    def __init__(self, *, terminate_blocks_s: float = 0.0) -> None:
+        super().__init__()
+        self.writes: list[bytes] = []
+        self.terminates = 0
+        self._terminate_blocks_s = terminate_blocks_s
+
+    def write_input(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    def terminate(self) -> None:
+        self.terminates += 1
+        if self._terminate_blocks_s:
+            # A real terminate blocks its thread for seconds; this one for a
+            # little, so a test can watch the loop stay responsive meanwhile.
+            time.sleep(self._terminate_blocks_s)
+        self._alive = False
+
+
+def pool_pty(app: SimpleNamespace, fake: RecordingPty | None = None) -> RecordingPty:
+    fake = fake or RecordingPty()
+    reg = registry(app)
+    with patch.object(reg, "_spawn_session", return_value=fake):
+        session, reused = reg.get_or_create_session(KEY, ["fake"])
+    assert session is fake and not reused
+    return fake
+
+
+def make_pty_app(*, hook: bool = True, clock: FakeClock | None = None) -> SimpleNamespace:
+    """An app whose stores phase (b) reads are present and empty."""
+    app = make_app(clock)
+    app.state.turn_hook_present = hook
+    app.state.turn_state = {}
+    app.state.transcript_map = {}
+    app.state.transcript_map_provisional = False
+    return app
+
+
+def set_store(app: SimpleNamespace, state: str, ts: float, key: str = KEY) -> None:
+    app.state.turn_state[key] = {"state": state, "ts": ts, "transcript_id": key}
+
+
+def write_transcript(path: Path, entries: list[dict], mtime: float) -> Path:
+    """Put *entries* at *path* with *mtime*, as one change.
+
+    Written next to the target and moved into place with the stamp already
+    set, so a wait polling the file in a worker thread never sees the write
+    and the stamp as two changes (and reads the tail twice for one edit).
+    """
+    staging = path.with_name(path.name + ".staging")
+    staging.write_text("".join(json.dumps(e) + "\n" for e in entries))
+    os.utime(staging, (mtime, mtime))
+    os.replace(staging, path)
+    return path
+
+
+def user_entry(text: str) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def assistant_entry(text: str) -> dict:
+    return {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+INTERRUPT_ENTRY = user_entry("[Request interrupted by user]")
+
+
+class Recorder:
+    """Stands in for phase (c): keeps what it was handed and hands the plan back."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[AcquirePlan, WaitOutcome]] = []
+
+    async def __call__(self, app, plan: AcquirePlan, outcome: WaitOutcome) -> AcquirePlan:
+        self.calls.append((plan, outcome))
+        return plan
+
+
+async def until(predicate, *, timeout: float = 5.0) -> None:
+    """Spin the loop (real time) until *predicate* holds."""
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            raise AssertionError("condition not reached in time")
+        await asyncio.sleep(0.001)
+
+
+async def ticks(app: SimpleNamespace, n: int) -> None:
+    """Let the wait take *n* more looks (each look ends in one fake sleep)."""
+    target = len(app.clock.sleeps) + n
+    await until(lambda: len(app.clock.sleeps) >= target)
+
+
+def assert_released(app: SimpleNamespace) -> None:
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+
+
+def assert_held(app: SimpleNamespace, channel: object) -> None:
+    assert get_state(app).pending[KEY].channel is channel
+    assert registry(app).is_reserved(KEY)
+
+
+# ---------------------------------------------------------------------------
+# Constants and the channel protocol
+# ---------------------------------------------------------------------------
+
+
+def test_the_channel_is_polled_at_least_every_200ms():
+    assert IDLE_POLL_S <= 0.2
+    assert INTERRUPT_GRACE_S == 5.0
+
+
+async def test_a_plain_token_never_closes():
+    """Phase (a) callers pass ``object()``; that must keep working."""
+    assert await channel_closed(object()) is False
+    assert await channel_closed(ChannelToken()) is False
+    assert not isinstance(object(), AcquireChannel)
+    assert isinstance(ChannelToken(), AcquireChannel)
+
+
+async def test_channel_token_accepts_sync_and_async_probes():
+    event = asyncio.Event()
+    sync_token = ChannelToken(event.is_set)
+    assert await channel_closed(sync_token) is False
+    event.set()
+    assert await channel_closed(sync_token) is True
+
+    answers = iter([False, True])
+
+    async def is_disconnected() -> bool:
+        return next(answers)
+
+    post_token = ChannelToken(is_disconnected)
+    assert await channel_closed(post_token) is False
+    assert await channel_closed(post_token) is True
+
+
+async def test_channel_closed_is_a_cancellation():
+    assert issubclass(ChannelClosed, asyncio.CancelledError)
+    assert issubclass(HandoffNeedsInterrupt, HandoffRefused)
+    assert not issubclass(HandoffError, HandoffRefused)
+
+
+# ---------------------------------------------------------------------------
+# Nothing to wait on
+# ---------------------------------------------------------------------------
+
+
+async def test_no_outgoing_or_no_wait_hands_c_reason_none():
+    # spawn: nothing live
+    app = make_pty_app()
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        await acquire_surface(app, KEY, "simple", object())
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_NONE)
+    assert app.clock.sleeps == []
+
+    # Expert reattaching to its own live PTY: no wait even if the turn runs.
+    app = make_pty_app()
+    pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        plan = await acquire_surface(app, KEY, "expert", object())
+    assert plan.action == ACTION_REUSE and plan.wait_for_idle is False
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_NONE)
+    assert app.clock.sleeps == []
+
+
+async def test_acquire_surface_hands_plan_and_outcome_to_phase_c():
+    app = make_pty_app()
+    chats(app).sessions[KEY] = FakeChatSession(busy=False)
+    recorder = Recorder()
+    channel = object()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        plan = await acquire_surface(app, KEY, "expert", channel)
+    assert plan.action == ACTION_HANDOFF
+    (handed_plan, outcome), *_ = recorder.calls
+    assert handed_plan is plan
+    assert outcome == WaitOutcome(REASON_IDLE)
+    # Phase (c) is a stub: the slot it will release still stands.
+    assert_held(app, channel)
+
+
+# ---------------------------------------------------------------------------
+# Chat-held keys
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_held_key_waits_on_is_busy_then_ends_idle():
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    channel = object()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel))
+        await ticks(app, 20)
+        assert not task.done()
+        assert_held(app, channel)
+        assert chats(app).terminated == []
+        chat.is_busy = False
+        plan = await task
+    assert plan.action == ACTION_HANDOFF and plan.teardown is True
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+    assert set(app.clock.sleeps) == {IDLE_POLL_S}
+    assert chats(app).terminated == []
+
+
+async def test_a_chat_held_key_needs_no_hook():
+    """Without the turn-state hook an Expert still waits on ``is_busy``."""
+    app = make_pty_app(hook=False)
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "expert", object()))
+        await ticks(app, 5)
+        assert not task.done()
+        chat.is_busy = False
+        plan = await task
+    assert plan.action == ACTION_HANDOFF
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+    assert chats(app).terminated == []
+
+
+async def test_simple_reusing_a_busy_chat_waits_too():
+    """Same surface, chat held: the route cannot take a turn on a busy chat."""
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+        await ticks(app, 5)
+        assert not task.done()
+        chat.is_busy = False
+        plan = await task
+    assert plan.action == ACTION_REUSE and plan.wait_for_idle is True
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+
+
+async def test_chat_held_key_with_interrupt_skips_the_wait():
+    app = make_pty_app()
+    chats(app).sessions[KEY] = FakeChatSession(busy=True)
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        await acquire_surface(app, KEY, "expert", object(), interrupt=True)
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_INTERRUPTED)
+    assert app.clock.sleeps == []
+    # Phase (b) never tears anything down; the pool's terminate is (c)'s.
+    assert chats(app).terminated == []
+
+
+async def test_simple_reusing_a_busy_chat_with_interrupt_leaves_the_cancel_to_c():
+    """``reuse`` + ``interrupted``: phase (c) owes ``session.cancel()``; (b) touched nothing."""
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        plan = await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+    assert (plan.action, plan.teardown, plan.wait_for_idle) == (ACTION_REUSE, False, True)
+    assert recorder.calls[-1] == (plan, WaitOutcome(REASON_INTERRUPTED))
+    assert chat.is_busy is True
+    assert chats(app).terminated == []
+    assert app.clock.sleeps == []
+
+
+async def test_chat_vanishing_mid_wait_is_an_error_and_releases_the_slot():
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    channel = object()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel))
+        await ticks(app, 3)
+        del chats(app).sessions[KEY]
+        with pytest.raises(HandoffError) as excinfo:
+            await task
+    assert excinfo.value.error == ERROR_OUTGOING_VANISHED
+    assert recorder.calls == []
+    assert_released(app)
+
+
+async def test_chat_dying_while_pooled_ends_the_wait_as_exited():
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "expert", object()))
+        await ticks(app, 3)
+        chat._active = False
+        await task
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_EXITED)
+
+
+# ---------------------------------------------------------------------------
+# PTY-held keys: the wait has no time bound
+# ---------------------------------------------------------------------------
+
+
+async def test_a_running_turn_is_never_terminated_while_the_channel_is_open():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    channel = ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", channel))
+        # Hours of fake time, a few hundred looks.
+        await ticks(app, 300)
+        app.clock.now += 6 * 3600
+        await ticks(app, 50)
+        assert not task.done()
+        assert pty.terminates == 0
+        assert pty.writes == []
+        assert pty.is_alive
+        assert registry(app).get_session(KEY) is pty
+        assert_held(app, channel)
+        assert recorder.calls == []
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert_released(app)
+    assert pty.terminates == 0
+
+
+async def test_pty_going_idle_in_the_store_ends_the_wait():
+    app = make_pty_app()
+    pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+        await ticks(app, 5)
+        assert not task.done()
+        set_store(app, "idle", time.time())
+        plan = await task
+    assert plan.action == ACTION_HANDOFF
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+
+
+async def test_pty_already_idle_hands_c_idle_without_a_sleep():
+    app = make_pty_app()
+    pool_pty(app)
+    set_store(app, "idle", time.time())
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        await acquire_surface(app, KEY, "simple", object())
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+    assert app.clock.sleeps == []
+
+
+async def test_pty_vanishing_mid_wait_is_an_error_and_releases_the_slot():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    channel = object()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", channel))
+        await ticks(app, 3)
+        assert registry(app).pop_session(KEY) is pty
+        with pytest.raises(HandoffError) as excinfo:
+            await task
+    assert excinfo.value.error == ERROR_OUTGOING_VANISHED
+    assert recorder.calls == []
+    assert pty.terminates == 0
+    assert_released(app)
+
+
+async def test_pty_dying_while_pooled_ends_the_wait_as_exited():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+        await ticks(app, 3)
+        pty._alive = False
+        await task
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_EXITED)
+    assert pty.terminates == 0
+
+
+# ---------------------------------------------------------------------------
+# The caller's channel closing
+# ---------------------------------------------------------------------------
+
+
+async def test_channel_closing_mid_wait_cancels_releases_and_touches_nothing():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    closed = asyncio.Event()
+    channel = ChannelToken(closed.is_set)
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", channel))
+        await ticks(app, 4)
+        assert_held(app, channel)
+        closed.set()
+        with pytest.raises(ChannelClosed):
+            await task
+    assert task.cancelled()
+    assert_released(app)
+    assert recorder.calls == []
+    assert pty.terminates == 0
+    assert pty.writes == []
+    assert registry(app).get_session(KEY) is pty
+    # The key is free for the next acquire.
+    result = await acquire_surface(app, KEY, "expert", object())
+    assert result.plan.action == ACTION_REUSE
+
+
+async def test_post_style_awaitable_probe_closes_the_wait_too():
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    disconnected = False
+
+    async def is_disconnected() -> bool:
+        return disconnected
+
+    channel = ChannelToken(is_disconnected)
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel))
+    await ticks(app, 3)
+    disconnected = True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert_released(app)
+    assert chats(app).terminated == []
+
+
+async def test_the_channel_is_asked_on_every_look():
+    app = make_pty_app()
+    chats(app).sessions[KEY] = FakeChatSession(busy=True)
+    probes = 0
+
+    def is_closed() -> bool:
+        nonlocal probes
+        probes += 1
+        return False
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", ChannelToken(is_closed)))
+    await ticks(app, 10)
+    looks = len(app.clock.sleeps)
+    assert probes >= looks
+    assert all(s <= 0.2 for s in app.clock.sleeps)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert_released(app)
+
+
+async def test_a_closed_channel_is_seen_on_the_first_look():
+    """A caller already gone when (b) starts never sees a tick of waiting."""
+    app = make_pty_app()
+    chats(app).sessions[KEY] = FakeChatSession(busy=True)
+    with pytest.raises(ChannelClosed):
+        await acquire_surface(app, KEY, "expert", ChannelToken(lambda: True))
+    assert app.clock.sleeps == []
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Hook-less PTY
+# ---------------------------------------------------------------------------
+
+
+async def test_hookless_pty_held_key_is_refused_without_an_interrupt():
+    app = make_pty_app(hook=False)
+    pty = pool_pty(app)
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        with pytest.raises(HandoffNeedsInterrupt) as excinfo:
+            await acquire_surface(app, KEY, "simple", object())
+    refused = excinfo.value
+    assert isinstance(refused, HandoffRefused)
+    assert (refused.status, refused.error) == (409, ERROR_HANDOFF_NEEDS_INTERRUPT)
+    assert refused.ws_close_code is None
+    assert HandoffRefused.needs_interrupt(KEY).error == ERROR_HANDOFF_NEEDS_INTERRUPT
+    assert recorder.calls == []
+    assert pty.writes == [] and pty.terminates == 0
+    assert app.clock.sleeps == []
+    assert_released(app)
+    # The PTY is untouched and still the holder.
+    assert registry(app).get_session(KEY) is pty
+
+
+async def test_hookless_pty_with_interrupt_is_escaped_and_ends_on_the_marker(tmp_path):
+    app = make_pty_app(hook=False)
+    pty = pool_pty(app)
+    transcript = write_transcript(tmp_path / f"{KEY}.jsonl", [user_entry("do it")], time.time())
+    recorder = Recorder()
+    with (
+        patch.object(session_handoff, "_transcript_path", lambda _app, _tid: transcript),
+        patch.object(session_handoff, "_phase_c", recorder),
+    ):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object(), interrupt=True))
+        await until(lambda: pty.writes == [ESC])
+        await ticks(app, 3)
+        assert not task.done()
+        write_transcript(transcript, [user_entry("do it"), INTERRUPT_ENTRY], time.time())
+        await task
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_INTERRUPTED)
+    assert pty.writes == [ESC]
+    assert pty.terminates == 0
+    assert sum(app.clock.sleeps) < INTERRUPT_GRACE_S
+
+
+async def test_hookless_pty_without_a_transcript_is_not_assumed_idle():
+    """No store entry and no file: nothing witnessed the turn end."""
+    app = make_pty_app(hook=False)
+    pty = pool_pty(app)
+    task = asyncio.create_task(acquire_surface(app, KEY, "simple", object(), interrupt=True))
+    await ticks(app, 5)
+    assert pty.writes == [ESC]
+    assert not task.done()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# ---------------------------------------------------------------------------
+# Interrupt with the hook present
+# ---------------------------------------------------------------------------
+
+
+async def test_interrupt_writes_escape_then_proceeds_on_the_store_idle_edge():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object(), interrupt=True))
+        await until(lambda: pty.writes == [ESC])
+        await ticks(app, 3)
+        assert not task.done()
+        set_store(app, "idle", time.time())
+        plan = await task
+    assert plan.interrupt is True
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_INTERRUPTED)
+    assert pty.terminates == 0
+    assert sum(app.clock.sleeps) < INTERRUPT_GRACE_S
+
+
+async def test_interrupt_on_an_idle_pty_writes_nothing():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "idle", time.time())
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+    assert pty.writes == []
+
+
+async def test_interrupt_that_never_lands_terminates_after_the_grace():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    recorder = Recorder()
+    channel = object()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        plan = await acquire_surface(app, KEY, "simple", channel, interrupt=True)
+    assert pty.writes == [ESC]
+    assert pty.terminates == 1
+    assert recorder.calls[-1] == (plan, WaitOutcome(REASON_FORCED))
+    # The grace is spent in full and by no more than one extra look.
+    assert sum(app.clock.sleeps) == pytest.approx(INTERRUPT_GRACE_S, abs=2 * IDLE_POLL_S)
+    assert len(app.clock.sleeps) >= round(INTERRUPT_GRACE_S / IDLE_POLL_S)
+    # Terminated, not popped: (c) runs its ordinary teardown and death check.
+    assert registry(app).get_session(KEY) is pty
+    assert_held(app, channel)
+
+
+async def test_the_loop_stays_responsive_during_a_slow_terminate():
+    app = make_pty_app()
+    pty = pool_pty(app, RecordingPty(terminate_blocks_s=0.3))
+    set_store(app, "busy", time.time())
+    heartbeats = 0
+    stop = asyncio.Event()
+
+    async def heartbeat() -> None:
+        nonlocal heartbeats
+        while not stop.is_set():
+            heartbeats += 1
+            await asyncio.sleep(0.01)
+
+    beat = asyncio.create_task(heartbeat())
+    with patch.object(session_handoff, "_phase_c", Recorder()):
+        started = time.monotonic()
+        await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+        wall = time.monotonic() - started
+    stop.set()
+    await beat
+    assert pty.terminates == 1
+    assert wall >= 0.3
+    # A blocked loop would have counted one or two beats across 300 ms; the
+    # bar is kept low so a loaded machine does not fail it.
+    assert heartbeats >= 3
+
+
+async def test_a_failed_escape_write_is_classified_by_the_next_look():
+    """The master fd closing between the liveness look and the write is an exit, not a crash."""
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+
+    def write_input(_data: bytes) -> None:
+        pty._alive = False
+        raise OSError("Input/output error")
+
+    pty.write_input = write_input  # type: ignore[method-assign]
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_EXITED)
+    assert pty.terminates == 0
+
+
+async def test_a_failed_escape_write_on_a_live_pty_still_runs_the_grace():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+
+    def write_input(_data: bytes) -> None:
+        raise OSError("Bad file descriptor")
+
+    pty.write_input = write_input  # type: ignore[method-assign]
+    recorder = Recorder()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_FORCED)
+    assert pty.terminates == 1
+    assert sum(app.clock.sleeps) == pytest.approx(INTERRUPT_GRACE_S, abs=2 * IDLE_POLL_S)
+
+
+async def test_channel_closing_during_the_interrupt_grace_still_cancels():
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    closed = asyncio.Event()
+    channel = ChannelToken(closed.is_set)
+    task = asyncio.create_task(acquire_surface(app, KEY, "simple", channel, interrupt=True))
+    await until(lambda: pty.writes == [ESC])
+    await ticks(app, 2)
+    closed.set()
+    with pytest.raises(ChannelClosed):
+        await task
+    assert pty.terminates == 0
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Store versus tail: the newer witness wins
+# ---------------------------------------------------------------------------
+
+
+def judge(app, store, transcript: Path | None) -> bool:
+    with patch.object(session_handoff, "_transcript_path", lambda _app, _tid: transcript):
+        return session_handoff._judge_pty_idle(app, store, KEY)
+
+
+def test_store_newer_than_tail_wins(tmp_path):
+    app = make_pty_app()
+    now = time.time()
+    # An unanswered prompt at the tail, written before the store's idle edge.
+    transcript = write_transcript(tmp_path / "t.jsonl", [user_entry("prompt")], now - 10)
+    assert judge(app, {"state": "idle", "ts": now}, transcript) is True
+    # The same tail, older than a busy edge: busy.
+    assert judge(app, {"state": "busy", "ts": now}, transcript) is False
+    # An interrupt marker older than a busy edge cannot end the newer turn.
+    interrupted = write_transcript(tmp_path / "i.jsonl", [INTERRUPT_ENTRY], now - 10)
+    assert judge(app, {"state": "busy", "ts": now}, interrupted) is False
+    # A tie goes to the store.
+    tied = write_transcript(tmp_path / "e.jsonl", [user_entry("prompt")], now)
+    assert judge(app, {"state": "idle", "ts": now}, tied) is True
+
+
+def test_tail_newer_than_store_wins_when_it_has_evidence(tmp_path):
+    app = make_pty_app()
+    now = time.time()
+    # Store idle, then a prompt was submitted: busy.
+    prompt = write_transcript(tmp_path / "p.jsonl", [user_entry("prompt")], now + 10)
+    assert judge(app, {"state": "idle", "ts": now}, prompt) is False
+    # Store busy, then the turn was interrupted: idle.
+    interrupted = write_transcript(tmp_path / "i.jsonl", [INTERRUPT_ENTRY], now + 10)
+    assert judge(app, {"state": "busy", "ts": now}, interrupted) is True
+    # Store busy, then slash-command output newer than the busy stamp: idle.
+    entry = user_entry("<local-command-stdout>ok</local-command-stdout>")
+    entry["timestamp"] = "2099-01-01T00:00:00Z"
+    command = write_transcript(tmp_path / "c.jsonl", [entry], now + 10)
+    assert judge(app, {"state": "busy", "ts": now}, command) is True
+
+
+def test_a_newer_tail_without_evidence_hands_back_to_the_store(tmp_path):
+    app = make_pty_app()
+    now = time.time()
+    reply = write_transcript(tmp_path / "a.jsonl", [assistant_entry("done")], now + 10)
+    assert judge(app, {"state": "idle", "ts": now}, reply) is True
+    assert judge(app, {"state": "busy", "ts": now}, reply) is False
+
+
+def test_without_a_store_entry_only_an_explicit_idle_shape_counts(tmp_path):
+    app = make_pty_app()
+    now = time.time()
+    assert judge(app, None, None) is False
+    reply = write_transcript(tmp_path / "a.jsonl", [assistant_entry("done")], now)
+    assert judge(app, None, reply) is False
+    prompt = write_transcript(tmp_path / "p.jsonl", [user_entry("prompt")], now)
+    assert judge(app, None, prompt) is False
+    interrupted = write_transcript(tmp_path / "i.jsonl", [INTERRUPT_ENTRY], now)
+    assert judge(app, None, interrupted) is True
+
+
+def test_a_missing_transcript_leaves_the_store_as_the_only_witness(tmp_path):
+    app = make_pty_app()
+    now = time.time()
+    assert judge(app, {"state": "idle", "ts": now}, None) is True
+    assert judge(app, {"state": "busy", "ts": now}, None) is False
+    gone = tmp_path / "gone.jsonl"
+    assert judge(app, {"state": "idle", "ts": now}, gone) is True
+
+
+async def test_the_tail_is_read_for_the_keys_current_transcript(tmp_path):
+    """After a ``/clear`` the key points at a new transcript; that is the one read."""
+    app = make_pty_app()
+    pool_pty(app)
+    moved = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    app.state.transcript_map[KEY] = moved
+    now = time.time()
+    set_store(app, "busy", now)
+    files = {
+        KEY: write_transcript(tmp_path / f"{KEY}.jsonl", [INTERRUPT_ENTRY], now + 10),
+        moved: write_transcript(tmp_path / f"{moved}.jsonl", [user_entry("prompt")], now + 10),
+    }
+    asked: list[str] = []
+
+    def transcript_path(_app, transcript_id: str):
+        asked.append(transcript_id)
+        return files.get(transcript_id)
+
+    with patch.object(session_handoff, "_transcript_path", transcript_path):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+        await ticks(app, 3)
+        assert not task.done(), "the old transcript's marker must not end the wait"
+        assert set(asked) == {moved}
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_an_unchanged_transcript_is_read_once_per_wait(tmp_path):
+    """Every look stats the file; only a changed file is read again."""
+    app = make_pty_app()
+    pool_pty(app)
+    now = time.time()
+    set_store(app, "busy", now)
+    # Newer than the store, so the tail rule is consulted on every look.
+    transcript = write_transcript(tmp_path / f"{KEY}.jsonl", [user_entry("prompt")], now + 10)
+    reads = 0
+    real_tail_state = session_handoff.tail_state
+
+    def counting_tail_state(path, busy_since):
+        nonlocal reads
+        reads += 1
+        return real_tail_state(path, busy_since)
+
+    with (
+        patch.object(session_handoff, "_transcript_path", lambda _app, _tid: transcript),
+        patch.object(session_handoff, "tail_state", counting_tail_state),
+        patch.object(session_handoff, "_phase_c", Recorder()),
+    ):
+        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object()))
+        await ticks(app, 30)
+        assert not task.done()
+        assert reads == 1
+        # The file moves: one more read, and its marker ends the wait.
+        write_transcript(transcript, [user_entry("prompt"), INTERRUPT_ENTRY], now + 20)
+        await task
+    assert reads == 2
+
+
+def test_the_tail_memo_keys_on_size_mtime_and_busy_stamp(tmp_path):
+    memo = session_handoff._TailMemo()
+    transcript = write_transcript(tmp_path / "t.jsonl", [INTERRUPT_ENTRY], 1_700_000_000)
+    reads = 0
+    real_tail_state = session_handoff.tail_state
+
+    def counting_tail_state(path, busy_since):
+        nonlocal reads
+        reads += 1
+        return real_tail_state(path, busy_since)
+
+    with patch.object(session_handoff, "tail_state", counting_tail_state):
+        stat = transcript.stat()
+        assert memo.verdict(transcript, stat, None) == "idle"
+        assert memo.verdict(transcript, stat, None) == "idle"
+        assert reads == 1
+        assert memo.verdict(transcript, stat, 1.0) == "idle"
+        assert reads == 2
+        write_transcript(transcript, [INTERRUPT_ENTRY, user_entry("again")], 1_700_000_100)
+        assert memo.verdict(transcript, transcript.stat(), 1.0) == "busy"
+        assert reads == 3
+
+
+def test_transcript_path_needs_a_project_cwd():
+    app = make_pty_app()
+    assert session_handoff._transcript_path(app, KEY) is None
+
+
+# ---------------------------------------------------------------------------
+# A newer Simple acquire with an interrupt supersedes a pending Simple wait
+# ---------------------------------------------------------------------------
+
+
+def busy_pty_app() -> tuple[SimpleNamespace, RecordingPty]:
+    """A hooked terminal in the middle of a turn: the wait a Simple acquire meets."""
+    app = make_pty_app()
+    pty = pool_pty(app)
+    set_store(app, "busy", time.time())
+    return app, pty
+
+
+async def start_wait(app: SimpleNamespace, surface: str, channel: object) -> asyncio.Task:
+    """Start an acquire and see it into its phase (b) wait."""
+    task = asyncio.create_task(acquire_surface(app, KEY, surface, channel))
+    await ticks(app, 3)
+    assert not task.done()
+    assert_held(app, channel)
+    return task
+
+
+def idle_once_escaped(app: SimpleNamespace, pty: RecordingPty) -> None:
+    """Report the terminal idle on the first look after Escape was written."""
+
+    def hook(_count: int) -> None:
+        if pty.writes:
+            set_store(app, "idle", time.time())
+
+    app.clock.on_sleep.append(hook)
+
+
+async def test_a_simple_interrupt_supersedes_a_pending_simple_wait():
+    """The first wait ends refused and released; the second carries the interrupt through."""
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel, second_channel = ChannelToken(), ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        first = await start_wait(app, "simple", first_channel)
+        idle_once_escaped(app, pty)
+        second = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", second_channel, interrupt=True)
+        )
+
+        with pytest.raises(HandoffSuperseded) as excinfo:
+            await first
+        assert excinfo.value.status == 409
+        assert excinfo.value.error == ERROR_HANDOFF_SUPERSEDED
+        assert excinfo.value.ws_close_code is None
+        # A refusal, not a cancellation: the route answers it like any other.
+        assert not first.cancelled()
+
+        plan = await second
+
+    assert plan.channel is second_channel
+    assert plan.action == ACTION_HANDOFF and plan.interrupt
+    assert recorder.calls == [(plan, WaitOutcome(REASON_INTERRUPTED))]
+    assert pty.writes == [ESC]
+    assert pty.terminates == 0
+    assert registry(app).get_session(KEY) is pty
+    assert_held(app, second_channel)
+
+
+async def test_the_superseded_mark_lands_before_the_waiter_runs():
+    """The mark is what the waiter reads; it is set on the look that cancels, once."""
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel = ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        first = await start_wait(app, "simple", first_channel)
+        second = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", ChannelToken(), interrupt=True)
+        )
+        # One loop step: the second has looked and cancelled; the first has not run yet.
+        await asyncio.sleep(0)
+        pending = get_state(app).pending[KEY]
+        assert pending.channel is first_channel
+        assert pending.superseded
+        assert not first.done()
+
+        with pytest.raises(HandoffSuperseded):
+            await first
+        idle_once_escaped(app, pty)
+        await second
+    assert pty.writes == [ESC]
+
+
+async def test_a_cancellation_from_elsewhere_arriving_with_the_supersede_is_honoured():
+    """Only the one cancellation the supersede delivered is withdrawn."""
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel = ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        first = await start_wait(app, "simple", first_channel)
+        second = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", ChannelToken(), interrupt=True)
+        )
+        await asyncio.sleep(0)
+        assert get_state(app).pending[KEY].superseded
+        first.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        assert first.cancelled()
+
+        idle_once_escaped(app, pty)
+        await second
+    assert pty.writes == [ESC]
+
+
+async def test_without_an_interrupt_a_second_simple_acquire_waits_out_the_grace():
+    """No interrupt, no supersede: blocked through the attach grace, then 409."""
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel = ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        first = await start_wait(app, "simple", first_channel)
+
+        with pytest.raises(HandoffRefused) as excinfo:
+            await acquire_surface(app, KEY, "simple", ChannelToken())
+        assert excinfo.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+        assert not isinstance(excinfo.value, HandoffSuperseded)
+
+        assert not first.done()
+        assert_held(app, first_channel)
+        assert not get_state(app).pending[KEY].superseded
+        assert pty.writes == []
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+    assert recorder.calls == []
+    assert_released(app)
+
+
+async def test_an_expert_acquire_never_supersedes_a_pending_simple_wait():
+    """The terminal handshake carries no interrupt; even asked for one it waits like today."""
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel = ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        first = await start_wait(app, "simple", first_channel)
+
+        with pytest.raises(HandoffRefused) as excinfo:
+            await acquire_surface(app, KEY, "expert", ChannelToken(), interrupt=True)
+        assert excinfo.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+
+        assert not first.done()
+        assert_held(app, first_channel)
+        assert not get_state(app).pending[KEY].superseded
+        assert pty.writes == []
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+    assert recorder.calls == []
+    assert_released(app)
+
+
+async def test_a_pending_expert_wait_is_not_superseded_by_a_simple_interrupt():
+    """The interrupt is a gesture at the Simple view's own wait, not at the other view's."""
+    app = make_pty_app()
+    chat = FakeChatSession(busy=True)
+    chats(app).sessions[KEY] = chat
+    recorder = Recorder()
+    expert_channel = ChannelToken()
+    with patch.object(session_handoff, "_phase_c", recorder):
+        first = await start_wait(app, "expert", expert_channel)
+
+        with pytest.raises(HandoffRefused) as excinfo:
+            await acquire_surface(app, KEY, "simple", ChannelToken(), interrupt=True)
+        assert excinfo.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+
+        assert not first.done()
+        assert get_state(app).pending[KEY].channel is expert_channel
+        assert not get_state(app).pending[KEY].superseded
+        chat.is_busy = False
+        plan = await first
+    assert plan.surface == "expert"
+    assert recorder.calls[-1][1] == WaitOutcome(REASON_IDLE)
+    assert chats(app).get(KEY) is chat
+
+
+async def test_three_requests_settle_on_one_supersede_and_one_completion():
+    """Two interrupts behind one wait: the first cancels it, the second is plainly blocked.
+
+    While the first wait is marked, a further interrupt is an ordinary
+    blocked look — the mark is never re-applied. Once the wait releases,
+    the interrupt that registers is superseded by the other, and that one
+    completes: exactly one ``HandoffSuperseded`` among the two, one plan
+    handed to phase (c), one Escape, and no ping-pong between them.
+
+    The interleaving is pinned, not observed: the PTY idle judgement is
+    replaced by one that reads the store and yields once, so no worker
+    thread decides which task runs next and the loop's own order does —
+    the second and third acquires are created in one step, so the third
+    looks while the first is marked; after the first releases, the second
+    registers and yields at its first look, and the third supersedes it
+    there, before any Escape is written.
+    """
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel, second_channel, third_channel = ChannelToken(), ChannelToken(), ChannelToken()
+
+    async def judge_from_the_store(_app, key: str, _memo=None) -> bool:
+        await asyncio.sleep(0)
+        return app.state.turn_state[key]["state"] == "idle"
+
+    with (
+        patch.object(session_handoff, "_phase_c", recorder),
+        patch.object(session_handoff, "_pty_turn_idle", judge_from_the_store),
+    ):
+        first = await start_wait(app, "simple", first_channel)
+        idle_once_escaped(app, pty)
+        second = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", second_channel, interrupt=True)
+        )
+        third = asyncio.create_task(
+            acquire_surface(app, KEY, "simple", third_channel, interrupt=True)
+        )
+        # One step: the second has marked the first, the third has met the
+        # mark and been plainly blocked, and the first has not run yet.
+        await asyncio.sleep(0)
+        pending = get_state(app).pending[KEY]
+        assert pending.channel is first_channel
+        assert pending.superseded
+        assert not first.done() and not second.done() and not third.done()
+
+        # One cancellation, not two: the first ends refused, not cancelled.
+        with pytest.raises(HandoffSuperseded):
+            await first
+        with pytest.raises(HandoffSuperseded):
+            await second
+        plan = await third
+
+    assert plan.channel is third_channel and plan.interrupt
+    assert recorder.calls == [(plan, WaitOutcome(REASON_INTERRUPTED))]
+    assert pty.writes == [ESC]
+    assert pty.terminates == 0
+    assert_held(app, third_channel)
+
+
+# ---------------------------------------------------------------------------
+# The mark ends the wait even when the cancellation is lost
+# ---------------------------------------------------------------------------
+
+
+def store_judge(app: SimpleNamespace):
+    """A PTY idle judgement that reads the store and yields once, so no thread decides the order."""
+
+    async def judge(_app, key: str, _memo=None) -> bool:
+        await asyncio.sleep(0)
+        return app.state.turn_state[key]["state"] == "idle"
+
+    return judge
+
+
+class AbsorbingProbe:
+    """A channel probe shaped like Starlette's ``is_disconnected``, with a hook inside the scope.
+
+    The probe awaits under an anyio cancel scope it has already cancelled,
+    exactly as the route's channel does. On look *on_look* it calls *spawn*
+    either just before the scope is entered or just after the scope was
+    cancelled, so a task *spawn* starts has its first step land on either side
+    of anyio's own cancellation delivery — the two orderings in which an
+    external ``task.cancel()`` can meet the scope.
+    """
+
+    def __init__(self, *, on_look: int, spawn, before_scope: bool) -> None:
+        self.calls = 0
+        self._on_look = on_look
+        self._spawn = spawn
+        self._before = before_scope
+
+    async def is_closed(self) -> bool:
+        self.calls += 1
+        if self.calls == self._on_look and self._before:
+            self._spawn()
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            if self.calls == self._on_look and not self._before:
+                self._spawn()
+            await asyncio.Event().wait()
+        return False
+
+
+@pytest.mark.parametrize("before_scope", [True, False], ids=["cancel-first", "scope-first"])
+async def test_a_supersede_meeting_the_channel_probes_scope_still_ends_the_wait(before_scope):
+    """Whether the cancel is delivered or absorbed by the probe's scope, the wait ends superseded.
+
+    The second acquire is started from inside the first wait's channel probe,
+    so its supersede — mark and ``task.cancel()`` — lands while the first is
+    suspended in the probe's anyio scope. However anyio resolves that, the
+    first ends ``handoff_superseded`` with no cancellation left counted on its
+    task, its slot released, and the second registered on its next looks.
+    """
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    second_channel = ChannelToken()
+    started: list[asyncio.Task] = []
+
+    def spawn() -> None:
+        started.append(
+            asyncio.create_task(acquire_surface(app, KEY, "simple", second_channel, interrupt=True))
+        )
+
+    first_channel = AbsorbingProbe(on_look=3, spawn=spawn, before_scope=before_scope)
+    with (
+        patch.object(session_handoff, "_phase_c", recorder),
+        patch.object(session_handoff, "_pty_turn_idle", store_judge(app)),
+    ):
+        idle_once_escaped(app, pty)
+        first = asyncio.create_task(acquire_surface(app, KEY, "simple", first_channel))
+
+        with pytest.raises(HandoffSuperseded):
+            await first
+        assert first.cancelling() == 0
+        assert first_channel.calls >= 3
+
+        (second,) = started
+        plan = await second
+
+    assert plan.channel is second_channel and plan.interrupt
+    assert recorder.calls == [(plan, WaitOutcome(REASON_INTERRUPTED))]
+    assert pty.writes == [ESC]
+    assert pty.terminates == 0
+    # The superseder was blocked for the marking look and at most the two
+    # steps the first needed to reach its next look; never the attach grace.
+    assert app.clock.sleeps.count(ATTACH_POLL_S) <= 3
+    assert_held(app, second_channel)
+
+
+async def test_the_mark_alone_ends_the_wait_with_no_cancellation_counted():
+    """A supersede whose cancellation never arrives is honoured from the mark on the next look."""
+    app, pty = busy_pty_app()
+    recorder = Recorder()
+    first_channel = ChannelToken()
+    with (
+        patch.object(session_handoff, "_phase_c", recorder),
+        patch.object(session_handoff, "_pty_turn_idle", store_judge(app)),
+    ):
+        first = await start_wait(app, "simple", first_channel)
+        looks = len(app.clock.sleeps)
+        get_state(app).pending[KEY].superseded = True
+
+        with pytest.raises(HandoffSuperseded) as excinfo:
+            await first
+
+    assert excinfo.value.error == ERROR_HANDOFF_SUPERSEDED
+    assert not first.cancelled()
+    assert first.cancelling() == 0
+    assert len(app.clock.sleeps) - looks <= 1
+    assert pty.writes == [] and pty.terminates == 0
+    assert recorder.calls == []
+    assert_released(app)
+
+
+class MarkingProbe:
+    """A channel probe that supersedes the wait it is polled by, on its *on_look*-th look.
+
+    Sets the mark between the look's first read of it and its verdict — the
+    shape of a supersede absorbed on the probe — with no cancellation at all.
+    """
+
+    def __init__(self, app: SimpleNamespace, *, on_look: int) -> None:
+        self._app = app
+        self._on_look = on_look
+        self.calls = 0
+
+    async def is_closed(self) -> bool:
+        self.calls += 1
+        if self.calls == self._on_look:
+            get_state(self._app).pending[KEY].superseded = True
+        return False
+
+
+async def test_a_mark_set_between_the_probe_and_an_idle_verdict_still_ends_the_wait():
+    """The look that would return idle re-reads the mark before returning, and refuses instead."""
+    app, pty = busy_pty_app()
+    set_store(app, "idle", time.time())
+    recorder = Recorder()
+    channel = MarkingProbe(app, on_look=1)
+    with (
+        patch.object(session_handoff, "_phase_c", recorder),
+        patch.object(session_handoff, "_pty_turn_idle", store_judge(app)),
+    ):
+        first = asyncio.create_task(acquire_surface(app, KEY, "simple", channel))
+        with pytest.raises(HandoffSuperseded):
+            await first
+
+    assert channel.calls == 1
+    assert first.cancelling() == 0
+    assert recorder.calls == []
+    assert pty.writes == [] and pty.terminates == 0
+    assert registry(app).get_session(KEY) is pty
+    assert_released(app)

--- a/tests/interfaces/web_terminal/test_handoff_phase_c.py
+++ b/tests/interfaces/web_terminal/test_handoff_phase_c.py
@@ -1,0 +1,1065 @@
+"""Phase (c) of a surface acquire: teardown, death check, spawn, attach, release.
+
+Phase (c) runs under the per-key lock inside a shielded task and turns the
+plan phase (a) made and the outcome phase (b) reported into a live process
+under the key. These tests pin the invariants around that:
+
+- the outgoing entry is popped from its pool before it is killed, the kill
+  runs off the loop, and the child is *observed* dead before anything is
+  spawned — whatever reason phase (b) gave;
+- a survivor goes back into its own pool unattached and the acquire is
+  refused with 503, spawning nothing;
+- the spawn callback is told what to resume from a fresh look at the
+  transcript map and the transcripts on disk, and is not called at all when
+  the incoming surface's own entry is already pooled;
+- an Expert caller is attached with its channel token before the pending
+  slot and the reservation are released, and a displaced Expert connection
+  is closed and detached first;
+- a cancellation delivered mid-phase does not stop the phase.
+
+Fakes and the faked clock come from the phase (a) and (b) suites. Phase (b)
+is real unless a test says otherwise; where a test is about how (c) answers a
+particular outcome, the wait is stubbed to return that outcome.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from osprey.interfaces.web_terminal import session_handoff
+from osprey.interfaces.web_terminal.chat_session_pool import ChatCapacityError, ChatSessionPool
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.session_handoff import (
+    ACTION_HANDOFF,
+    ACTION_REUSE,
+    ACTION_SPAWN,
+    ACTION_TAKEOVER,
+    DEATH_GRACE_S,
+    DEATH_POLL_S,
+    ERROR_CHAT_CAPACITY,
+    ERROR_OUTGOING_STILL_RUNNING,
+    ERROR_OUTGOING_VANISHED,
+    ERROR_SESSION_ATTACHED_ELSEWHERE,
+    ERROR_SPAWN_NOT_POOLED,
+    REASON_EXITED,
+    REASON_FORCED,
+    REASON_IDLE,
+    REASON_INTERRUPTED,
+    REASON_NONE,
+    WS_CLOSE_OUTGOING_RUNNING,
+    AcquireResult,
+    HandoffError,
+    HandoffRefused,
+    SpawnRequest,
+    WaitOutcome,
+    acquire_surface,
+    get_state,
+)
+from osprey.interfaces.web_terminal.turn_state import BUSY, IDLE, get_turn_state
+from tests.interfaces.web_terminal._fakes import FakeChatPool, FakeChatSession
+from tests.interfaces.web_terminal.test_handoff_phase_a import KEY, chats, registry
+from tests.interfaces.web_terminal.test_handoff_phase_b import (
+    RecordingPty,
+    assert_released,
+    make_pty_app,
+    pool_pty,
+    set_store,
+    until,
+)
+
+TRANSCRIPT = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+# ---------------------------------------------------------------------------
+# Fakes and helpers
+# ---------------------------------------------------------------------------
+
+
+class ChatPool(FakeChatPool):
+    """The phase (a) fake chat pool plus what phase (c) asks of it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reinserted: list[str] = []
+
+    async def reinsert(self, chat_id: str, session: FakeChatSession) -> bool:
+        self.reinserted.append(chat_id)
+        if chat_id in self.sessions or chat_id in self.starting:
+            return False
+        self.sessions[chat_id] = session
+        return True
+
+
+class Chat(FakeChatSession):
+    """A fake chat whose child's death is under the test's control.
+
+    ``exits`` is what ``process_exited`` reads after ``teardown``: True (the
+    ordinary case), False (a survivor), or None (no handle was ever captured).
+    ``dies_after`` sleeps lets a survivor become a corpse while (c) polls.
+    """
+
+    def __init__(
+        self,
+        *,
+        busy: bool = False,
+        exits: bool | None = True,
+        dies_after: int | None = None,
+    ) -> None:
+        super().__init__(busy=busy)
+        self._exits = exits
+        self._dies_after = dies_after
+        self.cancels = 0
+
+    async def teardown(self) -> None:
+        await super().teardown()
+        self.process_exited = self._exits
+
+    def let_die(self) -> None:
+        """Arm the next ``teardown`` to take: the child exits when signalled again."""
+        self._exits = True
+
+    async def cancel(self) -> None:
+        self.cancels += 1
+        self.is_busy = False
+
+    def dying(self, app: SimpleNamespace) -> None:
+        """Arm ``dies_after``: the child exits once that many polls have slept."""
+        assert self._dies_after is not None
+        target = len(app.clock.sleeps) + self._dies_after
+
+        def maybe_exit(count: int) -> None:
+            if count >= target:
+                self.process_exited = True
+
+        app.clock.on_sleep.append(maybe_exit)
+
+
+class SurvivorPty(RecordingPty):
+    """A PTY that ``terminate`` cannot kill — until ``die`` is called."""
+
+    def terminate(self) -> None:
+        self.terminates += 1
+
+    def die(self) -> None:
+        self._alive = False
+
+
+def make_app(**kwargs) -> SimpleNamespace:
+    app = make_pty_app(**kwargs)
+    app.state.operator_registry.chats = ChatPool()
+    return app
+
+
+def pty_spawner(
+    app: SimpleNamespace, *, pty: RecordingPty | None = None, gate: asyncio.Event | None = None
+):
+    """A spawn callback that pools a fake PTY the way the terminal handler does."""
+    calls: list[SpawnRequest] = []
+
+    async def spawn(request: SpawnRequest):
+        calls.append(request)
+        if gate is not None:
+            await gate.wait()
+        return pool_pty(app, pty or RecordingPty())
+
+    spawn.calls = calls  # type: ignore[attr-defined]
+    return spawn
+
+
+def chat_spawner(
+    app: SimpleNamespace, *, chat: Chat | None = None, gate: asyncio.Event | None = None
+):
+    """A spawn callback that pools a fake chat the way ``get_or_create`` does."""
+    calls: list[SpawnRequest] = []
+
+    async def spawn(request: SpawnRequest):
+        calls.append(request)
+        if gate is not None:
+            await gate.wait()
+        session = chat or Chat()
+        chats(app).starting.discard(request.key)
+        chats(app).sessions[request.key] = session
+        return session
+
+    spawn.calls = calls  # type: ignore[attr-defined]
+    return spawn
+
+
+def wait_returns(reason: str, *, before=None):
+    """Stub phase (b) to report *reason*, optionally after running *before*."""
+
+    async def wait(_app, _plan):
+        if before is not None:
+            before()
+        return WaitOutcome(reason)
+
+    return patch.object(session_handoff, "_wait_for_idle", wait)
+
+
+@pytest.fixture
+def disk():
+    """The transcripts on disk, as phase (c) sees them; tests add ids to it."""
+    ids: set[str] = set()
+    with patch.object(session_handoff, "_transcripts_on_disk", lambda _app: ids):
+        yield ids
+
+
+def turn_state(app: SimpleNamespace) -> str | None:
+    entry = get_turn_state(app, KEY)
+    return None if entry is None else entry["state"]
+
+
+# ---------------------------------------------------------------------------
+# Spawning onto a free key
+# ---------------------------------------------------------------------------
+
+
+async def test_free_key_expert_spawns_attaches_and_releases(disk):
+    app = make_app()
+    channel = object()
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", channel, spawn=spawn)
+
+    assert isinstance(result, AcquireResult)
+    assert result.plan.action == ACTION_SPAWN
+    assert result.outcome == WaitOutcome(REASON_NONE)
+    assert result.spawned is True
+    assert result.resume_id is None
+    assert spawn.calls == [
+        SpawnRequest(key=KEY, surface="expert", resume_id=None, transcript_id=KEY)
+    ]
+    assert registry(app).get_session(KEY) is result.session
+    assert registry(app).attached_owner(KEY) is channel
+    # A fresh TUI has no turn in flight: the store says so explicitly.
+    assert turn_state(app) == IDLE
+    assert_released(app)
+
+
+async def test_free_key_simple_spawns_the_chat_and_releases(disk):
+    app = make_app()
+    spawn = chat_spawner(app)
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert result.plan.action == ACTION_SPAWN
+    assert result.spawned is True
+    assert spawn.calls == [
+        SpawnRequest(key=KEY, surface="simple", resume_id=None, transcript_id=KEY)
+    ]
+    assert chats(app).get(KEY) is result.session
+    # Nothing to attach for a chat, and nothing of the PTY's turn store touched.
+    assert not registry(app).is_attached(KEY)
+    assert turn_state(app) is None
+    assert_released(app)
+
+
+@pytest.mark.parametrize(
+    ("mapped", "on_disk", "expected"),
+    [
+        (TRANSCRIPT, {TRANSCRIPT}, TRANSCRIPT),
+        (TRANSCRIPT, {TRANSCRIPT, KEY}, TRANSCRIPT),
+        (TRANSCRIPT, {KEY}, KEY),
+        (TRANSCRIPT, set(), None),
+        (None, {KEY}, KEY),
+        (None, set(), None),
+    ],
+)
+async def test_the_spawn_resumes_the_current_transcript_when_it_is_on_disk(
+    disk, mapped, on_disk, expected
+):
+    app = make_app()
+    if mapped is not None:
+        app.state.transcript_map[KEY] = mapped
+    disk.update(on_disk)
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    (request,) = spawn.calls
+    assert request.resume_id == expected
+    assert request.transcript_id == (mapped or KEY)
+    assert result.resume_id == expected
+
+
+async def test_the_disk_is_looked_at_when_the_spawn_happens_not_before(disk):
+    """A transcript that lands during the wait is what the new process resumes."""
+    app = make_app()
+    chats(app).sessions[KEY] = Chat(busy=False)
+    app.state.transcript_map[KEY] = TRANSCRIPT
+
+    def transcript_appears():
+        disk.add(TRANSCRIPT)
+
+    spawn = pty_spawner(app)
+    with wait_returns(REASON_IDLE, before=transcript_appears):
+        result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert result.resume_id == TRANSCRIPT
+
+
+# ---------------------------------------------------------------------------
+# The incoming surface already holds the key
+# ---------------------------------------------------------------------------
+
+
+async def test_expert_reuse_attaches_without_spawning(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, BUSY, 1.0)
+    channel = object()
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", channel, spawn=spawn)
+
+    assert result.plan.action == ACTION_REUSE
+    assert result.session is pty
+    assert result.spawned is False
+    assert result.resume_id is None
+    assert spawn.calls == []
+    assert registry(app).attached_owner(KEY) is channel
+    # A reattach is not a spawn edge: the running turn's state stands.
+    assert turn_state(app) == BUSY
+    assert_released(app)
+
+
+async def test_expert_reuse_needs_no_spawn_callback(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    result = await acquire_surface(app, KEY, "expert", object())
+    assert result.session is pty and result.spawned is False
+
+
+async def test_simple_reuse_hands_the_idle_chat_back_without_spawning(disk):
+    app = make_app()
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+    spawn = chat_spawner(app)
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert result.plan.action == ACTION_REUSE
+    assert result.outcome == WaitOutcome(REASON_IDLE)
+    assert result.session is chat and result.spawned is False
+    assert spawn.calls == []
+    assert chat.cancels == 0 and chat.teardowns == 0
+    assert_released(app)
+
+
+async def test_simple_reuse_with_interrupt_cancels_the_turn(disk):
+    app = make_app()
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    spawn = chat_spawner(app)
+    result = await acquire_surface(app, KEY, "simple", object(), interrupt=True, spawn=spawn)
+
+    assert result.outcome == WaitOutcome(REASON_INTERRUPTED)
+    assert result.session is chat
+    assert chat.cancels == 1
+    assert chat.teardowns == 0
+    assert chats(app).terminated == []
+    assert spawn.calls == []
+    assert_released(app)
+
+
+async def test_simple_reuse_of_a_chat_that_died_discards_it_and_spawns(disk):
+    app = make_app()
+    corpse = Chat(busy=True)
+    chats(app).sessions[KEY] = corpse
+    spawn = chat_spawner(app)
+    with wait_returns(REASON_EXITED):
+        result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert chats(app).terminated == [KEY]
+    assert result.spawned is True
+    assert result.session is not corpse
+    assert chats(app).get(KEY) is result.session
+    assert_released(app)
+
+
+async def test_simple_joining_a_creation_in_flight_goes_through_the_spawn(disk):
+    app = make_app()
+    chats(app).starting.add(KEY)
+    spawn = chat_spawner(app)
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert result.plan.action == ACTION_REUSE and result.plan.outgoing is None
+    assert len(spawn.calls) == 1
+    assert chats(app).get(KEY) is result.session
+    assert_released(app)
+
+
+async def test_no_spawn_callback_and_nothing_pooled_is_a_programming_error(disk):
+    app = make_app()
+    with pytest.raises(RuntimeError, match="no spawn callback"):
+        await acquire_surface(app, KEY, "expert", object())
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Takeover
+# ---------------------------------------------------------------------------
+
+
+async def test_takeover_closes_the_displaced_owner_then_attaches_the_newcomer(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    older, newer = object(), object()
+    assert registry(app).attach_session(KEY, older)
+    closed: list[str] = []
+
+    async def close_older() -> None:
+        closed.append("closed")
+        # The displaced handler is still holding the key when its socket
+        # closes; only (c)'s own detach releases it.
+        assert registry(app).attached_owner(KEY) is older
+
+    get_state(app).closers[older] = close_older
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", newer, spawn=spawn)
+
+    assert result.plan.action == ACTION_TAKEOVER
+    assert closed == ["closed"]
+    assert registry(app).attached_owner(KEY) is newer
+    assert result.session is pty and result.spawned is False
+    assert spawn.calls == []
+    assert pty.terminates == 0
+    assert_released(app)
+    # The displaced handler's own late detach is a no-op against the new owner.
+    registry(app).detach_session(KEY, older)
+    assert registry(app).attached_owner(KEY) is newer
+
+
+async def test_takeover_tolerates_a_missing_or_failing_closer(disk):
+    for closer in (None, "raises"):
+        app = make_app()
+        pool_pty(app)
+        older, newer = object(), object()
+        assert registry(app).attach_session(KEY, older)
+        if closer == "raises":
+
+            async def close_older() -> None:
+                raise OSError("socket already gone")
+
+            get_state(app).closers[older] = close_older
+        result = await acquire_surface(app, KEY, "expert", newer)
+        assert registry(app).attached_owner(KEY) is newer
+        assert result.spawned is False
+        assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Hand-off: chat out, PTY in
+# ---------------------------------------------------------------------------
+
+
+async def test_handoff_tears_the_chat_down_and_spawns_the_pty(disk):
+    app = make_app()
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+    channel = object()
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", channel, spawn=spawn)
+
+    assert result.plan.action == ACTION_HANDOFF
+    assert result.outcome == WaitOutcome(REASON_IDLE)
+    assert chats(app).terminated == [KEY]
+    assert chat.teardowns == 1
+    assert chats(app).get(KEY) is None
+    assert len(spawn.calls) == 1
+    assert registry(app).get_session(KEY) is result.session
+    assert registry(app).attached_owner(KEY) is channel
+    assert result.spawned is True
+    assert turn_state(app) == IDLE
+    assert_released(app)
+
+
+async def test_a_busy_chat_is_waited_for_before_it_is_torn_down(disk):
+    app = make_app()
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", object(), spawn=spawn))
+    await until(lambda: len(app.clock.sleeps) >= 5)
+    assert chat.teardowns == 0 and spawn.calls == []
+    chat.is_busy = False
+    result = await task
+    assert chat.teardowns == 1 and result.spawned is True
+
+
+async def test_an_interrupted_chat_handoff_cancels_the_turn_through_the_teardown(disk):
+    app = make_app()
+    chat = Chat(busy=True)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", object(), interrupt=True, spawn=spawn)
+    assert result.outcome == WaitOutcome(REASON_INTERRUPTED)
+    assert chats(app).terminated == [KEY]
+    assert chat.teardowns == 1
+    assert result.spawned is True
+
+
+async def test_the_chat_child_is_observed_dead_before_the_spawn(disk):
+    app = make_app()
+    chat = Chat(busy=False, exits=False, dies_after=3)
+    chats(app).sessions[KEY] = chat
+    chat.dying(app)
+    spawn = pty_spawner(app)
+    result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert result.spawned is True
+    assert chat.process_exited is True
+    polls = [s for s in app.clock.sleeps if s <= DEATH_POLL_S]
+    assert len(polls) >= 3
+
+
+async def test_a_chat_child_that_survives_is_reinserted_and_refused_503(disk):
+    app = make_app()
+    chat = Chat(busy=False, exits=False)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+
+    assert refused.value.status == 503
+    assert refused.value.error == ERROR_OUTGOING_STILL_RUNNING
+    assert refused.value.ws_close_code == WS_CLOSE_OUTGOING_RUNNING
+    assert chats(app).terminated == [KEY]
+    assert chats(app).reinserted == [KEY]
+    assert chats(app).get(KEY) is chat
+    assert spawn.calls == []
+    assert registry(app).get_session(KEY) is None
+    # The full grace was spent looking.
+    assert sum(app.clock.sleeps) == pytest.approx(DEATH_GRACE_S, abs=DEATH_POLL_S)
+    assert_released(app)
+
+
+async def test_the_next_acquire_meets_the_chat_survivor_and_kills_it_again(disk):
+    """A reinserted chat survivor is a holder, not a corpse: it is torn down again."""
+    app = make_app()
+    chat = Chat(busy=False, exits=False)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    with pytest.raises(HandoffRefused):
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert chat.teardowns == 1 and chats(app).get(KEY) is chat
+
+    chat.let_die()
+    result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    # Handed off, not discarded: popped and torn down a second time, and
+    # observed dead before the spawn.
+    assert result.plan.action == ACTION_HANDOFF
+    assert result.plan.outgoing is not None and result.plan.outgoing.session is chat
+    assert chats(app).terminated == [KEY, KEY]
+    assert chat.teardowns == 2
+    assert chat.process_exited is True
+    assert result.spawned is True
+    assert chats(app).get(KEY) is None
+    assert_released(app)
+
+
+async def test_a_chat_survivor_is_never_handed_back_to_the_simple_view(disk):
+    """Its client is closed; a Simple caller gets a fresh chat after the re-kill."""
+    app = make_app()
+    chat = Chat(busy=False, exits=False)
+    chats(app).sessions[KEY] = chat
+    with pytest.raises(HandoffRefused):
+        await acquire_surface(app, KEY, "expert", object(), spawn=pty_spawner(app))
+    assert chats(app).get(KEY) is chat
+
+    spawn = chat_spawner(app)
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    assert refused.value.error == ERROR_OUTGOING_STILL_RUNNING
+    assert chat.teardowns == 2
+    assert spawn.calls == []
+
+    chat.let_die()
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    assert result.plan.action == ACTION_HANDOFF
+    assert chat.teardowns == 3
+    assert result.spawned is True
+    assert result.session is not chat
+    assert chats(app).get(KEY) is result.session
+    assert_released(app)
+
+
+async def test_a_chat_survivor_that_still_survives_is_refused_again(disk):
+    app = make_app()
+    chat = Chat(busy=False, exits=False)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    for _ in range(2):
+        with pytest.raises(HandoffRefused) as refused:
+            await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+        assert refused.value.error == ERROR_OUTGOING_STILL_RUNNING
+    assert chat.teardowns == 2
+    assert chats(app).reinserted == [KEY, KEY]
+    assert chats(app).get(KEY) is chat
+    assert spawn.calls == []
+    assert_released(app)
+
+
+async def test_a_chat_survivor_whose_child_exited_meanwhile_is_a_corpse(disk):
+    """Once the child is gone the inactive entry is discarded by phase (a), no wait."""
+    app = make_app()
+    chat = Chat(busy=False, exits=False)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    with pytest.raises(HandoffRefused):
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+
+    chat.process_exited = True
+    app.clock.sleeps.clear()
+    result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert result.plan.action == ACTION_SPAWN
+    assert chat.teardowns == 2
+    assert app.clock.sleeps == []
+    assert result.spawned is True
+
+
+async def test_an_outgoing_chat_already_gone_is_still_torn_down_and_observed(disk):
+    """The reference (c) kept is torn down again — the kill re-signals — then watched."""
+    app = make_app()
+    chat = Chat(busy=False, exits=True)
+    chats(app).sessions[KEY] = chat
+
+    def gone():
+        chats(app).sessions.pop(KEY)
+
+    spawn = pty_spawner(app)
+    with wait_returns(REASON_IDLE, before=gone):
+        result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert chats(app).terminated == []
+    assert chat.teardowns == 1
+    assert chat.process_exited is True
+    assert result.spawned is True
+    assert_released(app)
+
+
+async def test_a_chat_without_a_process_handle_is_taken_as_gone_with_a_warning(disk, caplog):
+    app = make_app()
+    chat = Chat(busy=False, exits=None)
+    chats(app).sessions[KEY] = chat
+    spawn = pty_spawner(app)
+    with caplog.at_level(logging.WARNING, logger=session_handoff.__name__):
+        result = await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert result.spawned is True
+    assert "cannot be observed dead" in caplog.text
+    assert app.clock.sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# Hand-off: PTY out, chat in
+# ---------------------------------------------------------------------------
+
+
+async def test_handoff_pops_terminates_off_the_loop_and_resets_the_turn_state(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, IDLE, 1.0)
+    spawn = chat_spawner(app)
+    terminate_threads: list[str] = []
+    real_terminate = pty.terminate
+
+    def terminate() -> None:
+        import threading
+
+        terminate_threads.append(threading.current_thread().name)
+        real_terminate()
+
+    pty.terminate = terminate  # type: ignore[method-assign]
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert result.plan.action == ACTION_HANDOFF
+    assert result.outcome == WaitOutcome(REASON_IDLE)
+    assert pty.terminates == 1
+    assert terminate_threads and "MainThread" not in terminate_threads
+    assert registry(app).get_session(KEY) is None
+    assert not registry(app).is_attached(KEY)
+    assert turn_state(app) == IDLE
+    assert len(spawn.calls) == 1
+    assert chats(app).get(KEY) is result.session
+    assert_released(app)
+
+
+async def test_a_forced_outcome_still_pops_terminates_and_checks_death(disk):
+    """Phase (b) terminated once on the grace expiring; (c) does not trust it."""
+    app = make_app(hook=False)
+    pty = pool_pty(app)
+    set_store(app, BUSY, 1.0)
+    spawn = chat_spawner(app)
+    result = await acquire_surface(app, KEY, "simple", object(), interrupt=True, spawn=spawn)
+
+    assert result.outcome == WaitOutcome(REASON_FORCED)
+    assert pty.terminates == 2
+    assert registry(app).get_session(KEY) is None
+    assert turn_state(app) == IDLE
+    assert result.spawned is True
+
+
+async def test_an_exited_outcome_reaps_the_corpse_and_spawns(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, BUSY, 1.0)
+
+    def dies():
+        pty._alive = False
+
+    spawn = chat_spawner(app)
+    with wait_returns(REASON_EXITED, before=dies):
+        result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert pty.terminates == 1
+    assert registry(app).get_session(KEY) is None
+    assert turn_state(app) == IDLE
+    assert result.spawned is True
+    assert app.clock.sleeps == []
+
+
+async def test_a_pty_that_survives_is_reinserted_unattached_and_refused_503(disk):
+    app = make_app()
+    pty = SurvivorPty()
+    pool_pty(app, pty)
+    set_store(app, IDLE, 1.0)
+    set_store(app, BUSY, 2.0)
+    set_store(app, IDLE, 3.0)
+    spawn = chat_spawner(app)
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert refused.value.status == 503
+    assert refused.value.error == ERROR_OUTGOING_STILL_RUNNING
+    assert pty.terminates == 1
+    assert registry(app).get_session(KEY) is pty
+    assert not registry(app).is_attached(KEY)
+    assert not registry(app).is_reserved(KEY)
+    assert spawn.calls == []
+    assert chats(app).get(KEY) is None
+    # Not torn down, so not a teardown edge: the store is left alone.
+    assert turn_state(app) == IDLE and get_turn_state(app, KEY)["ts"] == 3.0
+    assert_released(app)
+
+
+async def test_the_next_acquire_meets_the_survivor_and_kills_it_again(disk):
+    app = make_app()
+    pty = SurvivorPty()
+    pool_pty(app, pty)
+    set_store(app, IDLE, 1.0)
+    spawn = chat_spawner(app)
+    with pytest.raises(HandoffRefused):
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    pty.die()
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    assert pty.terminates == 2
+    assert result.spawned is True
+    assert registry(app).get_session(KEY) is None
+
+
+async def test_a_pty_dying_during_the_death_poll_counts_as_dead(disk):
+    app = make_app()
+    pty = SurvivorPty()
+    pool_pty(app, pty)
+    set_store(app, IDLE, 1.0)
+    target = 4
+
+    def maybe_die(count: int) -> None:
+        if count >= target:
+            pty.die()
+
+    app.clock.on_sleep.append(maybe_die)
+    spawn = chat_spawner(app)
+    result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    assert result.spawned is True
+    assert registry(app).get_session(KEY) is None
+
+
+# ---------------------------------------------------------------------------
+# The premise no longer holds
+# ---------------------------------------------------------------------------
+
+
+async def test_an_outgoing_pty_replaced_mid_wait_is_an_error_and_kills_nothing(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, IDLE, 1.0)
+    impostor = RecordingPty()
+
+    def replace():
+        registry(app).pop_session(KEY)
+        pool_pty(app, impostor)
+
+    spawn = chat_spawner(app)
+    with wait_returns(REASON_IDLE, before=replace), pytest.raises(HandoffError) as failed:
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+
+    assert failed.value.error == ERROR_OUTGOING_VANISHED
+    assert pty.terminates == 0 and impostor.terminates == 0
+    assert registry(app).get_session(KEY) is impostor
+    assert spawn.calls == []
+    assert_released(app)
+
+
+async def test_an_outgoing_chat_replaced_mid_wait_is_an_error(disk):
+    app = make_app()
+    chats(app).sessions[KEY] = Chat(busy=False)
+    impostor = Chat(busy=False)
+
+    def replace():
+        chats(app).sessions[KEY] = impostor
+
+    spawn = pty_spawner(app)
+    with wait_returns(REASON_IDLE, before=replace), pytest.raises(HandoffError) as failed:
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert failed.value.error == ERROR_OUTGOING_VANISHED
+    assert chats(app).terminated == [] and impostor.teardowns == 0
+    assert spawn.calls == []
+    assert_released(app)
+
+
+async def test_an_outgoing_entry_already_gone_leaves_nothing_to_tear_down(disk):
+    app = make_app()
+    pty = pool_pty(app)
+    set_store(app, IDLE, 1.0)
+
+    def gone():
+        registry(app).pop_session(KEY)
+
+    spawn = chat_spawner(app)
+    with wait_returns(REASON_IDLE, before=gone):
+        result = await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    # The reference (c) kept is still reaped; the key was free for the spawn.
+    assert pty.terminates == 1
+    assert result.spawned is True
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# The spawn callback
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_capacity_is_the_429_refusal(disk):
+    app = make_app()
+
+    async def spawn(_request):
+        raise ChatCapacityError("full")
+
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "simple", object(), spawn=spawn)
+    assert refused.value.status == 429
+    assert refused.value.error == ERROR_CHAT_CAPACITY
+    assert refused.value.ws_close_code is None
+    assert_released(app)
+
+
+async def test_other_spawn_failures_escape_unchanged_after_the_release(disk):
+    app = make_app()
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+
+    async def spawn(_request):
+        raise OSError("fork failed")
+
+    with pytest.raises(OSError, match="fork failed"):
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    # The outgoing chat was already torn down; the key is empty and free.
+    assert chat.teardowns == 1
+    assert chats(app).get(KEY) is None
+    assert registry(app).get_session(KEY) is None
+    assert_released(app)
+
+
+async def test_a_spawn_that_pools_nothing_is_an_error(disk):
+    app = make_app()
+
+    async def spawn(_request):
+        return RecordingPty()
+
+    with pytest.raises(HandoffError) as failed:
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert failed.value.error == ERROR_SPAWN_NOT_POOLED
+    assert not registry(app).is_attached(KEY)
+    assert_released(app)
+
+
+async def test_an_attachment_taken_meanwhile_is_the_409_refusal(disk):
+    app = make_app()
+    intruder = object()
+
+    async def spawn(request):
+        pty = pool_pty(app)
+        registry(app).attach_session(request.key, intruder)
+        return pty
+
+    with pytest.raises(HandoffRefused) as refused:
+        await acquire_surface(app, KEY, "expert", object(), spawn=spawn)
+    assert refused.value.status == 409
+    assert refused.value.error == ERROR_SESSION_ATTACHED_ELSEWHERE
+    assert registry(app).attached_owner(KEY) is intruder
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Shield and lock
+# ---------------------------------------------------------------------------
+
+
+async def test_a_cancellation_mid_phase_lets_the_phase_finish(disk):
+    app = make_app()
+    chat = Chat(busy=False)
+    chats(app).sessions[KEY] = chat
+    gate = asyncio.Event()
+    channel = object()
+    spawn = pty_spawner(app, gate=gate)
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", channel, spawn=spawn))
+    await until(lambda: len(spawn.calls) == 1)
+    assert chat.teardowns == 1
+
+    task.cancel()
+    # Cancelled, but not done: the phase is still behind the gate.
+    await asyncio.sleep(0.01)
+    assert not task.done()
+    assert registry(app).get_session(KEY) is None
+
+    gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # The spawn landed, the PTY is pooled and attached, the slot is released.
+    session = registry(app).get_session(KEY)
+    assert session is not None
+    assert registry(app).attached_owner(KEY) is channel
+    assert_released(app)
+    # The caller's own cleanup detaches with its token, as a handler would.
+    registry(app).detach_session(KEY, channel)
+    assert not registry(app).is_attached(KEY)
+
+
+async def test_a_failure_after_the_caller_was_cancelled_is_logged_not_lost(disk, caplog):
+    """The phase's exception is retrieved by its own callback and logged."""
+    app = make_app()
+    chats(app).sessions[KEY] = Chat(busy=False)
+    gate = asyncio.Event()
+    calls: list[SpawnRequest] = []
+
+    async def spawn(request: SpawnRequest):
+        calls.append(request)
+        await gate.wait()
+        raise OSError("fork failed")
+
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", object(), spawn=spawn))
+    await until(lambda: len(calls) == 1)
+    task.cancel()
+    await asyncio.sleep(0.01)
+    assert not task.done()
+
+    with caplog.at_level(logging.WARNING, logger=session_handoff.__name__):
+        gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+    assert "failed after its caller was cancelled: fork failed" in caplog.text
+    assert_released(app)
+
+
+async def test_the_phase_holds_the_key_lock_so_a_second_acquire_waits(disk):
+    app = make_app()
+    gate = asyncio.Event()
+    first, second = object(), object()
+    spawn = pty_spawner(app, gate=gate)
+    task = asyncio.create_task(acquire_surface(app, KEY, "expert", first, spawn=spawn))
+    await until(lambda: len(spawn.calls) == 1)
+    assert get_state(app).lock_for(KEY).locked()
+
+    # The second blocks on the lock itself: not one look at the pools yet.
+    other = asyncio.create_task(acquire_surface(app, KEY, "expert", second))
+    await asyncio.sleep(0.02)
+    assert not other.done()
+    assert app.clock.sleeps == []
+
+    gate.set()
+    await task
+    result = await other
+    # ...and then takes the PTY over from the first, as the newer connection.
+    assert result.plan.action == ACTION_TAKEOVER
+    assert registry(app).attached_owner(KEY) is second
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+
+async def test_a_round_trip_keeps_one_process_live_and_resumes_the_transcript(disk):
+    app = make_app()
+    disk.add(KEY)
+
+    # Expert first: a fresh TUI under the key.
+    expert = object()
+    first = await acquire_surface(app, KEY, "expert", expert, spawn=pty_spawner(app))
+    pty1 = first.session
+    assert first.resume_id == KEY
+    registry(app).detach_session(KEY, expert)
+
+    # The TUI cleared: the transcript moved.
+    app.state.transcript_map[KEY] = TRANSCRIPT
+    disk.add(TRANSCRIPT)
+    set_store(app, IDLE, 5.0)
+
+    # Simple: the PTY goes, the chat resumes the moved transcript.
+    chat_spawn = chat_spawner(app)
+    second = await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawn)
+    assert pty1.terminates == 1 and registry(app).get_session(KEY) is None
+    assert chat_spawn.calls[0].resume_id == TRANSCRIPT
+    chat = second.session
+
+    # The next Simple turn reuses the chat, spawning nothing.
+    third = await acquire_surface(app, KEY, "simple", object(), spawn=chat_spawn)
+    assert third.session is chat and third.spawned is False
+    assert len(chat_spawn.calls) == 1
+
+    # Back to Expert: the chat goes, the TUI resumes the same transcript.
+    pty_spawn = pty_spawner(app)
+    fourth = await acquire_surface(app, KEY, "expert", expert, spawn=pty_spawn)
+    assert chat.teardowns == 1 and chats(app).get(KEY) is None
+    assert pty_spawn.calls[0].resume_id == TRANSCRIPT
+    assert registry(app).attached_owner(KEY) is expert
+    assert fourth.session is not pty1
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# The pools' reinsert
+# ---------------------------------------------------------------------------
+
+
+def test_pty_registry_reinsert_puts_a_popped_session_back_unheld():
+    reg = PtyRegistry(max_background=5)
+    pty = RecordingPty()
+    with patch.object(reg, "_spawn_session", return_value=pty):
+        reg.get_or_create_session(KEY, ["fake"])
+    reg.attach_session(KEY, object())
+    assert reg.pop_session(KEY) is pty
+
+    assert reg.reinsert(KEY, pty) is True
+    assert reg.get_session(KEY) is pty
+    assert not reg.is_attached(KEY)
+    assert not reg.is_reserved(KEY)
+    # An occupied key is left alone.
+    assert reg.reinsert(KEY, RecordingPty()) is False
+    assert reg.get_session(KEY) is pty
+
+
+async def test_chat_pool_reinsert_puts_a_terminated_session_back():
+    pool = ChatSessionPool(factory=lambda _cwd, _env, _key: Chat(), max_sessions=5)
+    chat = Chat(busy=False)
+    pool._sessions[KEY] = chat  # pooled by hand: the factory path needs a start()
+    assert await pool.terminate(KEY) is chat
+    assert pool.get(KEY) is None
+
+    assert await pool.reinsert(KEY, chat) is True
+    assert pool.get(KEY) is chat
+    assert await pool.reinsert(KEY, Chat()) is False
+    assert pool.get(KEY) is chat
+    # A creation in flight counts as occupied too.
+    other = "22222222-3333-4444-5555-666666666666"
+    pool._pending[other] = asyncio.get_running_loop().create_future()
+    assert await pool.reinsert(other, Chat()) is False

--- a/tests/interfaces/web_terminal/test_handoff_route.py
+++ b/tests/interfaces/web_terminal/test_handoff_route.py
@@ -1,0 +1,514 @@
+"""The Simple view's hand-off endpoint: ``POST /api/session/{key}/handoff``.
+
+The route is a thin translation of one call — ``acquire_surface`` for the
+Simple surface — into HTTP, and everything worth pinning is in that
+translation:
+
+- what the operator gets back when the flip works, with no turn taken on the
+  chat the flip leaves pooled;
+- every refusal carrying the status *and* the ``detail.error`` slug the client
+  branches on, rather than a sentence it would have to match;
+- a caller that goes away mid-wait costing nothing: no teardown, no spawn, no
+  body.
+
+The route is driven over HTTP throughout — through the router, the body model
+and the exception handlers — rather than by calling the handler. The pools
+behind it are the phase (a)/(b) fakes, and the wait's clock is faked with
+them, so a two-second attach grace and a five-second interrupt grace are
+exercised without being spent. The disconnect test drives the ASGI app
+directly because no HTTP test client can hang up mid-request: its ``receive``
+answers the hand-off's own disconnect polls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.web_terminal.chat_session_pool import (
+    ChatCapacityError,
+    ChatSessionTerminatedError,
+)
+from osprey.interfaces.web_terminal.operator_session import POSTURE_SOURCE_LIVE
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.routes.session_handoff import router
+from osprey.interfaces.web_terminal.session_handoff import (
+    ERROR_CHAT_CAPACITY,
+    ERROR_HANDOFF_NEEDS_INTERRUPT,
+    ERROR_HANDOFF_SUPERSEDED,
+    ERROR_OUTGOING_STILL_RUNNING,
+    ERROR_SESSION_ATTACHED_ELSEWHERE,
+    ERROR_SPAWN_NOT_POOLED,
+    HandoffState,
+    get_state,
+)
+from osprey.interfaces.web_terminal.turn_state import BUSY, IDLE
+from osprey_connectors import session_store
+from tests.interfaces.web_terminal._fakes import FakeChatPool, FakeChatSession, FakeClock
+from tests.interfaces.web_terminal.test_handoff_phase_a import KEY
+from tests.interfaces.web_terminal.test_handoff_phase_b import RecordingPty, pool_pty, set_store
+
+HANDOFF_PATH = f"/api/session/{KEY}/handoff"
+
+
+@pytest.fixture(autouse=True)
+def shared_root(tmp_path, monkeypatch):
+    """Pin the agent-data root so a spawned child's environment resolves in ``tmp_path``.
+
+    The environment builder stamps the root it resolves. Without a pinned one
+    the resolution walks up to the repository and the suite's leak guard
+    fires.
+    """
+    root = tmp_path / "shared_agent_data"
+    root.mkdir()
+    monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(root))
+    session_store.invalidate_cache()
+    yield root
+    session_store.invalidate_cache()
+
+
+# ---------------------------------------------------------------------------
+# The app under test
+# ---------------------------------------------------------------------------
+
+
+class SurvivingPty(RecordingPty):
+    """A terminal whose child outlives its kill: ``terminate`` returns, it does not."""
+
+    def terminate(self) -> None:
+        self.terminates += 1
+
+
+class Chat(FakeChatSession):
+    """A pooled chat that refuses to have a turn taken on it.
+
+    The hand-off leaves the chat idle and free; ``POST /api/chat`` is what
+    mints the per-turn guard. A route that took the turn here would strand it,
+    so the guard is made loud rather than merely unasserted.
+    """
+
+    def acquire_turn(self) -> int:
+        raise AssertionError("the hand-off must not take a turn on the chat")
+
+
+class FakeChatRegistry:
+    """The slice of ``OperatorRegistry`` the route and the acquire read.
+
+    ``get_or_create_chat_session`` is the route's spawn callback in one hop:
+    it records what it was asked for, calls the environment *builder* the way
+    the real pool does, and pools the session it returns. The knobs are the
+    three ways that can go wrong — an exception from the pool, and a spawn
+    whose session never reaches the pool.
+    """
+
+    def __init__(self, chats: FakeChatPool) -> None:
+        self.chats = chats
+        self.spawns: list[tuple[str, str, str | None]] = []
+        self.envs: list[dict[str, str]] = []
+        self.raises: Exception | None = None
+        self.pools_the_spawn = True
+
+    async def get_or_create_chat_session(
+        self,
+        chat_id: str,
+        cwd: str,
+        env: Any = None,
+        *,
+        resume_id: str | None = None,
+    ) -> tuple[Chat, bool]:
+        self.spawns.append((chat_id, cwd, resume_id))
+        if self.raises is not None:
+            raise self.raises
+        self.envs.append(env() if callable(env) else env)
+        session = Chat()
+        if self.pools_the_spawn:
+            self.chats.sessions[chat_id] = session
+        return session, False
+
+
+class PacedClock(FakeClock):
+    """The fake clock, spending a real millisecond per look.
+
+    The plain fake yields once per look, which makes a two-second attach grace
+    forty bare yields — gone before a worker thread the other request is
+    waiting on can even return. A real millisecond per look keeps fake time
+    fake and gives the two concurrent requests room to interleave the way
+    they do behind a real server.
+    """
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+        for hook in list(self.on_sleep):
+            hook(len(self.sleeps))
+        await asyncio.sleep(0.001)
+
+
+def make_app(tmp_path, *, hook: bool = True, paced: bool = False) -> FastAPI:
+    """A FastAPI app exposing the hand-off route over the fake pools."""
+    clock = PacedClock() if paced else FakeClock()
+    app = FastAPI()
+    app.include_router(router)
+    app.state.project_cwd = str(tmp_path)
+    app.state.pty_registry = PtyRegistry(max_background=5)
+    app.state.operator_registry = FakeChatRegistry(FakeChatPool())
+    app.state.handoff = HandoffState(clock=clock, sleep=clock.sleep)
+    app.state.turn_hook_present = hook
+    app.state.turn_state = {}
+    app.state.transcript_map = {}
+    app.state.transcript_map_provisional = False
+    app.state.clock = clock
+    return app
+
+
+def chats(app: FastAPI) -> FakeChatPool:
+    return app.state.operator_registry.chats
+
+
+def registry(app: FastAPI) -> PtyRegistry:
+    return app.state.pty_registry
+
+
+def post(app: FastAPI, **body) -> Any:
+    """POST a client-shaped hand-off body and return the response."""
+    payload = {"to": "simple"}
+    payload.update(body)
+    with TestClient(app) as client:
+        return client.post(HANDOFF_PATH, json=payload)
+
+
+def assert_released(app: FastAPI) -> None:
+    """The pending slot and the reservation an ended acquire leaves behind."""
+    assert KEY not in get_state(app).pending
+    assert not registry(app).is_reserved(KEY)
+
+
+# ---------------------------------------------------------------------------
+# Registration and the body model
+# ---------------------------------------------------------------------------
+
+
+def test_the_route_is_reachable_on_the_composite_router():
+    """The web terminal's own router serves the path the client posts to.
+
+    The composite router keeps its sub-routers unflattened until an app
+    resolves them, so the question is put to a request rather than to a list
+    of routes: a refused key is the handler answering, and a path nobody
+    registered would be a 404.
+    """
+    from osprey.interfaces.web_terminal.routes import router as composite
+
+    app = FastAPI()
+    app.include_router(composite)
+
+    resp = TestClient(app).post("/api/session/not-a-uuid/handoff", json={"to": "simple"})
+
+    assert resp.status_code == 400
+
+
+def test_only_the_simple_surface_can_be_asked_for(tmp_path):
+    """The Expert view acquires on its socket; there is no HTTP form of it."""
+    app = make_app(tmp_path)
+    resp = post(app, to="expert")
+    assert resp.status_code == 422
+    assert app.state.operator_registry.spawns == []
+
+
+def test_the_key_must_be_a_session_uuid(tmp_path):
+    """A key outside the grammar never reaches the acquire."""
+    app = make_app(tmp_path)
+    with TestClient(app) as client:
+        resp = client.post("/api/session/not-a-uuid/handoff", json={"to": "simple"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["error"] == "invalid_session_id"
+    assert app.state.operator_registry.spawns == []
+
+
+# ---------------------------------------------------------------------------
+# The flip itself
+# ---------------------------------------------------------------------------
+
+
+def test_an_unheld_key_starts_the_chat_and_answers_with_the_surface(tmp_path):
+    """Nothing live under the key: the chat is started fresh under it."""
+    app = make_app(tmp_path)
+
+    resp = post(app)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"state": "simple", "session_id": KEY}
+    assert app.state.operator_registry.spawns == [(KEY, str(tmp_path), None)]
+    assert isinstance(chats(app).sessions[KEY], Chat)
+    assert_released(app)
+
+
+def test_the_child_is_stamped_with_the_key_and_a_live_posture(tmp_path):
+    """The spawned chat carries the session key and the posture surface can address it."""
+    app = make_app(tmp_path)
+
+    assert post(app).status_code == 200
+
+    env = app.state.operator_registry.envs[0]
+    assert env["OSPREY_SESSION_ID"] == KEY
+    assert env["OSPREY_POSTURE_SESSION"] == KEY
+    assert env["OSPREY_POSTURE_SOURCE"] == POSTURE_SOURCE_LIVE
+
+
+def test_an_idle_chat_already_under_the_key_is_handed_back_untouched(tmp_path):
+    """The Simple view's own pooled chat is the answer; nothing is spawned or claimed."""
+    app = make_app(tmp_path)
+    pooled = Chat()
+    chats(app).sessions[KEY] = pooled
+
+    resp = post(app)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"state": "simple", "session_id": KEY}
+    assert app.state.operator_registry.spawns == []
+    assert chats(app).sessions[KEY] is pooled
+    assert pooled.teardowns == 0
+
+
+def test_a_terminal_holding_the_key_is_torn_down_before_the_chat_starts(tmp_path):
+    """The ordinary flip: the idle terminal dies, then the chat resumes the key."""
+    app = make_app(tmp_path)
+    pty = pool_pty(app)
+    set_store(app, IDLE, app.state.clock.now)
+
+    resp = post(app)
+
+    assert resp.status_code == 200
+    assert pty.terminates == 1
+    assert registry(app).get_session(KEY) is None
+    assert app.state.operator_registry.spawns == [(KEY, str(tmp_path), None)]
+    assert_released(app)
+
+
+def test_a_terminal_whose_turns_are_invisible_is_refused_until_the_caller_interrupts(tmp_path):
+    """No turn-state hook: waiting is refused, and *Stop and switch now* is honoured."""
+    app = make_app(tmp_path, hook=False)
+    pty = pool_pty(app)
+
+    refused = post(app)
+
+    assert refused.status_code == 409
+    assert refused.json()["detail"]["error"] == ERROR_HANDOFF_NEEDS_INTERRUPT
+    assert pty.terminates == 0
+    assert app.state.operator_registry.spawns == []
+    assert_released(app)
+
+    cut = post(app, interrupt=True)
+
+    assert cut.status_code == 200
+    assert pty.writes == [b"\x1b"]
+    assert registry(app).get_session(KEY) is None
+    assert app.state.operator_registry.spawns == [(KEY, str(tmp_path), None)]
+
+
+# ---------------------------------------------------------------------------
+# The refusals, one status and slug each
+# ---------------------------------------------------------------------------
+
+
+def test_a_key_another_view_is_consuming_is_a_409(tmp_path):
+    """An attached terminal is re-looked at for the grace, then refused."""
+    app = make_app(tmp_path)
+    pool_pty(app)
+    assert registry(app).attach_session(KEY, object())
+
+    resp = post(app)
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == ERROR_SESSION_ATTACHED_ELSEWHERE
+    assert app.state.operator_registry.spawns == []
+    assert_released(app)
+
+
+def test_a_full_chat_pool_is_a_429(tmp_path):
+    """Capacity is the pool's word, and it reaches the client as a retryable slug."""
+    app = make_app(tmp_path)
+    app.state.operator_registry.raises = ChatCapacityError("full")
+
+    resp = post(app)
+
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["error"] == ERROR_CHAT_CAPACITY
+    assert_released(app)
+
+
+def test_a_chat_torn_down_while_it_started_is_a_409(tmp_path):
+    """A posture flip or a DELETE landing inside the spawn is retryable, not a 500."""
+    app = make_app(tmp_path)
+    app.state.operator_registry.raises = ChatSessionTerminatedError("gone")
+
+    resp = post(app)
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "chat_terminated"
+    assert_released(app)
+
+
+def test_a_terminal_that_survives_its_kill_is_a_503(tmp_path):
+    """The previous agent is still shutting down; retrying re-runs the kill."""
+    app = make_app(tmp_path)
+    pty = pool_pty(app, SurvivingPty())
+    set_store(app, IDLE, app.state.clock.now)
+
+    resp = post(app)
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == ERROR_OUTGOING_STILL_RUNNING
+    assert pty.terminates == 1
+    assert registry(app).get_session(KEY) is pty
+    assert app.state.operator_registry.spawns == []
+    assert_released(app)
+
+
+def test_a_spawn_the_pool_does_not_hold_is_a_503(tmp_path):
+    """A started child nobody pooled is a broken premise, not a hand-off."""
+    app = make_app(tmp_path)
+    app.state.operator_registry.pools_the_spawn = False
+
+    resp = post(app)
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == ERROR_SPAWN_NOT_POOLED
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# The caller that goes away
+# ---------------------------------------------------------------------------
+
+
+async def call_asgi(app: FastAPI, path: str, body: dict, *, polls_before_hangup: int) -> list[dict]:
+    """POST to *app* over raw ASGI, hanging up after *polls_before_hangup* looks.
+
+    No HTTP client can disconnect mid-request — both test transports hold
+    their disconnect back until the response is complete — so the hand-off's
+    own ``request.is_disconnected()`` polls are answered here: the body first,
+    then that many messages that are not a disconnect, then the hang-up.
+    """
+    raw = json.dumps(body).encode()
+    messages: list[dict] = [{"type": "http.request", "body": raw, "more_body": False}]
+    messages += [{"type": "http.request", "body": b"", "more_body": False}] * polls_before_hangup
+
+    async def receive() -> dict:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    sent: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "root_path": "",
+            "query_string": b"",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(raw)).encode()),
+            ],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "state": {},
+        },
+        receive,
+        send,
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_a_caller_that_hangs_up_mid_wait_gets_no_body_and_costs_nothing(tmp_path):
+    """The flip is abandoned where it stood: nothing torn down, nothing started."""
+    app = make_app(tmp_path)
+    pty = pool_pty(app)
+    set_store(app, BUSY, app.state.clock.now)
+
+    sent = await call_asgi(app, HANDOFF_PATH, {"to": "simple"}, polls_before_hangup=2)
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 204
+    assert all(not m.get("body") for m in sent if m["type"] == "http.response.body")
+    assert app.state.clock.sleeps, "the hang-up must land while the wait is running"
+    assert pty.terminates == 0
+    assert pty.writes == []
+    assert registry(app).get_session(KEY) is pty
+    assert app.state.operator_registry.spawns == []
+    assert_released(app)
+
+
+# ---------------------------------------------------------------------------
+# Two requests for one key: the newer one, interrupting, takes over
+# ---------------------------------------------------------------------------
+
+
+def test_a_second_request_with_an_interrupt_takes_the_key_from_a_waiting_one(tmp_path):
+    """*Stop and switch now* from the transitional state, through the whole stack.
+
+    The first request waits on the terminal's turn; the second, made while it
+    waits and carrying the interrupt, is what the console sends when the
+    operator presses the button. The first is answered ``handoff_superseded``
+    and the second completes the flip — nothing depends on the server seeing
+    the first request abandoned, which under a browser it does not.
+    """
+    app = make_app(tmp_path, paced=True)
+    pty = pool_pty(app)
+    set_store(app, BUSY, app.state.clock.now)
+
+    def idle_once_escaped(_count: int) -> None:
+        if pty.writes:
+            set_store(app, IDLE, app.state.clock.now)
+
+    app.state.clock.on_sleep.append(idle_once_escaped)
+
+    # Every wait here is bounded, and the executor is never joined on a request
+    # that may still be waiting: should either POST fail to answer, the
+    # terminal is reported idle so the wait ends on its own, and the failure
+    # is a timeout in seconds rather than a join that never returns.
+    threads = ThreadPoolExecutor(max_workers=2)
+    try:
+        with TestClient(app) as client:
+            first = threads.submit(client.post, HANDOFF_PATH, json={"to": "simple"})
+            deadline = time.monotonic() + 5.0
+            while KEY not in get_state(app).pending:
+                assert time.monotonic() < deadline, "the first request never reached its wait"
+                time.sleep(0.005)
+            second = threads.submit(
+                client.post, HANDOFF_PATH, json={"to": "simple", "interrupt": True}
+            )
+            try:
+                superseded = first.result(timeout=30.0)
+                cut = second.result(timeout=30.0)
+            finally:
+                set_store(app, IDLE, app.state.clock.now)
+    finally:
+        threads.shutdown(wait=True)
+
+    assert superseded.status_code == 409
+    assert superseded.json()["detail"]["error"] == ERROR_HANDOFF_SUPERSEDED
+    assert cut.status_code == 200
+    assert cut.json() == {"state": "simple", "session_id": KEY}
+    assert pty.writes == [b"\x1b"]
+    assert pty.terminates == 1
+    assert registry(app).get_session(KEY) is None
+    assert app.state.operator_registry.spawns == [(KEY, str(tmp_path), None)]
+    assert_released(app)

--- a/tests/interfaces/web_terminal/test_operator_session.py
+++ b/tests/interfaces/web_terminal/test_operator_session.py
@@ -78,8 +78,9 @@ class FakeResultMessage:
 class FakeSystemMessage:
     """Mimics ``claude_agent_sdk.SystemMessage``."""
 
-    def __init__(self, subtype: str = "init"):
+    def __init__(self, subtype: str = "init", data: dict | None = None):
         self.subtype = subtype
+        self.data = data or {}
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +237,35 @@ class TestMessageToEvents:
         events = _message_to_events(msg)
         assert len(events) == 3
         assert [e["type"] for e in events] == ["thinking", "text", "tool_use"]
+
+
+class TestSystemEventCarriesResumeIdentity:
+    """The init message is where the child names the transcript it writes to.
+
+    A resume can be answered with a different id than the one asked for, so the
+    id the child reports is the only authoritative one — it has to reach the
+    consumer, not stop at the SDK boundary.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_system_message(self):
+        """Replace the SDK type reference so ``isinstance()`` sees our fake."""
+        with patch(
+            "osprey.interfaces.web_terminal.operator_session.SystemMessage",
+            FakeSystemMessage,
+        ):
+            yield
+
+    def test_the_init_session_id_reaches_the_system_event(self):
+        msg = FakeSystemMessage("init", data={"session_id": "abc-123"})
+        events = _message_to_events(msg)
+        assert events == [{"type": "system", "subtype": "init", "session_id": "abc-123"}]
+
+    def test_a_system_message_without_one_carries_no_key(self):
+        """Absent, not ``None``: a message that says nothing about identity
+        must not read as one reporting a missing id."""
+        events = _message_to_events(FakeSystemMessage("compact_boundary"))
+        assert events == [{"type": "system", "subtype": "compact_boundary"}]
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +506,127 @@ class TestOperatorSession:
             assert events[1]["type"] == "result"
 
             await session.stop()
+
+
+# ---------------------------------------------------------------------------
+# OperatorSession start identity: resume a transcript, or open one
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _capture_start_options(captured: dict):
+    """Patch the SDK seam and record the ``ClaudeAgentOptions`` kwargs.
+
+    Same patch set as the two start tests above, hoisted so the identity tests
+    read as the one assertion each is making.
+    """
+
+    def capture_options(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    seam = "osprey.interfaces.web_terminal.operator_session."
+    with (
+        patch(seam + "CLAUDE_SDK_AVAILABLE", True),
+        patch(seam + "ClaudeAgentOptions", side_effect=capture_options),
+        patch(seam + "ClaudeSDKClient", return_value=mock_client),
+        patch(seam + "validate_project_directory", return_value=[]),
+        patch(
+            seam + "build_system_prompt",
+            return_value={"type": "preset", "preset": "claude_code"},
+        ),
+        patch(seam + "get_facility_timezone", return_value=None),
+    ):
+        yield
+
+
+class TestOperatorSessionResumeOptions:
+    """The two shapes a chat child can be started in.
+
+    Either it continues a transcript that already exists (``resume``) or it
+    opens one under the session key (``session_id``). Never both: a resume
+    names the transcript, and a session id alongside it would ask the SDK to
+    write one conversation under two identities.
+    """
+
+    KEY = "11111111-2222-3333-4444-555555555555"
+
+    @pytest.mark.asyncio
+    async def test_a_resume_names_the_transcript_and_nothing_else(self):
+        session = OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"}, session_key=self.KEY)
+        captured: dict = {}
+
+        with _capture_start_options(captured):
+            await session.start(resume_id="transcript-9")
+
+        assert captured["resume"] == "transcript-9"
+        assert "session_id" not in captured
+        # Everything else about the launch is unchanged by the resume.
+        assert captured["setting_sources"] == ["project"]
+        assert captured["env"]["OSPREY_WEB_UX"] == "simple"
+
+    @pytest.mark.asyncio
+    async def test_without_a_resume_the_child_opens_one_under_the_session_key(self):
+        session = OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"}, session_key=self.KEY)
+        captured: dict = {}
+
+        with _capture_start_options(captured):
+            await session.start()
+
+        assert captured["session_id"] == self.KEY
+        assert "resume" not in captured
+
+    @pytest.mark.asyncio
+    async def test_the_telemetry_id_is_the_session_key_in_both_shapes(self):
+        """Never a fresh uuid: an id re-drawn per start would split one
+        conversation's traces across as many ids as it had surfaces."""
+        fresh: dict = {}
+        resumed: dict = {}
+
+        with _capture_start_options(fresh):
+            await OperatorSession(
+                cwd="/tmp", env={"PATH": "/usr/bin"}, session_key=self.KEY
+            ).start()
+        with _capture_start_options(resumed):
+            await OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"}, session_key=self.KEY).start(
+                resume_id="transcript-9"
+            )
+
+        assert fresh["env"]["OSPREY_TELEMETRY_SESSION_ID"] == self.KEY
+        assert resumed["env"]["OSPREY_TELEMETRY_SESSION_ID"] == self.KEY
+
+    @pytest.mark.asyncio
+    async def test_a_session_given_no_key_holds_one_stable_across_starts(self):
+        """The key belongs to the session object, not to a single start."""
+        session = OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"})
+        first: dict = {}
+        second: dict = {}
+
+        with _capture_start_options(first):
+            await session.start()
+        with _capture_start_options(second):
+            await session.start()
+
+        minted = first["env"]["OSPREY_TELEMETRY_SESSION_ID"]
+        assert minted
+        assert second["env"]["OSPREY_TELEMETRY_SESSION_ID"] == minted
+        assert second["session_id"] == minted
+
+    @pytest.mark.asyncio
+    async def test_two_keyless_sessions_do_not_share_an_identity(self):
+        first: dict = {}
+        second: dict = {}
+
+        with _capture_start_options(first):
+            await OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"}).start()
+        with _capture_start_options(second):
+            await OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"}).start()
+
+        assert first["session_id"] != second["session_id"]
 
 
 # ---------------------------------------------------------------------------
@@ -895,9 +1046,11 @@ class FakeTask:
 class FakeChatSession:
     """Lightweight OperatorSession double for registry pool tests."""
 
-    def __init__(self, cwd: str = "/tmp", env=None):
+    def __init__(self, cwd: str = "/tmp", env=None, session_key=None):
         self.cwd = cwd
         self.env = env
+        self.session_key = session_key
+        self.resume_id = None
         self.is_active = True
         self.last_activity = time.monotonic()
         self.in_flight = False
@@ -908,7 +1061,8 @@ class FakeChatSession:
         self.start_delay = 0.0
         self.start_error: Exception | None = None
 
-    async def start(self):
+    async def start(self, *, resume_id=None):
+        self.resume_id = resume_id
         if self.start_delay:
             await asyncio.sleep(self.start_delay)
         if self.start_error is not None:
@@ -975,12 +1129,129 @@ class TestOperatorSessionBusyAndTeardown:
         assert session.is_active is False
 
 
+class FakeChildProcess:
+    """The slice of the SDK transport's process handle ``stop`` reads and signals."""
+
+    def __init__(self, returncode: int | None = None, *, gone: bool = False, pid: int = 4242):
+        self.returncode = returncode
+        self.gone = gone
+        self.pid = pid
+        self.kills = 0
+
+    def kill(self) -> None:
+        if self.gone:
+            raise ProcessLookupError
+        self.kills += 1
+
+
+def _client_over(process: FakeChildProcess) -> AsyncMock:
+    client = AsyncMock()
+    client._transport = SimpleNamespace(_process=process)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+class TestOperatorSessionStopKillsALingeringChild:
+    """``stop`` sends SIGKILL to a retained child that has no return code yet.
+
+    The SDK's own close escalates through SIGTERM to SIGKILL with bounded
+    waits; this covers the child that outlived it, and — the case a hand-off
+    relies on — the second ``stop`` on a session whose client is already gone.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_child_still_running_after_the_client_closed_is_killed(self):
+        process = FakeChildProcess(returncode=None)
+        session = OperatorSession(cwd="/tmp")
+        session._client = _client_over(process)
+        session._started = True
+
+        await session.stop()
+
+        assert process.kills == 1
+        assert session._last_process is process
+        assert session.process_exited is False
+        assert session.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_a_child_that_exited_is_not_signalled(self):
+        process = FakeChildProcess(returncode=0)
+        session = OperatorSession(cwd="/tmp")
+        session._client = _client_over(process)
+        session._started = True
+
+        await session.stop()
+
+        assert process.kills == 0
+        assert session.process_exited is True
+
+    @pytest.mark.asyncio
+    async def test_a_second_stop_with_no_client_signals_the_retained_child_again(self):
+        process = FakeChildProcess(returncode=None)
+        session = OperatorSession(cwd="/tmp")
+        session._client = _client_over(process)
+        session._started = True
+        await session.stop()
+        assert process.kills == 1
+
+        await session.teardown()
+
+        assert process.kills == 2
+        assert session._last_process is process
+        assert session.process_exited is False
+
+    @pytest.mark.asyncio
+    async def test_a_child_gone_between_looks_is_tolerated(self):
+        process = FakeChildProcess(returncode=None, gone=True)
+        session = OperatorSession(cwd="/tmp")
+        session._last_process = process
+
+        await session.stop()
+
+        assert process.kills == 0
+        assert session.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_a_session_with_no_handle_signals_nothing(self):
+        session = OperatorSession(cwd="/tmp")
+        await session.stop()
+        assert session._last_process is None
+        assert session.process_exited is None
+
+
+def test_the_pid_names_the_running_child_and_nothing_else():
+    """``pid`` is the chat child's pid while it runs, and ``None`` when it is not.
+
+    The Simple view holds a session in this child, so anything addressed to
+    the process behind a session key — a controls-server record, a
+    diagnostic — has to be able to ask which process that is. A session that
+    never started has no handle, and a handle carrying a return code names a
+    process that is gone; both answer ``None`` rather than a pid nothing is
+    running under. A client already closed still answers from the handle the
+    session retained, which is what makes the question survive a teardown.
+    """
+    session = OperatorSession(cwd="/tmp")
+    assert session.pid is None
+
+    process = FakeChildProcess(returncode=None, pid=31337)
+    session._client = _client_over(process)
+    session._started = True
+    assert session.pid == 31337
+
+    session._client = None
+    session._last_process = process
+    assert session.pid == 31337
+
+    process.returncode = 0
+    assert session.pid is None
+
+
 def _session_factory(start_delay: float = 0.0):
     """Return a side_effect callable that builds FakeChatSessions and records them."""
     created: list[FakeChatSession] = []
 
-    def factory(cwd=None, env=None):
-        s = FakeChatSession(cwd=cwd, env=env)
+    def factory(cwd=None, env=None, session_key=None):
+        s = FakeChatSession(cwd=cwd, env=env, session_key=session_key)
         s.start_delay = start_delay
         created.append(s)
         return s
@@ -1184,8 +1455,8 @@ class TestOperatorRegistryChatPool:
 
         created: list[FakeChatSession] = []
 
-        def factory(cwd=None, env=None):
-            s = FakeChatSession(cwd=cwd, env=env)
+        def factory(cwd=None, env=None, session_key=None):
+            s = FakeChatSession(cwd=cwd, env=env, session_key=session_key)
             # First construction fails during start; later ones succeed.
             if not created:
                 s.start_error = RuntimeError("boom")

--- a/tests/interfaces/web_terminal/test_operator_session.py
+++ b/tests/interfaces/web_terminal/test_operator_session.py
@@ -545,12 +545,13 @@ def _capture_start_options(captured: dict):
 
 
 class TestOperatorSessionResumeOptions:
-    """The two shapes a chat child can be started in.
+    """The shapes a chat child can be started in.
 
     Either it continues a transcript that already exists (``resume``) or it
     opens one under the session key (``session_id``). Never both: a resume
     names the transcript, and a session id alongside it would ask the SDK to
-    write one conversation under two identities.
+    write one conversation under two identities. A pool key outside the
+    session-key grammar names neither, because the CLI would refuse it.
     """
 
     KEY = "11111111-2222-3333-4444-555555555555"
@@ -579,6 +580,28 @@ class TestOperatorSessionResumeOptions:
 
         assert captured["session_id"] == self.KEY
         assert "resume" not in captured
+
+    @pytest.mark.asyncio
+    async def test_a_pool_key_the_cli_would_reject_names_no_session_id(self):
+        """An embedder's own chat key never reaches the CLI as an identity.
+
+        ``POST /api/chat`` accepts any string as ``chat_id`` and pools the chat
+        under it, so the key can be ``"e2e"`` or ``"user-42-chat-3"``.
+        ``--session-id`` takes a canonical UUID and the CLI exits non-zero on
+        anything else, so naming the key there would fail the child on its
+        first prompt. It mints its own id instead.
+        """
+        session = OperatorSession(cwd="/tmp", env={"PATH": "/usr/bin"}, session_key="e2e")
+        captured: dict = {}
+
+        with _capture_start_options(captured):
+            await session.start()
+
+        # None, not the key: the SDK omits the flag entirely for a falsy id.
+        assert captured["session_id"] is None
+        assert "resume" not in captured
+        # The key still names the session everywhere it is ours to spend.
+        assert captured["env"]["OSPREY_TELEMETRY_SESSION_ID"] == "e2e"
 
     @pytest.mark.asyncio
     async def test_the_telemetry_id_is_the_session_key_in_both_shapes(self):

--- a/tests/interfaces/web_terminal/test_operator_session_exit.py
+++ b/tests/interfaces/web_terminal/test_operator_session_exit.py
@@ -1,0 +1,272 @@
+"""The child's death, observable after the session has been torn down.
+
+Tearing a chat session down closes its SDK client, and closing the client drops
+the transport that holds the child's process handle. A surface handing a
+conversation over has to wait for the outgoing child to be *gone*, not merely
+asked to leave, so the handle is kept one step before the close and read back
+through ``OperatorSession.process_exited``; ``terminate`` hands the torn-down
+session out so a caller has something to read it on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osprey.interfaces.web_terminal.chat_session_pool import ChatSessionPool
+from osprey.interfaces.web_terminal.operator_session import OperatorRegistry, OperatorSession
+
+_SEAM = "osprey.interfaces.web_terminal.operator_session"
+
+
+# ---------------------------------------------------------------------------
+# Fakes — an SDK client whose transport exposes a process handle
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """The child handle the SDK transport holds (``returncode`` is the signal)."""
+
+    def __init__(self, returncode: int | None = None):
+        self.returncode = returncode
+
+
+class _FakeTransport:
+    def __init__(self, process: _FakeProcess):
+        self._process = process
+
+
+class _FakeSDKClient:
+    """Stand-in for ``ClaudeSDKClient`` with a controllable transport.
+
+    ``transport=None`` models a client that never exposed one — the shape the
+    property must answer ``None`` for rather than ``False``.
+    """
+
+    def __init__(self, transport: _FakeTransport | None = None):
+        if transport is not None:
+            self._transport = transport
+        self.exited = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exited = True
+        return False
+
+
+@contextlib.contextmanager
+def _sdk_seam(client):
+    """Patch the SDK seam so ``start()`` connects *client* and nothing else."""
+    with (
+        patch(f"{_SEAM}.CLAUDE_SDK_AVAILABLE", True),
+        patch(f"{_SEAM}.ClaudeAgentOptions", side_effect=lambda **kw: MagicMock()),
+        patch(f"{_SEAM}.ClaudeSDKClient", return_value=client),
+        patch(f"{_SEAM}.validate_project_directory", return_value=[]),
+        patch(f"{_SEAM}.build_system_prompt", return_value={"type": "preset"}),
+        patch(f"{_SEAM}.get_facility_timezone", return_value=None),
+    ):
+        yield
+
+
+async def _started_session(client) -> OperatorSession:
+    session = OperatorSession(cwd="/tmp")
+    with _sdk_seam(client):
+        await session.start()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# OperatorSession.process_exited
+# ---------------------------------------------------------------------------
+
+
+class TestProcessExited:
+    """Three answers, and the difference between two of them matters."""
+
+    @pytest.mark.asyncio
+    async def test_a_child_still_running_after_the_close_reads_false(self):
+        """Closing the client is a request, not a death certificate.
+
+        The transport is gone but the process it held has no return code, so
+        the child is still there — the case a handover must keep waiting on.
+        """
+        client = _FakeSDKClient(_FakeTransport(_FakeProcess(returncode=None)))
+        session = await _started_session(client)
+
+        await session.stop()
+
+        assert client.exited is True
+        assert session.process_exited is False
+
+    @pytest.mark.asyncio
+    async def test_a_child_that_exited_reads_true(self):
+        client = _FakeSDKClient(_FakeTransport(_FakeProcess(returncode=0)))
+        session = await _started_session(client)
+
+        await session.stop()
+
+        assert session.process_exited is True
+
+    @pytest.mark.asyncio
+    async def test_a_non_zero_exit_still_reads_true(self):
+        """The question is whether the child is gone, not how it went."""
+        client = _FakeSDKClient(_FakeTransport(_FakeProcess(returncode=137)))
+        session = await _started_session(client)
+
+        await session.stop()
+
+        assert session.process_exited is True
+
+    @pytest.mark.asyncio
+    async def test_a_client_with_no_transport_reads_none(self):
+        """Nothing to observe is not the same as *not exited*."""
+        client = _FakeSDKClient(transport=None)
+        session = await _started_session(client)
+
+        await session.stop()
+
+        assert session.process_exited is None
+
+    def test_a_session_that_never_started_reads_none(self):
+        assert OperatorSession(cwd="/tmp").process_exited is None
+
+    @pytest.mark.asyncio
+    async def test_the_answer_survives_a_second_stop(self):
+        """``stop`` is called twice on ordinary paths (teardown, then a pool
+        drain). The second one finds no client and must not erase what the
+        first one captured."""
+        client = _FakeSDKClient(_FakeTransport(_FakeProcess(returncode=0)))
+        session = await _started_session(client)
+
+        await session.stop()
+        await session.stop()
+
+        assert session.process_exited is True
+
+    @pytest.mark.asyncio
+    async def test_the_handle_is_read_before_the_client_is_closed(self):
+        """Captured from the live transport, not from whatever survives close.
+
+        The real client drops ``_transport`` on ``__aexit__``; a fake that does
+        the same would answer ``None`` if the capture happened after.
+        """
+        process = _FakeProcess(returncode=None)
+        client = _FakeSDKClient(_FakeTransport(process))
+
+        async def _drop_transport(*exc):
+            client._transport = None
+            return False
+
+        client.__aexit__ = _drop_transport  # type: ignore[method-assign]
+        session = await _started_session(client)
+
+        await session.stop()
+
+        process.returncode = 0
+        assert session.process_exited is True
+
+
+# ---------------------------------------------------------------------------
+# terminate hands the torn-down session back
+# ---------------------------------------------------------------------------
+
+
+class _FakeChatSession:
+    """Lightweight OperatorSession double for the pool's terminate."""
+
+    def __init__(self, cwd: str = "/tmp", env=None, session_key=None):
+        self.cwd = cwd
+        self.env = env
+        self.session_key = session_key
+        self.is_active = True
+        self.is_busy = False
+        self.last_activity = time.monotonic()
+        self.teardown_calls = 0
+        self.process_exited: bool | None = None
+
+    async def start(self, *, resume_id=None):
+        return None
+
+    async def teardown(self):
+        self.teardown_calls += 1
+        self.is_active = False
+        self.process_exited = True
+
+
+def _pool() -> tuple[ChatSessionPool, list[_FakeChatSession]]:
+    created: list[_FakeChatSession] = []
+
+    def factory(cwd, env, session_key=None):
+        session = _FakeChatSession(cwd=cwd, env=env, session_key=session_key)
+        created.append(session)
+        return session
+
+    return ChatSessionPool(factory=factory), created
+
+
+class TestTerminateReturnsTheSession:
+    @pytest.mark.asyncio
+    async def test_the_pool_returns_the_session_it_tore_down(self):
+        pool, created = _pool()
+        session, _ = await pool.get_or_create("a", cwd="/tmp")
+
+        returned = await pool.terminate("a")
+
+        assert returned is session
+        assert created[0].teardown_calls == 1
+        # And the caller can read the child's fate off what it got back.
+        assert returned.process_exited is True
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_key_returns_none(self):
+        pool, _ = _pool()
+        assert await pool.terminate("nobody") is None
+
+    @pytest.mark.asyncio
+    async def test_a_second_terminate_returns_none(self):
+        """Idempotent, and the second call says there was nothing to pop."""
+        pool, _ = _pool()
+        await pool.get_or_create("a", cwd="/tmp")
+
+        assert await pool.terminate("a") is not None
+        assert await pool.terminate("a") is None
+
+    @pytest.mark.asyncio
+    async def test_a_creation_still_starting_is_superseded_and_returns_none(self):
+        """A terminate racing a first prompt has nothing to pop, and says so."""
+        started = asyncio.Event()
+
+        class _SlowSession(_FakeChatSession):
+            async def start(self, *, resume_id=None):
+                started.set()
+                await asyncio.sleep(0.05)
+
+        def factory(cwd, env, session_key=None):
+            return _SlowSession(cwd=cwd, env=env, session_key=session_key)
+
+        pool = ChatSessionPool(factory=factory)
+        creation = asyncio.create_task(pool.get_or_create("a", cwd="/tmp"))
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+        assert await pool.terminate("a") is None
+
+        with pytest.raises(Exception, match="terminated while it was starting"):
+            await creation
+
+    @pytest.mark.asyncio
+    async def test_the_registry_facade_passes_the_session_through(self):
+        registry = OperatorRegistry()
+        with patch(f"{_SEAM}.OperatorSession", side_effect=_FakeChatSession):
+            session, _ = await registry.get_or_create_chat_session("a", cwd="/tmp")
+
+        returned = await registry.terminate_chat_session("a")
+
+        assert returned is session
+        assert returned.process_exited is True
+        assert await registry.terminate_chat_session("a") is None

--- a/tests/interfaces/web_terminal/test_posture_toggle_browser.py
+++ b/tests/interfaces/web_terminal/test_posture_toggle_browser.py
@@ -47,6 +47,10 @@ no session discovery involved. The id the card settled on is then read back
 from ``localStorage['osprey-pty-session']``, which ``terminal.js`` writes on
 that same frame. The PTY command is a long-lived ``sleep`` because the route
 appends ``--session-id``/``--resume`` arguments that ``echo`` would choke on.
+In the Simple view the terminal deliberately does not connect — the console
+holds that view's session — so the id on the pointer is one the console minted
+and no process is running under it yet. Both are ordinary states of the same
+one key, and the chip speaks for it either way.
 
 Two more facts have to be true before any toggle in the popover can move, and
 both are arranged in :func:`_settled_chip`:
@@ -55,12 +59,15 @@ both are arranged in :func:`_settled_chip`:
   (the same seam ``test_posture_routes.py`` uses): "this session exists on
   disk" is otherwise only true after a real model turn has written a
   ``.jsonl``, and it is exactly the distinction case (e) turns on.
-* a controls-server state record is published for the PTY's own pid. Without
-  one the route answers ``enforceable: false`` — a PTY that resolves no record
-  is a session whose toggles would govern nothing — and every toggle in the
-  popover is locked. The record is written *after* the page has settled,
-  because it is addressed to a pid only the running PTY can supply; the chip
-  picks it up on its 5 s idle poll.
+* a controls-server state record is published for the pid of whatever process
+  holds the session (:func:`_holder_pid`). Without one a PTY session answers
+  ``enforceable: false`` — a PTY that resolves no record is a session whose
+  toggles would govern nothing — and every toggle in the popover is locked.
+  The record is written *after* the page has settled, because it is addressed
+  to a pid only the running process can supply; the chip picks it up on its
+  5 s idle poll. A key no process holds is enforceable without one: the route
+  withholds enforceability from an unmatched PTY, not from a session that has
+  yet to start.
 
 The agent-data root is stamped with ``OSPREY_AGENT_DATA_ROOT``, which is the
 one seam ``target_state`` and ``session_store`` both prefer — patching
@@ -421,6 +428,29 @@ def _pty_pid(app: Any, session_id: str) -> int:
     return pid
 
 
+def _holder_pid(app: Any, session_id: str) -> int | None:
+    """The pid of whatever process holds this session, or ``None`` for none.
+
+    A session key names one conversation and at most one live process, but
+    which process depends on the view holding it: a PTY in the Expert view, the
+    chat pool's SDK child in the Simple view. A controls-server record is
+    addressed to a process — the resolver walks its ancestry looking for the
+    session's own — so it has to be addressed to whichever one is really there.
+
+    ``None`` is an ordinary answer, not a failure: a tab pointed at a key whose
+    agent has not been started holds no process at all, and the route reads
+    that state the same way — enforceability is only ever withheld from a *PTY*
+    session that resolves no record, so a key with no PTY needs none.
+    """
+    pty = app.state.pty_registry.get_session(session_id)
+    if pty is not None:
+        pid = pty.pid
+        assert isinstance(pid, int) and pid > 0, f"the PTY reported no usable pid: {pid!r}"
+        return pid
+    chat = app.state.operator_registry.get_chat_session(session_id)
+    return chat.pid if chat is not None else None
+
+
 #: Seeded into every page before load: marks the onboarding tour as already
 #: dismissed. Under the default `once` policy the invite card (scrim + modal)
 #: would otherwise overlay the shell on the fresh profile these tests run
@@ -449,24 +479,30 @@ def _settled_chip(
     base_url: str,
     app: Any,
     known_ids: set[str],
-) -> tuple[Page, str, int]:
+) -> tuple[Page, str, int | None]:
     """Open the hub and wait until the chip speaks for an enforceable session.
 
-    A visible chip already means the whole chain ran: the terminal connected,
-    the route confirmed a session id, and ``GET /api/terminal/posture``
-    answered for it (the chip stays hidden until a read succeeds). Chip
-    visibility is what badge visibility used to be — the "this session has
-    settled" signal every test here starts from.
+    A visible chip already means the whole chain ran: the view took a session
+    id (the terminal socket's confirmation in the Expert view, the console's
+    own pointer in the Simple one) and ``GET /api/terminal/posture`` answered
+    for it — the chip stays hidden until a read succeeds. Chip visibility is
+    what badge visibility used to be — the "this session has settled" signal
+    every test here starts from.
 
     Two things are then arranged that only a settled session can supply: the id
     is added to the discovery set (POST refuses an id that names no session
-    file), and a controls-server record is published against the PTY's pid.
-    ``data-enforceable="true"`` is the observable proof both landed — until the
-    record resolves, the route says the toggles would govern nothing and the
-    popover locks every one of them.
+    file), and a controls-server record is published against the process
+    holding the session — the PTY in the Expert view, the chat child in the
+    Simple view (:func:`_holder_pid`). A key held by neither gets no record,
+    because none would resolve for it and none is asked for: only a PTY
+    session that resolves no record is refused enforceability.
+    ``data-enforceable="true"`` is the observable proof the arrangement landed
+    — while the route says the toggles would govern nothing, the popover locks
+    every one of them.
 
     Returns:
-        (page, session_id, pty_pid).
+        (page, session_id, holder_pid) — the pid is ``None`` when no process
+        holds the session yet.
     """
     page = browser.new_page()
     page.add_init_script(_DISMISS_TOUR)
@@ -478,11 +514,12 @@ def _settled_chip(
     assert session_id, "the terminal card never settled on a session id"
 
     known_ids.add(session_id)
-    pty_pid = _pty_pid(app, session_id)
-    _publish_record(owner_ppid=pty_pid)
+    holder_pid = _holder_pid(app, session_id)
+    if holder_pid is not None:
+        _publish_record(owner_ppid=holder_pid)
 
     expect(page.locator(CHIP)).to_have_attribute("data-enforceable", "true", timeout=TIMEOUT)
-    return page, session_id, pty_pid
+    return page, session_id, holder_pid
 
 
 def _open_popover(page: Page) -> None:

--- a/tests/interfaces/web_terminal/test_pty_attach_owner.py
+++ b/tests/interfaces/web_terminal/test_pty_attach_owner.py
@@ -1,0 +1,355 @@
+"""Attachment ownership in the PTY pool.
+
+A pool key can be reached by more than one consumer — a second tab, a reload
+whose disconnect the server sees late, a view flip. Attachment is therefore
+owned by a *token* the consumer holds, not by the key: only the holder can
+release it, and a key that is already attached is refused rather than shared,
+because two readers on one PTY file descriptor split the child's output
+between them.
+
+Two levels here:
+
+- The registry contract: what ``attach_session``/``detach_session`` do with a
+  token, and how the token survives a rekey, a terminate and a respawn.
+- The handler contract: ``terminal_ws`` honours a refused attach by closing
+  with 4409, and releases every key it took by the time the socket is gone.
+
+The pool's LRU behaviour around attachment lives in
+``test_pty_registry_pool.py``; the fake PTY here mirrors the harness in
+``test_ws_resume_confirm.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid as uuid_mod
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from osprey.interfaces.web_terminal.app import create_app
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from tests.interfaces.web_terminal._fakes import FakePtySession
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="PTY not available on Windows")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_session(alive: bool = True) -> MagicMock:
+    """A pool entry that records termination without owning a process."""
+    s = MagicMock()
+    s.is_alive = alive
+    s.resize = MagicMock()
+    s.terminate = MagicMock()
+    return s
+
+
+def _uuid() -> str:
+    return str(uuid_mod.uuid4())
+
+
+def _resume_url(session_id: str) -> str:
+    return f"/ws/terminal?session_id={session_id}&mode=resume"
+
+
+def _send_resize(ws, cols: int = 80, rows: int = 24):
+    """Send the initial resize the handler waits for before spawning."""
+    ws.send_json({"type": "resize", "cols": cols, "rows": rows})
+
+
+def _recv_type(ws, msg_type: str, max_frames: int = 30):
+    """Receive frames until a JSON message with the given ``type`` arrives."""
+    seen = []
+    for _ in range(max_frames):
+        raw = ws.receive()
+        if "text" in raw:
+            data = json.loads(raw["text"])
+            seen.append(data.get("type"))
+            if data.get("type") == msg_type:
+                return data
+    raise AssertionError(f"'{msg_type}' not received within {max_frames} frames. Got: {seen}")
+
+
+def _recv_close(ws, max_frames: int = 30) -> dict:
+    """The close frame that ends the socket, skipping anything sent first."""
+    seen = []
+    for _ in range(max_frames):
+        raw = ws.receive()
+        if raw["type"] == "websocket.close":
+            return raw
+        seen.append(raw.get("text") or raw["type"])
+    raise AssertionError(f"No close frame within {max_frames} frames. Got: {seen}")
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """A web terminal app pointed at a temp project dir."""
+    with patch(
+        "osprey.interfaces.web_terminal.app._load_web_config",
+        return_value={"watch_dir": str(tmp_path / "ws")},
+    ):
+        yield create_app(shell_command="fake-not-used", project_dir=str(tmp_path))
+
+
+@pytest.fixture()
+def sessions_dir(tmp_path, monkeypatch):
+    """Point ``SessionDiscovery`` at a tmp transcript directory."""
+    d = tmp_path / "claude_sessions"
+    d.mkdir()
+    monkeypatch.setattr(SessionDiscovery, "_resolve_sessions_dir", lambda self: d)
+    return d
+
+
+def _seed_session_file(sessions_dir, session_id: str) -> None:
+    (sessions_dir / f"{session_id}.jsonl").write_text("")
+
+
+def _patch_spawn(app):
+    """Replace ``_spawn_session`` so no real PTY is created."""
+    reg = app.state.pty_registry
+    spawned: list[FakePtySession] = []
+
+    def tracked_spawn(*_args, **_kwargs):
+        s = FakePtySession()
+        spawned.append(s)
+        return s
+
+    reg._spawn_session = tracked_spawn
+    return reg, spawned
+
+
+# ---------------------------------------------------------------------------
+# Registry contract
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentOwnership:
+    """``attach_session``/``detach_session`` answer to a token, not a key."""
+
+    def test_attach_records_the_owner(self):
+        """A taken attachment names the token that took it."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["x"] = _mock_session()
+        owner = object()
+
+        assert registry.attach_session("x", owner) is True
+        assert registry.is_attached("x") is True
+        assert registry.attached_owner("x") is owner
+
+    def test_a_free_key_has_no_owner(self):
+        """An unattached key — pooled or not — reports neither."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["x"] = _mock_session()
+
+        assert registry.is_attached("x") is False
+        assert registry.attached_owner("x") is None
+        assert registry.is_attached("never-pooled") is False
+        assert registry.attached_owner("never-pooled") is None
+
+    def test_a_refused_attach_leaves_the_owner_alone(self):
+        """The holder keeps the key when a second consumer is turned away."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["x"] = _mock_session()
+        holder, latecomer = object(), object()
+        registry.attach_session("x", holder)
+
+        assert registry.attach_session("x", latecomer) is False
+        assert registry.attached_owner("x") is holder
+
+    def test_attach_on_an_unpooled_key_records_nothing(self):
+        """A key with no session behind it cannot be attached."""
+        registry = PtyRegistry(max_background=3)
+
+        assert registry.attach_session("unknown", object()) is False
+        assert registry.is_attached("unknown") is False
+
+    def test_detach_from_a_non_owner_is_a_no_op(self):
+        """A departing consumer cannot release a key someone else holds.
+
+        The case this exists for: a handler whose PTY died is torn down after
+        a newer one has taken the key over. Releasing the attachment on the
+        way out would leave the live consumer's terminal evictable.
+        """
+        registry = PtyRegistry(max_background=3)
+        session = _mock_session()
+        registry._sessions["x"] = session
+        holder = object()
+        registry.attach_session("x", holder)
+
+        registry.detach_session("x", object())
+
+        assert registry.is_attached("x") is True
+        assert registry.attached_owner("x") is holder
+        session.terminate.assert_not_called()
+
+    def test_detach_from_the_owner_releases_the_key(self):
+        """The holder's detach frees the key without killing the session."""
+        registry = PtyRegistry(max_background=3)
+        session = _mock_session()
+        registry._sessions["x"] = session
+        owner = object()
+        registry.attach_session("x", owner)
+
+        registry.detach_session("x", owner)
+
+        assert registry.is_attached("x") is False
+        assert registry.attached_owner("x") is None
+        assert "x" in registry._sessions
+        session.terminate.assert_not_called()
+
+    def test_detach_of_an_unattached_key_is_a_no_op(self):
+        """Nothing to release, nothing to raise — and no LRU bump either."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["a"] = _mock_session()
+        registry._sessions["b"] = _mock_session()
+
+        registry.detach_session("a", object())
+
+        assert list(registry._sessions) == ["a", "b"]
+
+    def test_detach_lru_bumps_the_released_session(self):
+        """A released session moves to the back of the eviction queue."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["a"] = _mock_session()
+        registry._sessions["b"] = _mock_session()
+        owner = object()
+        registry.attach_session("a", owner)
+
+        registry.detach_session("a", owner)
+
+        assert list(registry._sessions) == ["b", "a"]
+
+    def test_the_owner_survives_a_rekey(self):
+        """A session renamed under the holder keeps its holder."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["temp-key"] = _mock_session()
+        owner = object()
+        registry.attach_session("temp-key", owner)
+
+        registry.rekey_session("temp-key", "real-uuid")
+
+        assert registry.is_attached("temp-key") is False
+        assert registry.attached_owner("real-uuid") is owner
+        # And the holder can still release it under its new name.
+        registry.detach_session("real-uuid", owner)
+        assert registry.is_attached("real-uuid") is False
+
+    def test_terminate_clears_the_attachment(self):
+        """A terminated session takes its attachment with it."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["x"] = _mock_session()
+        registry.attach_session("x", object())
+
+        registry.terminate_session("x")
+
+        assert registry.is_attached("x") is False
+        assert registry.attached_owner("x") is None
+
+    def test_respawning_a_dead_entry_clears_the_stale_attachment(self):
+        """A key whose child died is free for the consumer that respawns it."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["x"] = _mock_session(alive=False)
+        registry.attach_session("x", object())
+
+        with patch.object(registry, "_spawn_session") as mock_spawn:
+            mock_spawn.return_value = _mock_session()
+            registry.get_or_create_session("x", ["cmd"], 24, 80)
+
+        assert registry.is_attached("x") is False
+        assert registry.attach_session("x", object()) is True
+
+    def test_cleanup_all_releases_every_attachment(self):
+        """Shutdown leaves no key claimed."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["a"] = _mock_session()
+        registry._sessions["b"] = _mock_session()
+        registry.attach_session("a", object())
+
+        registry.cleanup_all()
+
+        assert registry.is_attached("a") is False
+        assert registry.attached_owner("a") is None
+
+
+# ---------------------------------------------------------------------------
+# Handler contract
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalWsAttachment:
+    """``terminal_ws`` holds one token and honours a refused attach."""
+
+    def test_connect_holds_the_key_and_releases_it_on_disconnect(self, app, sessions_dir):
+        """The key is attached while the socket is open and free after it."""
+        sid = _uuid()
+        _seed_session_file(sessions_dir, sid)
+        with TestClient(app) as client:
+            reg, _ = _patch_spawn(app)
+            with client.websocket_connect(_resume_url(sid)) as ws:
+                _send_resize(ws)
+                _recv_type(ws, "session_info")
+                assert reg.is_attached(sid) is True
+
+            assert reg.is_attached(sid) is False
+
+    def test_a_switch_moves_the_attachment_and_releases_both_keys(self, app, sessions_dir):
+        """One token per handler: it detaches the old key and takes the new.
+
+        Both keys are free after the socket closes, which is only true if the
+        token the switch detached with is the token the connect attached with.
+        """
+        initial, target = _uuid(), _uuid()
+        _seed_session_file(sessions_dir, initial)
+        _seed_session_file(sessions_dir, target)
+        with TestClient(app) as client:
+            reg, _ = _patch_spawn(app)
+            with client.websocket_connect(_resume_url(initial)) as ws:
+                _send_resize(ws)
+                _recv_type(ws, "session_info")
+                ws.send_json({"type": "switch_session", "session_id": target})
+                _recv_type(ws, "session_switched")
+
+                assert reg.is_attached(initial) is False
+                assert reg.is_attached(target) is True
+
+            assert reg.is_attached(initial) is False
+            assert reg.is_attached(target) is False
+
+    def test_a_refused_attach_closes_the_socket_with_4409(self, app, sessions_dir):
+        """A key someone else is reading is not served half a terminal."""
+        sid = _uuid()
+        _seed_session_file(sessions_dir, sid)
+        with TestClient(app) as client:
+            reg, _ = _patch_spawn(app)
+            reg.attach_session = lambda key, owner: False
+
+            with client.websocket_connect(_resume_url(sid)) as ws:
+                _send_resize(ws)
+                message = _recv_close(ws)
+
+        assert message["code"] == 4409
+
+    def test_a_refused_switch_closes_the_socket_with_4409(self, app, sessions_dir):
+        """Same refusal on the switch path, once the old key is released."""
+        initial, target = _uuid(), _uuid()
+        _seed_session_file(sessions_dir, initial)
+        _seed_session_file(sessions_dir, target)
+        with TestClient(app) as client:
+            reg, _ = _patch_spawn(app)
+
+            with client.websocket_connect(_resume_url(initial)) as ws:
+                _send_resize(ws)
+                _recv_type(ws, "session_info")
+                reg.attach_session = lambda key, owner: False
+
+                ws.send_json({"type": "switch_session", "session_id": target})
+                message = _recv_close(ws)
+
+        assert message["code"] == 4409

--- a/tests/interfaces/web_terminal/test_pty_pop_and_reserve.py
+++ b/tests/interfaces/web_terminal/test_pty_pop_and_reserve.py
@@ -1,0 +1,250 @@
+"""Tests for the teardown split and hand-off reservations on PtyRegistry.
+
+``pop_session`` is the bookkeeping half of ``terminate_session``: it empties
+the key without killing the child, so an event loop can do the pool work and
+leave the blocking kill to a thread. A reservation holds a key that a hand-off
+is about to re-fill, over the gap where it is attached to nobody.
+
+Mock PtySession objects throughout — no real PTY is spawned.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+
+#: Stand-in for a consumer's attachment token; see ``test_pty_attach_owner.py``.
+OWNER = object()
+
+
+def _mock_session(alive: bool = True) -> MagicMock:
+    """Create a mock PtySession with configurable is_alive."""
+    s = MagicMock()
+    s.is_alive = alive
+    s.resize = MagicMock()
+    s.terminate = MagicMock()
+    return s
+
+
+class TestPopSession:
+    """``pop_session`` empties the key and returns the live session."""
+
+    def test_returns_the_session_without_terminating_it(self):
+        """The child is handed to the caller alive — the kill is theirs."""
+        registry = PtyRegistry(max_background=3)
+        session = _mock_session()
+        registry._sessions["k"] = session
+
+        popped = registry.pop_session("k")
+
+        assert popped is session
+        session.terminate.assert_not_called()
+        assert popped.is_alive
+
+    def test_forgets_the_key_completely(self):
+        """Pool entry, fingerprint, audit alias and attachment all go."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["k"] = _mock_session()
+        registry._env_fingerprints["k"] = "fp"
+        registry.attach_session("k", OWNER)
+        registry.rekey_session("k", "new")
+
+        registry.pop_session("new")
+
+        assert "new" not in registry._sessions
+        assert "new" not in registry._env_fingerprints
+        assert "new" not in registry._audit_keys
+        assert not registry.is_attached("new")
+
+    def test_clears_the_notebook_binding_under_the_audit_alias(self):
+        """A rekeyed session's binding names the key its child stamped."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["spawned"] = _mock_session()
+        registry.rekey_session("spawned", "current")
+
+        with patch("osprey.interfaces.web_terminal.pty_manager._clear_notebook_binding") as clear:
+            registry.pop_session("current")
+
+        clear.assert_called_once_with("spawned")
+
+    def test_unknown_key_returns_none(self):
+        """No pooled session, no error — the bookkeeping is a no-op."""
+        registry = PtyRegistry(max_background=3)
+
+        with patch("osprey.interfaces.web_terminal.pty_manager._clear_notebook_binding") as clear:
+            assert registry.pop_session("absent") is None
+
+        # The binding is still cleared, under the key itself.
+        clear.assert_called_once_with("absent")
+
+    def test_reservation_survives_the_pop(self):
+        """A hand-off pops and re-fills under one reservation."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["k"] = _mock_session()
+        registry.reserve("k")
+
+        registry.pop_session("k")
+
+        assert registry.is_reserved("k")
+
+
+class TestTerminateSessionDelegates:
+    """``terminate_session`` is ``pop_session`` plus the kill."""
+
+    def test_pops_and_terminates(self):
+        """Same observable teardown as before the split."""
+        registry = PtyRegistry(max_background=3)
+        session = _mock_session()
+        registry._sessions["k"] = session
+        registry._env_fingerprints["k"] = "fp"
+        registry.attach_session("k", OWNER)
+
+        registry.terminate_session("k")
+
+        session.terminate.assert_called_once()
+        assert "k" not in registry._sessions
+        assert "k" not in registry._env_fingerprints
+        assert not registry.is_attached("k")
+
+    def test_unknown_key_kills_nothing(self):
+        """No session under the key means nothing to terminate."""
+        registry = PtyRegistry(max_background=3)
+        other = _mock_session()
+        registry._sessions["k"] = other
+
+        registry.terminate_session("absent")
+
+        other.terminate.assert_not_called()
+        assert "k" in registry._sessions
+
+
+class TestPopLruVictim:
+    """``pop_lru_victim`` is the eviction pass without the kill."""
+
+    def test_nothing_is_popped_below_capacity(self):
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["a"] = _mock_session()
+
+        assert registry.pop_lru_victim() is None
+        assert "a" in registry._sessions
+
+    def test_the_oldest_unheld_session_is_returned_alive_and_forgotten(self):
+        """The victim leaves the pool with its bookkeeping; the kill is the caller's."""
+        registry = PtyRegistry(max_background=2)
+        s1 = _mock_session()
+        s2 = _mock_session()
+        registry._sessions["a"] = s1
+        registry._sessions["b"] = s2
+        registry._env_fingerprints["a"] = "fp"
+
+        victim = registry.pop_lru_victim()
+
+        assert victim is s1
+        s1.terminate.assert_not_called()
+        assert "a" not in registry._sessions
+        assert "a" not in registry._env_fingerprints
+        assert "b" in registry._sessions
+
+    def test_held_sessions_are_stepped_over(self):
+        """An attached or reserved entry is never the victim, even when oldest."""
+        registry = PtyRegistry(max_background=3)
+        s1 = _mock_session()
+        s2 = _mock_session()
+        s3 = _mock_session()
+        registry._sessions["a"] = s1
+        registry._sessions["b"] = s2
+        registry._sessions["c"] = s3
+        registry.attach_session("a", OWNER)
+        registry.reserve("b")
+
+        assert registry.pop_lru_victim() is s3
+        assert registry.pop_lru_victim() is None
+        assert "a" in registry._sessions and "b" in registry._sessions
+
+
+class TestReservations:
+    """Reservations keep the eviction pass off a key mid-hand-off."""
+
+    def test_reserved_session_not_evicted(self):
+        """A reserved entry is skipped even when it is the oldest."""
+        registry = PtyRegistry(max_background=2)
+        s1 = _mock_session()
+        s2 = _mock_session()
+        registry._sessions["a"] = s1
+        registry._sessions["b"] = s2
+        registry.reserve("a")
+
+        with patch.object(registry, "_spawn_session") as mock_spawn:
+            mock_spawn.return_value = _mock_session()
+            registry.get_or_create_session("c", ["cmd"], 24, 80)
+
+        s1.terminate.assert_not_called()
+        s2.terminate.assert_called_once()
+        assert "a" in registry._sessions
+        assert "b" not in registry._sessions
+
+    def test_unreserve_restores_eviction_eligibility(self):
+        """Once the hand-off releases the key it is a background session again."""
+        registry = PtyRegistry(max_background=2)
+        s1 = _mock_session()
+        s2 = _mock_session()
+        registry._sessions["a"] = s1
+        registry._sessions["b"] = s2
+        registry.reserve("a")
+        registry.unreserve("a")
+
+        with patch.object(registry, "_spawn_session") as mock_spawn:
+            mock_spawn.return_value = _mock_session()
+            registry.get_or_create_session("c", ["cmd"], 24, 80)
+
+        s1.terminate.assert_called_once()
+        assert "a" not in registry._sessions
+        assert "b" in registry._sessions
+
+    def test_reserve_is_idempotent_and_release_is_total(self):
+        """Reserving twice is reserving once; one unreserve clears it."""
+        registry = PtyRegistry(max_background=3)
+
+        registry.reserve("k")
+        registry.reserve("k")
+        assert registry.is_reserved("k")
+
+        registry.unreserve("k")
+        assert not registry.is_reserved("k")
+
+    def test_unknown_key_is_unreserved(self):
+        """Never-reserved keys report false and release without error."""
+        registry = PtyRegistry(max_background=3)
+
+        assert not registry.is_reserved("absent")
+        registry.unreserve("absent")
+        assert not registry.is_reserved("absent")
+
+    def test_reserving_a_key_with_no_session_is_allowed(self):
+        """A hand-off may reserve the key before the entry exists."""
+        registry = PtyRegistry(max_background=3)
+
+        registry.reserve("k")
+
+        assert registry.is_reserved("k")
+        assert registry.get_session("k") is None
+
+    def test_reservation_is_not_an_attachment(self):
+        """A reserved key is still free for the incoming surface to attach."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["k"] = _mock_session()
+        registry.reserve("k")
+
+        assert not registry.is_attached("k")
+        assert registry.attach_session("k", OWNER)
+
+    def test_cleanup_all_drops_reservations(self):
+        """Shutdown leaves no reservation behind to block a later pool."""
+        registry = PtyRegistry(max_background=3)
+        registry._sessions["k"] = _mock_session()
+        registry.reserve("k")
+
+        registry.cleanup_all()
+
+        assert not registry.is_reserved("k")

--- a/tests/interfaces/web_terminal/test_pty_registry_pool.py
+++ b/tests/interfaces/web_terminal/test_pty_registry_pool.py
@@ -10,6 +10,11 @@ from unittest.mock import MagicMock, patch
 
 from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
 
+#: Stand-in for a consumer's attachment token. Attachment is owned by a token,
+#: not by a key, so every attach/detach in these tests names one; the
+#: ownership rules themselves are covered in ``test_pty_attach_owner.py``.
+OWNER = object()
+
 
 def _mock_session(alive: bool = True) -> MagicMock:
     """Create a mock PtySession with configurable is_alive."""
@@ -97,7 +102,7 @@ class TestPtyRegistryPool:
         s2 = _mock_session()
         registry._sessions["a"] = s1
         registry._sessions["b"] = s2
-        registry.attach_session("a")  # protect s1
+        registry.attach_session("a", OWNER)  # protect s1
 
         with patch.object(registry, "_spawn_session") as mock_spawn:
             s3 = _mock_session()
@@ -116,9 +121,9 @@ class TestPtyRegistryPool:
         registry = PtyRegistry(max_background=3)
         s = _mock_session()
         registry._sessions["x"] = s
-        registry.attach_session("x")
+        registry.attach_session("x", OWNER)
 
-        registry.detach_session("x")
+        registry.detach_session("x", OWNER)
 
         s.terminate.assert_not_called()
         assert "x" not in registry._attached
@@ -129,7 +134,7 @@ class TestPtyRegistryPool:
         registry = PtyRegistry(max_background=3)
         s = _mock_session()
         registry._sessions["temp-key"] = s
-        registry.attach_session("temp-key")
+        registry.attach_session("temp-key", OWNER)
 
         registry.rekey_session("temp-key", "real-uuid")
 
@@ -154,7 +159,7 @@ class TestPtyRegistryPool:
         registry._sessions["a"] = s1
         registry._sessions["b"] = s2
         registry._sessions["c"] = s3
-        registry.attach_session("a")
+        registry.attach_session("a", OWNER)
 
         registry.cleanup_all()
 
@@ -165,23 +170,23 @@ class TestPtyRegistryPool:
         assert len(registry._attached) == 0
 
     def test_attach_returns_false_if_already_attached(self):
-        """attach_session rejects double-attach (prevents concurrent fd reads)."""
+        """attach_session rejects a second attach, whichever token asks."""
         registry = PtyRegistry(max_background=3)
         s = _mock_session()
         registry._sessions["x"] = s
 
-        assert registry.attach_session("x") is True
-        assert registry.attach_session("x") is False
+        assert registry.attach_session("x", OWNER) is True
+        assert registry.attach_session("x", object()) is False
 
     def test_attach_returns_false_if_not_in_pool(self):
         """attach_session returns False for unknown session keys."""
         registry = PtyRegistry(max_background=3)
-        assert registry.attach_session("unknown") is False
+        assert registry.attach_session("unknown", OWNER) is False
 
     def test_detach_noop_for_unknown_key(self):
         """detach_session is safe to call with unknown keys."""
         registry = PtyRegistry(max_background=3)
-        registry.detach_session("nonexistent")  # should not raise
+        registry.detach_session("nonexistent", OWNER)  # should not raise
 
     def test_lru_ordering_after_reuse(self):
         """Reusing a session LRU-bumps it (moves to end)."""

--- a/tests/interfaces/web_terminal/test_session_chat_full.py
+++ b/tests/interfaces/web_terminal/test_session_chat_full.py
@@ -1,0 +1,130 @@
+"""Tests for the replay reads of ``GET /api/session-chat``.
+
+The endpoint serves two callers from one route: the diagnostics view, which
+wants a capped preview of the conversation, and a view flip, which wants the
+whole thing. These cover the second caller — the ``full`` flag and the
+session-key-to-transcript mapping the route reads through.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.agent_runner.project_paths import CLAUDE_CONFIG_DIR_ENV, claude_project_dir
+from osprey.interfaces.web_terminal.app import create_app
+from osprey.mcp_server.workspace.transcript_reader import MAX_CHAT_MESSAGE_LENGTH
+
+SESSION_KEY = "11111111-2222-3333-4444-555555555555"
+CLEARED_TRANSCRIPT = "99999999-8888-7777-6666-555555555555"
+
+
+def _entry(role: str, text: str) -> dict:
+    """A transcript entry holding one plain-text message."""
+    return {
+        "type": role,
+        "timestamp": datetime(2026, 2, 19, 12, 0, 0, tzinfo=UTC).isoformat(),
+        "sessionId": SESSION_KEY,
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _write(transcript_dir: Path, transcript_id: str, entries: list[dict]) -> None:
+    """Write *entries* as the JSONL transcript named *transcript_id*."""
+    path = transcript_dir / f"{transcript_id}.jsonl"
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+@pytest.fixture
+def transcripts(tmp_path, monkeypatch):
+    """A project whose Claude Code transcript directory lives under ``tmp_path``."""
+    monkeypatch.setenv(CLAUDE_CONFIG_DIR_ENV, str(tmp_path / "claude-config"))
+    project = tmp_path / "project"
+    project.mkdir()
+    transcript_dir = claude_project_dir(project)
+    transcript_dir.mkdir(parents=True)
+    return project, transcript_dir
+
+
+@pytest.fixture
+def client(tmp_path, transcripts):
+    """A Web Terminal client reading those transcripts, mapping nothing yet."""
+    project, _ = transcripts
+    workspace = tmp_path / "_agent_data"
+    workspace.mkdir()
+    with patch(
+        "osprey.interfaces.web_terminal.app._load_web_config",
+        return_value={"watch_dir": str(workspace)},
+    ):
+        app = create_app(shell_command="echo", project_dir=project)
+        with TestClient(app) as c:
+            app.state.transcript_map = {}
+            app.state.transcript_map_provisional = False
+            yield c
+
+
+class TestSessionChatFull:
+    def test_maps_key_to_its_current_transcript(self, client, transcripts):
+        """A key that has cleared reads the transcript it moved to, not its own name."""
+        _, transcript_dir = transcripts
+        _write(transcript_dir, SESSION_KEY, [_entry("user", "before the clear")])
+        _write(transcript_dir, CLEARED_TRANSCRIPT, [_entry("user", "after the clear")])
+        client.app.state.transcript_map[SESSION_KEY] = CLEARED_TRANSCRIPT
+
+        resp = client.get(f"/api/session-chat?session_id={SESSION_KEY}&full=1")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["turns"][0]["content"] == "after the clear"
+
+    def test_unmapped_key_reads_its_own_transcript(self, client, transcripts):
+        """A key that has never cleared needs no entry — it names its own transcript."""
+        _, transcript_dir = transcripts
+        _write(transcript_dir, SESSION_KEY, [_entry("user", "still the first conversation")])
+
+        resp = client.get(f"/api/session-chat?session_id={SESSION_KEY}&full=1")
+
+        assert resp.json()["turns"][0]["content"] == "still the first conversation"
+
+    def test_full_leaves_long_messages_whole(self, client, transcripts):
+        """``full=1`` returns the message at its real length."""
+        _, transcript_dir = transcripts
+        long_text = "x" * 5000
+        _write(transcript_dir, SESSION_KEY, [_entry("assistant", long_text)])
+
+        resp = client.get(f"/api/session-chat?session_id={SESSION_KEY}&full=1")
+
+        assert resp.json()["turns"][0]["content"] == long_text
+
+    def test_default_keeps_the_cap(self, client, transcripts):
+        """Without the flag the per-message cap stands, as the diagnostics view reads it."""
+        _, transcript_dir = transcripts
+        _write(transcript_dir, SESSION_KEY, [_entry("assistant", "x" * 5000)])
+
+        resp = client.get(f"/api/session-chat?session_id={SESSION_KEY}")
+
+        assert resp.json()["turns"][0]["content"] == "x" * MAX_CHAT_MESSAGE_LENGTH + "..."
+
+    def test_unknown_key_returns_an_empty_list(self, client):
+        """A key with no transcript anywhere collapses to an empty conversation."""
+        resp = client.get("/api/session-chat?session_id=no-such-key&full=1")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"turns": [], "count": 0}
+
+    def test_full_accepts_the_other_true_spellings(self, client, transcripts):
+        """``true`` reads the same as ``1``; an unrecognized value keeps the cap."""
+        _, transcript_dir = transcripts
+        _write(transcript_dir, SESSION_KEY, [_entry("assistant", "y" * 5000)])
+
+        whole = client.get(f"/api/session-chat?session_id={SESSION_KEY}&full=true")
+        capped = client.get(f"/api/session-chat?session_id={SESSION_KEY}&full=maybe")
+
+        assert len(whole.json()["turns"][0]["content"]) == 5000
+        assert len(capped.json()["turns"][0]["content"]) < 5000

--- a/tests/interfaces/web_terminal/test_session_switching.py
+++ b/tests/interfaces/web_terminal/test_session_switching.py
@@ -3,8 +3,11 @@
 L1 (Integration): Real PtyRegistry, fake PtySession via patched _spawn_session.
 Tests the WebSocket message protocol end-to-end through the real handler.
 
-L2 (Contract): Fully mocked PtyRegistry.
-Tests that terminal_ws calls registry methods in the correct sequence.
+L2 (Contract): Mocked PtyRegistry with a stateful pool behind it.
+Tests that terminal_ws calls registry methods in the correct sequence. The
+handler takes every key through ``acquire_surface``, which inspects the pool
+before spawning and checks the spawn was pooled afterwards, so the mock keeps
+a real dict of what sits under each key rather than a fixed return value.
 
 All tests connect in ``mode=resume`` with a pre-set UUID to avoid the
 5-second session-discovery poll that fires for new sessions. The
@@ -21,14 +24,17 @@ import asyncio
 import json
 import sys
 import uuid as uuid_mod
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
+import anyio
 import pytest
 from starlette.testclient import TestClient
 
 from osprey.interfaces.web_terminal.app import create_app
 from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.routes.websocket import _TerminalChannel
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from tests.interfaces.web_terminal._fakes import FakePtySession
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="PTY not available on Windows")
 
@@ -38,63 +44,38 @@ pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="PTY not availab
 # ---------------------------------------------------------------------------
 
 
-class FakePtySession:
-    """Minimal PtySession substitute — stays alive, produces no output."""
+#: How long one frame may take to arrive before the test fails. A handler
+#: that answers nothing is a regression, not a stall.
+RECV_TIMEOUT_S = 10.0
 
-    def __init__(self):
-        self._alive = True
-        self._last_rows = 24
-        self._last_cols = 80
-        self._command_list = ["fake"]
 
-    @property
-    def is_alive(self):
-        return self._alive
+async def _receive_within(rx, seconds: float):
+    with anyio.fail_after(seconds):
+        return await rx.receive()
 
-    @property
-    def exit_code(self):
-        return None if self._alive else 0
 
-    def start(self, initial_rows=24, initial_cols=80, extra_env=None):
-        self._last_rows = initial_rows
-        self._last_cols = initial_cols
+def _recv(ws):
+    """One frame off the socket, or ``TimeoutError`` after ``RECV_TIMEOUT_S``.
 
-    def resize(self, rows, cols):
-        self._last_rows = rows
-        self._last_cols = cols
-
-    def write_input(self, data):
-        pass
-
-    def terminate(self):
-        self._alive = False
-
-    async def read_output(self):
-        """Async generator that blocks quietly until the session dies."""
-        try:
-            while self._alive:
-                await asyncio.sleep(0.05)
-        except (asyncio.CancelledError, GeneratorExit):
-            return
-        # Unreachable yield — makes this function an async generator.
-        if False:
-            yield b""  # pragma: no cover
+    ``ws.receive()`` waits on the portal with no deadline, and the test thread
+    then sits in a lock wait that pytest-timeout's signal cannot interrupt.
+    The deadline runs inside the portal, on the stream the session reads. A
+    server close surfaces at once as ``WebSocketDisconnect``.
+    """
+    message = ws.portal.call(_receive_within, ws._send_rx, RECV_TIMEOUT_S)
+    ws._raise_on_close(message)
+    return message
 
 
 def _recv_json(ws, msg_type: str, max_frames: int = 30):
     """Receive frames until a JSON message with the given ``type`` arrives.
 
     Skips binary frames.  Raises ``AssertionError`` if ``msg_type`` is not
-    found within *max_frames* frames.
-
-    .. note::
-
-       If the server sends **nothing**, ``ws.receive()`` blocks indefinitely.
-       Use pytest-timeout or a CI-level timeout as a safety net.
+    found within *max_frames* frames, ``TimeoutError`` if a frame is late.
     """
     collected = []
     for _ in range(max_frames):
-        raw = ws.receive()
+        raw = _recv(ws)
         if "text" in raw:
             data = json.loads(raw["text"])
             collected.append(data)
@@ -355,17 +336,39 @@ class TestSessionSwitchingContract:
 
     @staticmethod
     def _mock_registry(app, fake_session=None):
-        """Replace the registry with a MagicMock that returns *fake_session*."""
+        """Replace the registry with a MagicMock over a real pool dict.
+
+        ``get_or_create_session`` hands out *fake_session* first, then
+        whatever a test appends to ``mock_reg.hand_out``, and pools it under
+        the key; ``get_session`` reads that pool, so the hand-off door sees an
+        empty key before the spawn and the spawned session after it — and the
+        handler's teardown asks it who currently owns the key.
+        test_disconnect_leaves_a_replacement_session_alone below replaces the
+        pool entry to model a newer handler's session under the same key.
+        """
         if fake_session is None:
             fake_session = FakePtySession()
+        pool: dict[str, FakePtySession] = {}
+        hand_out: list[FakePtySession] = [fake_session]
         mock_reg = MagicMock(spec=PtyRegistry)
-        mock_reg.get_or_create_session.return_value = (fake_session, False)
+
+        def get_or_create(key, *_args, **_kwargs):
+            pooled = pool.get(key)
+            if pooled is not None and pooled.is_alive:
+                return pooled, True
+            session = hand_out.pop(0) if hand_out else FakePtySession()
+            pool[key] = session
+            return session, False
+
+        mock_reg.get_or_create_session.side_effect = get_or_create
+        mock_reg.get_session.side_effect = pool.get
+        mock_reg.pop_session.side_effect = lambda key: pool.pop(key, None)
+        mock_reg.pop_lru_victim.return_value = None  # a pool below capacity evicts nothing
         mock_reg.attach_session.return_value = True
-        # The handler's teardown asks who currently owns the key before
-        # touching it; answer with the session it was handed, i.e. "still the
-        # owner". test_disconnect_leaves_a_replacement_session_alone below
-        # overrides this to model the other case.
-        mock_reg.get_session.return_value = fake_session
+        mock_reg.is_attached.return_value = False
+        mock_reg.attached_owner.return_value = None
+        mock_reg.pool = pool
+        mock_reg.hand_out = hand_out
         app.state.pty_registry = mock_reg
         return mock_reg, fake_session
 
@@ -385,9 +388,11 @@ class TestSessionSwitchingContract:
         key_used = mock_reg.get_or_create_session.call_args[0][0]
         assert key_used == sid
 
-        # attach_session was called (at least once) with the same key
-        attach_calls = [c for c in mock_reg.attach_session.call_args_list if c == call(sid)]
+        # attach_session was called (at least once) with the same key, and
+        # with the handler's attachment token alongside it.
+        attach_calls = [c for c in mock_reg.attach_session.call_args_list if c.args[0] == sid]
         assert len(attach_calls) >= 1
+        assert all(len(c.args) == 2 for c in attach_calls)
 
     # -- switch_session contract --
 
@@ -404,9 +409,7 @@ class TestSessionSwitchingContract:
 
                 # Reset to isolate switch calls from initial-connect calls
                 mock_reg.reset_mock()
-                new_fake = FakePtySession()
-                mock_reg.get_or_create_session.return_value = (new_fake, False)
-                mock_reg.attach_session.return_value = True
+                mock_reg.hand_out.append(FakePtySession())
 
                 ws.send_json({"type": "switch_session", "session_id": target})
                 _recv_json(ws, "session_switched")
@@ -427,8 +430,13 @@ class TestSessionSwitchingContract:
 
         assert detach_i < create_i < attach_after_create[0]
 
-        # Verify args
-        assert mock_reg.method_calls[detach_i] == call.detach_session(initial)
+        # Verify args. The detach names the old key and the token the attach
+        # that follows it hands to the new one — one token per handler.
+        detach_call = mock_reg.method_calls[detach_i]
+        assert detach_call[0] == "detach_session"
+        assert detach_call[1][0] == initial
+        token = detach_call[1][1]
+        assert mock_reg.method_calls[attach_after_create[0]][1] == (target, token)
         create_call = mock_reg.method_calls[create_i]
         assert create_call[1][0] == target  # first positional arg = target UUID
 
@@ -465,8 +473,8 @@ class TestSessionSwitchingContract:
                 _send_resize(ws)
                 mock_reg.reset_mock()
 
-        # Handler's finally: detach(current_key)
-        mock_reg.detach_session.assert_called_with(sid)
+        # Handler's finally: detach(current_key, token)
+        assert mock_reg.detach_session.call_args.args[0] == sid
         # Session is alive → nothing is terminated
         mock_reg.terminate_session.assert_not_called()
         mock_reg.terminate_session_if_owner.assert_not_called()
@@ -487,7 +495,7 @@ class TestSessionSwitchingContract:
                 dead._alive = False
                 time.sleep(0.2)  # let output loop notice and exit
 
-        mock_reg.detach_session.assert_called_with(sid)
+        assert mock_reg.detach_session.call_args.args[0] == sid
         # Terminated through the owner-checked entry point, which takes the
         # session this handler owns as well as the key — see
         # test_disconnect_leaves_a_replacement_session_alone.
@@ -515,8 +523,7 @@ class TestSessionSwitchingContract:
                 dead._alive = False
                 time.sleep(0.2)  # let output loop notice and exit
                 # A newer handler has since put its own session under this key.
-                replacement = FakePtySession()
-                mock_reg.get_session.return_value = replacement
+                mock_reg.pool[sid] = FakePtySession()
 
         # The newer handler's attachment is left intact...
         mock_reg.detach_session.assert_not_called()
@@ -525,3 +532,99 @@ class TestSessionSwitchingContract:
         # this handler owns without disturbing the pool.
         mock_reg.terminate_session.assert_not_called()
         mock_reg.terminate_session_if_owner.assert_called_with(sid, dead)
+
+
+# ---------------------------------------------------------------------------
+# L0: the socket reader under the hand-off door
+# ---------------------------------------------------------------------------
+
+
+class _MemoryWebSocket:
+    """A socket that hands a frame straight to a parked receiver.
+
+    Starlette's test client feeds the app from an anyio memory stream, which
+    delivers a frame to a waiting receiver in the sender's own loop turn; a
+    receiver cancelled before it runs then drops that frame.
+    """
+
+    def __init__(self) -> None:
+        self.tx, self.rx = anyio.create_memory_object_stream[dict](10)
+
+    async def receive(self) -> dict:
+        return await self.rx.receive()
+
+
+async def _ticks_until(condition, what: str) -> None:
+    """Run the loop tick by tick until *condition* holds; a bounded wait."""
+    for _ in range(50):
+        if condition():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"never reached: {what}")
+
+
+async def _park(ws: _MemoryWebSocket, task: asyncio.Task) -> None:
+    """Let *task* run until its socket read is a parked receiver on the stream."""
+    await _ticks_until(lambda: bool(ws.rx._state.waiting_receivers), "a parked receiver")
+    assert not task.done()
+
+
+def _switch_frame() -> dict:
+    return {
+        "type": "websocket.receive",
+        "text": json.dumps({"type": "switch_session", "session_id": _uuid()}),
+    }
+
+
+class TestTerminalChannelReader:
+    """The frame that lands as the door returns must reach the main loop."""
+
+    async def test_frame_delivered_as_the_side_reader_is_cancelled_is_kept(self):
+        ws = _MemoryWebSocket()
+        channel = _TerminalChannel(ws)
+        reader = asyncio.ensure_future(channel._read_while_acquiring())
+        await _park(ws, reader)
+
+        frame = _switch_frame()
+        ws.tx.send_nowait(frame)  # handed straight to the parked receiver
+        reader.cancel()  # before any wakeup runs
+        with pytest.raises(asyncio.CancelledError):
+            await reader
+
+        assert await asyncio.wait_for(channel.receive(), 1.0) == frame
+        channel.release()
+
+    async def test_frame_read_before_the_side_reader_is_cancelled_is_kept(self):
+        """The read has completed, the reader has not run: the cancel lands
+        on its wakeup, and the completed read must still be collected."""
+        ws = _MemoryWebSocket()
+        channel = _TerminalChannel(ws)
+        reader = asyncio.ensure_future(channel._read_while_acquiring())
+        await _park(ws, reader)
+
+        frame = _switch_frame()
+        ws.tx.send_nowait(frame)
+        await _ticks_until(lambda: channel._read is not None and channel._read.done(), "the read")
+        assert not channel.deferred  # the reader has not been woken yet
+        reader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await reader
+
+        assert await asyncio.wait_for(channel.receive(), 1.0) == frame
+        channel.release()
+
+    async def test_release_cancels_a_read_left_in_flight(self):
+        ws = _MemoryWebSocket()
+        channel = _TerminalChannel(ws)
+        waiter = asyncio.ensure_future(channel.receive())
+        await _park(ws, waiter)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        pending = channel._read
+        assert pending is not None and not pending.done()
+        channel.release()
+        await asyncio.sleep(0)
+        assert pending.cancelled()
+        assert channel._read is None

--- a/tests/interfaces/web_terminal/test_terminal_provenance_env.py
+++ b/tests/interfaces/web_terminal/test_terminal_provenance_env.py
@@ -2,10 +2,14 @@
 
 The terminal surface forces its ``claude`` onto a known session UUID
 (``--session-id``) and injects that id as ``OSPREY_TELEMETRY_SESSION_ID`` so the
-workspace provenance_locator tool can hand it back for a filed issue. Crucially,
-the telemetry id must NOT be conflated with ``OSPREY_SESSION_ID`` (which
-relocates the artifact store) — a new terminal session gets the telemetry var
-but keeps its default artifact root.
+workspace provenance_locator tool can hand it back for a filed issue. That id
+is also this session's pool key, so it is stamped as ``OSPREY_SESSION_ID`` too
+— one key names the conversation on every surface. The two variables stay
+separate names because they answer different questions and part company on the
+``switch_session`` path, which has a session key and no telemetry id.
+
+``OSPREY_SESSION_ID`` on all three spawn paths is pinned in
+``test_child_env_session_id.py``; what is pinned here is the telemetry pair.
 """
 
 from datetime import datetime
@@ -18,13 +22,13 @@ def _ws(hooks_env=None):
     return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(hooks_env=hooks_env or {})))
 
 
-def test_new_session_injects_telemetry_id_without_relocating_artifacts():
+def test_new_session_injects_the_telemetry_pair():
     env = _build_extra_env(_ws(), claude_session_id=None, telemetry_session_id="forced-uuid")
     assert env["OSPREY_TELEMETRY_SESSION_ID"] == "forced-uuid"
     # start stamp is present and ISO-8601 parseable
     datetime.fromisoformat(env["OSPREY_TELEMETRY_SESSION_START"])
-    # new session must NOT set the artifact-relocating var
-    assert "OSPREY_SESSION_ID" not in env
+    # the forced id is the pool key, so it is the session id as well
+    assert env["OSPREY_SESSION_ID"] == "forced-uuid"
 
 
 def test_resume_sets_both_ids():
@@ -37,6 +41,13 @@ def test_no_telemetry_id_sets_no_telemetry_vars():
     env = _build_extra_env(_ws(), claude_session_id=None, telemetry_session_id=None)
     assert "OSPREY_TELEMETRY_SESSION_ID" not in env
     assert "OSPREY_TELEMETRY_SESSION_START" not in env
+
+
+def test_switch_session_stamps_the_key_without_a_telemetry_id():
+    """The two names part company: a switch names a session, not a new run."""
+    env = _build_extra_env(_ws(), claude_session_id="sid", telemetry_session_id=None)
+    assert env["OSPREY_SESSION_ID"] == "sid"
+    assert "OSPREY_TELEMETRY_SESSION_ID" not in env
 
 
 def test_hooks_env_still_merged():

--- a/tests/interfaces/web_terminal/test_terminate_respawn.py
+++ b/tests/interfaces/web_terminal/test_terminate_respawn.py
@@ -46,6 +46,7 @@ from osprey.interfaces.web_terminal.operator_session import (
     POSTURE_SESSION_ENV,
     OperatorRegistry,
 )
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
 from osprey.interfaces.web_terminal.routes import chat as chat_routes
 from osprey.interfaces.web_terminal.routes import websocket as websocket_routes
 from osprey_connectors import session_store
@@ -131,6 +132,42 @@ class TestAChatKeyIsAddressable:
             assert callable(getattr(OperatorRegistry, name, None)), name
 
 
+def _chat_request(app):
+    """A ``Request`` double for ``_acquire_chat_turn``.
+
+    Beyond the app it carries ``is_disconnected``: every chat turn now takes
+    the session key through ``acquire_surface``, which polls the caller's
+    channel while it waits for whatever holds the key to let go.
+    """
+
+    async def is_disconnected() -> bool:
+        return False
+
+    return SimpleNamespace(app=app, is_disconnected=is_disconnected)
+
+
+class _PoolFace:
+    """The chat-pool view ``acquire_surface`` inspects on a registry double.
+
+    The door looks the key up in the pool before deciding anything, and looks
+    again after a spawn to confirm the new child was actually registered — so
+    a registry double that only answers ``get_or_create_chat_session`` is no
+    longer enough.
+    """
+
+    def __init__(self):
+        self.sessions: dict[str, object] = {}
+
+    def get(self, chat_id):
+        return self.sessions.get(chat_id)
+
+    def has_key(self, chat_id):
+        return chat_id in self.sessions
+
+    async def terminate(self, chat_id):
+        return self.sessions.pop(chat_id, None)
+
+
 class _FakeChatSession:
     """Lightweight OperatorSession double for pool tests.
 
@@ -140,9 +177,11 @@ class _FakeChatSession:
     ``_acquire_chat_turn`` rather than the pool directly.
     """
 
-    def __init__(self, cwd="/tmp", env=None):
+    def __init__(self, cwd="/tmp", env=None, session_key=None):
         self.cwd = cwd
         self.env = env
+        self.session_key = session_key
+        self.resume_id = None
         self.is_active = True
         self.last_activity = time.monotonic()
         self.in_flight = False
@@ -152,7 +191,8 @@ class _FakeChatSession:
         self.turns = 0
         self.started = asyncio.Event()
 
-    async def start(self):
+    async def start(self, *, resume_id=None):
+        self.resume_id = resume_id
         self.started.set()
         if self.start_delay:
             await asyncio.sleep(self.start_delay)
@@ -174,8 +214,8 @@ class _FakeChatSession:
 def _pool(start_delay: float = 0.0, **kwargs) -> tuple[ChatSessionPool, list[_FakeChatSession]]:
     created: list[_FakeChatSession] = []
 
-    def factory(cwd, env):
-        session = _FakeChatSession(cwd=cwd, env=env)
+    def factory(cwd, env, session_key=None):
+        session = _FakeChatSession(cwd=cwd, env=env, session_key=session_key)
         session.start_delay = start_delay
         created.append(session)
         return session
@@ -329,16 +369,24 @@ class TestChatRouteMapsTheRefusal:
         """
 
         class _Registry:
-            async def get_or_create_chat_session(self, chat_id, cwd, env=None):
+            chats = _PoolFace()
+
+            async def get_or_create_chat_session(self, chat_id, cwd, env=None, *, resume_id=None):
                 raise ChatSessionTerminatedError("terminated while starting")
 
-        request = SimpleNamespace(
-            app=SimpleNamespace(
-                state=SimpleNamespace(project_cwd="/tmp", operator_registry=_Registry())
+        request = _chat_request(
+            SimpleNamespace(
+                state=SimpleNamespace(
+                    project_cwd="/tmp",
+                    operator_registry=_Registry(),
+                    pty_registry=PtyRegistry(),
+                    transcript_map={},
+                    transcript_map_provisional=False,
+                )
             )
         )
 
-        with pytest.raises(Exception) as excinfo:
+        with known_sessions(), pytest.raises(Exception) as excinfo:
             await chat_routes._acquire_chat_turn(request, CHAT_A)
 
         assert excinfo.value.status_code == 409
@@ -462,26 +510,36 @@ class TestChatPoolEnvFingerprint:
     async def test_a_narrowing_does_not_rebuild_the_chat_child(self, client):
         """End to end on the real registry and the real chat handler.
 
-        The other side of the fingerprint, and the point of the whole feature:
-        a posture flip is NOT an environment change, so the child that is
-        already holding the operator\'s conversation is reused. The narrowing
-        still governs that child — its next write reads the store — which is
-        why nothing has to die for it to apply.
+        The point of the whole feature: a posture flip must not cost the
+        operator the conversation they are in. The second turn does not reach
+        the pool at all — the hand-off finds the chat already holding the key
+        and gives it straight back — so no environment is compared and nothing
+        can decide to rebuild. The narrowing still governs that child, because
+        its next write reads the store. The fingerprint rule itself is pinned
+        by the pool-level tests in this class.
         """
         registry = OperatorRegistry()
         client.app.state.operator_registry = registry
-        request = SimpleNamespace(app=client.app)
+        request = _chat_request(client.app)
 
-        with patch(
-            "osprey.interfaces.web_terminal.operator_session.OperatorSession",
-            _FakeChatSession,
+        with (
+            known_sessions(),
+            patch(
+                "osprey.interfaces.web_terminal.operator_session.OperatorSession",
+                _FakeChatSession,
+            ),
         ):
             first, _token, _ = await chat_routes._acquire_chat_turn(request, CHAT_A)
             websocket_routes._session_postures(client.app)[CHAT_A] = {"standin": "sandbox"}
-            second, _token2, was_reused = await chat_routes._acquire_chat_turn(request, CHAT_A)
+            second, _token2, fresh_conversation = await chat_routes._acquire_chat_turn(
+                request, CHAT_A
+            )
 
         assert second is first
-        assert was_reused is True
+        # The same statement as the old ``was_reused is True``, in the term the
+        # route now returns: nothing was spawned for the second turn, so the
+        # conversation did not start over and the client is sent no divider.
+        assert fresh_conversation is False
         assert first.stop_calls == 0
         # No mode was ever stamped; the child was handed the store key instead.
         assert "OSPREY_EXECUTION_MODE" not in first.env
@@ -491,7 +549,7 @@ class TestChatPoolEnvFingerprint:
 class TestTheEnvIsReadUnderThePoolLock:
     """Atomicity of "build the environment" and "register the creation".
 
-    Before, the route built the child\'s environment and handed the pool a
+    Before, the route built the child's environment and handed the pool a
     finished mapping. Nothing kept those two steps together except the accident
     that no await on the way in actually suspends — one added ``await`` in the
     handler and a change could land in the gap, with no test going red. The
@@ -557,16 +615,21 @@ class TestTheEnvIsReadUnderThePoolLock:
         captured: dict[str, object] = {}
 
         class _Registry:
-            async def get_or_create_chat_session(self, chat_id, cwd, env=None):
+            chats = _PoolFace()
+
+            async def get_or_create_chat_session(self, chat_id, cwd, env=None, *, resume_id=None):
                 captured["env"] = env
-                return SimpleNamespace(acquire_turn=lambda: 1), False
+                session = SimpleNamespace(acquire_turn=lambda: 1)
+                self.chats.sessions[chat_id] = session
+                return session, False
 
             async def cleanup_all(self):  # the lifespan's shutdown calls this
                 return None
 
         client.app.state.operator_registry = _Registry()
 
-        asyncio.run(chat_routes._acquire_chat_turn(SimpleNamespace(app=client.app), CHAT_A))
+        with known_sessions():
+            asyncio.run(chat_routes._acquire_chat_turn(_chat_request(client.app), CHAT_A))
 
         build_env = captured["env"]
         assert callable(build_env)

--- a/tests/interfaces/web_terminal/test_transcript_map.py
+++ b/tests/interfaces/web_terminal/test_transcript_map.py
@@ -1,0 +1,196 @@
+"""Tests for the per-session-key transcript map.
+
+The map exists because a session key and the transcript it points at diverge
+the moment a ``/clear`` starts a fresh conversation under the same key. Four
+properties are pinned here:
+
+* **A key with no entry answers itself.** The common case is a session that has
+  never cleared, and a caller resuming it must always have an id to resume.
+* **A move survives a restart.** The point of persisting at all: a recreated
+  container that answered the key would silently resume the wrong (empty)
+  conversation and read as a session that lost its history.
+* **The file sits beside the posture store**, under the same one path rule, so
+  a deployment that resolves one of the two resolves both.
+* **A map with no location still answers.** An unresolvable agent-data root
+  costs durability, never a working view flip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from osprey.interfaces.web_terminal import transcript_map
+from osprey_connectors import session_store
+
+# A session key: the bare UUID one browser tab keeps for its whole life.
+KEY = "aaaaaaaa-1111-2222-3333-444444444444"
+# A second key, so a stored entry can be shown not to answer for its neighbour.
+OTHER_KEY = "bbbbbbbb-1111-2222-3333-444444444444"
+# The transcript a ``/clear`` moved the first key to.
+TRANSCRIPT = "cccccccc-1111-2222-3333-444444444444"
+
+
+def _app() -> SimpleNamespace:
+    """A bare app object — the store helpers need ``state`` and nothing else."""
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+@pytest.fixture
+def shared_root(tmp_path, monkeypatch):
+    """Pin the agent-data root, the way a spawn does.
+
+    ``OSPREY_AGENT_DATA_ROOT`` is the first half of the one resolution rule the
+    map shares with the posture store, so setting it exercises the real
+    derivation instead of patching around it.
+    """
+    root = tmp_path / "shared_agent_data"
+    root.mkdir()
+    monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(root))
+    session_store.invalidate_cache()
+    yield root
+    session_store.invalidate_cache()
+
+
+@pytest.fixture
+def unresolvable_root(monkeypatch):
+    """No stamp and no config derivation: a map with nowhere to write."""
+    monkeypatch.delenv(session_store.AGENT_DATA_ROOT_ENV_VAR, raising=False)
+    monkeypatch.setattr(session_store, "resolve_shared_data_root", _raise_no_root)
+    session_store.invalidate_cache()
+    yield
+    session_store.invalidate_cache()
+
+
+def _raise_no_root() -> Path:
+    raise RuntimeError("no project root")
+
+
+class TestAKeyAnswersItselfByDefault:
+    def test_unknown_key_returns_itself(self, shared_root):
+        """The ordinary case: a session that has never cleared has no entry."""
+        assert transcript_map.get(_app(), KEY) == KEY
+
+    def test_a_stored_entry_does_not_answer_for_another_key(self, shared_root):
+        app = _app()
+        transcript_map.set(app, KEY, TRANSCRIPT)
+
+        assert transcript_map.get(app, OTHER_KEY) == OTHER_KEY
+
+    def test_an_entry_naming_the_key_is_not_stored(self, shared_root):
+        """``set(key, key)`` says what the default already says.
+
+        Storing it would add one identity line per session to a file that is
+        supposed to grow only per conversation that actually moved.
+        """
+        app = _app()
+        transcript_map.set(app, KEY, KEY)
+
+        assert app.state.transcript_map == {}
+        assert transcript_map.get(app, KEY) == KEY
+
+    def test_a_blank_transcript_id_is_ignored(self, shared_root):
+        """There is no such transcript, and it would replace a usable answer."""
+        app = _app()
+        transcript_map.set(app, KEY, TRANSCRIPT)
+        transcript_map.set(app, KEY, "   ")
+
+        assert transcript_map.get(app, KEY) == TRANSCRIPT
+
+
+class TestAMoveSurvivesARestart:
+    def test_set_then_a_new_app_gets_the_mapped_id(self, shared_root):
+        """The property the file exists for."""
+        transcript_map.set(_app(), KEY, TRANSCRIPT)
+
+        restarted = _app()
+        transcript_map.load(restarted)
+
+        assert transcript_map.get(restarted, KEY) == TRANSCRIPT
+
+    def test_a_new_app_loads_lazily_without_a_lifespan(self, shared_root):
+        """A helper reached before the lifespan load still reads the file."""
+        transcript_map.set(_app(), KEY, TRANSCRIPT)
+
+        assert transcript_map.get(_app(), KEY) == TRANSCRIPT
+
+    def test_clearing_an_entry_survives_too(self, shared_root):
+        app = _app()
+        transcript_map.set(app, KEY, TRANSCRIPT)
+        transcript_map.set(app, KEY, KEY)
+
+        restarted = _app()
+        transcript_map.load(restarted)
+
+        assert transcript_map.get(restarted, KEY) == KEY
+
+    def test_a_second_move_replaces_the_first(self, shared_root):
+        second = "dddddddd-1111-2222-3333-444444444444"
+        app = _app()
+        transcript_map.set(app, KEY, TRANSCRIPT)
+        transcript_map.set(app, KEY, second)
+
+        restarted = _app()
+        transcript_map.load(restarted)
+
+        assert transcript_map.get(restarted, KEY) == second
+
+
+class TestTheFileSitsBesideThePostureStore:
+    def test_the_path_is_the_posture_store_s_directory(self, shared_root):
+        posture_store = session_store.store_path()
+
+        assert transcript_map.store_path() == posture_store.parent / "session-transcripts.json"
+
+    def test_the_document_is_key_to_transcript_id(self, shared_root):
+        transcript_map.set(_app(), KEY, TRANSCRIPT)
+
+        written = json.loads(transcript_map.store_path().read_text(encoding="utf-8"))
+        assert written == {KEY: TRANSCRIPT}
+
+    def test_entries_that_cannot_name_a_transcript_are_dropped(self, shared_root):
+        """A hand-edited file loses only the entries nobody could have used."""
+        path = transcript_map.store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({KEY: TRANSCRIPT, OTHER_KEY: "", "third": 7}),
+            encoding="utf-8",
+        )
+
+        app = _app()
+        transcript_map.load(app)
+
+        assert app.state.transcript_map == {KEY: TRANSCRIPT}
+
+    def test_a_corrupt_file_is_an_empty_map(self, shared_root):
+        path = transcript_map.store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+
+        assert transcript_map.get(_app(), KEY) == KEY
+
+
+class TestAMapWithNoLocationStillAnswers:
+    def test_set_and_get_work_in_memory(self, unresolvable_root):
+        app = _app()
+        transcript_map.set(app, KEY, TRANSCRIPT)
+
+        assert transcript_map.store_path() is None
+        assert transcript_map.get(app, KEY) == TRANSCRIPT
+
+    def test_an_entry_made_during_the_outage_survives_the_recovery_load(
+        self, unresolvable_root, tmp_path, monkeypatch
+    ):
+        """A later load must not undo what memory learned while it had nowhere to write."""
+        app = _app()
+        transcript_map.set(app, KEY, TRANSCRIPT)
+
+        root = tmp_path / "recovered"
+        root.mkdir()
+        monkeypatch.setenv(session_store.AGENT_DATA_ROOT_ENV_VAR, str(root))
+        session_store.invalidate_cache()
+
+        assert transcript_map.get(app, KEY) == TRANSCRIPT

--- a/tests/interfaces/web_terminal/test_ws_handoff.py
+++ b/tests/interfaces/web_terminal/test_ws_handoff.py
@@ -1,0 +1,546 @@
+"""``terminal_ws`` through the hand-off door.
+
+Every PTY the terminal handler serves now comes from ``acquire_surface``:
+the session key is one session whichever view shows it, so a terminal that
+takes a key the chat surface holds is a hand-off, not a second process. What
+the handler owes the client around that door:
+
+- ``handoff_pending`` before the wait whenever the chat surface holds the
+  key, ``session_info`` once the terminal has it;
+- a busy chat is waited on, and ``interrupt=1`` on the resume URL cuts its
+  turn short instead;
+- a client that leaves during the wait gets nothing, and the chat it was
+  waiting on is left alone;
+- a newer terminal on the key displaces the older one, which is closed
+  with 4409; an outgoing child that survives its kill refuses the terminal
+  with 4503; a hand-off error is an ``error`` frame and a close;
+- a resize sent while waiting sizes the spawn, one that lands after the
+  spawn is applied once the door returns, and a reused PTY is resized to
+  the client's size by the handler itself;
+- the spawn resumes the key's current transcript when one is on disk and
+  starts fresh under the key otherwise;
+- ``switch_session`` to a chat-held key hands off the same way.
+
+Harness as in ``test_ws_resume_confirm.py``: a real app and ``PtyRegistry``
+with ``_spawn_session`` patched to a fake, and a stand-in operator registry
+whose chat pool is the phase (c) fake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+import uuid as uuid_mod
+from contextlib import ExitStack
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from osprey.interfaces.web_terminal.app import create_app
+from osprey.interfaces.web_terminal.pty_manager import PtyRegistry
+from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from osprey.interfaces.web_terminal.session_handoff import (
+    WS_CLOSE_OUTGOING_RUNNING,
+    WS_CLOSE_SESSION_ATTACHED,
+    HandoffError,
+    HandoffState,
+    get_state,
+)
+from tests.interfaces.web_terminal._fakes import FakeClock, FakePtySession
+from tests.interfaces.web_terminal.test_handoff_phase_c import Chat, ChatPool
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="PTY not available on Windows")
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class ObservedPty(FakePtySession):
+    """The resume-confirm fake, counting the output loops reading it."""
+
+    def __init__(self):
+        super().__init__()
+        self.readers = 0
+
+    async def read_output(self):
+        self.readers += 1
+        try:
+            async for chunk in super().read_output():
+                yield chunk
+        finally:
+            self.readers -= 1
+
+
+@dataclass
+class Spawn:
+    """One call the registry made to spawn a PTY, and what it got."""
+
+    command: list[str]
+    rows: int
+    cols: int
+    session: ObservedPty
+
+
+class ChatRegistry:
+    """An ``operator_registry`` whose chat pool the door inspects and tears down."""
+
+    def __init__(self) -> None:
+        self.chats = ChatPool()
+
+    def hold(self, key: str, chat: Chat | None = None) -> Chat:
+        chat = chat or Chat()
+        self.chats.sessions[key] = chat
+        return chat
+
+    def has_chat_key(self, session_id: str) -> bool:
+        return self.chats.has_key(session_id)
+
+    async def cleanup_all(self) -> None:
+        pass
+
+
+@pytest.fixture()
+def app(tmp_path):
+    with patch(
+        "osprey.interfaces.web_terminal.app._load_web_config",
+        return_value={"watch_dir": str(tmp_path / "ws")},
+    ):
+        yield create_app(shell_command="fake-not-used", project_dir=str(tmp_path))
+
+
+@pytest.fixture()
+def sessions_dir(tmp_path):
+    d = tmp_path / "claude_sessions"
+    d.mkdir()
+    with patch.object(SessionDiscovery, "_resolve_sessions_dir", lambda self: d):
+        yield d
+
+
+def _patch_spawn(app, *, failing: str | None = None) -> list[Spawn]:
+    """Replace ``_spawn_session`` so no real PTY is created; record each call.
+
+    A spawn whose command names *failing* raises ``OSError`` instead, the way
+    a CLI that cannot be executed does.
+    """
+    spawns: list[Spawn] = []
+
+    def tracked_spawn(command, rows, cols, extra_env, cwd=None):
+        if failing is not None and failing in command:
+            raise OSError("cannot spawn")
+        session = ObservedPty()
+        spawns.append(Spawn(list(command), rows, cols, session))
+        return session
+
+    app.state.pty_registry._spawn_session = tracked_spawn
+    return spawns
+
+
+def _chats(app) -> ChatRegistry:
+    registry = ChatRegistry()
+    app.state.operator_registry = registry
+    return registry
+
+
+def _uuid() -> str:
+    return str(uuid_mod.uuid4())
+
+
+def _resume_url(session_id: str, *, interrupt: bool = False) -> str:
+    url = f"/ws/terminal?session_id={session_id}&mode=resume"
+    return f"{url}&interrupt=1" if interrupt else url
+
+
+def _send_resize(ws, cols: int = 80, rows: int = 24) -> None:
+    ws.send_json({"type": "resize", "cols": cols, "rows": rows})
+
+
+def _json_frames_until(ws, msg_type: str, max_frames: int = 30) -> list[dict]:
+    """Every JSON frame up to and including the first of *msg_type*."""
+    collected: list[dict] = []
+    for _ in range(max_frames):
+        raw = ws.receive()
+        if raw.get("type") == "websocket.close":
+            raise AssertionError(f"socket closed ({raw.get('code')}) before '{msg_type}'")
+        if "text" in raw:
+            data = json.loads(raw["text"])
+            collected.append(data)
+            if data.get("type") == msg_type:
+                return collected
+    raise AssertionError(f"'{msg_type}' not received; got {[d.get('type') for d in collected]}")
+
+
+def _recv_json(ws, msg_type: str) -> dict:
+    return _json_frames_until(ws, msg_type)[-1]
+
+
+def _sync(ws, session_id: str) -> None:
+    """Round-trip through the main loop: a switch to the current key is a no-op answer."""
+    ws.send_json({"type": "switch_session", "session_id": session_id})
+    _recv_json(ws, "session_switched")
+
+
+def _until(predicate, timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert predicate(), "condition not met in time"
+
+
+def _fake_clock(app) -> FakeClock:
+    """Run the door's grace and death waits on a clock that only moves when slept."""
+    clock = FakeClock()
+    app.state.handoff = HandoffState(clock=clock, sleep=clock.sleep)
+    return clock
+
+
+# ---------------------------------------------------------------------------
+# A chat-held key: the frames and the spawn
+# ---------------------------------------------------------------------------
+
+
+def test_a_chat_held_key_is_handed_off_with_the_pending_frame_first(app, sessions_dir):
+    """``handoff_pending`` goes out before the wait, ``session_info`` after the door."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        chat = _chats(app).hold(sid)
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            frames = _json_frames_until(ws, "session_info")
+
+    assert [f["type"] for f in frames] == ["handoff_pending", "session_info"]
+    assert frames[-1]["session_id"] == sid
+    assert chat.teardowns == 1
+    assert app.state.operator_registry.chats.get(sid) is None
+    assert len(spawns) == 1
+
+
+def test_a_key_with_no_transcript_starts_fresh_under_the_key(app, sessions_dir):
+    """A chat that never wrote a transcript hands off to ``--session-id <key>``."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        _chats(app).hold(sid)
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "session_info")
+
+    command = spawns[0].command
+    assert command[command.index("--session-id") + 1] == sid
+    assert "--resume" not in command
+
+
+def test_the_spawn_resumes_the_keys_current_transcript(app, sessions_dir):
+    """The key's transcript may have moved (``/clear``); the spawn resumes the current one."""
+    sid, transcript = _uuid(), _uuid()
+    (sessions_dir / f"{transcript}.jsonl").write_text("")
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        _chats(app).hold(sid)
+        app.state.transcript_map = {sid: transcript}
+        app.state.transcript_map_provisional = False
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "session_info")
+
+    command = spawns[0].command
+    assert command[command.index("--resume") + 1] == transcript
+    assert "--session-id" not in command
+
+
+def test_a_spawn_at_capacity_evicts_the_oldest_background_pty_off_the_loop(app, sessions_dir):
+    """The pool's eviction kill blocks; the handler takes the victim out and kills it in a thread."""
+    sid, background = _uuid(), _uuid()
+    (sessions_dir / f"{sid}.jsonl").write_text("")
+
+    class EvictedPty(ObservedPty):
+        killed_on_loop: bool | None = None
+
+        def terminate(self):
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                self.killed_on_loop = False
+            else:
+                self.killed_on_loop = True
+            super().terminate()
+
+    victim = EvictedPty()
+    with TestClient(app) as client:
+        # The lifespan installs the app's registry; a one-slot pool replaces it.
+        registry = PtyRegistry(max_background=1)
+        app.state.pty_registry = registry
+        registry._sessions[background] = victim
+        spawns = _patch_spawn(app)
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "session_info")
+            assert background not in registry._sessions
+            assert len(spawns) == 1 and registry.get_session(sid) is spawns[0].session
+
+    assert victim.killed_on_loop is False
+
+
+def test_a_free_key_gets_no_pending_frame(app, sessions_dir):
+    """Nothing to wait on, nothing to announce: the first frame is the confirmation."""
+    sid = _uuid()
+    (sessions_dir / f"{sid}.jsonl").write_text("")
+    with TestClient(app) as client:
+        _patch_spawn(app)
+        _chats(app)
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            frames = _json_frames_until(ws, "session_info")
+
+    assert [f["type"] for f in frames] == ["session_info"]
+
+
+# ---------------------------------------------------------------------------
+# A busy chat: wait, interrupt, leave
+# ---------------------------------------------------------------------------
+
+
+def test_a_busy_chat_is_waited_on(app, sessions_dir):
+    """The terminal is confirmed once the chat's turn ends, and not before."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        chat = _chats(app).hold(sid, Chat(busy=True))
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "handoff_pending")
+            time.sleep(0.3)
+            assert spawns == []
+            assert app.state.operator_registry.chats.get(sid) is chat
+
+            chat.is_busy = False
+            assert _recv_json(ws, "session_info")["session_id"] == sid
+
+    assert chat.teardowns == 1
+    assert len(spawns) == 1
+
+
+def test_interrupt_cuts_the_chat_turn_short(app, sessions_dir):
+    """``interrupt=1`` on the resume URL is the "stop and switch now" path."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        chat = _chats(app).hold(sid, Chat(busy=True))
+        with client.websocket_connect(_resume_url(sid, interrupt=True)) as ws:
+            _send_resize(ws)
+            assert _recv_json(ws, "session_info")["session_id"] == sid
+
+    assert chat.teardowns == 1
+    assert len(spawns) == 1
+
+
+def test_leaving_during_the_wait_sends_nothing_and_spares_the_chat(app, sessions_dir):
+    """A closed socket ends the wait: no spawn, no frame, the chat untouched, the key clean."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        registry = app.state.pty_registry
+        spawns = _patch_spawn(app)
+        chat = _chats(app).hold(sid, Chat(busy=True))
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "handoff_pending")
+
+        _until(lambda: sid not in get_state(app).pending)
+        assert not registry.is_reserved(sid)
+        assert app.state.operator_registry.chats.get(sid) is chat
+        assert chat.teardowns == 0
+        assert spawns == []
+        assert registry.get_session(sid) is None
+
+
+# ---------------------------------------------------------------------------
+# Refusals and errors
+# ---------------------------------------------------------------------------
+
+
+def test_a_newer_terminal_displaces_the_older_one_with_4409(app, sessions_dir):
+    """Same key, second socket: the first is closed with 4409, the PTY is reused."""
+    with TestClient(app) as client, ExitStack() as stack:
+        spawns = _patch_spawn(app)
+        _chats(app)
+        first = stack.enter_context(client.websocket_connect("/ws/terminal"))
+        _send_resize(first)
+        sid = _recv_json(first, "session_info")["session_id"]
+
+        second = stack.enter_context(client.websocket_connect(_resume_url(sid)))
+        _send_resize(second)
+        assert _recv_json(second, "session_info")["session_id"] == sid
+
+        closed = first.receive()
+        assert closed["type"] == "websocket.close"
+        assert closed["code"] == WS_CLOSE_SESSION_ATTACHED
+        # The displaced handler's output loop is stopped before the close
+        # handshake completes: one reader on the PTY, the new terminal's.
+        _until(lambda: spawns[0].session.readers == 1)
+
+    assert len(spawns) == 1
+
+
+def test_an_outgoing_child_that_survives_its_kill_is_refused_with_4503(app, sessions_dir):
+    """The chat child would not die: nothing is spawned, the chat is pooled again, 4503."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        _fake_clock(app)
+        chat = _chats(app).hold(sid, Chat(exits=False))
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "handoff_pending")
+            closed = ws.receive()
+
+    assert closed["type"] == "websocket.close"
+    assert closed["code"] == WS_CLOSE_OUTGOING_RUNNING
+    assert spawns == []
+    assert app.state.operator_registry.chats.get(sid) is chat
+    assert app.state.pty_registry.get_session(sid) is None
+
+
+def test_a_handoff_error_is_an_error_frame_and_a_close(app, sessions_dir):
+    """An error from inside the door reaches the client as ``error``, then the socket closes."""
+    sid = _uuid()
+    (sessions_dir / f"{sid}.jsonl").write_text("")
+    failing = AsyncMock(side_effect=HandoffError.vanished(sid, "simple"))
+    with (
+        patch("osprey.interfaces.web_terminal.session_handoff.acquire_surface", failing),
+        TestClient(app) as client,
+    ):
+        spawns = _patch_spawn(app)
+        _chats(app)
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            error = _recv_json(ws, "error")
+            assert ws.receive()["type"] == "websocket.close"
+
+    assert sid in error["message"]
+    assert spawns == []
+
+
+# ---------------------------------------------------------------------------
+# Sizing
+# ---------------------------------------------------------------------------
+
+
+def test_a_resize_sent_while_waiting_sizes_the_spawn(app, sessions_dir):
+    """The side reader records the resize; the spawn starts at that size."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        chat = _chats(app).hold(sid, Chat(busy=True))
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _recv_json(ws, "handoff_pending")
+            _send_resize(ws, cols=132, rows=40)
+            time.sleep(0.2)
+            chat.is_busy = False
+            _recv_json(ws, "session_info")
+
+    assert (spawns[0].rows, spawns[0].cols) == (40, 132)
+
+
+def test_a_resize_landing_after_the_spawn_is_applied_after_the_door(app, sessions_dir):
+    """The spawn read the size before the resize arrived; the handler applies it after."""
+    sid = _uuid()
+    (sessions_dir / f"{sid}.jsonl").write_text("")
+
+    async def spawn_then_linger(app_, key, surface, channel, *, interrupt=False, spawn=None):
+        session = await spawn(SimpleNamespace(key=key, resume_id=None, transcript_id=key))
+        app_.state.pty_registry.attach_session(key, channel)
+        # The door is still busy after the spawn; the client's resize lands now.
+        await asyncio.sleep(0.4)
+        return SimpleNamespace(session=session, spawned=True, resume_id=None)
+
+    with (
+        patch("osprey.interfaces.web_terminal.session_handoff.acquire_surface", spawn_then_linger),
+        TestClient(app) as client,
+    ):
+        spawns = _patch_spawn(app)
+        _chats(app)
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            time.sleep(0.15)
+            assert (spawns[0].rows, spawns[0].cols) == (24, 80)
+            _send_resize(ws, cols=132, rows=40)
+            _recv_json(ws, "session_info")
+            session = spawns[0].session
+            assert (session._last_rows, session._last_cols) == (40, 132)
+
+
+def test_a_reused_pty_is_resized_to_the_clients_size(app, sessions_dir):
+    """The door hands a pooled PTY back as is; the handler applies the client's size."""
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        _chats(app)
+        with client.websocket_connect("/ws/terminal") as ws:
+            _send_resize(ws, cols=80, rows=24)
+            sid = _recv_json(ws, "session_info")["session_id"]
+
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws, cols=100, rows=30)
+            _recv_json(ws, "session_info")
+            _sync(ws, sid)
+            session = spawns[0].session
+            assert (session._last_rows, session._last_cols) == (30, 100)
+
+    assert len(spawns) == 1
+
+
+# ---------------------------------------------------------------------------
+# The switch path
+# ---------------------------------------------------------------------------
+
+
+def test_switching_to_a_chat_held_key_hands_off(app, sessions_dir):
+    """``switch_session`` to a key the chat holds: pending frame, then ``session_switched``."""
+    initial, target = _uuid(), _uuid()
+    (sessions_dir / f"{initial}.jsonl").write_text("")
+    with TestClient(app) as client:
+        spawns = _patch_spawn(app)
+        chat = _chats(app).hold(target)
+        with client.websocket_connect(_resume_url(initial)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "session_info")
+
+            ws.send_json({"type": "switch_session", "session_id": target})
+            frames = _json_frames_until(ws, "session_switched")
+
+    assert [f["type"] for f in frames] == ["handoff_pending", "session_switched"]
+    assert frames[-1]["session_id"] == target
+    assert chat.teardowns == 1
+    assert len(spawns) == 2
+    assert spawns[1].command[spawns[1].command.index("--session-id") + 1] == target
+
+
+def test_a_switch_whose_spawn_fails_is_an_error_frame_and_a_close(app, sessions_dir):
+    """The old session is already let go; a spawn that fails ends the connection cleanly."""
+    initial, target = _uuid(), _uuid()
+    (sessions_dir / f"{initial}.jsonl").write_text("")
+    (sessions_dir / f"{target}.jsonl").write_text("")
+    with TestClient(app) as client:
+        registry = app.state.pty_registry
+        spawns = _patch_spawn(app, failing=target)
+        _chats(app)
+        with client.websocket_connect(_resume_url(initial)) as ws:
+            _send_resize(ws)
+            _recv_json(ws, "session_info")
+
+            ws.send_json({"type": "switch_session", "session_id": target})
+            error = _recv_json(ws, "error")
+            assert ws.receive()["type"] == "websocket.close"
+
+        _until(lambda: target not in get_state(app).pending)
+        assert "switch" in error["message"].lower()
+        assert len(spawns) == 1
+        assert registry.get_session(target) is None
+        assert not registry.is_reserved(target)
+        assert not registry.is_attached(initial)
+        assert registry.get_session(initial) is spawns[0].session

--- a/tests/interfaces/web_terminal/test_ws_resume_confirm.py
+++ b/tests/interfaces/web_terminal/test_ws_resume_confirm.py
@@ -12,6 +12,10 @@ on disk. The outcomes covered here:
 - A cold resume of an id with no transcript spawns nothing: the server
   answers ``transcript_missing`` and closes, and the client renders that
   state instead of a dead PTY.
+- A cold resume of an id the chat pool answers to is served: both views are
+  windows onto one session key, so a conversation the operator started in
+  Simple is a session here even before a transcript names it. Serving it is
+  a hand-off — the chat is torn down and the terminal spawned in its place.
 - A ``--resume`` child that the pre-spawn check let through but which still
   reports ``No conversation found with session ID`` and exits gets the same
   ``transcript_missing`` frame in place of a bare ``exit``.
@@ -22,7 +26,6 @@ with ``_spawn_session`` patched to a ``FakePtySession``.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 import time
@@ -34,66 +37,9 @@ from starlette.testclient import TestClient
 
 from osprey.interfaces.web_terminal.app import create_app
 from osprey.interfaces.web_terminal.session_discovery import SessionDiscovery
+from tests.interfaces.web_terminal._fakes import FakePtySession
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="PTY not available on Windows")
-
-
-class FakePtySession:
-    """Minimal PtySession substitute — alive until told otherwise.
-
-    ``emit`` queues bytes the output loop will forward; ``exit`` ends the
-    child with a code. Queued output is drained before the loop sees the exit,
-    which is what a real PTY does too (:meth:`PtySession.read_output`).
-    """
-
-    def __init__(self):
-        self._alive = True
-        self._exit_code: int | None = None
-        self._chunks: list[bytes] = []
-        self._last_rows = 24
-        self._last_cols = 80
-        self._command_list = ["fake"]
-
-    @property
-    def is_alive(self):
-        return self._alive
-
-    @property
-    def exit_code(self):
-        if self._alive:
-            return None
-        return 0 if self._exit_code is None else self._exit_code
-
-    def start(self, initial_rows=24, initial_cols=80, extra_env=None, cwd=None):
-        self._last_rows = initial_rows
-        self._last_cols = initial_cols
-
-    def resize(self, rows, cols):
-        self._last_rows = rows
-        self._last_cols = cols
-
-    def write_input(self, data):
-        pass
-
-    def terminate(self):
-        self._alive = False
-
-    def emit(self, data: bytes) -> None:
-        self._chunks.append(data)
-
-    def exit(self, code: int) -> None:
-        self._exit_code = code
-        self._alive = False
-
-    async def read_output(self):
-        try:
-            while self._alive or self._chunks:
-                if self._chunks:
-                    yield self._chunks.pop(0)
-                else:
-                    await asyncio.sleep(0.05)
-        except (asyncio.CancelledError, GeneratorExit):
-            return
 
 
 def _recv_json(ws, msg_type: str, max_frames: int = 30):
@@ -174,6 +120,71 @@ def sessions_dir(tmp_path):
     d.mkdir()
     with patch.object(SessionDiscovery, "_resolve_sessions_dir", lambda self: d):
         yield d
+
+
+class _IdleChat:
+    """The slice of ``OperatorSession`` the hand-off door reads for an idle chat."""
+
+    is_busy = False
+
+    def __init__(self):
+        self._active = True
+        self.process_exited: bool | None = None
+        self.teardowns = 0
+
+    @property
+    def is_active(self) -> bool:
+        return self._active
+
+    async def teardown(self) -> None:
+        self.teardowns += 1
+        self._active = False
+        self.process_exited = True
+
+
+class _ChatPool:
+    """``ChatSessionPool`` as the door sees it: ``get``, ``has_key``, ``terminate``."""
+
+    def __init__(self):
+        self.sessions: dict[str, _IdleChat] = {}
+
+    def get(self, chat_id: str) -> _IdleChat | None:
+        return self.sessions.get(chat_id)
+
+    def has_key(self, chat_id: str) -> bool:
+        return chat_id in self.sessions
+
+    async def terminate(self, chat_id: str) -> _IdleChat | None:
+        session = self.sessions.pop(chat_id, None)
+        if session is not None:
+            await session.teardown()
+        return session
+
+    async def reinsert(self, chat_id: str, session: _IdleChat) -> bool:
+        self.sessions[chat_id] = session
+        return True
+
+
+class _ChatHoldingRegistry:
+    """An ``operator_registry`` whose chat pool holds exactly one idle chat.
+
+    The addressability facade the gate asks for
+    (:func:`~osprey.interfaces.web_terminal.routes.websocket._chat_pool_answers_to`
+    reaches ``has_chat_key``) and the ``chats`` pool the hand-off door
+    inspects and tears down; ``cleanup_all`` is the app's own shutdown hook.
+    """
+
+    def __init__(self, key: str):
+        self.key = key
+        self.chats = _ChatPool()
+        self.chat = _IdleChat()
+        self.chats.sessions[key] = self.chat
+
+    def has_chat_key(self, session_id: str) -> bool:
+        return self.chats.has_key(session_id)
+
+    async def cleanup_all(self) -> None:
+        pass
 
 
 def _patch_spawn(app):
@@ -331,3 +342,49 @@ def test_resume_child_exiting_for_another_reason_still_sends_exit(app, sessions_
 
     assert seen[-1] == {"type": "exit", "code": 0}
     assert "transcript_missing" not in [m["type"] for m in seen]
+
+
+# ---------------------------------------------------------------------------
+# A chat-held key is a session
+# ---------------------------------------------------------------------------
+
+
+def test_cold_resume_of_a_chat_held_key_is_not_refused(app, sessions_dir):
+    """An id only the chat pool holds resumes instead of being refused.
+
+    The Simple view keys its pool on the same session key the terminal does,
+    so a conversation started there names a session on this surface too — and
+    it can name one before any ``.jsonl`` exists, because the transcript is
+    written on the first turn. Refusing it would tell the operator the
+    conversation they are looking at is gone. What happens instead is the
+    hand-off: the chat is torn down and the terminal takes the key.
+    """
+    sid = _uuid()
+    with TestClient(app) as client:
+        _, spawned = _patch_spawn(app)
+        holder = _ChatHoldingRegistry(sid)
+        app.state.operator_registry = holder
+
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            assert _recv_json(ws, "session_info")["session_id"] == sid
+
+    assert len(spawned) == 1
+    assert holder.chats.get(sid) is None
+    assert holder.chat.teardowns == 1
+
+
+def test_cold_resume_of_a_key_no_surface_holds_is_refused(app, sessions_dir):
+    """With a chat pool answering to some OTHER key, the refusal still stands."""
+    sid = _uuid()
+    with TestClient(app) as client:
+        reg, spawned = _patch_spawn(app)
+        app.state.operator_registry = _ChatHoldingRegistry(_uuid())
+
+        with client.websocket_connect(_resume_url(sid)) as ws:
+            _send_resize(ws)
+            assert _recv_json(ws, "transcript_missing")["session_id"] == sid
+            assert ws.receive()["type"] == "websocket.close"
+
+        assert spawned == []
+        assert reg.get_session(sid) is None

--- a/tests/mcp_server/workspace/test_transcript_tail_and_replay.py
+++ b/tests/mcp_server/workspace/test_transcript_tail_and_replay.py
@@ -1,0 +1,380 @@
+"""Tests for the transcript tail rule and full-fidelity chat replay.
+
+The tail rule reads a transcript's newest message entry to decide whether the
+agent that owns it is mid-turn; replay reads the same transcript as
+conversation, without the TUI's bookkeeping and without a per-message cap.
+Fixtures mirror the shapes Claude Code actually writes: a ``/model`` slash
+command, an interrupted turn, a ``/clear``, and a prompt nobody answered yet.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from osprey.mcp_server.workspace.transcript_reader import (
+    COMMAND_NAME_PREFIX,
+    INTERRUPT_MARKER,
+    LOCAL_COMMAND_STDERR_PREFIX,
+    LOCAL_COMMAND_STDOUT_PREFIX,
+    MAX_CHAT_MESSAGE_LENGTH,
+    TranscriptReader,
+    is_bookkeeping_entry,
+    tail_state,
+)
+
+
+def _ts(minute: int) -> str:
+    """Generate an ISO timestamp at a fixed date with the given minute."""
+    return datetime(2026, 2, 19, 12, minute, 0, tzinfo=UTC).isoformat()
+
+
+def _epoch(minute: int) -> float:
+    """POSIX seconds for the same instant as :func:`_ts`."""
+    return datetime(2026, 2, 19, 12, minute, 0, tzinfo=UTC).timestamp()
+
+
+def _user(timestamp: str, text: str, *, is_meta: bool = False) -> dict:
+    """Build a user entry carrying a single text block."""
+    entry: dict = {
+        "type": "user",
+        "timestamp": timestamp,
+        "sessionId": "tail-session",
+        "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+    }
+    if is_meta:
+        entry["isMeta"] = True
+    return entry
+
+
+def _assistant(timestamp: str, text: str) -> dict:
+    """Build an assistant entry carrying a single text block."""
+    return {
+        "type": "assistant",
+        "timestamp": timestamp,
+        "sessionId": "tail-session",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _tool_result(timestamp: str, tool_use_id: str, content: str) -> dict:
+    """Build a user entry carrying only a tool_result block."""
+    return {
+        "type": "user",
+        "timestamp": timestamp,
+        "sessionId": "tail-session",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": content}],
+        },
+    }
+
+
+def _slash_command(timestamp: str, name: str) -> dict:
+    """Build the meta entry Claude Code writes when a slash command runs."""
+    return _user(
+        timestamp,
+        f"<command-message>{name} is running…</command-message>\n"
+        f"{COMMAND_NAME_PREFIX}/{name}</command-name>",
+        is_meta=True,
+    )
+
+
+def _command_stdout(timestamp: str, text: str) -> dict:
+    """Build the entry holding a slash command's captured output."""
+    return _user(timestamp, f"{LOCAL_COMMAND_STDOUT_PREFIX}{text}</local-command-stdout>")
+
+
+def _write(path: Path, entries: list[dict]) -> Path:
+    """Write entries as JSONL and return the path."""
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# is_bookkeeping_entry
+# ---------------------------------------------------------------------------
+
+
+class TestIsBookkeepingEntry:
+    def test_meta_entry(self):
+        """An entry flagged isMeta is bookkeeping whatever it holds."""
+        assert is_bookkeeping_entry(_slash_command(_ts(0), "model")) is True
+
+    def test_command_name_without_meta_flag(self):
+        """The slash-command echo counts even when isMeta is absent."""
+        entry = _user(_ts(0), f"{COMMAND_NAME_PREFIX}/clear</command-name>")
+
+        assert is_bookkeeping_entry(entry) is True
+
+    def test_local_command_stdout(self):
+        """Captured slash-command output is bookkeeping."""
+        assert is_bookkeeping_entry(_command_stdout(_ts(1), "Set model to sonnet")) is True
+
+    def test_local_command_stderr(self):
+        """Captured slash-command errors are bookkeeping."""
+        entry = _user(
+            _ts(1), f"{LOCAL_COMMAND_STDERR_PREFIX}no such command</local-command-stderr>"
+        )
+
+        assert is_bookkeeping_entry(entry) is True
+
+    def test_interrupt_marker(self):
+        """The cancellation marker is bookkeeping."""
+        entry = _user(_ts(2), f"{INTERRUPT_MARKER}]")
+
+        assert is_bookkeeping_entry(entry) is True
+
+    def test_ordinary_user_message(self):
+        """A real prompt is not bookkeeping."""
+        assert is_bookkeeping_entry(_user(_ts(0), "What is the beam current?")) is False
+
+    def test_assistant_message(self):
+        """An assistant reply is not bookkeeping."""
+        assert is_bookkeeping_entry(_assistant(_ts(1), "500 mA.")) is False
+
+    def test_tool_result_only_entry(self):
+        """A tool-result-only entry carries no text and is not bookkeeping."""
+        assert is_bookkeeping_entry(_tool_result(_ts(1), "tu-1", "500")) is False
+
+    def test_non_dict(self):
+        """A non-dict entry is rejected rather than raising."""
+        assert is_bookkeeping_entry("not an entry") is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# read_chat_history replay
+# ---------------------------------------------------------------------------
+
+
+class TestChatHistoryReplay:
+    def test_skips_bookkeeping_entries(self, tmp_path):
+        """A /model round trip and an interrupt leave no conversation turns."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [
+                _user(_ts(0), "Read the current."),
+                _assistant(_ts(1), "Reading it now."),
+                _slash_command(_ts(2), "model"),
+                _command_stdout(_ts(3), "Set model to sonnet"),
+                _user(_ts(4), f"{INTERRUPT_MARKER}]"),
+                _user(_ts(5), "Try again."),
+            ],
+        )
+
+        history = TranscriptReader(tmp_path).read_chat_history(transcript)
+
+        assert [(t["role"], t["content"]) for t in history] == [
+            ("user", "Read the current."),
+            ("assistant", "Reading it now."),
+            ("user", "Try again."),
+        ]
+
+    def test_clear_command_is_not_a_turn(self, tmp_path):
+        """The /clear echo is dropped, and earlier conversation survives."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [
+                _user(_ts(0), "Hello."),
+                _slash_command(_ts(1), "clear"),
+            ],
+        )
+
+        history = TranscriptReader(tmp_path).read_chat_history(transcript)
+
+        assert len(history) == 1
+        assert history[0]["content"] == "Hello."
+
+    def test_default_cap_preserves_existing_behaviour(self, tmp_path):
+        """Without max_chars, messages are still capped as before."""
+        long_text = "x" * (MAX_CHAT_MESSAGE_LENGTH + 500)
+        transcript = _write(tmp_path / "session.jsonl", [_user(_ts(0), long_text)])
+
+        history = TranscriptReader(tmp_path).read_chat_history(transcript)
+
+        assert len(history[0]["content"]) == MAX_CHAT_MESSAGE_LENGTH + 3
+        assert history[0]["content"].endswith("...")
+
+    def test_none_cap_leaves_messages_whole(self, tmp_path):
+        """max_chars=None replays the full message text."""
+        long_text = "x" * (MAX_CHAT_MESSAGE_LENGTH + 500)
+        transcript = _write(tmp_path / "session.jsonl", [_user(_ts(0), long_text)])
+
+        history = TranscriptReader(tmp_path).read_chat_history(transcript, max_chars=None)
+
+        assert history[0]["content"] == long_text
+
+    def test_explicit_cap_is_honoured(self, tmp_path):
+        """A caller-supplied cap replaces the module default."""
+        transcript = _write(tmp_path / "session.jsonl", [_user(_ts(0), "abcdefghij")])
+
+        history = TranscriptReader(tmp_path).read_chat_history(transcript, max_chars=4)
+
+        assert history[0]["content"] == "abcd..."
+
+    def test_by_id_passes_cap_through(self, tmp_path, monkeypatch):
+        """read_chat_history_by_id forwards max_chars to the file reader."""
+        long_text = "y" * (MAX_CHAT_MESSAGE_LENGTH + 10)
+        transcript = _write(tmp_path / "abc-123.jsonl", [_user(_ts(0), long_text)])
+        reader = TranscriptReader(tmp_path)
+        monkeypatch.setattr(reader, "find_transcript_by_id", lambda _sid: transcript)
+
+        capped = reader.read_chat_history_by_id("abc-123")
+        whole = reader.read_chat_history_by_id("abc-123", max_chars=None)
+
+        assert len(capped[0]["content"]) == MAX_CHAT_MESSAGE_LENGTH + 3
+        assert whole[0]["content"] == long_text
+
+
+# ---------------------------------------------------------------------------
+# tail_state
+# ---------------------------------------------------------------------------
+
+
+class TestTailState:
+    def test_unanswered_prompt_is_busy(self, tmp_path):
+        """A text-bearing user entry with no reply after it means mid-turn."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [_assistant(_ts(0), "Done."), _user(_ts(1), "Now set the setpoint.")],
+        )
+
+        assert tail_state(transcript, _epoch(1)) == "busy"
+
+    def test_interrupt_marker_is_idle(self, tmp_path):
+        """A cancelled turn leaves the marker as the newest entry."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [_user(_ts(0), "Long job."), _user(_ts(1), f"{INTERRUPT_MARKER} for tool use]")],
+        )
+
+        assert tail_state(transcript, _epoch(0)) == "idle"
+
+    def test_command_output_newer_than_busy_stamp_is_idle(self, tmp_path):
+        """/model output written after the busy stamp means the prompt returned."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [
+                _user(_ts(0), "Switch model."),
+                _slash_command(_ts(1), "model"),
+                _command_stdout(_ts(2), "Set model to sonnet"),
+            ],
+        )
+
+        assert tail_state(transcript, _epoch(1)) == "idle"
+
+    def test_command_output_older_than_busy_stamp_is_unknown(self, tmp_path):
+        """Output predating the busy stamp proves nothing about this turn."""
+        transcript = _write(
+            tmp_path / "session.jsonl", [_command_stdout(_ts(2), "Set model to sonnet")]
+        )
+
+        assert tail_state(transcript, _epoch(9)) == "unknown"
+
+    def test_command_output_without_busy_stamp_is_idle(self, tmp_path):
+        """With no busy stamp there is no turn to be inside of."""
+        transcript = _write(
+            tmp_path / "session.jsonl", [_command_stdout(_ts(2), "Set model to sonnet")]
+        )
+
+        assert tail_state(transcript, None) == "idle"
+
+    def test_command_output_without_timestamp_is_unknown(self, tmp_path):
+        """An undatable entry cannot be shown to postdate the busy stamp."""
+        entry = _command_stdout(_ts(2), "Set model to sonnet")
+        entry["timestamp"] = ""
+        transcript = _write(tmp_path / "session.jsonl", [entry])
+
+        assert tail_state(transcript, _epoch(0)) == "unknown"
+
+    def test_clear_echo_is_unknown(self, tmp_path):
+        """The /clear echo is bookkeeping and carries no turn evidence."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [_user(_ts(0), "Hello."), _slash_command(_ts(1), "clear")],
+        )
+
+        assert tail_state(transcript, _epoch(0)) == "unknown"
+
+    def test_assistant_tail_is_unknown(self, tmp_path):
+        """An assistant entry says nothing about whether the turn finished."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [_user(_ts(0), "Read it."), _assistant(_ts(1), "500 mA.")],
+        )
+
+        assert tail_state(transcript, _epoch(0)) == "unknown"
+
+    def test_tool_result_tail_is_unknown(self, tmp_path):
+        """A tool-result-only user entry falls through to the caller's store."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [_user(_ts(0), "Read it."), _tool_result(_ts(1), "tu-1", "500")],
+        )
+
+        assert tail_state(transcript, _epoch(0)) == "unknown"
+
+    def test_missing_file_is_unknown(self, tmp_path):
+        """A transcript that does not exist yet is unknown, not busy."""
+        assert tail_state(tmp_path / "nope.jsonl", _epoch(0)) == "unknown"
+
+    def test_empty_file_is_unknown(self, tmp_path):
+        """An empty transcript holds no message entry."""
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text("")
+
+        assert tail_state(transcript, _epoch(0)) == "unknown"
+
+    def test_malformed_trailing_lines_are_skipped(self, tmp_path):
+        """A half-written final line does not hide the entry before it."""
+        transcript = tmp_path / "session.jsonl"
+        transcript.write_text(
+            json.dumps(_user(_ts(0), "Set the setpoint.")) + '\n{"type": "user", "mess'
+        )
+
+        assert tail_state(transcript, _epoch(0)) == "busy"
+
+    def test_summary_entries_do_not_mask_the_tail(self, tmp_path):
+        """Non-message entries after the last turn are stepped over."""
+        transcript = _write(
+            tmp_path / "session.jsonl",
+            [
+                _user(_ts(0), "Set the setpoint."),
+                {"type": "summary", "summary": "setpoint work", "leafUuid": "abc"},
+            ],
+        )
+
+        assert tail_state(transcript, _epoch(0)) == "busy"
+
+    def test_large_transcript_reads_only_the_tail(self, tmp_path):
+        """A transcript far larger than the read window still classifies."""
+        padding = [_assistant(_ts(0), "z" * 4000) for _ in range(200)]
+        transcript = _write(
+            tmp_path / "session.jsonl", [*padding, _user(_ts(1), "Set the setpoint.")]
+        )
+        assert transcript.stat().st_size > 256 * 1024
+
+        assert tail_state(transcript, _epoch(1)) == "busy"
+
+    def test_falls_back_to_full_read_for_one_huge_entry(self, tmp_path):
+        """A closing entry bigger than the window is found by the full read."""
+        transcript = _write(tmp_path / "session.jsonl", [_user(_ts(1), "q" * (300 * 1024))])
+        assert transcript.stat().st_size > 256 * 1024
+
+        assert tail_state(transcript, _epoch(1)) == "busy"
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("[Request interrupted by user]", "idle"),
+        ("[Request interrupted by user for tool use]", "idle"),
+        ("Request interrupted by user", "busy"),
+    ],
+)
+def test_interrupt_marker_variants(tmp_path, text, expected):
+    """Both marker wordings read as idle; prose that merely resembles it does not."""
+    transcript = _write(tmp_path / "session.jsonl", [_user(_ts(0), text)])
+
+    assert tail_state(transcript, _epoch(0)) == expected

--- a/tests/templates/test_hook_panel_token.py
+++ b/tests/templates/test_hook_panel_token.py
@@ -1,10 +1,13 @@
 """Shipped hooks authenticate their terminal-API calls with the panel token.
 
-Three template hooks talk to an app the web terminal serves — the SessionStart
+Four template hooks talk to an app the web terminal serves — the SessionStart
 panels-context hook and the UserPromptSubmit workspace-delta hook both
-``GET /api/panels``, and the approval hook ``POST``s ``/api/focus`` at the
-artifact gallery. Once those endpoints require a bearer token, an unauthenticated
-hook goes quietly blind: it keeps exiting 0 and simply stops reporting anything.
+``GET /api/panels``, the approval hook ``POST``s ``/api/focus`` at the artifact
+gallery, and the turn-state hook ``POST``s ``/api/agent-turn`` at the terminal
+(covered in ``tests/templates/test_turn_state_hook.py``, which owns that hook's
+whole contract including this one). Once those endpoints require a bearer token,
+an unauthenticated hook goes quietly blind: it keeps exiting 0 and simply stops
+reporting anything.
 
 So these tests pin the contract from the hook side:
 

--- a/tests/templates/test_turn_state_hook.py
+++ b/tests/templates/test_turn_state_hook.py
@@ -1,0 +1,556 @@
+"""The turn-state hook, its wiring, and the server's detection of both.
+
+A web terminal may move a conversation between its two surfaces only while the
+process holding it is between turns. Nothing in the terminal's output says when
+that is, so the process reports its own turn edges: ``osprey_turn_state.py``
+POSTs to ``/api/agent-turn`` on the four events that carry one.
+
+Three claims are pinned here, because a break in any of them is silent.
+
+* **The wiring.** ``settings.json.j2`` registers the hook on ``UserPromptSubmit``
+  (a turn starts), on ``Stop`` and ``StopFailure`` (a turn ends), and on
+  ``SessionStart`` under an explicit ``startup|resume|clear`` matcher.
+  ``compact`` must never match: auto-compaction fires *inside* a running turn,
+  and its idle report would invite a teardown mid-answer.
+* **The hook.** It reports the right state for each event, carries both
+  identities (the never-changing pool key and Claude Code's own session id,
+  which names the transcript), authenticates with the panel token, and is a
+  silent no-op outside a web terminal. Every path exits 0 and writes nothing to
+  stdout — this hook runs on the operator's prompt and on the end of their turn,
+  and neither may be blocked by it.
+* **The detection.** ``app.state.turn_hook_present`` is a permission, not a
+  prediction: it says an idle edge can actually arrive, so a deployment whose
+  settings carry no turn hook is never left waiting for one.
+
+The hook is exercised in-process against a stub terminal on loopback, so no
+test here reaches a real server or a real Claude Code.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import osprey.templates.claude_code.claude.hooks.osprey_turn_state as turn_state
+from osprey.cli.templates.manager import TemplateManager
+from osprey.interfaces.web_terminal.app import (
+    TURN_HOOK_SESSION_START_MATCHER,
+    TURN_STATE_HOOK,
+    _detect_turn_hook,
+)
+
+SETTINGS_TEMPLATE = "claude_code/claude/settings.json.j2"
+
+PORT_ENV = "OSPREY_WEB_PORT"
+KEY_ENV = "OSPREY_SESSION_ID"
+SURFACE_ENV = "OSPREY_WEB_UX"
+TOKEN_ENV = "OSPREY_PANEL_TOKEN"
+
+#: A session key and a transcript id that are deliberately different values —
+#: the whole point of the two-identity payload is that a ``/clear`` moves one
+#: and not the other, and a test reusing one value for both would pass while
+#: the hook swapped them.
+POOL_KEY = "11111111-2222-3333-4444-555555555555"
+TRANSCRIPT_ID = "99999999-8888-7777-6666-555555555555"
+
+#: Context sufficient to render ``settings.json.j2``. Keys the hooks block does
+#: not read are supplied only because the permissions block above it would fail
+#: on an undefined mapping.
+_BASE_CTX: dict[str, Any] = {
+    "current_python_env": "/usr/bin/python3",
+    "agent_data_root": "/tmp/turn-state-demo/agent_data",
+    "servers": [],
+    "agents": [],
+    "facility_permissions": {},
+    "deny_defaults": ["Bash"],
+    "declared_hooks": {},
+    "declared_extra_events": [],
+    "framework_pre_hooks": [],
+    "framework_post_hooks": [],
+}
+
+
+def _no_duplicate_keys(pairs):
+    """``object_pairs_hook`` that refuses a JSON object with a repeated key.
+
+    ``json.loads`` keeps the last of a repeated key and drops the rest without
+    a word, so a template that emitted ``"Stop"`` twice — once from the
+    framework, once from a profile's declaration — would parse into settings
+    that silently lost the framework's entry. This turns that into a failure.
+    """
+    seen: dict[str, Any] = {}
+    for key, value in pairs:
+        assert key not in seen, f"duplicate JSON key: {key}"
+        seen[key] = value
+    return seen
+
+
+def render_settings(**overrides: Any) -> dict[str, Any]:
+    """Render ``settings.json.j2`` and parse it, refusing duplicate keys."""
+    rendered = (
+        TemplateManager()
+        .jinja_env.get_template(SETTINGS_TEMPLATE)
+        .render(**{**_BASE_CTX, **overrides})
+    )
+    return json.loads(rendered, object_pairs_hook=_no_duplicate_keys)
+
+
+def turn_hook_entries(settings: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Map each event to the entries whose commands name the turn-state hook."""
+    found: dict[str, list[dict[str, Any]]] = {}
+    for event, entries in settings["hooks"].items():
+        for entry in entries:
+            if any(TURN_STATE_HOOK in hook["command"] for hook in entry["hooks"]):
+                found.setdefault(event, []).append(entry)
+    return found
+
+
+def declared_rule(hook_file: str, matcher: str | None = None) -> dict[str, Any]:
+    """A profile-declared hook rule in the shape the renderer hands the template."""
+    rule: dict[str, Any] = {
+        "hooks": [
+            {
+                "type": "command",
+                "command": f'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/{hook_file}"',
+                "timeout": 60,
+            }
+        ]
+    }
+    if matcher is not None:
+        rule["matcher"] = matcher
+    return rule
+
+
+# ---------------------------------------------------------------------------
+# The wiring: what settings.json.j2 registers
+# ---------------------------------------------------------------------------
+
+
+def test_settings_register_the_turn_hook_on_all_four_edges():
+    """Both edges of a turn, a failed turn, and a session opening are wired."""
+    events = turn_hook_entries(render_settings())
+
+    assert set(events) == {"UserPromptSubmit", "Stop", "StopFailure", "SessionStart"}
+    for event, entries in events.items():
+        assert len(entries) == 1, f"{event} registers the hook more than once"
+
+
+def test_settings_session_start_matcher_excludes_compaction():
+    """The SessionStart registration names the three real starts, never compact."""
+    entry = turn_hook_entries(render_settings())["SessionStart"][0]
+
+    assert entry["matcher"] == TURN_HOOK_SESSION_START_MATCHER
+    assert "compact" not in entry["matcher"]
+
+
+def test_settings_turn_hook_command_fails_open():
+    """Every registration runs the shipped file and swallows its own failure.
+
+    The suffix is what the other framework entries carry: a hook that cannot be
+    found or cannot run must not turn into a non-zero exit that Claude Code
+    reports to the operator.
+    """
+    for entries in turn_hook_entries(render_settings()).values():
+        commands = [h["command"] for h in entries[0]["hooks"] if TURN_STATE_HOOK in h["command"]]
+        assert len(commands) == 1
+        assert commands[0].endswith(f'{TURN_STATE_HOOK}" 2>/dev/null || true')
+        assert commands[0].startswith('"/usr/bin/python3"')
+
+
+def test_settings_keep_the_other_session_start_hooks_unmatched():
+    """The framework's existing SessionStart entry keeps running on every source.
+
+    The matcher belongs to the turn hook alone. Attaching it to the entry that
+    carries the config-drift and panels-context hooks would quietly stop those
+    from running after a compaction.
+    """
+    entries = render_settings()["hooks"]["SessionStart"]
+    others = [e for e in entries if all(TURN_STATE_HOOK not in h["command"] for h in e["hooks"])]
+
+    assert len(others) == 1
+    assert "matcher" not in others[0]
+
+
+def test_settings_stop_absorbs_a_declared_rule_into_one_key():
+    """A profile declaring its own Stop hook extends the framework's array.
+
+    ``Stop`` is now framework-wired, so a declared rule must be appended to the
+    same key rather than emitted as a second ``"Stop"`` — which would be legal
+    JSON whose framework half is dropped on parse. ``render_settings`` refuses
+    duplicate keys, so this test fails loudly either way.
+    """
+    settings = render_settings(
+        declared_hooks={"Stop": [declared_rule("facility_audit.py")]},
+        declared_extra_events=["Stop"],
+    )
+
+    commands = [h["command"] for entry in settings["hooks"]["Stop"] for h in entry["hooks"]]
+    assert any(TURN_STATE_HOOK in command for command in commands)
+    assert any("facility_audit.py" in command for command in commands)
+
+
+def test_settings_still_emit_declared_events_the_framework_does_not_wire():
+    """Filtering Stop out of the extra-events loop leaves the other events alone."""
+    settings = render_settings(
+        declared_hooks={"SessionEnd": [declared_rule("facility_farewell.py")]},
+        declared_extra_events=["SessionEnd"],
+    )
+
+    commands = [h["command"] for entry in settings["hooks"]["SessionEnd"] for h in entry["hooks"]]
+    assert any("facility_farewell.py" in command for command in commands)
+
+
+# ---------------------------------------------------------------------------
+# The hook: what it sends, and when it stays quiet
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_terminal(monkeypatch):
+    """No inherited web-terminal environment: each test states what it wants."""
+    for name in (PORT_ENV, KEY_ENV, SURFACE_ENV, TOKEN_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def turn_server():
+    """Stub web terminal recording ``POST /api/agent-turn`` calls.
+
+    Yields ``(port, received)``; a call is appended before the response is
+    written, so a hook that has returned has necessarily already been recorded.
+    """
+    received: list[dict[str, Any]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 - http.server API
+            length = int(self.headers.get("Content-Length", 0))
+            received.append(
+                {
+                    "path": self.path,
+                    "body": json.loads(self.rfile.read(length) or b"{}"),
+                    "content_type": self.headers.get("Content-Type"),
+                    "authorization": self.headers.get("Authorization"),
+                }
+            )
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1], received
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def run_hook(monkeypatch, payload, *, port, surface="expert", key=POOL_KEY, token=None):
+    """Drive the hook's ``main`` over *payload*, returning its exit status."""
+    if port is not None:
+        monkeypatch.setenv(PORT_ENV, str(port))
+    if key is not None:
+        monkeypatch.setenv(KEY_ENV, key)
+    if surface is not None:
+        monkeypatch.setenv(SURFACE_ENV, surface)
+    if token is not None:
+        monkeypatch.setenv(TOKEN_ENV, token)
+    monkeypatch.setattr(turn_state.sys, "stdin", io.StringIO(json.dumps(payload)))
+    return turn_state.main()
+
+
+def record_calls(monkeypatch, *, raises=None):
+    """Stub the hook's ``urlopen`` and hand back the requests it was given."""
+    seen = []
+
+    def _fake(target, timeout=None):
+        seen.append(target)
+        if raises is not None:
+            raise raises
+        return SimpleNamespace(close=lambda: None)
+
+    monkeypatch.setattr(turn_state.urllib.request, "urlopen", _fake)
+    return seen
+
+
+def payload_for(event, *, session_id=TRANSCRIPT_ID, **extra):
+    """A hook stdin payload for *event*, shaped as Claude Code sends it."""
+    return {"hook_event_name": event, "session_id": session_id, **extra}
+
+
+def test_reports_busy_when_a_prompt_starts_a_turn(monkeypatch, turn_server, capsys):
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("UserPromptSubmit"), port=port) == 0
+
+    assert len(received) == 1
+    call = received[0]
+    assert call["path"] == "/api/agent-turn"
+    assert call["content_type"] == "application/json"
+    assert call["body"]["state"] == "busy"
+    assert capsys.readouterr().out == ""
+
+
+def test_reports_the_two_identities_and_the_surface(monkeypatch, turn_server):
+    """The body carries the pool key, the transcript id and the surface apart."""
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=port) == 0
+
+    body = received[0]["body"]
+    assert body["pool_key"] == POOL_KEY
+    assert body["session_id"] == TRANSCRIPT_ID
+    assert body["surface"] == "expert"
+    assert body["state"] == "idle"
+    assert body["source"] == "Stop"
+    assert isinstance(body["ts"], float)
+    assert set(body) == {"session_id", "pool_key", "state", "surface", "ts", "source"}
+
+
+@pytest.mark.parametrize(
+    ("event", "state"),
+    [
+        ("UserPromptSubmit", "busy"),
+        ("Stop", "idle"),
+        ("StopFailure", "idle"),
+        ("SessionStart", "idle"),
+    ],
+)
+def test_each_wired_event_reports_its_state(monkeypatch, turn_server, event, state):
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for(event), port=port) == 0
+
+    assert [call["body"]["state"] for call in received] == [state]
+
+
+def test_a_session_start_after_compaction_reports_nothing(monkeypatch):
+    """The matcher keeps compact out; the hook refuses it a second time.
+
+    A hand-edited ``settings.json`` that dropped the matcher would otherwise
+    have the hook announce idleness in the middle of the turn the compaction
+    happened in.
+    """
+    seen = record_calls(monkeypatch)
+
+    assert run_hook(monkeypatch, payload_for("SessionStart", source="compact"), port=10100) == 0
+
+    assert seen == []
+
+
+def test_a_turn_ending_is_reported_whatever_the_payload_calls_its_source(monkeypatch, turn_server):
+    """The compaction backstop asks only about SessionStart.
+
+    ``source`` means "which kind of session start"; on any other event the word
+    is not that, so a Stop that happened to carry it must still report the turn
+    it ended.
+    """
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("Stop", source="compact"), port=port) == 0
+
+    assert [call["body"]["state"] for call in received] == ["idle"]
+
+
+@pytest.mark.parametrize("source", ["startup", "resume", "clear"])
+def test_the_other_session_start_sources_are_reported(monkeypatch, turn_server, source):
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("SessionStart", source=source), port=port) == 0
+
+    assert len(received) == 1
+
+
+@pytest.mark.parametrize("event", ["PreToolUse", "SubagentStop", "", None])
+def test_an_event_that_is_not_a_turn_edge_reports_nothing(monkeypatch, event):
+    seen = record_calls(monkeypatch)
+
+    assert run_hook(monkeypatch, payload_for(event), port=10100) == 0
+
+    assert seen == []
+
+
+def test_a_payload_without_a_transcript_id_reports_nothing(monkeypatch):
+    """A blank id would erase the key's recorded transcript, not update it."""
+    seen = record_calls(monkeypatch)
+
+    assert run_hook(monkeypatch, payload_for("Stop", session_id=""), port=10100) == 0
+
+    assert seen == []
+
+
+def test_unreadable_stdin_reports_nothing(monkeypatch):
+    seen = record_calls(monkeypatch)
+    monkeypatch.setenv(PORT_ENV, "10100")
+    monkeypatch.setenv(KEY_ENV, POOL_KEY)
+    monkeypatch.setattr(turn_state.sys, "stdin", io.StringIO("not json"))
+
+    assert turn_state.main() == 0
+    assert seen == []
+
+
+@pytest.mark.parametrize("absent", [PORT_ENV, KEY_ENV])
+def test_a_session_outside_the_web_terminal_reports_nothing(monkeypatch, absent, capsys):
+    """No port or no session key means there is no server that knows this session."""
+    seen = record_calls(monkeypatch)
+    monkeypatch.setenv(PORT_ENV, "10100")
+    monkeypatch.setenv(KEY_ENV, POOL_KEY)
+    monkeypatch.delenv(absent)
+    monkeypatch.setattr(turn_state.sys, "stdin", io.StringIO(json.dumps(payload_for("Stop"))))
+
+    assert turn_state.main() == 0
+    assert seen == []
+    assert capsys.readouterr().out == ""
+
+
+def test_the_simple_surface_still_reports(monkeypatch, turn_server):
+    """The hook does not decide which surface counts — the server drops the rest.
+
+    Keeping one code path here means a surface the server later starts caring
+    about needs no change in a file that ships into every deployment.
+    """
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=port, surface="simple") == 0
+
+    assert received[0]["body"]["surface"] == "simple"
+
+
+def test_a_missing_surface_variable_reports_an_empty_surface(monkeypatch, turn_server):
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=port, surface=None) == 0
+
+    assert received[0]["body"]["surface"] == ""
+
+
+@pytest.mark.parametrize(("value", "reported"), [("  expert\n", "expert"), ("   ", "")])
+def test_the_surface_variable_is_read_stripped(monkeypatch, turn_server, value, reported):
+    """The same rule the other env reads apply: padding is not part of the value.
+
+    An uninterpolated compose variable arrives blank and a hand-edited one can
+    arrive padded; the server compares the surface for equality, so a padded
+    ``expert`` would be dropped as an unrecognised surface.
+    """
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=port, surface=value) == 0
+
+    assert received[0]["body"]["surface"] == reported
+
+
+def test_the_panel_token_authenticates_the_report(monkeypatch, turn_server):
+    port, received = turn_server
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=port, token="s3cret-panel-token") == 0
+
+    assert received[0]["authorization"] == "Bearer s3cret-panel-token"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_a_blank_panel_token_sends_no_bearer(monkeypatch, blank):
+    """A blank carrier is absent, not a credential — the same rule the server applies."""
+    seen = record_calls(monkeypatch)
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=10100, token=blank) == 0
+
+    assert seen[0].get_header("Authorization") is None
+
+
+def test_a_web_terminal_that_refuses_the_report_costs_only_the_report(monkeypatch, capsys):
+    """An unreachable or refusing terminal must not fail the turn that reported."""
+    record_calls(monkeypatch, raises=OSError("connection refused"))
+
+    assert run_hook(monkeypatch, payload_for("Stop"), port=10100) == 0
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# The detection: what the server concludes from the rendered settings
+# ---------------------------------------------------------------------------
+
+
+def project_with(settings: Any, tmp_path: Path):
+    """Write *settings* into a project tree and return an app pointed at it."""
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    if settings is not None:
+        claude_dir.joinpath("settings.json").write_text(
+            settings if isinstance(settings, str) else json.dumps(settings)
+        )
+    return SimpleNamespace(
+        state=SimpleNamespace(project_cwd=str(tmp_path), turn_hook_present=False)
+    )
+
+
+def test_a_rendered_project_is_detected_as_reporting_turns(tmp_path, caplog):
+    """The template's own output satisfies the detection it is read by."""
+    app = project_with(render_settings(), tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="osprey.interfaces.web_terminal.app"):
+        _detect_turn_hook(app)
+
+    assert app.state.turn_hook_present is True
+    assert caplog.records == []
+
+
+def test_settings_without_a_stop_entry_are_not_turn_reporting(tmp_path):
+    settings = render_settings()
+    del settings["hooks"]["Stop"]
+
+    app = project_with(settings, tmp_path)
+    _detect_turn_hook(app)
+
+    assert app.state.turn_hook_present is False
+
+
+def test_settings_whose_session_start_lost_its_matcher_are_not_turn_reporting(tmp_path):
+    """Without the matcher the hook also runs on compact, so it is not trusted."""
+    settings = render_settings()
+    for entry in settings["hooks"]["SessionStart"]:
+        entry.pop("matcher", None)
+
+    app = project_with(settings, tmp_path)
+    _detect_turn_hook(app)
+
+    assert app.state.turn_hook_present is False
+
+
+def test_settings_without_stop_failure_still_report_turns_but_warn(tmp_path, caplog):
+    """A missing failure edge is a gap worth naming, not a reason to distrust the rest."""
+    settings = render_settings()
+    del settings["hooks"]["StopFailure"]
+
+    app = project_with(settings, tmp_path)
+    with caplog.at_level(logging.WARNING, logger="osprey.interfaces.web_terminal.app"):
+        _detect_turn_hook(app)
+
+    assert app.state.turn_hook_present is True
+    assert "StopFailure" in caplog.text
+
+
+def test_a_project_without_settings_reports_no_turns(tmp_path):
+    app = project_with(None, tmp_path)
+    _detect_turn_hook(app)
+
+    assert app.state.turn_hook_present is False
+
+
+def test_unreadable_settings_report_no_turns(tmp_path):
+    """A malformed artifact reads as "no hook" rather than breaking the boot."""
+    app = project_with("{ not json", tmp_path)
+    _detect_turn_hook(app)
+
+    assert app.state.turn_hook_present is False

--- a/tests/unit/dispatch_worker/test_sdk_runner.py
+++ b/tests/unit/dispatch_worker/test_sdk_runner.py
@@ -69,7 +69,7 @@ async def _drain(queue: asyncio.Queue) -> list[dict]:
 
 @pytest.mark.asyncio
 async def test_happy_path(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text="hello world")], model="m")
         yield _result_message(cost_usd=0.5, num_turns=4)
 
@@ -98,7 +98,7 @@ async def test_tool_result_in_user_message_is_captured(monkeypatch):
     must pair them with the originating ToolUseBlock (permission-denial
     messages surface this way; the parity e2e depends on seeing them)."""
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(
             content=[ToolUseBlock(id="tu1", name="mcp__x__y", input={})], model="m"
         )
@@ -150,7 +150,7 @@ async def test_tool_policy_wiring(monkeypatch, tmp_path):
     monkeypatch.setenv("CONFIG_FILE", str(tmp_path / "build" / "config.yml"))
     captured: dict = {}
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         captured["options"] = options
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
@@ -222,7 +222,7 @@ async def test_config_file_env_points_at_the_render(monkeypatch):
     monkeypatch.delenv("OSPREY_CONFIG", raising=False)
     captured: dict = {}
 
-    async def fake_query(options, render_dir, prompt):
+    async def fake_query(options, render_dir, prompt, **_kw):
         captured["options"] = options
         captured["render_dir"] = render_dir
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
@@ -246,7 +246,7 @@ async def test_worker_trusts_the_config_file_its_service_sets(monkeypatch):
     monkeypatch.setenv("CONFIG_FILE", "/srv/staged/config.yml")
     captured: dict = {}
 
-    async def fake_query(options, render_dir, prompt):
+    async def fake_query(options, render_dir, prompt, **_kw):
         captured["options"] = options
         captured["render_dir"] = render_dir
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
@@ -286,7 +286,7 @@ async def test_subagent_surfaces_are_discovered_from_the_render(tmp_path, monkey
     monkeypatch.setenv("CONFIG_FILE", str(tmp_path / "build" / "config.yml"))
     captured: dict = {}
 
-    async def fake_query(options, render_dir, prompt):
+    async def fake_query(options, render_dir, prompt, **_kw):
         captured["options"] = options
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
@@ -313,7 +313,7 @@ async def test_no_discoverable_agents_denies_every_delegation(tmp_path, monkeypa
     monkeypatch.setenv("CONFIG_FILE", str(tmp_path / "build" / "config.yml"))
     captured: dict = {}
 
-    async def fake_query(options, render_dir, prompt):
+    async def fake_query(options, render_dir, prompt, **_kw):
         captured["options"] = options
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
@@ -346,7 +346,7 @@ async def test_subagent_delegation_runs_in_the_foreground(monkeypatch):
     """
     captured: dict = {}
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         captured["options"] = options
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
@@ -374,7 +374,7 @@ async def test_sdk_missing(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cancellation_propagates(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text="partial")], model="m")
         raise asyncio.CancelledError
 
@@ -386,7 +386,7 @@ async def test_cancellation_propagates(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_error_path_does_not_raise(monkeypatch):
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         raise Exception("boom")
         yield  # pragma: no cover - makes this an async generator
 
@@ -415,7 +415,7 @@ async def test_inactivity_timeout_aborts_with_clear_error(monkeypatch):
     stalling silently to the outer dispatch timeout."""
     monkeypatch.setattr(sdk_runner, "_INACTIVITY_TIMEOUT_SEC", 0.2, raising=False)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         await asyncio.sleep(30)  # hang — never yields a message
         yield  # pragma: no cover - never reached
 
@@ -445,7 +445,7 @@ async def test_inactivity_timeout_after_partial_progress(monkeypatch):
     then stalls is still aborted, with the partial text preserved."""
     monkeypatch.setattr(sdk_runner, "_INACTIVITY_TIMEOUT_SEC", 0.2, raising=False)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text="working...")], model="m")
         await asyncio.sleep(30)  # then hang
         yield  # pragma: no cover - never reached
@@ -484,7 +484,7 @@ def test_scrub_replaces_secret_values():
 async def test_oversized_text_output_is_truncated(monkeypatch):
     huge = "y" * (sdk_runner._MAX_TEXT_OUTPUT + 10000)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text=huge)], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
 
@@ -500,7 +500,7 @@ async def test_secret_scrubbed_from_text_output(monkeypatch):
     secret = "tok-abcdef-1234567890"  # len >= 12
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", secret)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text=f"leaked {secret} here")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
 
@@ -516,7 +516,7 @@ async def test_tool_use_and_result_are_captured(monkeypatch):
     """A ToolUseBlock + matching ToolResultBlock land in tool_calls with the result."""
     from claude_agent_sdk import ToolResultBlock, ToolUseBlock
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(
             content=[ToolUseBlock(id="tu1", name="Read", input={"path": "f"})], model="m"
         )
@@ -561,7 +561,7 @@ async def test_surface_prompt_forwarded_to_build_system_prompt(monkeypatch):
         _spy_build_system_prompt,
     )
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
 
@@ -590,7 +590,7 @@ async def test_surface_prompt_omitted_leaves_system_prompt_unchanged(monkeypatch
         _spy_build_system_prompt,
     )
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
         yield _result_message(cost_usd=0.1, num_turns=1)
 
@@ -608,7 +608,7 @@ async def test_oversized_tool_result_is_truncated(monkeypatch):
 
     huge = "z" * (sdk_runner._MAX_TOOL_RESULT + 5000)
 
-    async def fake_query(options, project_dir, prompt):
+    async def fake_query(options, project_dir, prompt, **_kw):
         yield AssistantMessage(content=[ToolUseBlock(id="tu1", name="Read", input={})], model="m")
         yield AssistantMessage(
             content=[ToolResultBlock(tool_use_id="tu1", content=huge)], model="m"
@@ -621,3 +621,100 @@ async def test_oversized_tool_result_is_truncated(monkeypatch):
     body = result["tool_calls"][0]["result"]
     assert len(body) <= sdk_runner._MAX_TOOL_RESULT + 100
     assert "[truncated" in body
+
+
+# ---------------------------------------------------------------------------
+# MCP readiness: a required server that is not up is an infrastructure error,
+# and every run record carries the readiness snapshot.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_not_ready_is_an_infrastructure_error(monkeypatch):
+    """The worker's own machinery (the CLI's MCP servers) was not ready before
+    the run: stamped infrastructure (retryable once the host catches up), never
+    a "completed" run that quietly lacked the tool it was dispatched to use."""
+    snapshot = [
+        {"name": "controls", "status": "connected", "tools": 6, "error": None},
+        {"name": "osprey_workspace", "status": "pending", "tools": 0, "error": None},
+    ]
+
+    async def fake_query(options, project_dir, prompt, **kw):
+        kw["mcp_snapshot"][:] = snapshot
+        raise sdk_runner.McpNotReadyError("MCP server 'osprey_workspace' not connected (pending)")
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
+
+    queue: asyncio.Queue = asyncio.Queue()
+    result = await sdk_runner.run_dispatch(
+        "do it", ["Read", "mcp__osprey_workspace__artifact_register"], event_queue=queue
+    )
+
+    assert result["status"] == "error"
+    assert result["failure_class"] == "infrastructure"
+    assert "osprey_workspace" in result["error"]
+    assert result["mcp_servers"] == snapshot
+    events = await _drain(queue)
+    assert any(e["type"] == "error" and "osprey_workspace" in e["message"] for e in events)
+
+
+@pytest.mark.asyncio
+async def test_run_record_carries_the_mcp_snapshot(monkeypatch):
+    """Persisted with the run so a missing tool can be read off the record as
+    INFRA (server not connected) or MODEL (tool registered, agent ignored it)."""
+    snapshot = [{"name": "controls", "status": "connected", "tools": 6, "error": None}]
+
+    async def fake_query(options, project_dir, prompt, **kw):
+        kw["mcp_snapshot"][:] = snapshot
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
+    result = await sdk_runner.run_dispatch("do it", ["Read"], event_queue=asyncio.Queue())
+
+    assert result["status"] == "completed"
+    assert result["mcp_servers"] == snapshot
+
+
+@pytest.mark.asyncio
+async def test_required_servers_are_the_allow_listed_ones(monkeypatch):
+    captured: dict = {}
+
+    async def fake_query(options, project_dir, prompt, **kw):
+        captured.update(kw)
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
+    await sdk_runner.run_dispatch(
+        "do it",
+        ["Glob", "mcp__osprey_workspace__artifact_register", "mcp__controls__channel_read"],
+        event_queue=asyncio.Queue(),
+    )
+
+    assert captured["required_servers"] == {"osprey_workspace", "controls"}
+
+
+@pytest.mark.asyncio
+async def test_cli_mcp_startup_limit_matches_the_barrier(monkeypatch):
+    """The CLI marks a stdio server failed after its own ``MCP_TIMEOUT`` (30s by
+    default) — shorter than the barrier, which would then wait for a server the
+    CLI has already given up on. One figure drives both; an operator's explicit
+    ``MCP_TIMEOUT`` wins."""
+    captured: dict = {}
+
+    async def fake_query(options, project_dir, prompt, **_kw):
+        captured["env"] = options.env
+        yield AssistantMessage(content=[TextBlock(text="ok")], model="m")
+        yield _result_message(cost_usd=0.1, num_turns=1)
+
+    monkeypatch.setattr(sdk_runner, "_stream_with_ready_mcp", fake_query)
+    await sdk_runner.run_dispatch("do it", ["Read"], event_queue=asyncio.Queue())
+    assert captured["env"]["MCP_TIMEOUT"] == str(int(sdk_runner.MCP_READY_TIMEOUT_S * 1000))
+
+    monkeypatch.setattr(
+        "osprey.agent_runner.clean_env.build_clean_env", lambda **kw: {"MCP_TIMEOUT": "5000"}
+    )
+    await sdk_runner.run_dispatch("do it", ["Read"], event_queue=asyncio.Queue())
+    assert captured["env"]["MCP_TIMEOUT"] == "5000"

--- a/tests/unit/dispatch_worker/test_sdk_runner_mcp_barrier.py
+++ b/tests/unit/dispatch_worker/test_sdk_runner_mcp_barrier.py
@@ -115,5 +115,120 @@ async def test_no_declared_servers_is_skipped_rather_than_polled_to_the_deadline
     assert elapsed < 1.0, f"run stalled {elapsed:.1f}s on an empty MCP expectation"
 
 
+@pytest.mark.asyncio
+async def test_required_server_not_connected_refuses_to_send_the_prompt(monkeypatch):
+    """The CLI fixes a session's MCP toolset at the first turn, so a server the
+    trigger's own allow-list names that is not connected by then is lost for
+    the whole run: the agent would run without the tool it was dispatched to
+    use and report "completed". Refuse before the prompt goes out, naming the
+    server and the status it was left in."""
+    events: list[str] = []
+    monkeypatch.setattr(sdk_runner, "ClaudeSDKClient", lambda options: _FakeClient(events))
+    monkeypatch.setattr(
+        sdk_runner, "expected_mcp_servers", lambda _p: {"controls", "osprey_workspace"}
+    )
+    monkeypatch.setattr(
+        sdk_runner,
+        "await_mcp_ready",
+        lambda _c, _e: _ready(
+            [
+                {"name": "controls", "status": "connected", "tools": [{"name": "channel_read"}]},
+                {"name": "osprey_workspace", "status": "pending"},
+            ]
+        ),
+    )
+    snapshot: list[dict] = []
+
+    with pytest.raises(sdk_runner.McpNotReadyError) as excinfo:
+        await _drain(
+            sdk_runner._stream_with_ready_mcp(
+                object(),
+                "/proj",
+                object(),
+                required_servers={"osprey_workspace"},
+                mcp_snapshot=snapshot,
+            )
+        )
+
+    assert "query" not in events, "prompt was sent despite a required server being absent"
+    assert events[-1] == "disconnect"
+    msg = str(excinfo.value)
+    assert "osprey_workspace" in msg and "pending" in msg
+    # The snapshot is handed back even on refusal, so the run record can carry it.
+    assert {s["name"]: s["status"] for s in snapshot} == {
+        "controls": "connected",
+        "osprey_workspace": "pending",
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_required_server_is_named_with_its_error(monkeypatch):
+    events: list[str] = []
+    monkeypatch.setattr(sdk_runner, "ClaudeSDKClient", lambda options: _FakeClient(events))
+    monkeypatch.setattr(sdk_runner, "expected_mcp_servers", lambda _p: {"osprey_workspace"})
+    monkeypatch.setattr(
+        sdk_runner,
+        "await_mcp_ready",
+        lambda _c, _e: _ready(
+            [{"name": "osprey_workspace", "status": "failed", "error": "spawn: ENOENT"}]
+        ),
+    )
+
+    with pytest.raises(sdk_runner.McpNotReadyError) as excinfo:
+        await _drain(
+            sdk_runner._stream_with_ready_mcp(
+                object(), "/proj", object(), required_servers={"osprey_workspace"}
+            )
+        )
+
+    assert "failed" in str(excinfo.value) and "spawn: ENOENT" in str(excinfo.value)
+    assert "query" not in events
+
+
+@pytest.mark.asyncio
+async def test_optional_server_not_connected_still_runs(monkeypatch, caplog):
+    """A declared server the trigger does not allow-list cannot be called by
+    the main thread anyway; its absence is logged, not fatal."""
+    events: list[str] = []
+    monkeypatch.setattr(sdk_runner, "ClaudeSDKClient", lambda options: _FakeClient(events))
+    monkeypatch.setattr(sdk_runner, "expected_mcp_servers", lambda _p: {"controls", "graph"})
+    monkeypatch.setattr(
+        sdk_runner,
+        "await_mcp_ready",
+        lambda _c, _e: _ready(
+            [
+                {"name": "controls", "status": "connected", "tools": [{"name": "channel_read"}]},
+                {"name": "graph", "status": "pending"},
+            ]
+        ),
+    )
+    snapshot: list[dict] = []
+
+    with caplog.at_level(logging.WARNING, logger=sdk_runner.logger.name):
+        messages = await _drain(
+            sdk_runner._stream_with_ready_mcp(
+                object(),
+                "/proj",
+                object(),
+                required_servers={"controls"},
+                mcp_snapshot=snapshot,
+            )
+        )
+
+    assert messages == ["message-1", "message-2"]
+    assert "graph" in caplog.text and "not connected" in caplog.text
+    assert [s["tools"] for s in snapshot] == [1, 0]
+
+
+def test_required_servers_are_read_off_the_allow_list():
+    """Every ``mcp__<server>__<tool>`` (or server-level ``mcp__<server>``) entry
+    names a server the run cannot do without; built-in tools name none."""
+    assert sdk_runner.required_mcp_servers(
+        ["Glob", "Read", "mcp__osprey_workspace__artifact_register", "mcp__controls", "Task"]
+    ) == {"osprey_workspace", "controls"}
+    assert sdk_runner.required_mcp_servers([]) == set()
+    assert sdk_runner.required_mcp_servers(["mcp__channel-finder__search"]) == {"channel-finder"}
+
+
 async def _ready(servers: list[dict]) -> list[dict]:
     return servers


### PR DESCRIPTION
The Expert view hosts a Claude Code TUI on a pty; the Simple view runs an Agent
SDK chat. Each spawned its own agent under its own session id, so flipping
between the views started a second conversation. History, posture and working
context stayed behind in the view you left.

Both views now address one session key: a bare UUID that never moves, and that
serves as the pool key, the posture key, the audit key and `OSPREY_SESSION_ID`.
A per-key transcript pointer tracks the conversation the key currently holds, so
`/clear` in the TUI moves the pointer without moving the key. One live process
at a time, across both pools.

A flip is a hand-off rather than a spawn. Every surface that wants the session
goes through one door. Under a per-key lock it inspects both pools; outside the
lock it waits for the outgoing agent to finish its turn; then, shielded, it
tears that agent down and spawns the incoming one only after observing the
process dead. A survivor of a failed kill is returned to its own pool
unattached, so the next acquire finds it as an ordinary holder and re-runs the
teardown instead of forgetting it.

The wait needs to know when a turn ends. A turn-state hook reports
`UserPromptSubmit`, `Stop` and `StopFailure` from the CLI back to the web
terminal. Where no hook is present the server reads the transcript tail instead,
and the flip offers only "Stop and switch now". The server never tears a busy
agent down on a clock.

## How it hangs together

```text
        Expert view                            Simple view
     terminal.js (xterm)                   chat.js (SSE chat)
             |                                     |
             +------------> session-pointer.js <---+
                          one key K, never moves
                                    |
  ==================================|==================================
                          web terminal (FastAPI)
                                    |
      /ws/terminal                  |     POST /api/session/{K}/handoff
            +---------------------- + ----------------------+
                                    v
                    session_handoff.acquire_surface()
              +-------------------------------------------+
              |  (a) inspect both pools          [lock]    |
              |  (b) wait until the holder is idle         |<--- turn_state.py
              |  (c) kill -> verify dead -> spawn [shield] |        ^
              +-------------------------------------------+        |
                        |                      |                   |
                        v                      v                   |
                  PtyRegistry            ChatSessionPool            |
                 (claude TUI)             (Agent SDK)               |
                        |                      |                    |
                        +------- resume -------+                   |
                            transcript_map.py                      |
                                                                   |
  =================================================================|===
                          agent process                            |
        .claude/hooks/osprey_turn_state.py --> POST /api/agent-turn +
        UserPromptSubmit -> busy   ·   Stop / StopFailure -> idle
```

## Deployment

Projects scaffolded before this change need the `turn-state` hook in their
`hooks:` list and a rebuild. Without it a flip offers only "Stop and switch
now", and an idle TUI can take the full five seconds to be recognised as idle.

Every bundled preset's hash moves, because `turn-state` joins every preset's
`hooks:`. A rebuilt project gains the hook file and four `settings.json`
registrations. The deploy-side staleness advisory firing on already-deployed
projects is the correct signal.

## Still owed before this is trusted in the field

A run on a real Control Assistant deployment, which no test covers: start a
conversation in one view, flip, and confirm the conversation continues.

Three checks a reviewer cannot get from the suite:

- a flip in both directions completes without a page reload;
- a flip to Simple shows the transitional state, then replayed history, then
  enabled input;
- the new overlay elements (`.op-handoff`, `.op-session-new`,
  `#terminal-handoff`) render correctly in both dark and light themes.

Optional: refresh the `web_terminal_hub_{dark,light}_simple.png` baselines on
Linux.

## Known limits

Deliberately left in place, none of them reachable from the normal flip:

- a server-shutdown cancel landing on a POST-channel acquire can be absorbed by
  the disconnect probe's cancel scope; only the supersede path is protected;
- `request.is_disconnected` never reports a fetch abort under uvicorn h11 during
  the wait, so navigating away mid-wait completes the hand-off to a Simple chat
  nobody reads;
- a supersede landing between the wait and the teardown lock ends the first
  request cancelled rather than 409, which an aborted fetch never sees;
- `PtyRegistry.rekey_session` is dead code at this commit;
- `/ws/operator` children also carry `OSPREY_SESSION_ID`, which is intended;
- a second prompt on a busy chat waits server-side for the whole turn;
- any `MagicMock(spec=PtyRegistry)` must pin `pop_lru_victim=None`;
- `test_ws_new_session_confirm.py` still carries its own pty session double, and
  two out-of-scope docstrings name `_require_session_uuid`'s old home;
- `tests/interfaces/web_terminal/test_bar_items_browser.py` flakes under load at
  `-n 4`, which predates this branch;
- with a hung websocket handler the bounded test still spends about 25 seconds in
  `websocket_connect` teardown;
- `tests/test_version.py::TestBuildStampParity` fails on a dirty tree between
  17:00 and midnight Pacific: the runtime stamps the local date while
  setuptools-scm stamps UTC. Clean checkouts never hit it.
