### PR TITLE
feat(web-terminal): name one owner for a deployment's feedback

### DIFF
--- a/changelog.d/feedback-destination.added.md
+++ b/changelog.d/feedback-destination.added.md
@@ -1,0 +1,9 @@
+Feedback now goes to one destination: whoever owns the deployment. A new
+`web.feedback.owner` block names them — a display name, an address and an
+issue tracker on either GitHub or GitLab — so a facility redirects both halves
+in one place instead of two settings that could be edited apart. Reports
+arriving there carry which preset and channel-finder mode produced them, plus
+a prefilled upstream issue link, so a maintainer who decides a bug belongs to
+OSPREY can forward it in one click. `web.feedback.email` and
+`web.feedback.github_repo` still take precedence wherever they are set, and
+`osprey build` now warns when only one of the two was moved.

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -1409,6 +1409,25 @@ keys:
     {rendered: false, covered-by: web.feedback.owner.tracker}
   web.feedback.owner.tracker.label:
     {rendered: false, covered-by: web.feedback.owner.tracker}
+  provenance:
+    # Stamped into the RESOLVED config by build_profile_emit, never written in
+    # a template, so it is not part of the rendered union and carries
+    # rendered: false rather than an all-templates disposition.
+    rendered: false
+    evidence: 'get_config_value\("provenance\.'
+    note: >-
+      Build provenance, and — since the feedback destination gained an
+      escalation path — read at run time after all. The web terminal stamps
+      the preset and its content hash into a feedback report so a facility
+      maintainer can forward a framework bug upstream without anyone
+      re-deriving what was running. The evidence anchors on the prefix the
+      two leaf readers share, so this entry dies with the last of them.
+  provenance.preset:
+    rendered: false
+    evidence: 'get_config_value\("provenance\.preset", None\)'
+  provenance.preset_hash:
+    rendered: false
+    evidence: 'get_config_value\("provenance\.preset_hash", None\)'
   web.feedback.max_store_bytes:
     evidence: 'get_config_value\(\s*"web\.feedback\.max_store_bytes",\s*DEFAULT_FEEDBACK_MAX_STORE_BYTES\s*\)'
   web.channel_suggestions: {evidence: 'web\.get\("channel_suggestions"\)'}

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -1366,7 +1366,13 @@ keys:
       anchors on the prefix those readers share, so this entry dies with the
       last of them rather than outliving them all.
   web.feedback.github_repo:
-    evidence: 'get_config_value\(\s*"web\.feedback\.github_repo",\s*DEFAULT_FEEDBACK_GITHUB_REPO\s*\)'
+    evidence: 'get_config_value\("web\.feedback\.github_repo", None\)'
+    note: >-
+      Read with a None sentinel rather than its own default, unlike its
+      neighbours: `web.feedback.owner` can stand in for this key, and the
+      resolver has to tell "absent" from "spelled, and equal to the default"
+      to know which of the two wins. The default lives in
+      interfaces/web_terminal/feedback_destination.py and is applied there.
   web.feedback.trackers:
     # Documented in every template as a commented example beside github_repo,
     # never rendered as a live key: the shipped posture is the github_repo
@@ -1374,7 +1380,35 @@ keys:
     rendered: false
     evidence: 'get_config_value\(\s*"web\.feedback\.trackers",\s*None\s*\)'
   web.feedback.email:
