### PR TITLE
test(dryrun): add test_dryrun_beta to the throwaway module

### DIFF
--- a/tests/test_train_dryrun.py
+++ b/tests/test_train_dryrun.py
@@ -1,0 +1,5 @@
+"""Throwaway module used to exercise the train skill; delete after the dry run."""
+
+
+def test_dryrun_beta():
+    assert "train".upper() == "TRAIN"


### PR DESCRIPTION
Adds `test_dryrun_beta` to the throwaway module `tests/test_train_dryrun.py`.

## Commits

- `test(dryrun): add test_dryrun_beta to the throwaway module`

## Why

The module is a disposable target used to exercise the multi-item build path end to end: several items append to the same file, so the staging branch gets a real merge surface without any production code being touched. Nothing here is imported by `src/`, so a deployer sees no change in behaviour; the file is meant to be deleted once the exercise is over.

## Not in this PR

No docs and no changelog fragment — the spec cuts both, since nothing under `src/` or `packages/` changes.
