### PR TITLE
test(dryrun): add a throwaway module with test_dryrun_alpha

### DIFF
--- a/tests/test_train_dryrun.py
+++ b/tests/test_train_dryrun.py
@@ -1,0 +1,5 @@
+"""Throwaway module used to exercise the train skill; delete after the dry run."""
+
+
+def test_dryrun_alpha():
+    assert sorted([3, 1, 2]) == [1, 2, 3]


### PR DESCRIPTION
Adds `tests/test_train_dryrun.py`, a throwaway test module holding a single trivial test.

## Commits
- `test(dryrun): add a throwaway module with test_dryrun_alpha`

## Why
The module exists only to exercise the build-and-review pipeline end to end on a change with no behavioral surface: a self-contained test file that touches no package code, so a run can be validated without any risk to shipped behavior. Its docstring says so, and it is meant to be deleted once the exercise is over.

## Not in this PR
No changelog fragment and no documentation: nothing under `src/` or `packages/` changes, so neither is required.