-    evidence: 'get_config_value\(\s*"web\.feedback\.email",\s*DEFAULT_FEEDBACK_EMAIL\s*\)'
+    evidence: 'get_config_value\("web\.feedback\.email", None\)'
+    note: >-
+      Read with a None sentinel for the same reason as
+      `web.feedback.github_repo` — see that entry.
+  web.feedback.owner:
+    # Documented in every template that carries a `web:` block as a commented
+    # example, never rendered as a live key: the shipped destination is the
+    # OSPREY project, and a facility that redirects feedback writes the block
+    # by hand. Rendering it live would force `osprey profile expand` on every
+    # already-deployed profile to clear a drift report.
+    rendered: false
+    evidence: 'get_config_value\("web\.feedback\.owner", None\)'
+    note: >-
+      One block naming who owns this deployment: `name`, `email` and a
+      forge-agnostic `tracker`. The leaf keys `web.feedback.email` and
+      `web.feedback.github_repo` still outrank it wherever they are spelled,
+      so no already-deployed profile changes meaning. The three leaves below
+      have no dotted lookup of their own — the block is read whole and taken
+      apart by `coerce_feedback_owner`, so they are covered-by rather than
+      evidenced.
+  web.feedback.owner.name: {rendered: false, covered-by: web.feedback.owner}
+  web.feedback.owner.email: {rendered: false, covered-by: web.feedback.owner}
+  web.feedback.owner.tracker: {rendered: false, covered-by: web.feedback.owner}
+  web.feedback.owner.tracker.kind:
+    {rendered: false, covered-by: web.feedback.owner.tracker}
+  web.feedback.owner.tracker.target:
+    {rendered: false, covered-by: web.feedback.owner.tracker}
+  web.feedback.owner.tracker.label:
+    {rendered: false, covered-by: web.feedback.owner.tracker}
   web.feedback.max_store_bytes:
     evidence: 'get_config_value\(\s*"web\.feedback\.max_store_bytes",\s*DEFAULT_FEEDBACK_MAX_STORE_BYTES\s*\)'
   web.channel_suggestions: {evidence: 'web\.get\("channel_suggestions"\)'}

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -3256,6 +3256,7 @@ def _build_repo(
             # that is itself attached hosts nothing and projects nothing.
             from .build_profile_reach import (
                 ariel_ingestion_advisories,
+                feedback_owner_advisories,
                 pva_address_source_advisories,
             )
 
@@ -3264,6 +3265,10 @@ def _build_repo(
             # with no address source are named once, here. Advisory: the
             # build is sound, the reads would time out.
             for advisory in pva_address_source_advisories(rendered):
+                output.note(f"⚠ {advisory}")
+            # Feedback has one destination but two settings that aim it.
+            # Advisory: the build is sound, half the reports go upstream.
+            for advisory in feedback_owner_advisories(rendered):
                 output.note(f"⚠ {advisory}")
             if build_profile.deploy_services:
                 shared = shared._replace(host_config=rendered)

--- a/src/osprey/cli/build_profile_reach.py
+++ b/src/osprey/cli/build_profile_reach.py
@@ -34,6 +34,18 @@ from typing import Any
 
 from osprey.deployment.reach import REACH_CONTRACTS, dotted_get, project_attached_overrides
 
+# The unconfigured deployment's destination — the OSPREY project itself.
+# Imported rather than re-typed, so this advisory cannot outlive a change to
+# the shipped defaults. Cheap: the web_terminal package resolves `run_web`
+# through a module __getattr__ precisely so a sibling import stays a sibling
+# import, and feedback_destination itself imports only the standard library.
+from osprey.interfaces.web_terminal.feedback_destination import (
+    DEFAULT_FEEDBACK_EMAIL as _PROJECT_EMAIL,
+)
+from osprey.interfaces.web_terminal.feedback_destination import (
+    DEFAULT_FEEDBACK_GITHUB_REPO as _PROJECT_REPO,
+)
+
 
 def attached_render_overrides(
     host_config: Mapping[str, Any] | None,
@@ -140,6 +152,77 @@ def pva_address_source_advisories(rendered_config: Mapping[str, Any]) -> list[st
             f"not reach the connector."
         )
     return advisories
+
+
+def feedback_owner_advisories(rendered_config: Mapping[str, Any]) -> list[str]:
+    """Say when a deployment redirected half of where its feedback goes.
+
+    Feedback has one destination — whoever owns the deployment — and it is
+    reached by two independent settings: the mail address and the issue
+    tracker. A facility that moves one and leaves the other pointed upstream
+    sends half its users' reports to the OSPREY maintainers, who cannot answer
+    them and cannot tell that a facility was meant to.
+
+    Nothing here is wrong enough to refuse: a deployment may legitimately want
+    mail locally and issues upstream. But it is almost never what a half-edited
+    config meant, and the symptom (reports arriving in the wrong place) is
+    invisible from the deployment itself.
+
+    Blank is not a half-move. ``email: ""`` or ``github_repo: ""`` retires that
+    channel outright, which is a deliberate posture — an air-gapped control
+    room has no outbound mail. A retired channel sends nothing anywhere, so it
+    cannot be the half that leaks upstream, and it is silent here whatever its
+    neighbour says. The advisory needs one channel aimed at the facility AND
+    the other still aimed at the project.
+
+    Args:
+        rendered_config: A render's config, after its ``config:`` overlay.
+
+    Returns:
+        One message when exactly one of the two was moved off the project
+        default; empty otherwise.
+    """
+    email = dotted_get(rendered_config, "web.feedback.email")
+    repo = dotted_get(rendered_config, "web.feedback.github_repo")
+    owner = dotted_get(rendered_config, "web.feedback.owner")
+    if isinstance(owner, Mapping) and (owner.get("email") or owner.get("tracker")):
+        # An owner block is the coherent way to say this; it moves both at once.
+        return []
+
+    email_aim = _feedback_aim(email, _PROJECT_EMAIL)
+    repo_aim = _feedback_aim(repo, _PROJECT_REPO)
+    if not ({email_aim, repo_aim} == {"moved", "upstream"}):
+        return []
+
+    moved, stale, stale_key = (
+        ("web.feedback.email", "web.feedback.github_repo", _PROJECT_REPO)
+        if email_aim == "moved"
+        else ("web.feedback.github_repo", "web.feedback.email", _PROJECT_EMAIL)
+    )
+    return [
+        f"{moved} points at this facility but {stale} is still the OSPREY "
+        f"project's ({stale_key}), so half of this deployment's feedback goes "
+        f"upstream — move both, or name them together under web.feedback.owner."
+    ]
+
+
+def _feedback_aim(value: Any, project_default: str) -> str:
+    """Where one feedback setting points: ``moved``, ``upstream`` or ``retired``.
+
+    ``retired`` is the explicitly blank posture. It is deliberately NOT a
+    synonym for either of the others: a retired channel delivers nothing, so it
+    neither reaches the facility nor leaks upstream.
+
+    A value the runtime could not use (a mapping from a mis-indented config)
+    reads as ``upstream``, because that is where the runtime's own coercion
+    will send it.
+    """
+    if not isinstance(value, str):
+        return "upstream"
+    stripped = value.strip()
+    if not stripped:
+        return "retired"
+    return "upstream" if stripped == project_default else "moved"
 
 
 def spelled_values(config: Any, dotted_key: str) -> list[tuple[str, Any]]:

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -40,8 +40,6 @@ from osprey.interfaces.web_terminal.bar_items_store import (
 )
 from osprey.interfaces.web_terminal.feedback_destination import (
     DEFAULT_DOCS_URL,
-    DEFAULT_FEEDBACK_EMAIL,
-    DEFAULT_FEEDBACK_GITHUB_REPO,
     DEFAULT_FEEDBACK_MAX_STORE_BYTES,
     resolve_feedback_destination,
 )
@@ -2200,22 +2198,27 @@ def _create_lifespan(
         # facility with no config.yml still gets working Documentation and
         # Feedback controls pointed at the project defaults.
         #
-        # The four raw values are read together — a failure here means the
-        # config is unreadable, which really does concern all four — but each
-        # is validated SEPARATELY below. A single unusable value (a hand-written
-        # "256MB" ceiling, say) must not drag the others back to project
-        # defaults: silently redirecting a facility's feedback address to the
-        # upstream maintainer is exactly the failure a fail-open path must not
-        # produce.
+        # The raw values are read together — a failure here means the config is
+        # unreadable, which really does concern all of them — but each is
+        # validated SEPARATELY by the resolver. A single unusable value (a
+        # hand-written "256MB" ceiling, say) must not drag the others back to
+        # project defaults: silently redirecting a facility's feedback address
+        # to the upstream maintainer is exactly the failure a fail-open path
+        # must not produce.
+        #
+        # The two keys `web.feedback.owner` can stand in for are read with a
+        # None sentinel rather than their own default, because the resolver has
+        # to tell "absent" from "spelled, and equal to the default" to know
+        # whether the leaf outranks the owner block. Every other key reads with
+        # its default, as before.
         try:
             from osprey.utils.config import get_config_value
 
             raw_docs_url = get_config_value("web.docs_url", DEFAULT_DOCS_URL)
-            raw_github_repo = get_config_value(
-                "web.feedback.github_repo", DEFAULT_FEEDBACK_GITHUB_REPO
-            )
-            raw_email = get_config_value("web.feedback.email", DEFAULT_FEEDBACK_EMAIL)
+            raw_github_repo = get_config_value("web.feedback.github_repo", None)
+            raw_email = get_config_value("web.feedback.email", None)
             raw_trackers = get_config_value("web.feedback.trackers", None)
+            raw_owner = get_config_value("web.feedback.owner", None)
             raw_max_store_bytes = get_config_value(
                 "web.feedback.max_store_bytes", DEFAULT_FEEDBACK_MAX_STORE_BYTES
             )
@@ -2224,21 +2227,24 @@ def _create_lifespan(
                 "Could not read web.docs_url / web.feedback.* config keys; using defaults",
                 exc_info=True,
             )
-            raw_docs_url = raw_github_repo = raw_email = raw_trackers = raw_max_store_bytes = None
+            raw_docs_url = raw_github_repo = raw_email = raw_trackers = None
+            raw_owner = raw_max_store_bytes = None
         # One resolver, so this block and the `GET /api/panels` fallback cannot
-        # disagree: `trackers` is derived from `github_repo`, and two copies of
-        # that derivation are two chances to drift.
+        # disagree: `trackers` is derived from `github_repo` and the owner
+        # block, and two copies of that derivation are two chances to drift.
         destination = resolve_feedback_destination(
             docs_url=raw_docs_url,
             email=raw_email,
             github_repo=raw_github_repo,
             trackers=raw_trackers,
             max_store_bytes=raw_max_store_bytes,
+            owner=raw_owner,
         )
         app.state.docs_url = destination.docs_url
         app.state.feedback_github_repo = destination.github_repo
         app.state.feedback_trackers = destination.trackers
         app.state.feedback_email = destination.email
+        app.state.feedback_owner_name = destination.owner_name
         app.state.feedback_max_store_bytes = destination.max_store_bytes
 
         # The server-side stores are sited on the CONFIGURED agent-data root

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -43,10 +43,7 @@ from osprey.interfaces.web_terminal.feedback_destination import (
     DEFAULT_FEEDBACK_EMAIL,
     DEFAULT_FEEDBACK_GITHUB_REPO,
     DEFAULT_FEEDBACK_MAX_STORE_BYTES,
-    coerce_config_str,
-    coerce_feedback_trackers,
-    coerce_store_ceiling,
-    resolve_feedback_trackers,
+    resolve_feedback_destination,
 )
 from osprey.interfaces.web_terminal.file_watcher import (
     FileEventBroadcaster,
@@ -2228,17 +2225,21 @@ def _create_lifespan(
                 exc_info=True,
             )
             raw_docs_url = raw_github_repo = raw_email = raw_trackers = raw_max_store_bytes = None
-        app.state.docs_url = coerce_config_str("web.docs_url", raw_docs_url, DEFAULT_DOCS_URL)
-        app.state.feedback_github_repo = coerce_config_str(
-            "web.feedback.github_repo", raw_github_repo, DEFAULT_FEEDBACK_GITHUB_REPO
+        # One resolver, so this block and the `GET /api/panels` fallback cannot
+        # disagree: `trackers` is derived from `github_repo`, and two copies of
+        # that derivation are two chances to drift.
+        destination = resolve_feedback_destination(
+            docs_url=raw_docs_url,
+            email=raw_email,
+            github_repo=raw_github_repo,
+            trackers=raw_trackers,
+            max_store_bytes=raw_max_store_bytes,
         )
-        app.state.feedback_trackers = resolve_feedback_trackers(
-            coerce_feedback_trackers(raw_trackers), app.state.feedback_github_repo
-        )
-        app.state.feedback_email = coerce_config_str(
-            "web.feedback.email", raw_email, DEFAULT_FEEDBACK_EMAIL
-        )
-        app.state.feedback_max_store_bytes = coerce_store_ceiling(raw_max_store_bytes)
+        app.state.docs_url = destination.docs_url
+        app.state.feedback_github_repo = destination.github_repo
+        app.state.feedback_trackers = destination.trackers
+        app.state.feedback_email = destination.email
+        app.state.feedback_max_store_bytes = destination.max_store_bytes
 
         # The server-side stores are sited on the CONFIGURED agent-data root
         # and deliberately NOT on workspace_dir: with web_terminal.watch_dir

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -38,6 +38,16 @@ from osprey.interfaces.web_terminal.bar_items_store import (
     layout_path,
     load_layout,
 )
+from osprey.interfaces.web_terminal.feedback_destination import (
+    DEFAULT_DOCS_URL,
+    DEFAULT_FEEDBACK_EMAIL,
+    DEFAULT_FEEDBACK_GITHUB_REPO,
+    DEFAULT_FEEDBACK_MAX_STORE_BYTES,
+    coerce_config_str,
+    coerce_feedback_trackers,
+    coerce_store_ceiling,
+    resolve_feedback_trackers,
+)
 from osprey.interfaces.web_terminal.file_watcher import (
     FileEventBroadcaster,
     WorkspaceWatcher,
@@ -413,29 +423,6 @@ def resolve_tour_policy(configured: str | None) -> str:
 #: /api/panels`` echoes it to the browser so ``rail-position.js`` can follow
 #: a live family switch without carrying its own copy.
 FAMILY_RAIL_DEFAULTS: dict[str, str] = {"retro": "top"}
-
-#: Where the Documentation control in the rail's utility cluster points when
-#: ``web.docs_url`` is absent. A facility hosting its own copy of the docs
-#: overrides the key; the default is the published site.
-DEFAULT_DOCS_URL = "https://als-apg.github.io/osprey"
-
-#: ``owner/repo`` used to build the prefilled new-issue URL when
-#: ``web.feedback.github_repo`` is absent.
-DEFAULT_FEEDBACK_GITHUB_REPO = "als-apg/osprey"
-
-#: Tracker kinds ``web.feedback.trackers`` accepts, each with the radio caption
-#: used when an entry names no ``label`` of its own. The client's URL builders
-#: (``static/js/feedback-prefill.js``) are keyed by the same two words.
-FEEDBACK_TRACKER_LABELS: dict[str, str] = {"github": "GitHub", "gitlab": "GitLab"}
-
-#: Recipient of the prefilled ``mailto:`` draft when ``web.feedback.email``
-#: is absent — the OSPREY maintainers.
-DEFAULT_FEEDBACK_EMAIL = "thellert@lbl.gov"
-
-#: Ceiling (bytes) on the on-disk feedback store before the oldest saved
-#: contexts are pruned; 256 MB unless ``web.feedback.max_store_bytes`` says
-#: otherwise. Submission headers are never pruned, only their contexts.
-DEFAULT_FEEDBACK_MAX_STORE_BYTES = 256 * 1024 * 1024
 
 #: How each value of the forwarded role-source header reads in the session
 #: menu. The keys are the auth sidecar's closed vocabulary, spelled here
@@ -990,141 +977,6 @@ def bar_render_plan(layout: dict, *, context: dict) -> BarRenderPlan:
     )
 
 
-def coerce_config_str(key: str, value: object, default: str) -> str:
-    """Return a configured string value, falling back to *default*.
-
-    An **absent** key means "use the default": the caller reads it with
-    *default* already in hand, so a facility with no ``config.yml`` still gets
-    working Documentation and Feedback controls.
-
-    An **explicitly blank** value (``docs_url: ""``) means "this deployment has
-    no such target", and is returned as ``""``. That posture is what the rail
-    anchor, the status-bar link and the dialog's channel guard are built on: an
-    air-gapped control room blanks ``web.docs_url`` and gets no documentation
-    link rather than one that opens a dead tab, and blanking
-    ``web.feedback.github_repo`` retires the GitHub channel instead of aiming it
-    at the upstream maintainers' tracker. Folding blank back into the default
-    would make that whole posture unreachable while the UI kept claiming it.
-
-    A YAML key written with no value at all (``docs_url:``, i.e. ``None``) reads
-    as absent, not as blank — "I have not decided" rather than "there is none".
-
-    A value of some other type (a nested mapping from a mis-indented
-    ``config.yml``, say) is reported and discarded rather than repr'd into an
-    ``href`` or a ``mailto:``, which would render a control that silently goes
-    nowhere.
-
-    Args:
-        key: Dotted config key, used only for the warning message.
-        value: Whatever the config reader returned.
-        default: The shipped default for *key*.
-
-    Returns:
-        The stripped configured string (possibly ``""``), or *default*.
-    """
-    if isinstance(value, str):
-        return value.strip()
-    if value is not None:
-        logger.warning("%s is %r, not a string; using %r instead", key, value, default)
-    return default
-
-
-def coerce_feedback_trackers(value: object) -> list[dict[str, str]]:
-    """Return ``web.feedback.trackers`` as a list of normalised tracker entries.
-
-    Each usable entry becomes ``{"kind", "label", "repo"}`` (GitHub, ``repo`` an
-    ``owner/name``) or ``{"kind", "label", "url"}`` (GitLab, ``url`` the
-    project's base URL — gitlab.com or self-hosted, trailing slash dropped).
-    A missing ``label`` takes the kind's own name.
-
-    Lenient per entry, strict per field: one malformed line — an unknown
-    ``kind``, a GitHub entry without an ``owner/name`` repo, a GitLab entry
-    whose ``url`` is not ``http(s)://`` — is reported and dropped while the rest
-    of the list stands, because one typo must not retire every tracker the
-    facility configured. A value that is not a list at all is reported and
-    reads as no list.
-
-    Args:
-        value: Whatever the config reader returned for the key.
-
-    Returns:
-        The usable entries, in the order written.
-    """
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        logger.warning("web.feedback.trackers is %r, not a list; ignoring it", value)
-        return []
-    trackers: list[dict[str, str]] = []
-    for index, entry in enumerate(value):
-        tracker = _coerce_feedback_tracker(entry)
-        if tracker is None:
-            logger.warning("web.feedback.trackers[%d] is %r; dropping it", index, entry)
-            continue
-        trackers.append(tracker)
-    return trackers
-
-
-def _coerce_feedback_tracker(entry: object) -> dict[str, str] | None:
-    """One entry of :func:`coerce_feedback_trackers`, or ``None`` when unusable."""
-    if not isinstance(entry, dict):
-        return None
-    kind = entry.get("kind")
-    if not isinstance(kind, str) or kind.strip() not in FEEDBACK_TRACKER_LABELS:
-        return None
-    kind = kind.strip()
-    label = entry.get("label")
-    label = label.strip() if isinstance(label, str) and label.strip() else ""
-    tracker = {"kind": kind, "label": label or FEEDBACK_TRACKER_LABELS[kind]}
-    if kind == "github":
-        repo = entry.get("repo")
-        repo = repo.strip() if isinstance(repo, str) else ""
-        if repo.count("/") != 1 or any(ch.isspace() for ch in repo) or not all(repo.split("/")):
-            return None
-        tracker["repo"] = repo
-    else:
-        url = entry.get("url")
-        url = url.strip().rstrip("/") if isinstance(url, str) else ""
-        if not url.startswith(("http://", "https://")) or any(ch.isspace() for ch in url):
-            return None
-        tracker["url"] = url
-    return tracker
-
-
-def resolve_feedback_trackers(
-    trackers: list[dict[str, str]], github_repo: str
-) -> list[dict[str, str]]:
-    """The tracker list the dialog offers: the configured list plus the sugar.
-
-    ``web.feedback.github_repo`` keeps its meaning as a single GitHub tracker,
-    appended after the facility-authored list (blank retires it — that is the
-    posture :func:`coerce_config_str` preserves). Two entries naming the same
-    target collapse to the first, so a facility that lists the upstream repo
-    under its own label does not get it rendered twice by the sugar.
-
-    Args:
-        trackers: Output of :func:`coerce_feedback_trackers`.
-        github_repo: Resolved ``web.feedback.github_repo`` (``""`` when blank).
-
-    Returns:
-        The de-duplicated list, in render order.
-    """
-    candidates = list(trackers)
-    if github_repo:
-        candidates.append(
-            {"kind": "github", "label": FEEDBACK_TRACKER_LABELS["github"], "repo": github_repo}
-        )
-    seen: set[tuple[str, str]] = set()
-    resolved: list[dict[str, str]] = []
-    for tracker in candidates:
-        key = (tracker["kind"], tracker.get("repo") or tracker.get("url") or "")
-        if key in seen:
-            continue
-        seen.add(key)
-        resolved.append(dict(tracker))
-    return resolved
-
-
 #: Words a human writes when they mean a boolean but YAML kept a string —
 #: ``enabled: "false"`` (quoted) is the one that matters, because for a
 #: default-ON switch a bare ``bool("false")`` is ``True``: the deployment
@@ -1195,43 +1047,6 @@ def coerce_config_flag(key: str, value: object, default: bool) -> bool:
         if token in _FALSE_WORDS:
             return False
     logger.warning("%s is %r, not a boolean; using %r instead", key, value, default)
-    return default
-
-
-def coerce_store_ceiling(value: object, default: int = DEFAULT_FEEDBACK_MAX_STORE_BYTES) -> int:
-    """Return ``web.feedback.max_store_bytes`` as a positive byte count.
-
-    Guarded rather than trusted: the pruner deletes stored contexts until the
-    store fits under this number, so a ``0``, a negative, or a ``True`` that
-    ``int()`` would happily turn into ``1`` would empty the store on the next
-    submission while looking like ordinary pruning. A human-written ``256MB``
-    is rejected the same way — this key is a plain byte count.
-
-    Args:
-        value: Whatever the config reader returned.
-        default: The shipped ceiling to fall back to.
-
-    Returns:
-        A positive integer byte ceiling.
-    """
-    if value is None:
-        return default
-    if not isinstance(value, bool):
-        try:
-            ceiling = int(value)
-        except (TypeError, ValueError, OverflowError):
-            # OverflowError is not hypothetical: YAML parses `.inf` and any
-            # overflowing exponent (1.0e+400) to float("inf"), which int()
-            # refuses. This helper is called outside the lifespan's try, so an
-            # escaping exception would abort startup outright.
-            ceiling = 0
-        if ceiling > 0:
-            return ceiling
-    logger.warning(
-        "web.feedback.max_store_bytes is %r, not a positive byte count; using %d",
-        value,
-        default,
-    )
     return default
 
 

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -41,7 +41,10 @@ from osprey.interfaces.web_terminal.bar_items_store import (
 from osprey.interfaces.web_terminal.feedback_destination import (
     DEFAULT_DOCS_URL,
     DEFAULT_FEEDBACK_MAX_STORE_BYTES,
+    osprey_version,
+    resolve_deployment_identity,
     resolve_feedback_destination,
+    upstream_escalation_url,
 )
 from osprey.interfaces.web_terminal.file_watcher import (
     FileEventBroadcaster,
@@ -2246,6 +2249,37 @@ def _create_lifespan(
         app.state.feedback_email = destination.email
         app.state.feedback_owner_name = destination.owner_name
         app.state.feedback_max_store_bytes = destination.max_store_bytes
+
+        # ── Deployment identity + the escalation link ──
+        # A user files to whoever owns this deployment, because a user cannot
+        # know whether a bug is OSPREY's code or this facility's config. The
+        # maintainer who CAN tell then forwards the framework bugs upstream —
+        # and only will if that is nearly free, so the identity upstream would
+        # otherwise have to ask for rides along with every report, and the
+        # forwarding link is prefilled.
+        #
+        # Nothing here varies per report, so it is resolved once at startup:
+        # no per-submission composition, and no fitting to a URL length cap.
+        try:
+            from osprey.utils.config import get_config_value
+
+            raw_preset = get_config_value("provenance.preset", None)
+            raw_preset_hash = get_config_value("provenance.preset_hash", None)
+            raw_finder_mode = get_config_value("channel_finder.pipeline_mode", None)
+        except Exception:  # noqa: BLE001 — an unreadable identity is not fatal
+            logger.warning("Could not read the deployment identity keys", exc_info=True)
+            raw_preset = raw_preset_hash = raw_finder_mode = None
+        app.state.deployment_identity = resolve_deployment_identity(
+            osprey_version=osprey_version(),
+            preset=raw_preset,
+            preset_hash=raw_preset_hash,
+            channel_finder_mode=raw_finder_mode,
+        )
+        # "" for a deployment the OSPREY project already owns — a link inviting
+        # a maintainer to forward a report to themselves is noise.
+        app.state.feedback_escalation_url = upstream_escalation_url(
+            app.state.deployment_identity, destination
+        )
 
         # The server-side stores are sited on the CONFIGURED agent-data root
         # and deliberately NOT on workspace_dir: with web_terminal.watch_dir

--- a/src/osprey/interfaces/web_terminal/feedback_destination.py
+++ b/src/osprey/interfaces/web_terminal/feedback_destination.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 
@@ -414,3 +415,183 @@ def resolve_feedback_destination(
         max_store_bytes=coerce_store_ceiling(max_store_bytes),
         owner_name=owner_name,
     )
+
+
+#: The OSPREY project's own issue tracker. A framework **constant**, not
+#: facility config: it names the upstream project, which does not vary per
+#: facility. A deployment configures where ITS reports go — never where the
+#: framework's do — which is why the config surface has one owner block rather
+#: than two configurable destinations.
+UPSTREAM_ISSUE_REPO = DEFAULT_FEEDBACK_GITHUB_REPO
+
+#: What a forwarded issue's title starts with. A prefix rather than a whole
+#: title: the maintainer has diagnosed the bug and is the one who can name it,
+#: and a canned title would survive into a tracker unedited.
+UPSTREAM_ISSUE_TITLE_PREFIX = "[forwarded] "
+
+#: How much of the preset content hash a report prints. Long enough to pin a
+#: build, short enough to read in a metadata line; the same shortening
+#: ``osprey build``'s drift advisory uses.
+PRESET_HASH_CHARS = 19
+
+
+def osprey_version() -> str:
+    """The running OSPREY version, or ``"unknown"`` when it cannot be read.
+
+    Never raises. Every caller is composing a feedback report or a deployment
+    identity, and losing a bug report over a version lookup would be absurd.
+    """
+    try:
+        from osprey import __version__
+
+        return str(__version__)
+    except Exception:  # noqa: BLE001 — a version lookup must not lose the report
+        logger.debug("could not read the OSPREY version", exc_info=True)
+        return "unknown"
+
+
+@dataclass(frozen=True)
+class DeploymentIdentity:
+    """Which OSPREY this is — what a forwarded report must not make anyone re-derive.
+
+    A facility maintainer who decides a report is a framework bug forwards it
+    upstream, and upstream then needs to know what was actually running. Asking
+    for that afterwards costs a round trip through two people and usually loses
+    the report, so it rides along from the start.
+
+    Every field degrades to ``""`` and an empty field is simply not printed: an
+    identity is a convenience for the reader, and a deployment whose provenance
+    cannot be read must still be able to file feedback.
+    """
+
+    osprey_version: str = ""
+    """``osprey.__version__`` as the server sees it."""
+
+    preset: str = ""
+    """``provenance.preset`` — which shipped preset this profile was built from."""
+
+    preset_hash: str = ""
+    """``provenance.preset_hash`` — the content fingerprint of that preset, so a
+    locally edited profile is distinguishable from the shipped one."""
+
+    channel_finder_mode: str = ""
+    """``channel_finder.pipeline_mode`` — the single biggest behavioural fork
+    between two otherwise identical deployments."""
+
+    def build_lines(self) -> dict[str, str]:
+        """The BUILD facts as report-metadata lines, empty fields dropped.
+
+        Deliberately excludes the version: both report builders already have
+        their own source for it (the server reads the package, the browser
+        reads ``/health``), and a second copy here would render it twice.
+
+        The preset and its hash render as one line rather than two. They are
+        one fact — "this build" — and a hash with no preset beside it tells a
+        reader nothing they can act on.
+
+        Labels are canonical Title Case. The two report builders write their
+        blocks in different cases (the server's are lowercase, the browser's
+        Title Case), which predates this and is not worth a format change to
+        an already-shipped record; the server lowercases these on the way in,
+        so both still render one set of facts from one definition.
+        """
+        lines: dict[str, str] = {}
+        if self.preset:
+            digest = self.preset_hash[:PRESET_HASH_CHARS]
+            lines["Preset"] = f"{self.preset} ({digest}…)" if digest else self.preset
+        if self.channel_finder_mode:
+            lines["Channel finder"] = self.channel_finder_mode
+        return lines
+
+    def as_metadata(self) -> dict[str, str]:
+        """The whole identity — the version, then the build facts."""
+        version = {"OSPREY version": self.osprey_version} if self.osprey_version else {}
+        return {**version, **self.build_lines()}
+
+
+def resolve_deployment_identity(
+    *,
+    osprey_version: object = None,
+    preset: object = None,
+    preset_hash: object = None,
+    channel_finder_mode: object = None,
+) -> DeploymentIdentity:
+    """Coerce the raw identity facts, dropping anything unusable.
+
+    Pure, like :func:`resolve_feedback_destination`, and for the same reason:
+    the config reads stay where the config-key manifest can see them.
+
+    Nothing here warns. Unlike a feedback address, a missing identity field
+    costs a maintainer a question rather than sending a report to the wrong
+    place, and a deployment built before provenance was stamped is not
+    misconfigured — it simply cannot answer.
+
+    Args:
+        osprey_version: The running version.
+        preset: Raw ``provenance.preset``.
+        preset_hash: Raw ``provenance.preset_hash``.
+        channel_finder_mode: Raw ``channel_finder.pipeline_mode``.
+
+    Returns:
+        A :class:`DeploymentIdentity` with unusable fields left ``""``.
+    """
+
+    def _text(value: object) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
+    return DeploymentIdentity(
+        osprey_version=_text(osprey_version),
+        preset=_text(preset),
+        preset_hash=_text(preset_hash),
+        channel_finder_mode=_text(channel_finder_mode),
+    )
+
+
+def upstream_escalation_url(identity: DeploymentIdentity, destination: FeedbackDestination) -> str:
+    """A prefilled upstream issue for a maintainer forwarding a framework bug.
+
+    This is the load-bearing half of the one-destination model. Users file to
+    whoever owns the deployment, because a user cannot know whether a bug is
+    OSPREY's code or the facility's configuration — working that out is usually
+    the point of the report. The distinction is still made, just by the person
+    who can actually make it. That only holds if forwarding is nearly free:
+    a maintainer who has to open a tracker, re-describe the deployment and
+    re-explain the bug will answer their user and upstream will never hear it.
+
+    So the URL is prefilled with the deployment's identity and carries **no**
+    user content. That is not a size compromise, it is the right split:
+
+    * The maintainer is forwarding a bug they have now diagnosed, and their
+      diagnosis is the valuable part. Prefilling the user's raw words would
+      invite forwarding them unread.
+    * A session id refers to a transcript on the *facility's* deployment and
+      is unreadable upstream, so carrying it would only mislead.
+    * Nothing varies per report, so the URL is resolved once at startup rather
+      than composed per submission, and never has to be fitted to a length cap.
+
+    Returns ``""`` when this deployment's reports already reach the OSPREY
+    project — an unconfigured deployment IS owned by the project, and a link
+    inviting a maintainer to forward a report to themselves is noise.
+
+    Args:
+        identity: What is running here.
+        destination: The resolved destination, consulted only to detect that
+            the owner is already the upstream project.
+
+    Returns:
+        A ``https://github.com/.../issues/new`` URL, or ``""``.
+    """
+    if any(
+        tracker.get("kind") == "github" and tracker.get("repo") == UPSTREAM_ISSUE_REPO
+        for tracker in destination.trackers
+    ):
+        return ""
+
+    body_lines = ["Forwarded by a deployment maintainer.", ""]
+    body_lines += [f"- **{key}:** {value}" for key, value in identity.as_metadata().items()]
+    if destination.owner_name:
+        body_lines.append(f"- **Deployment:** {destination.owner_name}")
+    body_lines += ["", "Describe the framework bug and paste what the user reported."]
+
+    query = urlencode({"title": UPSTREAM_ISSUE_TITLE_PREFIX, "body": "\n".join(body_lines)})
+    return f"https://github.com/{UPSTREAM_ISSUE_REPO}/issues/new?{query}"

--- a/src/osprey/interfaces/web_terminal/feedback_destination.py
+++ b/src/osprey/interfaces/web_terminal/feedback_destination.py
@@ -26,6 +26,7 @@ degraded case nobody is watching.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
@@ -223,3 +224,84 @@ def coerce_store_ceiling(value: object, default: int = DEFAULT_FEEDBACK_MAX_STOR
         default,
     )
     return default
+
+
+@dataclass(frozen=True)
+class FeedbackDestination:
+    """Everything the Documentation and Feedback controls need, resolved.
+
+    One struct rather than five loose values, because the fields are not
+    independent: ``trackers`` is partly *derived* from ``github_repo`` (the
+    sugar expansion), so a caller that resolved them separately could hold a
+    repo the tracker list does not mention. Returning them together makes that
+    unrepresentable.
+    """
+
+    docs_url: str
+    """``web.docs_url`` — ``""`` when the deployment retired the link."""
+
+    email: str
+    """``web.feedback.email`` — ``""`` when the deployment retired the channel."""
+
+    github_repo: str
+    """``web.feedback.github_repo`` — the sugar, already folded into *trackers*."""
+
+    trackers: list[dict[str, str]] = field(default_factory=list)
+    """The outbound channels the dialog offers, in render order."""
+
+    max_store_bytes: int = DEFAULT_FEEDBACK_MAX_STORE_BYTES
+    """Ceiling on the on-disk record store. Server-side only."""
+
+
+def resolve_feedback_destination(
+    *,
+    docs_url: object = None,
+    email: object = None,
+    github_repo: object = None,
+    trackers: object = None,
+    max_store_bytes: object = None,
+) -> FeedbackDestination:
+    """Resolve the raw config values into one coherent destination.
+
+    Deliberately **pure**: it reads no config of its own and takes whatever the
+    reader returned, so the ``get_config_value`` calls stay in the lifespan
+    where the config-key manifest can see them, and this function stays
+    callable from a route that has no config at all.
+
+    That second caller is the point. ``GET /api/panels`` falls back to shipped
+    defaults whenever app state is missing, and it used to reach them by
+    re-typing the literals — including a hand-rolled second copy of the
+    ``github_repo`` -> one-GitHub-tracker sugar. Both callers now run this one
+    function, so the lifespan's answer and the fallback's answer cannot
+    disagree even in principle.
+
+    Every argument is ``None`` by default and ``None`` means *absent*, so a
+    bare call is the unconfigured deployment: the one whose owner is the
+    OSPREY project itself.
+
+    Each field is coerced separately. A single unusable value must not drag the
+    others back to project defaults — silently redirecting a facility's
+    feedback address to the upstream maintainers because its store ceiling was
+    written ``256MB`` is exactly the failure a fail-open path must not produce.
+
+    Args:
+        docs_url: Raw ``web.docs_url``.
+        email: Raw ``web.feedback.email``.
+        github_repo: Raw ``web.feedback.github_repo``.
+        trackers: Raw ``web.feedback.trackers``.
+        max_store_bytes: Raw ``web.feedback.max_store_bytes``.
+
+    Returns:
+        A freshly built :class:`FeedbackDestination`; nothing is shared between
+        calls, so no caller can mutate the next one's tracker list.
+    """
+    resolved_repo = coerce_config_str(
+        "web.feedback.github_repo", github_repo, DEFAULT_FEEDBACK_GITHUB_REPO
+    )
+    return FeedbackDestination(
+        docs_url=coerce_config_str("web.docs_url", docs_url, DEFAULT_DOCS_URL),
+        email=coerce_config_str("web.feedback.email", email, DEFAULT_FEEDBACK_EMAIL),
+        github_repo=resolved_repo,
+        trackers=resolve_feedback_trackers(coerce_feedback_trackers(trackers), resolved_repo),
+        max_store_bytes=coerce_store_ceiling(max_store_bytes),
+    )

--- a/src/osprey/interfaces/web_terminal/feedback_destination.py
+++ b/src/osprey/interfaces/web_terminal/feedback_destination.py
@@ -1,0 +1,225 @@
+"""Where this deployment's documentation and feedback controls point.
+
+One module owns the whole answer: the shipped defaults, the coercion of every
+``web.docs_url`` / ``web.feedback.*`` value a facility may write, and the
+resolution of those values into the destination the rail's Documentation link
+and the Feedback dialog's channels actually use.
+
+It is a **leaf**: it imports nothing from :mod:`osprey.interfaces.web_terminal.app`
+and nothing from the route modules, so both may import it. That matters,
+because before this module existed the app owned the constants and
+``routes/panels.py`` re-typed them as literals in its ``getattr`` fallbacks —
+with a comment blaming an ``app -> routes -> panels`` import cycle. The cycle
+is real for a top-level ``from ...app import`` (the app pulls the router in at
+import time), but it was never a reason to duplicate a value: a sibling leaf
+beside :mod:`~osprey.interfaces.web_terminal.feedback_composer` and
+:mod:`~osprey.interfaces.web_terminal.feedback_store` is reachable from both
+sides with no cycle at all.
+
+Duplicating them was worse than untidy. The copies lived on the *fallback*
+path — ``getattr(app.state, "feedback_email", "<literal>")`` — which only runs
+when app state is missing. Drift between the two spellings was therefore
+invisible in every ordinary deployment and would surface exactly once, in the
+degraded case nobody is watching.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Where the Documentation control in the rail's utility cluster points when
+#: ``web.docs_url`` is absent. A facility hosting its own copy of the docs
+#: overrides the key; the default is the published site.
+DEFAULT_DOCS_URL = "https://als-apg.github.io/osprey"
+
+#: ``owner/repo`` used to build the prefilled new-issue URL when
+#: ``web.feedback.github_repo`` is absent.
+DEFAULT_FEEDBACK_GITHUB_REPO = "als-apg/osprey"
+
+#: Tracker kinds ``web.feedback.trackers`` accepts, each with the radio caption
+#: used when an entry names no ``label`` of its own. The client's URL builders
+#: (``static/js/feedback-prefill.js``) are keyed by the same two words.
+FEEDBACK_TRACKER_LABELS: dict[str, str] = {"github": "GitHub", "gitlab": "GitLab"}
+
+#: Recipient of the prefilled ``mailto:`` draft when ``web.feedback.email``
+#: is absent — the OSPREY maintainers.
+DEFAULT_FEEDBACK_EMAIL = "thellert@lbl.gov"
+
+#: Ceiling (bytes) on the on-disk feedback store before the oldest saved
+#: contexts are pruned; 256 MB unless ``web.feedback.max_store_bytes`` says
+#: otherwise. Submission headers are never pruned, only their contexts.
+DEFAULT_FEEDBACK_MAX_STORE_BYTES = 256 * 1024 * 1024
+
+
+def coerce_config_str(key: str, value: object, default: str) -> str:
+    """Return a configured string value, falling back to *default*.
+
+    An **absent** key means "use the default": the caller reads it with
+    *default* already in hand, so a facility with no ``config.yml`` still gets
+    working Documentation and Feedback controls.
+
+    An **explicitly blank** value (``docs_url: ""``) means "this deployment has
+    no such target", and is returned as ``""``. That posture is what the rail
+    anchor, the status-bar link and the dialog's channel guard are built on: an
+    air-gapped control room blanks ``web.docs_url`` and gets no documentation
+    link rather than one that opens a dead tab, and blanking
+    ``web.feedback.github_repo`` retires the GitHub channel instead of aiming it
+    at the upstream maintainers' tracker. Folding blank back into the default
+    would make that whole posture unreachable while the UI kept claiming it.
+
+    A YAML key written with no value at all (``docs_url:``, i.e. ``None``) reads
+    as absent, not as blank — "I have not decided" rather than "there is none".
+
+    A value of some other type (a nested mapping from a mis-indented
+    ``config.yml``, say) is reported and discarded rather than repr'd into an
+    ``href`` or a ``mailto:``, which would render a control that silently goes
+    nowhere.
+
+    Args:
+        key: Dotted config key, used only for the warning message.
+        value: Whatever the config reader returned.
+        default: The shipped default for *key*.
+
+    Returns:
+        The stripped configured string (possibly ``""``), or *default*.
+    """
+    if isinstance(value, str):
+        return value.strip()
+    if value is not None:
+        logger.warning("%s is %r, not a string; using %r instead", key, value, default)
+    return default
+
+
+def coerce_feedback_trackers(value: object) -> list[dict[str, str]]:
+    """Return ``web.feedback.trackers`` as a list of normalised tracker entries.
+
+    Each usable entry becomes ``{"kind", "label", "repo"}`` (GitHub, ``repo`` an
+    ``owner/name``) or ``{"kind", "label", "url"}`` (GitLab, ``url`` the
+    project's base URL — gitlab.com or self-hosted, trailing slash dropped).
+    A missing ``label`` takes the kind's own name.
+
+    Lenient per entry, strict per field: one malformed line — an unknown
+    ``kind``, a GitHub entry without an ``owner/name`` repo, a GitLab entry
+    whose ``url`` is not ``http(s)://`` — is reported and dropped while the rest
+    of the list stands, because one typo must not retire every tracker the
+    facility configured. A value that is not a list at all is reported and
+    reads as no list.
+
+    Args:
+        value: Whatever the config reader returned for the key.
+
+    Returns:
+        The usable entries, in the order written.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        logger.warning("web.feedback.trackers is %r, not a list; ignoring it", value)
+        return []
+    trackers: list[dict[str, str]] = []
+    for index, entry in enumerate(value):
+        tracker = _coerce_feedback_tracker(entry)
+        if tracker is None:
+            logger.warning("web.feedback.trackers[%d] is %r; dropping it", index, entry)
+            continue
+        trackers.append(tracker)
+    return trackers
+
+
+def _coerce_feedback_tracker(entry: object) -> dict[str, str] | None:
+    """One entry of :func:`coerce_feedback_trackers`, or ``None`` when unusable."""
+    if not isinstance(entry, dict):
+        return None
+    kind = entry.get("kind")
+    if not isinstance(kind, str) or kind.strip() not in FEEDBACK_TRACKER_LABELS:
+        return None
+    kind = kind.strip()
+    label = entry.get("label")
+    label = label.strip() if isinstance(label, str) and label.strip() else ""
+    tracker = {"kind": kind, "label": label or FEEDBACK_TRACKER_LABELS[kind]}
+    if kind == "github":
+        repo = entry.get("repo")
+        repo = repo.strip() if isinstance(repo, str) else ""
+        if repo.count("/") != 1 or any(ch.isspace() for ch in repo) or not all(repo.split("/")):
+            return None
+        tracker["repo"] = repo
+    else:
+        url = entry.get("url")
+        url = url.strip().rstrip("/") if isinstance(url, str) else ""
+        if not url.startswith(("http://", "https://")) or any(ch.isspace() for ch in url):
+            return None
+        tracker["url"] = url
+    return tracker
+
+
+def resolve_feedback_trackers(
+    trackers: list[dict[str, str]], github_repo: str
+) -> list[dict[str, str]]:
+    """The tracker list the dialog offers: the configured list plus the sugar.
+
+    ``web.feedback.github_repo`` keeps its meaning as a single GitHub tracker,
+    appended after the facility-authored list (blank retires it — that is the
+    posture :func:`coerce_config_str` preserves). Two entries naming the same
+    target collapse to the first, so a facility that lists the upstream repo
+    under its own label does not get it rendered twice by the sugar.
+
+    Args:
+        trackers: Output of :func:`coerce_feedback_trackers`.
+        github_repo: Resolved ``web.feedback.github_repo`` (``""`` when blank).
+
+    Returns:
+        The de-duplicated list, in render order.
+    """
+    candidates = list(trackers)
+    if github_repo:
+        candidates.append(
+            {"kind": "github", "label": FEEDBACK_TRACKER_LABELS["github"], "repo": github_repo}
+        )
+    seen: set[tuple[str, str]] = set()
+    resolved: list[dict[str, str]] = []
+    for tracker in candidates:
+        key = (tracker["kind"], tracker.get("repo") or tracker.get("url") or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append(dict(tracker))
+    return resolved
+
+
+def coerce_store_ceiling(value: object, default: int = DEFAULT_FEEDBACK_MAX_STORE_BYTES) -> int:
+    """Return ``web.feedback.max_store_bytes`` as a positive byte count.
+
+    Guarded rather than trusted: the pruner deletes stored contexts until the
+    store fits under this number, so a ``0``, a negative, or a ``True`` that
+    ``int()`` would happily turn into ``1`` would empty the store on the next
+    submission while looking like ordinary pruning. A human-written ``256MB``
+    is rejected the same way — this key is a plain byte count.
+
+    Args:
+        value: Whatever the config reader returned.
+        default: The shipped ceiling to fall back to.
+
+    Returns:
+        A positive integer byte ceiling.
+    """
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        try:
+            ceiling = int(value)
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError is not hypothetical: YAML parses `.inf` and any
+            # overflowing exponent (1.0e+400) to float("inf"), which int()
+            # refuses. This helper is called outside the lifespan's try, so an
+            # escaping exception would abort startup outright.
+            ceiling = 0
+        if ceiling > 0:
+            return ceiling
+    logger.warning(
+        "web.feedback.max_store_bytes is %r, not a positive byte count; using %d",
+        value,
+        default,
+    )
+    return default

--- a/src/osprey/interfaces/web_terminal/feedback_destination.py
+++ b/src/osprey/interfaces/web_terminal/feedback_destination.py
@@ -155,29 +155,102 @@ def _coerce_feedback_tracker(entry: object) -> dict[str, str] | None:
     return tracker
 
 
-def resolve_feedback_trackers(
-    trackers: list[dict[str, str]], github_repo: str
-) -> list[dict[str, str]]:
-    """The tracker list the dialog offers: the configured list plus the sugar.
+def coerce_feedback_owner(value: object) -> tuple[str, str | None, dict[str, str] | None]:
+    """Read ``web.feedback.owner`` into ``(name, email, tracker)``.
 
-    ``web.feedback.github_repo`` keeps its meaning as a single GitHub tracker,
-    appended after the facility-authored list (blank retires it — that is the
-    posture :func:`coerce_config_str` preserves). Two entries naming the same
-    target collapse to the first, so a facility that lists the upstream repo
-    under its own label does not get it rendered twice by the sugar.
+    The block exists because a facility redirecting feedback has to move both
+    the address and the tracker, and moving one is precisely the mistake it
+    prevents. It is one block so that the two cannot be edited apart.
+
+    ``email`` is returned as ``None`` when the block names none, which the
+    caller feeds to :func:`coerce_config_str` as an *absent* value — that is
+    what makes the leaf ``web.feedback.email`` outrank it without either key
+    knowing about the other.
+
+    The tracker is spelled ``{kind, target}`` rather than the internal
+    ``{kind, repo}`` / ``{kind, url}`` pair: a facility writing this block is
+    naming one destination and should not have to know which field name its
+    forge happens to use. ``label`` is optional and defaults to the kind's own
+    caption, exactly as in ``web.feedback.trackers``.
+
+    Every field degrades on its own. A malformed tracker must not take the
+    owner's address down with it — half a redirect is the failure mode, and
+    silently reverting a facility's address to the upstream maintainers is the
+    worst half to lose.
+
+    Args:
+        value: Whatever the config reader returned for ``web.feedback.owner``.
+
+    Returns:
+        The owner's name (``""`` when unnamed), the owner's address (``None``
+        when unnamed) and the owner's tracker as one normalised entry
+        (``None`` when unnamed or unusable).
+    """
+    if value is None:
+        return "", None, None
+    if not isinstance(value, dict):
+        logger.warning("web.feedback.owner is %r, not a mapping; ignoring it", value)
+        return "", None, None
+
+    raw_name = value.get("name")
+    name = raw_name.strip() if isinstance(raw_name, str) else ""
+
+    raw_email = value.get("email")
+    email = raw_email if isinstance(raw_email, str) or raw_email is None else None
+    if raw_email is not None and email is None:
+        logger.warning("web.feedback.owner.email is %r, not a string; ignoring it", raw_email)
+
+    tracker = None
+    raw_tracker = value.get("tracker")
+    if raw_tracker is not None:
+        tracker = _coerce_owner_tracker(raw_tracker)
+        if tracker is None:
+            logger.warning("web.feedback.owner.tracker is %r; ignoring it", raw_tracker)
+    return name, email, tracker
+
+
+def _coerce_owner_tracker(entry: object) -> dict[str, str] | None:
+    """``{kind, target}`` as one normalised tracker entry, or ``None``.
+
+    Translates the owner block's forge-agnostic ``target`` into the field name
+    :func:`_coerce_feedback_tracker` expects for that kind, then validates
+    through it — so the owner tracker and a ``web.feedback.trackers`` entry are
+    held to exactly the same rules and cannot drift apart.
+    """
+    if not isinstance(entry, dict):
+        return None
+    kind = entry.get("kind")
+    if not isinstance(kind, str):
+        return None
+    target_field = "repo" if kind.strip() == "github" else "url"
+    return _coerce_feedback_tracker(
+        {"kind": kind, "label": entry.get("label"), target_field: entry.get("target")}
+    )
+
+
+def resolve_feedback_trackers(
+    trackers: list[dict[str, str]], owner_tracker: dict[str, str] | None
+) -> list[dict[str, str]]:
+    """The tracker list the dialog offers: the configured list, then the owner's.
+
+    The deployment owner's own tracker is appended after the facility-authored
+    ``web.feedback.trackers`` list, so a facility that also curates channels
+    keeps its order and the owner's is the last resort. ``None`` retires it —
+    that is the posture a blank ``web.feedback.github_repo`` reaches. Two
+    entries naming the same target collapse to the first, so a facility that
+    lists its own tracker explicitly does not get it rendered twice.
 
     Args:
         trackers: Output of :func:`coerce_feedback_trackers`.
-        github_repo: Resolved ``web.feedback.github_repo`` (``""`` when blank).
+        owner_tracker: The owner's tracker as one normalised entry, or ``None``
+            when the deployment has no owner tracker at all.
 
     Returns:
         The de-duplicated list, in render order.
     """
     candidates = list(trackers)
-    if github_repo:
-        candidates.append(
-            {"kind": "github", "label": FEEDBACK_TRACKER_LABELS["github"], "repo": github_repo}
-        )
+    if owner_tracker:
+        candidates.append(owner_tracker)
     seen: set[tuple[str, str]] = set()
     resolved: list[dict[str, str]] = []
     for tracker in candidates:
@@ -252,6 +325,12 @@ class FeedbackDestination:
     max_store_bytes: int = DEFAULT_FEEDBACK_MAX_STORE_BYTES
     """Ceiling on the on-disk record store. Server-side only."""
 
+    owner_name: str = ""
+    """``web.feedback.owner.name`` — how this deployment's owner is written in a
+    report. ``""`` when no owner block names one, including the unconfigured
+    deployment: the OSPREY project is not a facility and does not caption
+    itself as one."""
+
 
 def resolve_feedback_destination(
     *,
@@ -260,6 +339,7 @@ def resolve_feedback_destination(
     github_repo: object = None,
     trackers: object = None,
     max_store_bytes: object = None,
+    owner: object = None,
 ) -> FeedbackDestination:
     """Resolve the raw config values into one coherent destination.
 
@@ -284,24 +364,53 @@ def resolve_feedback_destination(
     feedback address to the upstream maintainers because its store ceiling was
     written ``256MB`` is exactly the failure a fail-open path must not produce.
 
+    ``web.feedback.owner`` names the destination as one block. The two leaf
+    keys still outrank it wherever they are spelled, which is what keeps every
+    already-deployed profile meaning exactly what it meant before this key
+    existed. The precedence falls out of :func:`coerce_config_str` rather than
+    being written as a branch: the owner's value is passed as the *default* for
+    the leaf key, so "leaf if spelled, else owner, else the project" is one
+    expression and cannot be half-applied. A blank leaf key still retires its
+    channel, because blank is a posture and outranks an owner that named one.
+
     Args:
         docs_url: Raw ``web.docs_url``.
         email: Raw ``web.feedback.email``.
         github_repo: Raw ``web.feedback.github_repo``.
         trackers: Raw ``web.feedback.trackers``.
         max_store_bytes: Raw ``web.feedback.max_store_bytes``.
+        owner: Raw ``web.feedback.owner``.
 
     Returns:
         A freshly built :class:`FeedbackDestination`; nothing is shared between
         calls, so no caller can mutate the next one's tracker list.
     """
-    resolved_repo = coerce_config_str(
-        "web.feedback.github_repo", github_repo, DEFAULT_FEEDBACK_GITHUB_REPO
-    )
+    owner_name, owner_email, owner_tracker = coerce_feedback_owner(owner)
+
+    # The leaf repo, when spelled, replaces the owner's tracker outright — it
+    # is the older way of saying the same thing, so honouring both would
+    # render the destination twice.
+    if github_repo is None and owner_tracker is not None:
+        resolved_repo = owner_tracker.get("repo", "")
+    else:
+        resolved_repo = coerce_config_str(
+            "web.feedback.github_repo", github_repo, DEFAULT_FEEDBACK_GITHUB_REPO
+        )
+        owner_tracker = (
+            {"kind": "github", "label": FEEDBACK_TRACKER_LABELS["github"], "repo": resolved_repo}
+            if resolved_repo
+            else None
+        )
+
     return FeedbackDestination(
         docs_url=coerce_config_str("web.docs_url", docs_url, DEFAULT_DOCS_URL),
-        email=coerce_config_str("web.feedback.email", email, DEFAULT_FEEDBACK_EMAIL),
+        email=coerce_config_str(
+            "web.feedback.email",
+            email,
+            coerce_config_str("web.feedback.owner.email", owner_email, DEFAULT_FEEDBACK_EMAIL),
+        ),
         github_repo=resolved_repo,
-        trackers=resolve_feedback_trackers(coerce_feedback_trackers(trackers), resolved_repo),
+        trackers=resolve_feedback_trackers(coerce_feedback_trackers(trackers), owner_tracker),
         max_store_bytes=coerce_store_ceiling(max_store_bytes),
+        owner_name=owner_name,
     )

--- a/src/osprey/interfaces/web_terminal/routes/feedback.py
+++ b/src/osprey/interfaces/web_terminal/routes/feedback.py
@@ -45,6 +45,7 @@ from osprey.interfaces.web_terminal.feedback_composer import (
 )
 from osprey.interfaces.web_terminal.feedback_destination import (
     DEFAULT_FEEDBACK_MAX_STORE_BYTES,
+    osprey_version,
 )
 from osprey.interfaces.web_terminal.feedback_store import (
     new_record_id,
@@ -230,14 +231,12 @@ def _identity(request: Request) -> str:
 
 
 def _version() -> str:
-    """The running OSPREY version, or ``"unknown"`` if it cannot be read."""
-    try:
-        from osprey import __version__
+    """The running OSPREY version, or ``"unknown"`` if it cannot be read.
 
-        return str(__version__)
-    except Exception:  # noqa: BLE001 — a version lookup must not lose the report
-        logger.debug("feedback: could not read the OSPREY version", exc_info=True)
-        return "unknown"
+    Delegates so the record header and the deployment identity in the report
+    body cannot disagree about which OSPREY this is.
+    """
+    return osprey_version()
 
 
 def _feedback_dir(request: Request) -> Path:
@@ -297,12 +296,17 @@ def _metadata(
 
     Who and when are always present — the dialog's help popover says the report
     always carries the text, the timestamp and the username when it is known.
-    The metadata checkbox governs which OSPREY this is, what the deployment
-    calls itself, and the submitting browser (from the ``User-Agent`` header —
-    the popover names it, so it must not travel unticked). The session id rides
-    with the context it belongs to: an outbound draft's body is just a pointer
-    line, so this tier is where a maintainer finds the session a pasted report
-    came from.
+    The metadata checkbox governs which OSPREY this is, which build it is, what
+    the deployment calls itself, and the submitting browser (from the
+    ``User-Agent`` header — the popover names it, so it must not travel
+    unticked). The session id rides with the context it belongs to: an outbound
+    draft's body is just a pointer line, so this tier is where a maintainer
+    finds the session a pasted report came from.
+
+    The build lines and the escalation link are what let a facility maintainer
+    forward a framework bug upstream without re-investigating the deployment
+    first. They are resolved once at startup, not composed here, because
+    nothing in them varies per report.
 
     ``now`` is passed in rather than read here so that one request stamps one
     instant: the record's ``created_at`` and the bundle's ``submitted`` line
@@ -314,12 +318,22 @@ def _metadata(
     }
     if include_metadata:
         metadata["osprey version"] = _version()
+        # Lowercased to match this block's own case; the browser's builder
+        # renders the same lines Title Case beside its own neighbours. One
+        # definition, two local conventions — see DeploymentIdentity.
+        deployment = getattr(request.app.state, "deployment_identity", None)
+        if deployment is not None:
+            for label, value in deployment.build_lines().items():
+                metadata[label.lower()] = value
         app_name = getattr(request.app.state, "app_name", "")
         if app_name:
             metadata["app"] = str(app_name)
         browser = request.headers.get("user-agent", "").strip()
         if browser:
             metadata["browser"] = browser
+        escalation_url = getattr(request.app.state, "feedback_escalation_url", "")
+        if escalation_url:
+            metadata["escalate to OSPREY"] = escalation_url
     if session_id:
         metadata["session"] = session_id
     return metadata

--- a/src/osprey/interfaces/web_terminal/routes/feedback.py
+++ b/src/osprey/interfaces/web_terminal/routes/feedback.py
@@ -43,6 +43,9 @@ from osprey.interfaces.web_terminal.feedback_composer import (
     render_bundle,
     validate_session_id,
 )
+from osprey.interfaces.web_terminal.feedback_destination import (
+    DEFAULT_FEEDBACK_MAX_STORE_BYTES,
+)
 from osprey.interfaces.web_terminal.feedback_store import (
     new_record_id,
     prune_store,
@@ -62,10 +65,11 @@ EXCERPT_CHARS = 200
 """How much of the report the header carries, for the ``osprey feedback list``
 table. The full text lives in the paired context document."""
 
-DEFAULT_MAX_STORE_BYTES = 256 * 1024 * 1024
-"""Mirrors ``app.DEFAULT_FEEDBACK_MAX_STORE_BYTES`` (256 MB). Spelled as a
-literal here, as routes do for every app.state default, to keep routes from
-importing the app module."""
+DEFAULT_MAX_STORE_BYTES = DEFAULT_FEEDBACK_MAX_STORE_BYTES
+"""The shipped store ceiling (256 MB), under the name this module's fallback
+path reads it by. Not a second spelling: it is bound to the one definition in
+:mod:`~osprey.interfaces.web_terminal.feedback_destination`, which a route may
+import because that module imports neither the app nor any route."""
 
 MAX_REQUEST_BYTES = 4 * 1024 * 1024
 """Largest report + scrollback one submission may carry, in UTF-8 bytes.

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -231,6 +231,8 @@ async def get_panels(request: Request):
             "docs_url": str,            # target of the rail's Documentation control
             "feedback_trackers": [...],  # [{"kind", "label", "repo"|"url"}], render order
             "feedback_email": str,      # recipient of the prefilled mailto: draft
+            "feedback_deployment": {...},  # identity lines for a report's metadata
+            "feedback_escalation_url": str,  # prefilled upstream issue; "" upstream
         }
 
     ``project_key`` is an opaque, stable per-project identifier (16 hex chars,
@@ -382,6 +384,14 @@ async def get_panels(request: Request):
     docs_url = getattr(request.app.state, "docs_url", unconfigured.docs_url)
     feedback_trackers = getattr(request.app.state, "feedback_trackers", unconfigured.trackers)
     feedback_email = getattr(request.app.state, "feedback_email", unconfigured.email)
+    # What the browser stamps into a prefilled draft's metadata block, and the
+    # link a maintainer forwards a framework bug by. Both are resolved once at
+    # startup; the browser renders them and invents nothing. Absent state (or a
+    # deployment the OSPREY project already owns) leaves them empty, and an
+    # empty metadata value is dropped by the body composer.
+    identity = getattr(request.app.state, "deployment_identity", None)
+    feedback_deployment = identity.build_lines() if identity is not None else {}
+    feedback_escalation_url = getattr(request.app.state, "feedback_escalation_url", "")
     # Onboarding tour: the resolved invite policy, the derived capability
     # list for the "Ask in plain language" card, and whether the logbook
     # (ARIEL panel) is available. All resolved at startup (web.tour /
@@ -415,6 +425,8 @@ async def get_panels(request: Request):
         "docs_url": docs_url,
         "feedback_trackers": [dict(tracker) for tracker in feedback_trackers],
         "feedback_email": feedback_email,
+        "feedback_deployment": feedback_deployment,
+        "feedback_escalation_url": feedback_escalation_url,
         "config_panel_enabled": config_panel_enabled,
         "scaffold_write_enabled": scaffold_write_enabled,
         "tour": tour,

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -18,12 +18,7 @@ from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 
 from osprey.interfaces.common_middleware import apply_url_prefix, compute_url_prefix
-from osprey.interfaces.web_terminal.feedback_destination import (
-    DEFAULT_DOCS_URL,
-    DEFAULT_FEEDBACK_EMAIL,
-    DEFAULT_FEEDBACK_GITHUB_REPO,
-    resolve_feedback_trackers,
-)
+from osprey.interfaces.web_terminal.feedback_destination import resolve_feedback_destination
 from osprey.interfaces.web_terminal.routes.agent_activity import record_activity
 from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS, BUILTIN_PANELS
 
@@ -376,22 +371,17 @@ async def get_panels(request: Request):
     open_tiles_ts = getattr(request.app.state, "open_tiles_ts", None)
     open_tiles_age = None if open_tiles_ts is None else time.time() - open_tiles_ts
     open_tiles_dock = getattr(request.app.state, "open_tiles_dock", None)
-    # Utility-cluster targets. The fallbacks are the shipped defaults
-    # themselves, imported from the feedback_destination leaf — no literal is
-    # re-typed here. The leaf is reachable from a route module because it
-    # imports neither the app nor any route, so the cycle that forced the old
-    # literals (app -> routes -> panels) does not arise.
-    #
-    # The sugar expansion is called rather than hand-rolled for the same
-    # reason: `github_repo` -> one GitHub tracker entry is a rule, and a
-    # second copy of it here could disagree with the lifespan's.
-    docs_url = getattr(request.app.state, "docs_url", DEFAULT_DOCS_URL)
-    feedback_trackers = getattr(
-        request.app.state,
-        "feedback_trackers",
-        resolve_feedback_trackers([], DEFAULT_FEEDBACK_GITHUB_REPO),
-    )
-    feedback_email = getattr(request.app.state, "feedback_email", DEFAULT_FEEDBACK_EMAIL)
+    # Utility-cluster targets. The fallbacks come from the same resolver the
+    # lifespan runs, called with nothing — which is the deployment that
+    # configured nothing, i.e. the one the OSPREY project owns. No default is
+    # re-typed here and no derivation is repeated, so the two paths cannot
+    # drift. The leaf is importable from a route because it imports neither
+    # the app nor any route; the cycle that once forced literals here
+    # (app -> routes -> panels) does not arise.
+    unconfigured = resolve_feedback_destination()
+    docs_url = getattr(request.app.state, "docs_url", unconfigured.docs_url)
+    feedback_trackers = getattr(request.app.state, "feedback_trackers", unconfigured.trackers)
+    feedback_email = getattr(request.app.state, "feedback_email", unconfigured.email)
     # Onboarding tour: the resolved invite policy, the derived capability
     # list for the "Ask in plain language" card, and whether the logbook
     # (ARIEL panel) is available. All resolved at startup (web.tour /

--- a/src/osprey/interfaces/web_terminal/routes/panels.py
+++ b/src/osprey/interfaces/web_terminal/routes/panels.py
@@ -18,6 +18,12 @@ from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 
 from osprey.interfaces.common_middleware import apply_url_prefix, compute_url_prefix
+from osprey.interfaces.web_terminal.feedback_destination import (
+    DEFAULT_DOCS_URL,
+    DEFAULT_FEEDBACK_EMAIL,
+    DEFAULT_FEEDBACK_GITHUB_REPO,
+    resolve_feedback_trackers,
+)
 from osprey.interfaces.web_terminal.routes.agent_activity import record_activity
 from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS, BUILTIN_PANELS
 
@@ -370,17 +376,22 @@ async def get_panels(request: Request):
     open_tiles_ts = getattr(request.app.state, "open_tiles_ts", None)
     open_tiles_age = None if open_tiles_ts is None else time.time() - open_tiles_ts
     open_tiles_dock = getattr(request.app.state, "open_tiles_dock", None)
-    # Utility-cluster targets. The defaults mirror app.DEFAULT_DOCS_URL /
-    # DEFAULT_FEEDBACK_GITHUB_REPO (as the one sugar tracker) /
-    # DEFAULT_FEEDBACK_EMAIL, spelled as literals here for the same
-    # routes->app import-cycle reason as above.
-    docs_url = getattr(request.app.state, "docs_url", "https://als-apg.github.io/osprey")
+    # Utility-cluster targets. The fallbacks are the shipped defaults
+    # themselves, imported from the feedback_destination leaf — no literal is
+    # re-typed here. The leaf is reachable from a route module because it
+    # imports neither the app nor any route, so the cycle that forced the old
+    # literals (app -> routes -> panels) does not arise.
+    #
+    # The sugar expansion is called rather than hand-rolled for the same
+    # reason: `github_repo` -> one GitHub tracker entry is a rule, and a
+    # second copy of it here could disagree with the lifespan's.
+    docs_url = getattr(request.app.state, "docs_url", DEFAULT_DOCS_URL)
     feedback_trackers = getattr(
         request.app.state,
         "feedback_trackers",
-        [{"kind": "github", "label": "GitHub", "repo": "als-apg/osprey"}],
+        resolve_feedback_trackers([], DEFAULT_FEEDBACK_GITHUB_REPO),
     )
-    feedback_email = getattr(request.app.state, "feedback_email", "thellert@lbl.gov")
+    feedback_email = getattr(request.app.state, "feedback_email", DEFAULT_FEEDBACK_EMAIL)
     # Onboarding tour: the resolved invite policy, the derived capability
     # list for the "Ask in plain language" card, and whether the logbook
     # (ARIEL panel) is available. All resolved at startup (web.tour /

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-boot.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-boot.js
@@ -110,6 +110,12 @@ const TRACKER_KINDS = Object.freeze({ github: 'GitHub', gitlab: 'GitLab' });
  * @property {string} email - maintainer address, or "" when this deployment
  *   retired the channel.
  * @property {string} version - `osprey.__version__`, for the metadata block.
+ * @property {Record<string, string>} deployment - the deployment's build facts
+ *   (preset and its hash, channel-finder mode), already rendered as metadata
+ *   lines by the server. Empty when the deployment cannot report them.
+ * @property {string} escalationUrl - prefilled upstream new-issue URL for a
+ *   maintainer forwarding a framework bug, or "" when this deployment's
+ *   reports already reach the OSPREY project.
  */
 
 /**
@@ -133,7 +139,14 @@ const TRACKER_KINDS = Object.freeze({ github: 'GitHub', gitlab: 'GitLab' });
  */
 export function initFeedback(options = {}) {
   /** @type {FeedbackConfig} */
-  const config = { status: 'pending', trackers: [], email: '', version: '' };
+  const config = {
+    status: 'pending',
+    trackers: [],
+    email: '',
+    version: '',
+    deployment: {},
+    escalationUrl: '',
+  };
 
   const modal = createFeedbackModal(config, options);
   onFeedbackClick(() => modal.open());
@@ -154,6 +167,12 @@ export function initFeedback(options = {}) {
     config.status = panels === null ? 'unreadable' : 'ok';
     config.trackers = normalizeTrackers(panels == null ? undefined : panels.feedback_trackers);
     config.email = trimmedString(panels == null ? undefined : panels.feedback_email);
+    // Rendered server-side and echoed verbatim: the browser cannot know which
+    // preset this deployment was built from, and must not guess.
+    config.deployment = normalizeDeployment(panels == null ? undefined : panels.feedback_deployment);
+    config.escalationUrl = trimmedString(
+      panels == null ? undefined : panels.feedback_escalation_url,
+    );
     // Handed to the dialog as well as kept here: the radios are built from
     // the list, and the dialog may already be open when it lands.
     modal.setTrackers(config.trackers);
@@ -401,20 +420,57 @@ function normalizeTrackers(value) {
 /**
  * The deployment metadata block carried by a prefilled issue or mail draft.
  *
- * Only the two facts the *page* is the best source for: the running version
- * (which the browser cannot know) and the browser itself (which the server
- * cannot know). Everything else — identity, timestamps, app name — is stamped
- * server-side onto the record and the composed bundle. Blank values are
- * dropped by `buildPrefillBody`, so a failed `/health` degrades quietly.
+ * What the *page* is the best source for — the running version (which the
+ * browser cannot know until `/health` answers) and the browser itself (which
+ * the server cannot know) — plus two things resolved server-side at startup
+ * and echoed here verbatim: the build facts, and the escalation link.
+ *
+ * Those two are why the deployment's owner can act as the single destination.
+ * A user cannot be asked whether a bug is OSPREY's code or this facility's
+ * configuration, so they are not asked; the maintainer who can tell makes the
+ * call, and this block is what makes forwarding one nearly free. Both are
+ * empty for a deployment the OSPREY project already owns — a link inviting a
+ * maintainer to forward a report to themselves is noise.
+ *
+ * Everything else — identity, timestamps, app name — is stamped server-side
+ * onto the record and the composed bundle. Blank values are dropped by
+ * `buildPrefillBody`, so a failed `/health` degrades quietly.
  *
  * @param {FeedbackConfig} config
  * @returns {Record<string, unknown>}
  */
 function buildMetadata(config) {
+  const escalate = config.escalationUrl
+    ? { 'Escalate to OSPREY': config.escalationUrl }
+    : {};
   return {
     'OSPREY version': config.version,
+    ...config.deployment,
     Browser: typeof navigator === 'undefined' ? '' : navigator.userAgent,
+    ...escalate,
   };
+}
+
+/**
+ * The server's rendered build facts, kept only where they are usable strings.
+ *
+ * The payload is server-authored, but this module treats every field of it as
+ * untrusted shape the way it does the tracker list: a mistyped value would
+ * otherwise reach `String(value)` in the body composer and print `[object
+ * Object]` into a maintainer's issue.
+ *
+ * @param {unknown} value
+ * @returns {Record<string, string>}
+ */
+function normalizeDeployment(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return {};
+  /** @type {Record<string, string>} */
+  const lines = {};
+  for (const [key, entry] of Object.entries(value)) {
+    const rendered = trimmedString(entry);
+    if (rendered) lines[key] = rendered;
+  }
+  return lines;
 }
 
 /**

--- a/src/osprey/interfaces/web_terminal/static/js/feedback-modal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/feedback-modal.js
@@ -90,8 +90,9 @@ export const ARTIFACT_WINDOW_DISCLOSURE =
 export const FEEDBACK_DISCLOSURE_PARAGRAPHS = Object.freeze([
   'Always sent: the feedback text you type, a timestamp, and your username ' +
     'when the deployment knows it.',
-  'Deployment metadata (on by default): the OSPREY version, the application ' +
-    'name, and your browser.',
+  'Deployment metadata (on by default): the OSPREY version, which preset this ' +
+    'deployment was built from, its channel-finder mode, the application name, ' +
+    'and your browser.',
   'Session context (off by default): this session’s id, its tool-call and ' +
     'agent event log, its chat history, and the terminal scrollback. It is ' +
     'triaged newest-first and truncated to fit a size budget, so a long ' +

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -665,14 +665,35 @@ web:
   scaffold_gallery:
     write_enabled: true
 
-  # Where the Feedback dialog's two outbound channels send a user. Nothing is
-  # ever posted for them: the browser opens a prefilled GitHub issue form or a
-  # prefilled mail draft, and the user decides whether to send it. Every
-  # submission is also recorded on this deployment, readable with
-  # `osprey feedback list` / `osprey feedback export`.
+  # Where the Feedback dialog's outbound channels send a user. Nothing is ever
+  # posted for them: the browser opens a prefilled issue form or a prefilled
+  # mail draft, and the user decides whether to send it. Every submission is
+  # also recorded on this deployment, readable with `osprey feedback list` /
+  # `osprey feedback export`.
+  #
+  # Reports go to ONE destination: whoever owns this deployment. A user cannot
+  # be asked whether a bug is OSPREY's code or this facility's configuration —
+  # working that out is usually the point of the report — so the choice is not
+  # put to them. Left unconfigured, the owner is the OSPREY project itself.
+  # A facility that names an `owner:` below becomes the destination, and the
+  # reports it receives carry a one-click link for forwarding a genuine
+  # framework bug upstream.
   feedback:
-    # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in. Shorthand for one
+    # Who owns this deployment. One block, because the address and the tracker
+    # have to move together — a facility that redirects the mail but leaves the
+    # tracker upstream sends half its reports to strangers.
+    # owner:
+    #   name: ALS Controls
+    #   email: controls@example.org
+    #   tracker:
+    #     kind: gitlab            # gitlab | github
+    #     target: https://git.example.org/controls/osprey
+    #                             # gitlab: the project URL
+    #                             # github: owner/name
+    #     label: Controls GitLab  # optional caption for the radio
+    # owner/repo whose new-issue form the GitHub channel prefills. Predates
+    # `owner:` above and still wins over it wherever it is spelled, so an
+    # existing deployment keeps meaning what it meant. Shorthand for one
     # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
     # Further issue trackers, one channel each, captioned by `label`. A
@@ -682,7 +703,8 @@ web:
     #   - kind: gitlab
     #     url: https://git.example.org/controls/osprey
     #     label: Facility GitLab
-    # Recipient of the prefilled mailto: draft the Email channel opens.
+    # Recipient of the prefilled mailto: draft the Email channel opens. Wins
+    # over `owner.email` above, on the same grounds as `github_repo`.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
     # OLDEST saved session contexts are deleted; the small submission headers

--- a/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
@@ -358,14 +358,35 @@ web:
   scaffold_gallery:
     write_enabled: true
 
-  # Where the Feedback dialog's two outbound channels send a user. Nothing is
-  # ever posted for them: the browser opens a prefilled GitHub issue form or a
-  # prefilled mail draft, and the user decides whether to send it. Every
-  # submission is also recorded on this deployment, readable with
-  # `osprey feedback list` / `osprey feedback export`.
+  # Where the Feedback dialog's outbound channels send a user. Nothing is ever
+  # posted for them: the browser opens a prefilled issue form or a prefilled
+  # mail draft, and the user decides whether to send it. Every submission is
+  # also recorded on this deployment, readable with `osprey feedback list` /
+  # `osprey feedback export`.
+  #
+  # Reports go to ONE destination: whoever owns this deployment. A user cannot
+  # be asked whether a bug is OSPREY's code or this facility's configuration —
+  # working that out is usually the point of the report — so the choice is not
+  # put to them. Left unconfigured, the owner is the OSPREY project itself.
+  # A facility that names an `owner:` below becomes the destination, and the
+  # reports it receives carry a one-click link for forwarding a genuine
+  # framework bug upstream.
   feedback:
-    # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in. Shorthand for one
+    # Who owns this deployment. One block, because the address and the tracker
+    # have to move together — a facility that redirects the mail but leaves the
+    # tracker upstream sends half its reports to strangers.
+    # owner:
+    #   name: ALS Controls
+    #   email: controls@example.org
+    #   tracker:
+    #     kind: gitlab            # gitlab | github
+    #     target: https://git.example.org/controls/osprey
+    #                             # gitlab: the project URL
+    #                             # github: owner/name
+    #     label: Controls GitLab  # optional caption for the radio
+    # owner/repo whose new-issue form the GitHub channel prefills. Predates
+    # `owner:` above and still wins over it wherever it is spelled, so an
+    # existing deployment keeps meaning what it meant. Shorthand for one
     # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
     # Further issue trackers, one channel each, captioned by `label`. A
@@ -375,7 +396,8 @@ web:
     #   - kind: gitlab
     #     url: https://git.example.org/controls/osprey
     #     label: Facility GitLab
-    # Recipient of the prefilled mailto: draft the Email channel opens.
+    # Recipient of the prefilled mailto: draft the Email channel opens. Wins
+    # over `owner.email` above, on the same grounds as `github_repo`.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
     # OLDEST saved session contexts are deleted; the small submission headers

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -1551,14 +1551,35 @@ web:
   scaffold_gallery:
     write_enabled: true
 
-  # Where the Feedback dialog's two outbound channels send a user. Nothing is
-  # ever posted for them: the browser opens a prefilled GitHub issue form or a
-  # prefilled mail draft, and the user decides whether to send it. Every
-  # submission is also recorded on this deployment, readable with
-  # `osprey feedback list` / `osprey feedback export`.
+  # Where the Feedback dialog's outbound channels send a user. Nothing is ever
+  # posted for them: the browser opens a prefilled issue form or a prefilled
+  # mail draft, and the user decides whether to send it. Every submission is
+  # also recorded on this deployment, readable with `osprey feedback list` /
+  # `osprey feedback export`.
+  #
+  # Reports go to ONE destination: whoever owns this deployment. A user cannot
+  # be asked whether a bug is OSPREY's code or this facility's configuration —
+  # working that out is usually the point of the report — so the choice is not
+  # put to them. Left unconfigured, the owner is the OSPREY project itself.
+  # A facility that names an `owner:` below becomes the destination, and the
+  # reports it receives carry a one-click link for forwarding a genuine
+  # framework bug upstream.
   feedback:
-    # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in. Shorthand for one
+    # Who owns this deployment. One block, because the address and the tracker
+    # have to move together — a facility that redirects the mail but leaves the
+    # tracker upstream sends half its reports to strangers.
+    # owner:
+    #   name: ALS Controls
+    #   email: controls@example.org
+    #   tracker:
+    #     kind: gitlab            # gitlab | github
+    #     target: https://git.example.org/controls/osprey
+    #                             # gitlab: the project URL
+    #                             # github: owner/name
+    #     label: Controls GitLab  # optional caption for the radio
+    # owner/repo whose new-issue form the GitHub channel prefills. Predates
+    # `owner:` above and still wins over it wherever it is spelled, so an
+    # existing deployment keeps meaning what it meant. Shorthand for one
     # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
     # Further issue trackers, one channel each, captioned by `label`. A
@@ -1568,7 +1589,8 @@ web:
     #   - kind: gitlab
     #     url: https://git.example.org/controls/osprey
     #     label: Facility GitLab
-    # Recipient of the prefilled mailto: draft the Email channel opens.
+    # Recipient of the prefilled mailto: draft the Email channel opens. Wins
+    # over `owner.email` above, on the same grounds as `github_repo`.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
     # OLDEST saved session contexts are deleted; the small submission headers

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -583,14 +583,35 @@ web:
   #   header_visible: true
   #   status_visible: true
 
-  # Where the Feedback dialog's two outbound channels send a user. Nothing is
-  # ever posted for them: the browser opens a prefilled GitHub issue form or a
-  # prefilled mail draft, and the user decides whether to send it. Every
-  # submission is also recorded on this deployment, readable with
-  # `osprey feedback list` / `osprey feedback export`.
+  # Where the Feedback dialog's outbound channels send a user. Nothing is ever
+  # posted for them: the browser opens a prefilled issue form or a prefilled
+  # mail draft, and the user decides whether to send it. Every submission is
+  # also recorded on this deployment, readable with `osprey feedback list` /
+  # `osprey feedback export`.
+  #
+  # Reports go to ONE destination: whoever owns this deployment. A user cannot
+  # be asked whether a bug is OSPREY's code or this facility's configuration —
+  # working that out is usually the point of the report — so the choice is not
+  # put to them. Left unconfigured, the owner is the OSPREY project itself.
+  # A facility that names an `owner:` below becomes the destination, and the
+  # reports it receives carry a one-click link for forwarding a genuine
+  # framework bug upstream.
   feedback:
-    # owner/repo whose new-issue form the GitHub channel prefills. Point it at
-    # the repository your users' reports should land in. Shorthand for one
+    # Who owns this deployment. One block, because the address and the tracker
+    # have to move together — a facility that redirects the mail but leaves the
+    # tracker upstream sends half its reports to strangers.
+    # owner:
+    #   name: ALS Controls
+    #   email: controls@example.org
+    #   tracker:
+    #     kind: gitlab            # gitlab | github
+    #     target: https://git.example.org/controls/osprey
+    #                             # gitlab: the project URL
+    #                             # github: owner/name
+    #     label: Controls GitLab  # optional caption for the radio
+    # owner/repo whose new-issue form the GitHub channel prefills. Predates
+    # `owner:` above and still wins over it wherever it is spelled, so an
+    # existing deployment keeps meaning what it meant. Shorthand for one
     # `github` entry under `trackers`; set it to "" to offer no GitHub channel.
     github_repo: als-apg/osprey
     # Further issue trackers, one channel each, captioned by `label`. A
@@ -600,7 +621,8 @@ web:
     #   - kind: gitlab
     #     url: https://git.example.org/controls/osprey
     #     label: Facility GitLab
-    # Recipient of the prefilled mailto: draft the Email channel opens.
+    # Recipient of the prefilled mailto: draft the Email channel opens. Wins
+    # over `owner.email` above, on the same grounds as `github_repo`.
     email: thellert@lbl.gov
     # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
     # OLDEST saved session contexts are deleted; the small submission headers

--- a/tests/cli/test_feedback_owner_advisory.py
+++ b/tests/cli/test_feedback_owner_advisory.py
@@ -1,0 +1,117 @@
+"""``osprey build`` naming a half-redirected feedback destination.
+
+Feedback has ONE destination — whoever owns the deployment — reached by two
+independent settings. Moving one and leaving the other pointed upstream sends
+half a facility's reports to the OSPREY maintainers, who cannot answer them.
+The symptom is invisible from the deployment itself, so the build says it.
+
+Advisory only: a deployment that genuinely wants mail locally and issues
+upstream is buildable, it is just asked to mean it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.cli.build_profile_reach import feedback_owner_advisories
+from osprey.interfaces.web_terminal.feedback_destination import (
+    DEFAULT_FEEDBACK_EMAIL,
+    DEFAULT_FEEDBACK_GITHUB_REPO,
+)
+
+FACILITY_EMAIL = "controls@example.org"
+FACILITY_REPO = "facility/ops"
+
+
+def _config(**feedback: object) -> dict:
+    """A rendered config carrying only the `web.feedback` block under test."""
+    return {"web": {"feedback": feedback}}
+
+
+class TestHalfMovedDestination:
+    def test_a_moved_email_with_an_upstream_repo_is_named(self):
+        advisories = feedback_owner_advisories(
+            _config(email=FACILITY_EMAIL, github_repo=DEFAULT_FEEDBACK_GITHUB_REPO)
+        )
+        assert len(advisories) == 1
+        assert "web.feedback.email" in advisories[0]
+        assert "web.feedback.github_repo" in advisories[0]
+        assert "web.feedback.owner" in advisories[0]
+
+    def test_a_moved_repo_with_an_upstream_email_is_named(self):
+        advisories = feedback_owner_advisories(
+            _config(email=DEFAULT_FEEDBACK_EMAIL, github_repo=FACILITY_REPO)
+        )
+        assert len(advisories) == 1
+        assert DEFAULT_FEEDBACK_EMAIL in advisories[0]
+
+    def test_moving_both_is_silent(self):
+        assert (
+            feedback_owner_advisories(_config(email=FACILITY_EMAIL, github_repo=FACILITY_REPO))
+            == []
+        )
+
+    def test_moving_neither_is_silent(self):
+        """The shipped deployment is owned by the OSPREY project, coherently."""
+        assert (
+            feedback_owner_advisories(
+                _config(email=DEFAULT_FEEDBACK_EMAIL, github_repo=DEFAULT_FEEDBACK_GITHUB_REPO)
+            )
+            == []
+        )
+
+    def test_a_config_with_no_feedback_block_is_silent(self):
+        assert feedback_owner_advisories({}) == []
+        assert feedback_owner_advisories({"web": {}}) == []
+
+
+class TestRetiredChannelsAreNotHalfMoves:
+    """Blank is a deliberate posture, not a half-finished edit."""
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_a_retired_email_beside_an_upstream_repo_is_silent(self, blank):
+        assert (
+            feedback_owner_advisories(
+                _config(email=blank, github_repo=DEFAULT_FEEDBACK_GITHUB_REPO)
+            )
+            == []
+        )
+
+    def test_a_retired_repo_beside_a_moved_email_is_silent(self):
+        """A retired channel delivers nothing, so it cannot be the leaking half."""
+        assert feedback_owner_advisories(_config(email=FACILITY_EMAIL, github_repo="")) == []
+
+    def test_a_retired_repo_beside_an_upstream_email_is_silent(self):
+        """Neither channel reaches a facility; that is the shipped posture."""
+        assert (
+            feedback_owner_advisories(_config(email=DEFAULT_FEEDBACK_EMAIL, github_repo="")) == []
+        )
+
+    def test_both_retired_is_silent(self):
+        """An air-gapped deployment offers no outbound channel at all."""
+        assert feedback_owner_advisories(_config(email="", github_repo="")) == []
+
+
+class TestOwnerBlock:
+    """Naming an owner is the coherent way to redirect; it is never a half-move."""
+
+    def test_an_owner_email_silences_the_advisory(self):
+        assert feedback_owner_advisories(_config(owner={"email": FACILITY_EMAIL})) == []
+
+    def test_an_owner_tracker_silences_the_advisory(self):
+        config = _config(
+            owner={"tracker": {"kind": "gitlab", "target": "https://git.example.org/x"}}
+        )
+        assert feedback_owner_advisories(config) == []
+
+    def test_an_owner_naming_only_itself_does_not_silence_a_half_move(self):
+        """A `name:` with no destination redirects nothing."""
+        advisories = feedback_owner_advisories(
+            _config(owner={"name": "ALS Controls"}, email=FACILITY_EMAIL)
+        )
+        assert len(advisories) == 1
+
+    @pytest.mark.parametrize("bad", ["nonsense", 3, []])
+    def test_an_unusable_owner_block_does_not_silence_a_half_move(self, bad):
+        advisories = feedback_owner_advisories(_config(owner=bad, email=FACILITY_EMAIL))
+        assert len(advisories) == 1

--- a/tests/interfaces/web_terminal/feedback-boot.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-boot.test.mjs
@@ -704,6 +704,89 @@ describe('outbound channels', () => {
     expect(body).toContain('9.9.9');
   });
 
+  test('the prefilled body carries the deployment build facts', async () => {
+    // Preset and channel-finder mode are what let a maintainer forward a
+    // framework bug without anyone re-deriving what was running.
+    booted = await boot({
+      panels: {
+        docs_url: DOCS_URL,
+        feedback_trackers: [GH_TRACKER],
+        feedback_deployment: {
+          Preset: 'control-assistant (a3f91c7d2e8b4f6a1c9…)',
+          'Channel finder': 'hierarchical',
+        },
+      },
+    });
+    booted.fetch.mockImplementation(() => new Promise(() => {}));
+    clickFeedbackButton();
+    typeReport('a report');
+    pickChannel(GH);
+
+    qs(document, '.feedback-open-channel').click();
+
+    const body = decodeURIComponent(booted.windowOpen.mock.calls[0][0]);
+    expect(body).toContain('control-assistant (a3f91c7d2e8b4f6a1c9…)');
+    expect(body).toContain('hierarchical');
+  });
+
+  test('a configured deployment carries the escalation link', async () => {
+    const escalate = 'https://github.com/als-apg/osprey/issues/new?title=x';
+    booted = await boot({
+      panels: {
+        docs_url: DOCS_URL,
+        feedback_trackers: [GH_TRACKER],
+        feedback_escalation_url: escalate,
+      },
+    });
+    booted.fetch.mockImplementation(() => new Promise(() => {}));
+    clickFeedbackButton();
+    typeReport('a report');
+    pickChannel(GH);
+
+    qs(document, '.feedback-open-channel').click();
+
+    const body = decodeURIComponent(booted.windowOpen.mock.calls[0][0]);
+    expect(body).toContain('Escalate to OSPREY');
+    expect(body).toContain(escalate);
+  });
+
+  test('a deployment the project owns carries no escalation link', async () => {
+    // The server sends "" for it, and an empty metadata value is dropped —
+    // a link inviting a maintainer to forward a report to themselves is noise.
+    booted = await boot({
+      panels: { docs_url: DOCS_URL, feedback_trackers: [GH_TRACKER], feedback_escalation_url: '' },
+    });
+    booted.fetch.mockImplementation(() => new Promise(() => {}));
+    clickFeedbackButton();
+    typeReport('a report');
+    pickChannel(GH);
+
+    qs(document, '.feedback-open-channel').click();
+
+    const body = decodeURIComponent(booted.windowOpen.mock.calls[0][0]);
+    expect(body).not.toContain('Escalate to OSPREY');
+  });
+
+  test('an unusable build-facts payload is dropped, not printed', async () => {
+    booted = await boot({
+      panels: {
+        docs_url: DOCS_URL,
+        feedback_trackers: [GH_TRACKER],
+        feedback_deployment: { Preset: { nested: 'object' }, 'Channel finder': 'graph' },
+      },
+    });
+    booted.fetch.mockImplementation(() => new Promise(() => {}));
+    clickFeedbackButton();
+    typeReport('a report');
+    pickChannel(GH);
+
+    qs(document, '.feedback-open-channel').click();
+
+    const body = decodeURIComponent(booted.windowOpen.mock.calls[0][0]);
+    expect(body).not.toContain('[object Object]');
+    expect(body).toContain('graph');
+  });
+
   test('a deployment with no trackers offers no tracker radio at all', async () => {
     // The blank-`github_repo` posture: the server resolves it to an empty
     // list, and an empty list is not a channel that refuses — it is no

--- a/tests/interfaces/web_terminal/feedback-modal.test.mjs
+++ b/tests/interfaces/web_terminal/feedback-modal.test.mjs
@@ -718,12 +718,23 @@ describe('feedback modal state — disclosure popover', () => {
     // false privacy claim, and would contradict the "Always sent" paragraph.
     const metadata = FEEDBACK_DISCLOSURE_PARAGRAPHS[1];
     expect(metadata).toBe(
-      'Deployment metadata (on by default): the OSPREY version, the application ' +
-        'name, and your browser.'
+      'Deployment metadata (on by default): the OSPREY version, which preset this ' +
+        'deployment was built from, its channel-finder mode, the application name, ' +
+        'and your browser.'
     );
     expect(metadata).not.toContain('identity');
     expect(metadata).not.toContain('username');
     expect(metadata).not.toContain('timestamp');
+  });
+
+  test('state: the metadata paragraph names the build facts it now carries', () => {
+    // The block gained the preset (with its content hash) and the
+    // channel-finder mode so a maintainer can forward a framework bug without
+    // anyone re-deriving what was running. Both are deployment facts a user is
+    // entitled to see named before ticking the box.
+    const metadata = FEEDBACK_DISCLOSURE_PARAGRAPHS[1];
+    expect(metadata).toContain('preset');
+    expect(metadata).toContain('channel-finder mode');
   });
 
   test('state: the disclosure covers everything FR6 requires', () => {

--- a/tests/interfaces/web_terminal/test_feedback_config.py
+++ b/tests/interfaces/web_terminal/test_feedback_config.py
@@ -29,6 +29,7 @@ from osprey.interfaces.web_terminal.feedback_destination import (
     coerce_config_str,
     coerce_feedback_trackers,
     coerce_store_ceiling,
+    resolve_feedback_destination,
     resolve_feedback_trackers,
 )
 from osprey.interfaces.web_terminal.routes.panels import router as panels_router
@@ -447,3 +448,100 @@ class TestFeedbackTrackers:
             assert app.state.feedback_trackers == [
                 {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
             ]
+
+
+class TestResolveFeedbackDestination:
+    """One resolver behind both the lifespan and the ``/api/panels`` fallback.
+
+    The duplication this replaced lived on the fallback path, so a drift
+    between the two spellings only showed when app state was missing. These
+    tests pin the two paths to each other rather than to literals, so the same
+    class of drift cannot come back through a copy that merely *looks* right.
+    """
+
+    def test_no_arguments_is_the_unconfigured_deployment(self):
+        """A deployment that configured nothing is owned by the OSPREY project."""
+        destination = resolve_feedback_destination()
+        assert destination.docs_url == DEFAULT_DOCS_URL
+        assert destination.email == DEFAULT_FEEDBACK_EMAIL
+        assert destination.github_repo == DEFAULT_FEEDBACK_GITHUB_REPO
+        assert destination.max_store_bytes == DEFAULT_FEEDBACK_MAX_STORE_BYTES
+        assert destination.trackers == [
+            {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
+        ]
+
+    def test_the_sugar_expansion_happens_once(self):
+        """``github_repo`` becomes a tracker entry inside the resolver, not outside it."""
+        destination = resolve_feedback_destination(github_repo="facility/ops")
+        assert destination.github_repo == "facility/ops"
+        assert destination.trackers == [
+            {"kind": "github", "label": "GitHub", "repo": "facility/ops"}
+        ]
+
+    def test_a_blank_repo_retires_the_github_channel(self):
+        """The blank posture survives the move into the resolver."""
+        destination = resolve_feedback_destination(github_repo="")
+        assert destination.github_repo == ""
+        assert destination.trackers == []
+
+    def test_configured_trackers_precede_the_sugar(self):
+        """Render order is the facility's list, then the ``github_repo`` sugar."""
+        destination = resolve_feedback_destination(
+            trackers=[{"kind": "gitlab", "url": GITLAB_URL, "label": "Ops"}],
+            github_repo="facility/ops",
+        )
+        assert destination.trackers == [
+            {"kind": "gitlab", "label": "Ops", "url": GITLAB_URL},
+            {"kind": "github", "label": "GitHub", "repo": "facility/ops"},
+        ]
+
+    def test_one_unusable_value_does_not_drag_the_others_to_defaults(self):
+        """Each field is coerced separately — the fail-open posture app.py states."""
+        destination = resolve_feedback_destination(
+            email="controls@example.org",
+            max_store_bytes="256MB",
+        )
+        assert destination.email == "controls@example.org"
+        assert destination.max_store_bytes == DEFAULT_FEEDBACK_MAX_STORE_BYTES
+
+    def test_every_field_is_returned_fresh(self):
+        """No caller can mutate the next caller's trackers."""
+        first = resolve_feedback_destination()
+        first.trackers.append({"kind": "github", "label": "X", "repo": "a/b"})
+        assert len(resolve_feedback_destination().trackers) == 1
+
+    def test_the_panels_fallback_is_the_resolver_and_not_a_copy(self):
+        """The route's defaults ARE the resolver's output, field for field.
+
+        This is the test the whole commit exists for: it fails if anyone
+        re-types a default into the ``getattr`` fallbacks, however carefully.
+        """
+        app = FastAPI()
+        app.include_router(panels_router)
+        app.state.project_cwd = "/tmp"
+        payload = TestClient(app).get("/api/panels").json()
+
+        unconfigured = resolve_feedback_destination()
+        assert payload["docs_url"] == unconfigured.docs_url
+        assert payload["feedback_email"] == unconfigured.email
+        assert payload["feedback_trackers"] == unconfigured.trackers
+
+    def test_the_lifespan_resolves_the_same_way_the_fallback_does(self, project_dir, shared_root):
+        """A configured lifespan and a direct resolve agree on every field."""
+        overrides = {
+            "web.docs_url": "https://docs.example.org",
+            "web.feedback.email": "controls@example.org",
+            "web.feedback.github_repo": "facility/ops",
+        }
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (client, app):
+            payload = client.get("/api/panels").json()
+
+        expected = resolve_feedback_destination(
+            docs_url="https://docs.example.org",
+            email="controls@example.org",
+            github_repo="facility/ops",
+        )
+        assert payload["docs_url"] == expected.docs_url
+        assert payload["feedback_email"] == expected.email
+        assert payload["feedback_trackers"] == expected.trackers
+        assert app.state.feedback_max_store_bytes == expected.max_store_bytes

--- a/tests/interfaces/web_terminal/test_feedback_config.py
+++ b/tests/interfaces/web_terminal/test_feedback_config.py
@@ -20,7 +20,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from osprey.interfaces.web_terminal.app import (
+from osprey.interfaces.web_terminal.app import create_app
+from osprey.interfaces.web_terminal.feedback_destination import (
     DEFAULT_DOCS_URL,
     DEFAULT_FEEDBACK_EMAIL,
     DEFAULT_FEEDBACK_GITHUB_REPO,
@@ -28,7 +29,6 @@ from osprey.interfaces.web_terminal.app import (
     coerce_config_str,
     coerce_feedback_trackers,
     coerce_store_ceiling,
-    create_app,
     resolve_feedback_trackers,
 )
 from osprey.interfaces.web_terminal.routes.panels import router as panels_router

--- a/tests/interfaces/web_terminal/test_feedback_config.py
+++ b/tests/interfaces/web_terminal/test_feedback_config.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import unquote_plus
 
 import pytest
 from fastapi import FastAPI
@@ -29,8 +30,10 @@ from osprey.interfaces.web_terminal.feedback_destination import (
     coerce_config_str,
     coerce_feedback_trackers,
     coerce_store_ceiling,
+    resolve_deployment_identity,
     resolve_feedback_destination,
     resolve_feedback_trackers,
+    upstream_escalation_url,
 )
 from osprey.interfaces.web_terminal.routes.panels import router as panels_router
 
@@ -668,3 +671,109 @@ class TestFeedbackOwner:
             {"kind": "gitlab", "label": "GitLab", "url": GITLAB_URL}
         ]
         assert app.state.feedback_owner_name == "ALS Controls"
+
+
+class TestDeploymentIdentityAndEscalation:
+    """What a forwarded report carries, and when the forwarding link exists.
+
+    A user files to whoever owns the deployment because a user cannot know
+    whether a bug is OSPREY's code or the facility's configuration. That only
+    works if the maintainer who *can* tell forwards the framework bugs — and
+    they only will if forwarding is nearly free.
+    """
+
+    IDENTITY = {
+        "osprey_version": "2026.9.0b1",
+        "preset": "control-assistant",
+        "preset_hash": "a3f91c7d2e8b4f6a1c9d0e2f",
+        "channel_finder_mode": "hierarchical",
+    }
+
+    def test_build_lines_omit_the_version(self):
+        """Both report builders already have their own source for it."""
+        identity = resolve_deployment_identity(**self.IDENTITY)
+        assert "OSPREY version" not in identity.build_lines()
+        assert identity.as_metadata()["OSPREY version"] == "2026.9.0b1"
+
+    def test_the_preset_and_its_hash_render_as_one_fact(self):
+        identity = resolve_deployment_identity(**self.IDENTITY)
+        assert identity.build_lines()["Preset"].startswith("control-assistant (a3f91c")
+        assert identity.build_lines()["Channel finder"] == "hierarchical"
+
+    def test_a_preset_with_no_hash_still_renders(self):
+        identity = resolve_deployment_identity(preset="control-assistant")
+        assert identity.build_lines() == {"Preset": "control-assistant"}
+
+    @pytest.mark.parametrize("bad", [None, 3, [], {"a": 1}, "   "])
+    def test_unusable_identity_fields_are_dropped_not_printed(self, bad):
+        identity = resolve_deployment_identity(preset=bad, channel_finder_mode=bad)
+        assert identity.build_lines() == {}
+
+    def test_a_configured_deployment_gets_an_escalation_link(self):
+        destination = resolve_feedback_destination(
+            owner={"name": "ALS Controls", "email": "c@x.org", "tracker": OWNER_GITLAB}
+        )
+        url = upstream_escalation_url(resolve_deployment_identity(**self.IDENTITY), destination)
+        assert url.startswith(f"https://github.com/{DEFAULT_FEEDBACK_GITHUB_REPO}/issues/new?")
+        decoded = unquote_plus(url)
+        assert "control-assistant" in decoded
+        assert "hierarchical" in decoded
+        assert "2026.9.0b1" in decoded
+        assert "ALS Controls" in decoded
+
+    def test_the_unconfigured_deployment_gets_no_link(self):
+        """Its owner IS the OSPREY project — the link would point at itself."""
+        url = upstream_escalation_url(
+            resolve_deployment_identity(**self.IDENTITY), resolve_feedback_destination()
+        )
+        assert url == ""
+
+    def test_a_facility_that_also_files_upstream_gets_no_link(self):
+        """Reports already reach the project, so there is nothing to forward."""
+        destination = resolve_feedback_destination(
+            trackers=[{"kind": "github", "repo": DEFAULT_FEEDBACK_GITHUB_REPO, "label": "Up"}],
+            owner={"email": "c@x.org", "tracker": OWNER_GITLAB},
+        )
+        assert upstream_escalation_url(resolve_deployment_identity(), destination) == ""
+
+    def test_the_link_carries_no_user_content(self):
+        """It is built once at startup, so nothing per-report can leak into it."""
+        destination = resolve_feedback_destination(owner={"tracker": OWNER_GITLAB})
+        url = upstream_escalation_url(resolve_deployment_identity(**self.IDENTITY), destination)
+        decoded = unquote_plus(url)
+        assert "session" not in decoded.lower()
+        assert "paste what the user reported" in decoded
+
+    def test_an_identity_that_cannot_be_read_still_yields_a_link(self):
+        """A deployment with no provenance can still forward a bug."""
+        destination = resolve_feedback_destination(owner={"tracker": OWNER_GITLAB})
+        url = upstream_escalation_url(resolve_deployment_identity(), destination)
+        assert url.startswith("https://github.com/")
+
+    def test_the_running_deployment_publishes_both(self, project_dir, shared_root):
+        """End to end: lifespan resolves them, /api/panels echoes them."""
+        overrides = {
+            "web.feedback.owner": {"name": "ALS Controls", "tracker": OWNER_GITLAB},
+            "provenance.preset": "control-assistant",
+            "provenance.preset_hash": "a3f91c7d2e8b4f6a1c9d0e2f",
+            "channel_finder.pipeline_mode": "hierarchical",
+        }
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (client, _app):
+            payload = client.get("/api/panels").json()
+        assert payload["feedback_deployment"]["Channel finder"] == "hierarchical"
+        assert payload["feedback_deployment"]["Preset"].startswith("control-assistant (a3f91c")
+        assert DEFAULT_FEEDBACK_GITHUB_REPO in payload["feedback_escalation_url"]
+
+    def test_an_unconfigured_deployment_publishes_an_empty_link(self, project_dir, shared_root):
+        with _lifespan_client(project_dir, shared_root) as (client, _app):
+            payload = client.get("/api/panels").json()
+        assert payload["feedback_escalation_url"] == ""
+
+    def test_the_route_survives_a_lifespan_that_never_ran(self):
+        """The getattr fallbacks cover the new fields too."""
+        app = FastAPI()
+        app.include_router(panels_router)
+        app.state.project_cwd = "/tmp"
+        payload = TestClient(app).get("/api/panels").json()
+        assert payload["feedback_deployment"] == {}
+        assert payload["feedback_escalation_url"] == ""

--- a/tests/interfaces/web_terminal/test_feedback_config.py
+++ b/tests/interfaces/web_terminal/test_feedback_config.py
@@ -340,6 +340,7 @@ class TestPanelsPayload:
 
 
 GITLAB_URL = "https://git.example.org/controls/osprey"
+UPSTREAM_TRACKER = {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
 
 
 class TestFeedbackTrackers:
@@ -395,30 +396,30 @@ class TestFeedbackTrackers:
             {"kind": "github", "label": "GitHub", "repo": "keep/me"}
         ]
 
-    def test_github_repo_sugar_is_appended_as_a_tracker(self):
+    def test_the_owner_tracker_is_appended_last(self):
         trackers = [{"kind": "gitlab", "label": "Ops", "url": GITLAB_URL}]
-        assert resolve_feedback_trackers(trackers, "als-apg/osprey") == [
+        assert resolve_feedback_trackers(trackers, UPSTREAM_TRACKER) == [
             {"kind": "gitlab", "label": "Ops", "url": GITLAB_URL},
             {"kind": "github", "label": "GitHub", "repo": "als-apg/osprey"},
         ]
 
-    def test_blank_github_repo_adds_nothing(self):
-        """Explicitly blank still retires the sugar channel."""
+    def test_no_owner_tracker_adds_nothing(self):
+        """A retired owner channel (blank `github_repo`) appends nothing."""
         trackers = [{"kind": "gitlab", "label": "Ops", "url": GITLAB_URL}]
-        assert resolve_feedback_trackers(trackers, "") == trackers
-        assert resolve_feedback_trackers([], "") == []
+        assert resolve_feedback_trackers(trackers, None) == trackers
+        assert resolve_feedback_trackers([], None) == []
 
-    def test_a_listed_tracker_wins_over_the_sugar_duplicate(self):
+    def test_a_listed_tracker_wins_over_the_owner_duplicate(self):
         """Listing the same repo with its own label must not render it twice."""
         trackers = [{"kind": "github", "label": "OSPREY upstream", "repo": "als-apg/osprey"}]
-        assert resolve_feedback_trackers(trackers, "als-apg/osprey") == trackers
+        assert resolve_feedback_trackers(trackers, UPSTREAM_TRACKER) == trackers
 
     def test_duplicates_inside_the_list_collapse_to_the_first(self):
         trackers = [
             {"kind": "gitlab", "label": "One", "url": GITLAB_URL},
             {"kind": "gitlab", "label": "Two", "url": GITLAB_URL},
         ]
-        assert resolve_feedback_trackers(trackers, "") == [trackers[0]]
+        assert resolve_feedback_trackers(trackers, None) == [trackers[0]]
 
     def test_lifespan_resolves_the_list_plus_sugar(self, project_dir, shared_root):
         overrides = {
@@ -545,3 +546,125 @@ class TestResolveFeedbackDestination:
         assert payload["feedback_email"] == expected.email
         assert payload["feedback_trackers"] == expected.trackers
         assert app.state.feedback_max_store_bytes == expected.max_store_bytes
+
+
+OWNER_GITLAB = {"kind": "gitlab", "target": GITLAB_URL}
+
+
+class TestFeedbackOwner:
+    """``web.feedback.owner`` — email and tracker, moved together.
+
+    The block exists because a facility that redirects feedback has to move
+    both, and moving one is the failure it is meant to prevent. The two leaf
+    keys still win where they are spelled, so no already-deployed profile
+    changes meaning by upgrading into this.
+    """
+
+    def test_owner_supplies_the_address_when_the_leaf_key_is_absent(self):
+        destination = resolve_feedback_destination(
+            owner={"name": "ALS Controls", "email": "controls@als.example.org"}
+        )
+        assert destination.email == "controls@als.example.org"
+        assert destination.owner_name == "ALS Controls"
+
+    def test_the_leaf_key_still_wins(self):
+        """An already-deployed profile spelling the leaf key keeps its meaning."""
+        destination = resolve_feedback_destination(
+            email="legacy@example.org",
+            owner={"email": "controls@als.example.org"},
+        )
+        assert destination.email == "legacy@example.org"
+
+    def test_a_blank_leaf_key_still_retires_the_channel(self):
+        """Blank is a posture, not an absence — it outranks the owner block."""
+        destination = resolve_feedback_destination(
+            email="", owner={"email": "controls@als.example.org"}
+        )
+        assert destination.email == ""
+
+    def test_an_owner_gitlab_tracker_becomes_the_destination(self):
+        """A GitLab facility is first-class: no `trackers:` list required."""
+        destination = resolve_feedback_destination(owner={"tracker": OWNER_GITLAB})
+        assert destination.trackers == [{"kind": "gitlab", "label": "GitLab", "url": GITLAB_URL}]
+        assert destination.github_repo == ""
+
+    def test_an_owner_github_tracker_takes_owner_slash_name(self):
+        destination = resolve_feedback_destination(
+            owner={"tracker": {"kind": "github", "target": "facility/ops"}}
+        )
+        assert destination.trackers == [
+            {"kind": "github", "label": "GitHub", "repo": "facility/ops"}
+        ]
+        assert destination.github_repo == "facility/ops"
+
+    def test_an_owner_tracker_may_be_captioned(self):
+        destination = resolve_feedback_destination(
+            owner={"tracker": {**OWNER_GITLAB, "label": "Controls GitLab"}}
+        )
+        assert destination.trackers[0]["label"] == "Controls GitLab"
+
+    def test_the_leaf_repo_wins_over_the_owner_tracker(self):
+        destination = resolve_feedback_destination(
+            github_repo="legacy/repo", owner={"tracker": OWNER_GITLAB}
+        )
+        assert destination.trackers == [
+            {"kind": "github", "label": "GitHub", "repo": "legacy/repo"}
+        ]
+
+    def test_a_blank_leaf_repo_retires_the_channel_over_the_owner_tracker(self):
+        destination = resolve_feedback_destination(github_repo="", owner={"tracker": OWNER_GITLAB})
+        assert destination.trackers == []
+
+    def test_the_facility_tracker_list_still_precedes_the_owner(self):
+        destination = resolve_feedback_destination(
+            trackers=[{"kind": "github", "repo": "facility/fork", "label": "Fork"}],
+            owner={"tracker": OWNER_GITLAB},
+        )
+        assert destination.trackers == [
+            {"kind": "github", "label": "Fork", "repo": "facility/fork"},
+            {"kind": "gitlab", "label": "GitLab", "url": GITLAB_URL},
+        ]
+
+    def test_no_owner_block_is_the_osprey_project(self):
+        """The unconfigured deployment's owner is unchanged by this key."""
+        destination = resolve_feedback_destination()
+        assert destination.email == DEFAULT_FEEDBACK_EMAIL
+        assert destination.github_repo == DEFAULT_FEEDBACK_GITHUB_REPO
+        assert destination.owner_name == ""
+
+    @pytest.mark.parametrize("bad", ["nonsense", 3, [], True])
+    def test_an_unusable_owner_block_falls_back_without_taking_anything_down(self, bad):
+        destination = resolve_feedback_destination(owner=bad)
+        assert destination.email == DEFAULT_FEEDBACK_EMAIL
+        assert destination.github_repo == DEFAULT_FEEDBACK_GITHUB_REPO
+        assert destination.owner_name == ""
+
+    def test_a_bad_owner_tracker_does_not_take_the_owner_email_with_it(self):
+        """Fields are coerced separately here too."""
+        destination = resolve_feedback_destination(
+            owner={
+                "email": "controls@als.example.org",
+                "tracker": {"kind": "svn", "target": "whatever"},
+            }
+        )
+        assert destination.email == "controls@als.example.org"
+        assert destination.trackers == [
+            {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
+        ]
+
+    def test_the_owner_block_reaches_the_running_deployment(self, project_dir, shared_root):
+        """End to end: the lifespan reads the block and /api/panels echoes it."""
+        overrides = {
+            "web.feedback.owner": {
+                "name": "ALS Controls",
+                "email": "controls@als.example.org",
+                "tracker": OWNER_GITLAB,
+            }
+        }
+        with _lifespan_client(project_dir, shared_root, overrides=overrides) as (client, app):
+            payload = client.get("/api/panels").json()
+        assert payload["feedback_email"] == "controls@als.example.org"
+        assert payload["feedback_trackers"] == [
+            {"kind": "gitlab", "label": "GitLab", "url": GITLAB_URL}
+        ]
+        assert app.state.feedback_owner_name == "ALS Controls"

--- a/tests/interfaces/web_terminal/test_feedback_routes.py
+++ b/tests/interfaces/web_terminal/test_feedback_routes.py
@@ -39,6 +39,7 @@ from osprey.interfaces.web_terminal.feedback_composer import (
     PAYLOAD_CAP_BYTES,
     PAYLOAD_SEPARATOR,
 )
+from osprey.interfaces.web_terminal.feedback_destination import resolve_deployment_identity
 from osprey.interfaces.web_terminal.routes.feedback import router
 from osprey.utils.identity import AUDIT_IDENTITY_ENV, TERMINAL_USER_ENV
 
@@ -652,6 +653,67 @@ def test_bundle_drops_the_metadata_tier_when_the_checkbox_is_off(env: _Env) -> N
 
 
 def test_bundle_keeps_the_metadata_tier_for_a_client_that_omits_the_flag(env: _Env) -> None:
+    body = env.client.post(
+        "/api/feedback/bundle",
+        json={"session_id": SESSION_ID, "text_len": 0, "scrollback": ""},
+    ).json()["bundle"]
+
+    assert "OSPREY Test Rig" in body
+
+
+def test_the_bundle_carries_the_deployment_build_facts(env: _Env) -> None:
+    """The maintainer's own copy names which build produced the report.
+
+    Lowercase here, Title Case in the browser's block: the two report builders
+    have different local conventions and render one definition
+    (``DeploymentIdentity.build_lines``) into each.
+    """
+    env.client.app.state.deployment_identity = resolve_deployment_identity(
+        preset="control-assistant",
+        preset_hash="a3f91c7d2e8b4f6a1c9d0e2f",
+        channel_finder_mode="hierarchical",
+    )
+    request = {"session_id": SESSION_ID, "text_len": 0, "scrollback": ""}
+
+    with_metadata = env.client.post("/api/feedback/bundle", json=request).json()["bundle"]
+    without = env.client.post(
+        "/api/feedback/bundle", json={**request, "include_metadata": False}
+    ).json()["bundle"]
+
+    assert "preset" in with_metadata
+    assert "control-assistant (a3f91c" in with_metadata
+    assert "hierarchical" in with_metadata
+    # The checkbox governs them, so unticked means absent.
+    assert "control-assistant" not in without
+
+
+def test_the_bundle_carries_the_escalation_link(env: _Env) -> None:
+    """The load-bearing half: forwarding a framework bug must be nearly free."""
+    env.client.app.state.feedback_escalation_url = (
+        "https://github.com/als-apg/osprey/issues/new?title=x"
+    )
+    body = env.client.post(
+        "/api/feedback/bundle",
+        json={"session_id": SESSION_ID, "text_len": 0, "scrollback": ""},
+    ).json()["bundle"]
+
+    assert "escalate to OSPREY" in body
+    assert "https://github.com/als-apg/osprey/issues/new?title=x" in body
+
+
+def test_a_deployment_the_project_owns_carries_no_escalation_link(env: _Env) -> None:
+    """An empty link is dropped, not rendered as a blank line."""
+    env.client.app.state.feedback_escalation_url = ""
+    body = env.client.post(
+        "/api/feedback/bundle",
+        json={"session_id": SESSION_ID, "text_len": 0, "scrollback": ""},
+    ).json()["bundle"]
+
+    assert "escalate" not in body.lower()
+
+
+def test_the_bundle_survives_a_deployment_with_no_identity(env: _Env) -> None:
+    """A lifespan that never ran must not cost the report."""
     body = env.client.post(
         "/api/feedback/bundle",
         json={"session_id": SESSION_ID, "text_len": 0, "scrollback": ""},

--- a/tests/interfaces/web_terminal/test_panels_routes.py
+++ b/tests/interfaces/web_terminal/test_panels_routes.py
@@ -124,6 +124,8 @@ def test_project_key_does_not_disturb_existing_fields(tmp_path):
         "docs_url",
         "feedback_trackers",
         "feedback_email",
+        "feedback_deployment",
+        "feedback_escalation_url",
         "config_panel_enabled",
         "scaffold_write_enabled",
         "tour",


### PR DESCRIPTION
A deployment's feedback has one destination — whoever runs it — but it was
reached by two independent settings. A facility could redirect the mail and
leave the tracker pointed upstream, so half its users' reports landed with the
OSPREY maintainers, who cannot answer them and cannot tell that a facility was
meant to.

Underneath that, the three "who owns this deployment" defaults each lived in two
places and the second copy was hand-typed. `routes/panels.py` re-spelled the docs
URL, the maintainer address, and the `github_repo` → tracker sugar expansion as
literals in its `getattr` fallbacks; `routes/feedback.py` did the same for the
store ceiling. Because the copies sit on the fallback path, drift between the two
spellings was invisible in every ordinary deployment and would have surfaced
once, in the degraded case nobody is watching. The comment blamed a routes → app
import cycle — real for a top-level import, but never a reason to duplicate a
value, since a sibling leaf is reachable from both sides.

`feedback_destination.py` now owns the constants and the coercion family that
only ever served them, and `resolve_feedback_destination()` derives the
destination once. It is pure on purpose: it reads no config itself, so the
`get_config_value` calls stay in the lifespan where the config-key manifest's
evidence regexes can see them, and a route with no config reader in scope can
still call it. The lifespan passes raw config values; the panels route calls it
with nothing, which *is* the deployment that configured nothing.

`web.feedback.owner` then names the destination once:

```yaml
web:
  feedback:
    owner:
      name: ALS Controls
      email: controls@example.org
      tracker:
        kind: gitlab
        target: https://git.example.org/controls/osprey
```

The tracker is forge-agnostic, so a GitLab facility names its destination in the
one block instead of falling back to a hand-written `trackers:` list — the shape
most likely to be edited apart from the address. `web.feedback.email` and
`web.feedback.github_repo` still win wherever they are spelled, so no deployed
profile changes meaning. The precedence falls out of `coerce_config_str` rather
than a branch: the owner's value is passed as the leaf key's default, so "leaf if
spelled, else owner, else the project" is one expression and cannot be
half-applied. A blank leaf key still retires its channel — blank is a posture and
outranks an owner that named one. The key is a commented example in all four
templates and carries `rendered: false`, because a rendered preset key would make
every existing profile report drift until `osprey profile expand` ran, to say
something the shipped deployment already means.

One destination only works if the second hop is nearly free. A user cannot know
whether a bug is OSPREY's code or the facility's configuration — working that out
is usually the point of the report — so the distinction gets made by the
maintainer who can make it. But a maintainer who has to open a tracker,
re-describe the deployment and re-explain the bug will answer their user instead,
and upstream never hears about it. A report now carries which build produced it
(the preset and its content hash, the channel-finder mode) and a prefilled
upstream new-issue URL. Both resolve once at startup; nothing in them varies per
report.

The link deliberately carries no user content. The maintainer is forwarding a bug
they have now diagnosed, and that diagnosis is the valuable part; prefilling the
user's raw words would invite forwarding them unread, and a session id refers to
a transcript on the facility's own deployment. It is empty for a deployment the
OSPREY project already owns — a link inviting a maintainer to forward a report to
themselves is noise.

Both report builders carry the block, which is not incidental: a short report
reaches the maintainer through the URL body the browser composes, a report with
session context through the clipboard payload the server composes, and a fact
present in only one would be missing exactly half the time.
`DeploymentIdentity.build_lines()` is the one definition; each side keeps its
local casing. Measured, since the block rides inside a percent-encoded URL: a
mailto goes from 574 to 1144 characters of an 1800 cap, leaving ~650 characters
of report before the existing POINTER mode takes over — and context-attached
reports already use POINTER mode, where the link travels in the 60 KB clipboard
payload for free. The metadata popover names both new facts, since a user
deciding whether to attach a report to a public issue is entitled to have the
disclosure describe what is actually attached.

`osprey build` now names a half-moved destination. Advisory, not a refusal: mail
locally and issues upstream is a legitimate if unusual posture. A retired channel
is never a half-move — it delivers nothing, so it cannot be the half that leaks
upstream.

Two things worth disagreeing with. `feedback_owner_advisories()` is filed in
`build_profile_reach.py` next to the two existing build advisories even though
that module's docstring is about service reach; it is a pure function over
rendered config in the same shape, called from the same block in `build_cmd.py`.
And the two metadata builders keep their own casing (server lowercase, browser
Title Case) rather than being renormalized — a test pins the server's `submitted`
key, and changing it was out of scope here.

## How it hangs together

```text
  web.feedback.email · github_repo · trackers  ──┐  leaf keys win where spelled
  web.feedback.owner {name, email, tracker}    ──┤
                                                 ▼
        ┌──────────────────────────────────────────────────────┐
        │  feedback_destination.py        the one leaf module   │
        │    defaults · coercions · store ceiling               │
        │    resolve_feedback_destination()   — pure            │
        │    DeploymentIdentity.build_lines()                   │
        └──────────────────────────────────────────────────────┘
             ▲                    ▲                    ▲
             │                    │                    │
      app.py lifespan     routes/panels.py     routes/feedback.py
      (raw config in)     GET /api/panels      (store ceiling)
             │            fallback = call
             │            it with nothing
             ▼  app state
        ┌────────────────────────────┬────────────────────────────┐
        │  feedback-boot.js          │  routes/feedback.py        │
        │  short report → URL body   │  context report → payload  │
        │  Title Case                │  lowercase                 │
        └────────────────────────────┴────────────────────────────┘
                          │  both carry preset(hash) · CF mode ·
                          │  prefilled upstream issue link
                          ▼
              the deployment's owner ──forward──▶ OSPREY upstream

  osprey build ──▶ feedback_owner_advisories()   names a half-moved destination
```
