### PR TITLE
fix(safety): close the write-guard parity gaps in the executor tables, hooks and tool wiring

### DIFF
--- a/changelog.d/bluesky-unsupported-text.fixed.md
+++ b/changelog.d/bluesky-unsupported-text.fixed.md
@@ -1,0 +1,5 @@
+A deployment whose control system is not one the plan stack can execute against
+is no longer told to switch to the simulator. The refusal now states the
+condition — the queue worker builds its devices over Channel Access — instead
+of offering a remedy that would swap a facility's machine for a soft-IOC. The
+`mock` connector still gets the flip command, where it is the right advice.

--- a/changelog.d/entry-publish-gate.fixed.md
+++ b/changelog.d/entry-publish-gate.fixed.md
@@ -1,0 +1,4 @@
+Publishing an ARIEL logbook entry now asks for approval, as creating one always
+did. `entry_publish` is the call that writes an entry through to the facility's
+logbook, and it was gated nowhere — so a headless read-only query could publish
+to the logbook with no prompt at all.

--- a/changelog.d/eval-substring-match.fixed.md
+++ b/changelog.d/eval-substring-match.fixed.md
@@ -1,0 +1,5 @@
+Python submitted to the executor is no longer refused for merely *containing*
+the letters `eval(` or `exec(`. `retrieval(...)`, a pandas `df.eval("a + b")`
+and a PyTorch `model.eval()` all ran afoul of the substring check; the gate now
+matches an actual call of the builtin. Real `eval`, `exec`, `__import__` and
+`compile` calls are still refused.

--- a/changelog.d/hook-write-tools.fixed.md
+++ b/changelog.d/hook-write-tools.fixed.md
@@ -1,0 +1,6 @@
+The channel-limits and config-drift hooks now read the tools this deployment
+actually renders instead of one hard-coded tool name. On a deployment whose
+controls server is an `extends` clone, the limits hook ran and reported nothing
+— which in a transcript looks like a write that passed its check — and the
+session-start drift check claimed nothing about the write posture while looking
+like it had checked.

--- a/changelog.d/init-failed-env.fixed.md
+++ b/changelog.d/init-failed-env.fixed.md
@@ -1,0 +1,4 @@
+A failed `osprey init` no longer leaves the `.env` it seeded from your shell's
+provider keys behind. The refusal already said "Nothing was materialized", but
+the seeded secrets file survived it — and left the repo root non-empty, so the
+next attempt refused too. An `.env` that was already there is still untouched.

--- a/changelog.d/knowledge-capabilities.removed.md
+++ b/changelog.d/knowledge-capabilities.removed.md
@@ -1,0 +1,5 @@
+The facility-knowledge `capabilities` tool no longer reports `write_enabled`. It
+was a constant `true` that no consumer read, and on the shipped knowledge
+persona — which denies `draft_concept` — it was simply wrong. The tools that
+cannot reach the bundle now say why: the deployment names no bundle, the bundle
+would not load, or the server is not running. Each names its own fix.

--- a/changelog.d/write-surface.security.md
+++ b/changelog.d/write-surface.security.md
@@ -1,0 +1,8 @@
+A `readonly` Python run now refuses two more Channel Access routes to the
+machine: `doocs4py`, the client the DOOCS connector itself writes through, and
+`aioca`, which every OSPREY environment carries as ophyd-async's Channel Access
+backend. Both are refused at import and at the call. Driving hardware through
+ophyd-async signals or a Bluesky `RunEngine` is refused too, while importing
+those libraries for analysis stays allowed. The runtime guard and the import
+denylist are now generated from one table, so they cannot describe different
+libraries.

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -131,9 +131,9 @@ Nine safety layers are applied in sequence:
    in **every** execution mode.
 
 7. **Limits monkeypatch** (``ExecutionWrapper`` /
-   ``LimitsValidator``)---at runtime, ``epics.caput()`` calls are
-   intercepted and validated against the channel limits database.
-   Out-of-range values are blocked.
+   ``LimitsValidator``)---at runtime, direct client writes this build knows
+   how to intercept (pyepics, p4p, Tango, caproto and DOOCS) are validated
+   against the channel limits database. Out-of-range values are blocked.
 
 8. **Process isolation**---code always runs in a separate subprocess, never
    inside the MCP server process.

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -204,8 +204,10 @@ program, and the ``exec`` half of every fork-and-exec is already refused.
 
    The consequence of the second group is that a ``readonly`` script cannot
    shell out or load a shared library *at all*, even for something unrelated
-   to the control system. Resubmit such work with
-   ``execution_mode="readwrite"``, which requires human approval.
+   to the control system. ``readwrite`` is not a way around it: ``import
+   subprocess`` is refused before execution in **every** mode, by the
+   prohibited-import check. Work that genuinely needs a child process belongs
+   outside the executor.
 
 .. _python-executor-protected-paths:
 

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -108,8 +108,10 @@ Nine safety layers are applied in sequence:
 
 3. **Readonly import denylist** (``check_readonly_imports``)---a
    ``readonly`` run may not import control-system client libraries
-   (``epics``, ``p4p``, ``caproto``, ``pvaccess``, ``tango``) at all.
-   Reads go through ``read_channel()``.
+   (``epics``, ``aioca``, ``p4p``, ``caproto``, ``pvaccess``, ``tango``,
+   ``doocs4py``) at all. Reads go through ``read_channel()``. The list is
+   derived from the client half of the write surface below, so a client
+   added there is denied at import in the same change.
 
 4. **Control-system pattern detection**
    (``detect_control_system_operations``)---identifies read and write
@@ -151,9 +153,9 @@ What counts as a control-system write
 -------------------------------------
 
 A ``readonly`` run refuses all of the following. The list is generated from
-one table in the code (``_READONLY_WRITE_TARGETS`` in
-``services/python_executor/execution/wrapper.py``), so adding a library there
-is all it takes to enforce it.
+one table in the code (``services/python_executor/write_surface.py``), so
+adding a library there is all it takes to enforce it --- the runtime guard,
+the import denylist and this page all read that one table.
 
 **Approved API** --- the path everything should use:
 
@@ -164,15 +166,26 @@ is all it takes to enforce it.
 resolved dynamically:
 
 - **pyepics** --- ``caput``, ``caput_many``, ``PV.put``, ``ca.put``
+- **aioca** --- ``caput``, ``caput_many``. Every OSPREY environment carries
+  it: it is the Channel Access backend of ``ophyd-async[ca]``
 - **p4p** --- ``Context.put``/``rpc`` for the thread, asyncio and cothread
   clients; ``SharedPV.post``/``open`` on the server side
 - **caproto** --- ``sync.client.write``, ``threading.client.PV.write``,
   ``Batch.write``, ``asyncio.client.PV.write``
 - **pvaPy** --- every ``Channel.put*`` method, including the typed setters
   such as ``putDouble`` and ``putScalarArray``
+- **doocs4py** --- ``set``, the call the DOOCS connector writes through
 - **Tango** --- ``DeviceProxy.write_attribute`` and its variants,
   ``AttributeProxy.write``, and ``command_inout`` (a Tango command acts on
   the device rather than reading it)
+
+**Acquisition frameworks.** These drive hardware through a client below them,
+so their write entry points refuse --- but they are also ordinary document and
+analysis libraries, so *importing* them stays allowed in a ``readonly`` run:
+
+- **ophyd-async** --- ``SignalW.set`` / ``SignalRW.set``, and ``SignalX``
+  execution
+- **Bluesky** --- ``RunEngine.__call__``, which is how a plan is run
 
 **Routes out of Python.** These reach a control system without importing a
 client at all, so they are refused in ``readonly`` runs too:

--- a/docs/source/how-to/agent-interfaces/add-mcp-server.rst
+++ b/docs/source/how-to/agent-interfaces/add-mcp-server.rst
@@ -99,6 +99,13 @@ own to edit:
    :ref:`tool permission <profile-tool-permissions>` — ``ask:`` prompts before
    the call — or a framework server, which can carry hooks of its own.
 
+   One preset is narrower than attaching it to a whole server suggests:
+   ``limits`` validates only ``channel_write``-shaped input — a call carrying a
+   ``channel``/``value`` pair, or an ``operations`` list. It abstains on any
+   other shape (denying would deny the server's reads), so a tool that writes
+   in another shape is *not* limits-checked. The build says so in a warning
+   when a server attaches it.
+
 Every key an ``mcp_servers:`` entry accepts — the remote ``url`` and
 ``transport`` forms, the ``port`` shorthand, the placeholder rules, and how to
 ship the server's own Python package inside the profile so the launch command

--- a/docs/source/how-to/bluesky/queue.rst
+++ b/docs/source/how-to/bluesky/queue.rst
@@ -259,9 +259,13 @@ quirks worth knowing:
    ``control-assistant`` preset, off unless a deployment says so.
 
    Whether a deployment can execute plans at all is decided by its control
-   system: ``virtual_accelerator`` and ``epics`` can, ``mock`` is
-   browse-only. The panels and the agent both surface this as a capability
-   banner; on a browse-only deployment it names the flip:
+   system. The queue worker builds its devices over Channel Access, so the
+   connectors that speak it execute plans — ``epics``, ``virtual_accelerator``
+   and the live stand-in — and every other one browses. ``mock`` browses
+   because it moves nothing; a connector for another protocol browses because
+   no device layer for it exists yet, which is a gap in the plan stack rather
+   than a property of the facility. The panels and the agent both surface this
+   as a capability banner; on the ``mock`` connector it names the flip:
 
    .. code-block:: bash
 

--- a/docs/source/how-to/facility-knowledge/okf-bundle.rst
+++ b/docs/source/how-to/facility-knowledge/okf-bundle.rst
@@ -189,8 +189,7 @@ Working with a Bundle
         path minus the ``.md`` extension, e.g. ``subsystems/timing-system``)
       * ``search`` — ranked search across all concept documents (see
         `Searching the Bundle`_)
-      * ``capabilities`` — report the bundle's path, size, concept types, and
-        whether draft writes are enabled
+      * ``capabilities`` — report the bundle's path, size and concept types
       * ``draft_concept`` — author a new concept document (requires human approval)
 
       **The facility-knowledge subagent.** When it is enabled in a project's

--- a/packages/osprey-connectors/src/osprey_connectors/types.py
+++ b/packages/osprey-connectors/src/osprey_connectors/types.py
@@ -125,8 +125,12 @@ INVENTED_HISTORY_TYPES = (VIRTUAL_ACCELERATOR, LIVE_STANDIN)
 
 #: Types that speak real Channel Access — the facility's own EPICS machine, a
 #: virtual-accelerator soft-IOC, or the live stand-in soft-IOC. The queue worker
-#: builds its devices over Channel Access and nothing else, so these are the
-#: only types plans can execute against; every other type browses.
+#: builds its devices over Channel Access, so these are the types plans can
+#: execute against today and every other type browses. That is a property of
+#: the worker's device layer, not of the plan stack: a facility whose machine
+#: speaks another protocol executes plans once a device layer for it exists,
+#: and adds its type here — this list is not a statement that no other protocol
+#: can ever run plans.
 CHANNEL_ACCESS_TYPES = (EPICS, VIRTUAL_ACCELERATOR, LIVE_STANDIN)
 
 #: The target each self-standing machine's type is the baseline of. A type

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -527,6 +527,13 @@ keys:
       Inert in hello_world: that template disables the ariel server, so the
       tool never exists. Harmless (fail-closed either way); recorded so it is
       not mistaken for drift.
+  approval.tools.entry_publish:
+    evidence: 'entry_publish'
+    note: >-
+      The second half of the logbook write: entry_create drafts, entry_publish
+      writes the entry through to the facility's logbook. Both carry the
+      approval hook, so both belong here. Inert in hello_world for the same
+      reason entry_create is.
   hooks:
     evidence: 'full_config\.get\("hooks", \{\}\)'
   hooks.debug:
@@ -1809,9 +1816,9 @@ governed_sets:
   claims:
     ariel_standalone:
       template: src/osprey/templates/apps/ariel_standalone/config.yml.j2
-      comment_claim: 'in this app exactly three'
+      comment_claim: 'in this app exactly four'
       exhaustive: true
-      tools: [entry_create, setup_patch, draft_concept]
+      tools: [entry_create, entry_publish, setup_patch, draft_concept]
     channel_finder_standalone:
       template: src/osprey/templates/apps/channel_finder_standalone/config.yml.j2
       comment_claim: 'the only tool it governs is the workspace setup_patch tool'
@@ -1824,8 +1831,8 @@ governed_sets:
       2026-08-27 with the method above: execute_file joined every set when the
       policy-unit rescue gave it the same approval hook as execute (they share
       one gate on the python server, so the pair moves together).
-    project: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, entry_create, draft_concept]
-    control_assistant: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, entry_create, draft_concept]
+    project: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, entry_create, entry_publish, draft_concept]
+    control_assistant: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, entry_create, entry_publish, draft_concept]
     hello_world: [channel_write, channel_read, archiver_read, control_target_set, execute, execute_file, setup_patch, draft_concept]
   draft_concept_note: >-
     draft_concept is approval-governed in project, control_assistant and

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -1072,11 +1072,12 @@ def _cleanup(target: Path, seeded: tuple[str, ...] = ()) -> str:
 
     Args:
         target: The repo root the failed materialization was writing into.
-        seeded: Write-once directories THIS run created (the ``seed_dirs`` it
-            actually copied — never one it found already there). They are not
-            in :data:`MATERIALIZED_SOURCE_ENTRIES`, because a later ``--force``
-            must leave an operator's own edits inside them alone; but a run that
-            just created one and then failed owns it, so a first init that fails
+        seeded: Entries THIS run created that the table does not cover — the
+            ``seed_dirs`` it actually copied, and a ``.env`` it wrote where
+            there was none. Never one it found already there. They are not in
+            :data:`MATERIALIZED_SOURCE_ENTRIES`, because a later ``--force``
+            must leave an operator's own copy alone; but a run that just
+            created one and then failed owns it, so a first init that fails
             leaves nothing behind.
 
     Returns:
@@ -1422,6 +1423,15 @@ def _materialize_profile_directory(
     # seeds this run created are the only ones it is allowed to remove.
     seeded: list[str] = []
 
+    # `.env` is an operator file, so it is not in MATERIALIZED_SOURCE_ENTRIES
+    # and a re-materialization never touches one it found. A run that CREATES
+    # one owns it exactly the way it owns a seed: without this, a first init
+    # that fails leaves the operator's shell-exported keys sitting in a
+    # directory the same refusal calls empty, and the next attempt then finds
+    # the root non-empty.
+    env_pre_existed = (target / _PROFILE_ENV_FILENAME).exists()
+    run_written: list[str] = []
+
     try:
         # Verbatim copy (D1/FR2): staging subdirectories and any stray `.j2`
         # come across byte-identical — a profile data tree is content, never
@@ -1450,6 +1460,11 @@ def _materialize_profile_directory(
             referenced_providers,
         )
         logger.debug("  Secrets: %s", ", ".join(secret_files))
+        if not env_pre_existed and (target / _PROFILE_ENV_FILENAME).exists():
+            # The sibling lock file is created beside the `.env` by the shared
+            # writer and deliberately never removed while the `.env` lives; a
+            # discarded `.env` takes it along.
+            run_written += [_PROFILE_ENV_FILENAME, f"{_PROFILE_ENV_FILENAME}.lock"]
         if shell_keys.skipped:
             # Debug only. `osprey init`'s summary prints the same sentence from
             # the same helper, and this is the only caller, so logging it here
@@ -1540,11 +1555,13 @@ def _materialize_profile_directory(
             if (overrides or set_pairs)
             else "The materialized profile does not validate"
         )
-        raise click.UsageError(f"{blame}: {e}\n{_cleanup(target, seeded=tuple(seeded))}") from e
+        raise click.UsageError(
+            f"{blame}: {e}\n{_cleanup(target, seeded=(*seeded, *run_written))}"
+        ) from e
     except Exception:
         # Any other failure (a copy error, a full disk) must not leave a
         # half-materialized directory that looks buildable.
-        _cleanup(target, seeded=tuple(seeded))
+        _cleanup(target, seeded=(*seeded, *run_written))
         raise
 
     logger.debug("Wrote profile directory: %s", target)

--- a/src/osprey/mcp_server/facility_knowledge/server.py
+++ b/src/osprey/mcp_server/facility_knowledge/server.py
@@ -50,6 +50,12 @@ mcp = FastMCP(
 
 _bundle: OKFBundle | None = None  # resolved lazily at startup by create_server
 
+#: Why :data:`_bundle` is ``None``, recorded by :func:`create_server` so the
+#: tools can name the cause instead of guessing. ``None`` here means
+#: ``create_server`` never ran — the genuine "server not initialised" case, and
+#: the only one of the three the operator fixes by starting the server.
+_bundle_error: tuple[str, str, list[str]] | None = None
+
 # ---------------------------------------------------------------------------
 # Concurrent-draft collision guard
 # ---------------------------------------------------------------------------
@@ -141,16 +147,24 @@ def _touch_bundle_marker(root: Path) -> bool:
 def _get_bundle() -> OKFBundle:
     """Return the initialised OKFBundle singleton.
 
+    Three different faults leave the bundle unavailable, and they have three
+    different fixes: the deployment never named a bundle, the bundle it named
+    could not be loaded, or the server was never started. Answering all three
+    with "start the server" sent an operator whose config was wrong to restart a
+    server that was already running. :func:`create_server` records which one it
+    was; this raises that one.
+
     Raises:
-        ToolError: If the bundle has not been initialised (server not started
-            via :func:`create_server`).
+        ToolError: Carrying ``bundle_not_configured``, ``bundle_load_failed`` or
+            ``server_not_initialised``, whichever actually applies.
     """
     if _bundle is None:
-        make_error(
+        code, message, remedies = _bundle_error or (
             "server_not_initialised",
             "Facility knowledge bundle has not been initialised.",
             ["Start the server via `python -m osprey.mcp_server.facility_knowledge`."],
         )
+        make_error(code, message, remedies)
     return _bundle
 
 
@@ -192,13 +206,15 @@ def create_server() -> FastMCP:
     Returns:
         The configured :class:`~fastmcp.FastMCP` instance.
     """
-    global _bundle
+    global _bundle, _bundle_error
 
     from osprey.services.facility_knowledge.okf.bundle import OKFBundle, OKFBundleError
     from osprey.utils.workspace import load_osprey_config, resolve_config_path
 
     config_path = resolve_config_path()
     config = load_osprey_config()
+
+    _bundle_error = None
 
     try:
         bundle_path = _resolve_bundle_path(config, config_path.parent)
@@ -207,6 +223,14 @@ def create_server() -> FastMCP:
             "facility_knowledge.bundle_path not set in config — tools will return errors"
         )
         bundle_path = None
+        _bundle_error = (
+            "bundle_not_configured",
+            "This deployment names no facility knowledge bundle.",
+            [
+                "Set `facility_knowledge.bundle_path` in the deployment's config "
+                "and run `osprey build`.",
+            ],
+        )
 
     if bundle_path is not None:
         try:
@@ -215,6 +239,15 @@ def create_server() -> FastMCP:
         except OKFBundleError as exc:
             logger.error("Failed to load facility knowledge bundle: %s", exc)
             _bundle = None
+            _bundle_error = (
+                "bundle_load_failed",
+                f"The facility knowledge bundle at {bundle_path} could not be loaded: {exc}",
+                [
+                    f"Check that {bundle_path} exists and holds a readable OKF bundle.",
+                    "Point `facility_knowledge.bundle_path` at the right directory and "
+                    "run `osprey build`.",
+                ],
+            )
 
     # Tools are defined below in this module and self-register via @mcp.tool()
     # at import time — no separate tool imports needed.
@@ -269,13 +302,13 @@ def _tool_error_envelope(operation: str) -> Iterator[None]:
 async def capabilities() -> str:
     """Report facility knowledge bundle capabilities.
 
-    Returns bundle path, concept count, sorted list of distinct concept types,
-    and whether draft writes are enabled.  Does NOT require database connectivity
-    beyond the already-initialised bundle singleton.
+    Returns bundle path, concept count and the sorted list of distinct concept
+    types.  Does NOT require database connectivity beyond the
+    already-initialised bundle singleton.
 
     Returns:
-        JSON object with ``bundle_path``, ``count``, ``types`` (sorted list of
-        distinct ``type`` frontmatter values), and ``write_enabled: true``.
+        JSON object with ``bundle_path``, ``count`` and ``types`` (sorted list
+        of distinct ``type`` frontmatter values).
     """
     with _tool_error_envelope("capabilities"):
         bundle = _get_bundle()
@@ -297,7 +330,6 @@ async def capabilities() -> str:
                 "bundle_path": str(bundle.root),
                 "count": len(entries),
                 "types": sorted(raw_types),
-                "write_enabled": True,
             }
         )
 

--- a/src/osprey/mcp_server/python_executor/tools/python_execute.py
+++ b/src/osprey/mcp_server/python_executor/tools/python_execute.py
@@ -41,8 +41,8 @@ async def execute(
       2. ``path_policy_issues()`` — in *every* mode, blocks literal writes into
          the render zone, the profile sources and the audit ledger, and code
          that names the sandbox guard's own internals
-      3. ``check_readonly_imports()`` — readonly runs may not import
-         control-system client libraries (epics, p4p, ...) at all
+      3. ``check_readonly_imports()`` — readonly runs may not import a
+         control-system client library at all; read through ``osprey.runtime``
       4. ``detect_control_system_operations()`` — blocks detected write
          spellings in readonly mode
     Safety layers applied during execution:
@@ -51,7 +51,9 @@ async def execute(
          import (starting a process, ``ctypes``); the connectors refuse
          ``write_channel``, and the EPICS connector stays on the read_only
          gateway (``OSPREY_EXECUTION_MODE``)
-      6. ``ExecutionWrapper`` monkeypatch — validates epics.caput() against limits DB
+      6. ``ExecutionWrapper`` monkeypatch — writes through ``osprey.runtime``
+         are checked against the limits database, as are the direct client
+         writes this build knows how to intercept
       7. Process isolation — code runs outside the MCP server process
       8. Execution timeout — kills execution after configured timeout
 

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -155,6 +155,11 @@ _DANGEROUS_PATTERNS: list[tuple[str, str]] = [
     ("epics", "epics module"),
     ("caput", "caput()"),
     ("PV.put", "PV.put()"),
+    # EPICS Channel Access via aioca - ophyd-async's backend, so it is present
+    # in every OSPREY environment whether or not the facility installed it
+    ("aioca", "aioca module"),
+    # DOOCS / control system - the client the DOOCS connector writes through
+    ("doocs4py", "doocs4py module"),
     # Tango / control system
     ("tango", "tango module"),
     ("DeviceProxy", "Tango DeviceProxy"),

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -88,3 +88,4 @@ default_panel: ariel
 # ── Config overrides ─────────────────────────────────────────────────────────
 config:
   approval.tools.entry_create: always
+  approval.tools.entry_publish: always

--- a/src/osprey/profiles/presets/control-assistant-logbook.yml
+++ b/src/osprey/profiles/presets/control-assistant-logbook.yml
@@ -108,8 +108,10 @@ config:
   # must not drift if the base's default ever changes.
   control_system.writes_enabled: false
   # Creating a logbook entry is this agent's only write of any kind, and it is
-  # approval-gated like every other write in OSPREY.
+  # approval-gated like every other write in OSPREY. Publishing it is the half
+  # that actually reaches the facility's logbook, so it is gated too.
   approval.tools.entry_create: always
+  approval.tools.entry_publish: always
   # Full split-pane layout: the ARIEL search panel is the point of this tier, so
   # it needs the panel area. Pinned rather than left to the server default for
   # the same reason the other two tiers pin theirs.

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -1330,6 +1330,21 @@ def _custom_server_from_spec(name: str, spec: dict) -> ServerDefinition | None:
                 resolved.append(hook)
             else:
                 logger.warning("Unknown hook preset %r for server %r — skipping", preset, name)
+        if "limits" in pre_presets:
+            # The rule below matches every tool on the server, but the limits
+            # hook only knows one input shape: a `channel_write`-shaped call
+            # carrying `channel`/`value` or an `operations` list. It abstains on
+            # anything else — which is right (denying would deny reads) and is
+            # also why attaching it to a whole server is not the guarantee the
+            # config line looks like.
+            logger.warning(
+                "Server %r attaches the 'limits' hook preset to every tool "
+                "(mcp__%s__.*), but the hook validates only channel_write-shaped "
+                "input (a `channel`/`value` pair, or an `operations` list). Tools "
+                "on this server that write in another shape are NOT limits-checked",
+                name,
+                name,
+            )
         if resolved:
             hooks_pre = [HookRule(matcher=f"mcp__{name}__.*", hooks=resolved)]
 

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -319,10 +319,21 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "status",
             "filter_options",
         ],
-        permissions_ask=["entry_create"],
+        # entry_publish is gated alongside entry_create: it is the tool that
+        # actually writes the entry through to the facility's logbook, so a
+        # deployment that prompts for the draft and not for the publish gates
+        # the half that never leaves the deployment. It is deliberately NOT
+        # writes-check gated — whether a logbook write-through belongs under
+        # the hardware kill switch is one question for every non-hardware
+        # write, and it is answered in one place, not here.
+        permissions_ask=["entry_create", "entry_publish"],
         hooks_pre=[
             HookRule(
                 matcher="mcp__ariel__entry_create",
+                hooks=[_APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__ariel__entry_publish",
                 hooks=[_APPROVAL],
             ),
         ],

--- a/src/osprey/services/bluesky_bridge/queue_backend.py
+++ b/src/osprey/services/bluesky_bridge/queue_backend.py
@@ -1351,7 +1351,9 @@ class QueueBackend:
                 lane_degraded=lane_degraded,
                 detail=(
                     f"The {connector_type!r} connector is not one the plan stack can execute "
-                    f"plans against. To execute plans, run `{FLIP_COMMAND}` and redeploy."
+                    "plans against: the queue worker builds its devices over Channel "
+                    "Access, so a deployment executes plans only on a connector that "
+                    "speaks it. Plans can be composed and validated here."
                 ),
             )
 

--- a/src/osprey/services/python_executor/analysis/pattern_detection.py
+++ b/src/osprey/services/python_executor/analysis/pattern_detection.py
@@ -49,14 +49,16 @@ def get_framework_standard_patterns() -> dict[str, list[str]]:
         Dictionary with 'write' and 'read' pattern lists
 
     Security Note:
-        These patterns cover the libraries OSPREY supports: pyepics (Channel
-        Access), p4p (PVAccess), PyTango, and LabVIEW bindings, plus the
-        osprey.runtime API itself. A library outside that list is not detected
-        - add facility-specific spellings under control_system.patterns in
-        config.yml. Detection here is best-effort text matching; the layers
-        that do not depend on spelling are the readonly runtime guard, the
-        readonly import denylist (``check_readonly_imports``), and the
-        always-ask approval policy for readwrite runs.
+        This is best-effort TEXT MATCHING, not a list of what OSPREY can
+        enforce. It names the spellings the framework happens to know -
+        osprey.runtime, pyepics (Channel Access), p4p (PVAccess), PyTango,
+        doocs4py and LabVIEW bindings - and a library or an idiom outside that
+        list is simply not detected. Extend it with facility-specific
+        spellings under control_system.patterns in config.yml. The layers that
+        do NOT depend on spelling are the ones to rely on: the readonly
+        runtime guard, the readonly import denylist
+        (``check_readonly_imports``), and the always-ask approval policy for
+        readwrite runs.
     """
     return {
         "write": [
@@ -93,6 +95,13 @@ def get_framework_standard_patterns() -> dict[str, list[str]]:
             r"\.write_attribute\s*\(",  # device.write_attribute(...)
             r"\.write_attribute_asynch\s*\(",  # device.write_attribute_asynch(...)
             r"tango\.DeviceProxy\([^)]*\)\.write",  # tango.DeviceProxy(...).write_attribute(...)
+            # ============================================================
+            # CIRCUMVENTION DETECTION: DOOCS (doocs4py library)
+            # ============================================================
+            # Anchored to doocs4py for the same reason the p4p entries are
+            # anchored: a bare r"\.set\s*\(" would flag every set() call in
+            # ordinary analysis code.
+            r"\bdoocs4py\b[\s\S]*?\.set\s*\(",  # doocs4py.set('ADDRESS', value)
             # ============================================================
             # CIRCUMVENTION DETECTION: LabVIEW (potential patterns)
             # ============================================================

--- a/src/osprey/services/python_executor/analysis/safety_checks.py
+++ b/src/osprey/services/python_executor/analysis/safety_checks.py
@@ -1,9 +1,11 @@
-"""Standalone code safety checks — no framework dependencies.
+"""Standalone code safety checks — no third-party dependencies.
 
 Usable by the MCP execute tool for pre-execution validation.
 """
 
 import ast
+
+from osprey.services.python_executor.write_surface import READONLY_DENIED_IMPORTS
 
 
 def check_syntax(code: str) -> list[str]:
@@ -67,7 +69,13 @@ def check_imports(code: str) -> list[str]:
 # import statement is immune to the aliasing that defeats call-site regexes
 # (``from epics import caput as _w``), and an import never appears inside a
 # comment or string, so it has none of the regex false positives either.
-_READONLY_DENIED_IMPORTS = frozenset({"epics", "p4p", "caproto", "pvaccess", "tango", "PyTango"})
+#
+# Derived from the client half of the write surface rather than spelled again
+# here: one producer means a client added to the runtime guard is denied at
+# import in the same change. Acquisition frameworks (ophyd-async, Bluesky) are
+# deliberately NOT in it — they are document and analysis libraries too, so
+# only their write entry points refuse, and that happens at runtime.
+_READONLY_DENIED_IMPORTS = READONLY_DENIED_IMPORTS
 
 
 def check_readonly_imports(code: str) -> list[str]:

--- a/src/osprey/services/python_executor/analysis/safety_checks.py
+++ b/src/osprey/services/python_executor/analysis/safety_checks.py
@@ -20,11 +20,24 @@ def check_syntax(code: str) -> list[str]:
     return issues
 
 
-# Patterns that indicate security risks in user-submitted code
+# Builtins that run code the caller supplies as data. Matched on the AST, as a
+# CALL of a bare name — never as a substring. ``"eval(" in code`` refuses
+# ``retrieval(...)``, ``df.eval("a + b")`` (a pandas expression) and
+# ``model.eval()`` (put a torch module in inference mode); none of those runs
+# caller-supplied code, and all three are ordinary analysis an operator has
+# every reason to submit. An attribute call such as ``builtins.eval(...)`` is
+# deliberately not matched here either: it is not a bare-name call, and the
+# layer that answers obfuscation is the runtime guard, not this text scan.
+_DANGEROUS_CALLS = {
+    "exec": "Use of exec() function",
+    "eval": "Use of eval() function",
+    "__import__": "Dynamic import usage",
+    "compile": "Dynamic code compilation",
+}
+
+# Substring signals that stay substrings: each names a module or a dotted
+# attribute rather than a call, so there is no bare-name call to key on.
 _DANGEROUS_PATTERNS = [
-    ("exec(", "Use of exec() function"),
-    ("eval(", "Use of eval() function"),
-    ("__import__", "Dynamic import usage"),
     ("open(", "File operations - ensure proper handling"),
     ("subprocess", "Subprocess usage - potential security risk"),
     ("os.system", "System command execution"),
@@ -33,9 +46,29 @@ _DANGEROUS_PATTERNS = [
 _PROHIBITED_IMPORTS = ["subprocess", "os.system", "eval", "exec"]
 
 
+def _dangerous_call_issues(code: str) -> list[str]:
+    """One issue per :data:`_DANGEROUS_CALLS` builtin actually *called*.
+
+    Reported once per builtin, however often it appears. Syntax errors are the
+    business of :func:`check_syntax`; this walker stays quiet on them.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        warning = _DANGEROUS_CALLS.get(node.func.id)
+        if warning is not None and warning not in found:
+            found.append(warning)
+    return found
+
+
 def check_security(code: str) -> list[str]:
     """Check for dangerous code patterns. Returns list of issues."""
-    issues = []
+    issues = [f"Security risk: {warning}" for warning in _dangerous_call_issues(code)]
     for pattern, warning in _DANGEROUS_PATTERNS:
         if pattern in code:
             if pattern in ["open(", "subprocess"]:

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -14,6 +14,15 @@ from osprey.services.python_executor.execution.fs_guard import (
     render_fs_guard,
 )
 from osprey.services.python_executor.execution.net_guard import render_net_guard
+
+# The write surface the readonly guard installs. Imported rather than spelled
+# here so that the guard and the readonly import denylist
+# (``analysis.safety_checks``) are produced by one table and cannot describe
+# different libraries. Re-exported by this module because every existing
+# consumer — the guard tests included — reads it from here.
+from osprey.services.python_executor.write_surface import (
+    _READONLY_WRITE_TARGETS,
+)
 from osprey.utils.logger import get_logger
 
 logger = get_logger("execution_wrapper")
@@ -57,143 +66,6 @@ READONLY_FS_REFUSAL_PREFIX = f"Refused ({READONLY_REFUSAL_MARKER}):"
 #: :meth:`ExecutionWrapper._get_filesystem_guard` for what that costs and why it
 #: is still the right trade.
 READWRITE_FS_REFUSAL_PREFIX = DEFAULT_DENYLIST_PREFIX
-
-
-#: Every entry point a readonly run refuses, as ``(dotted target, attributes)``.
-#: This table is the canonical machine-readable answer to "what counts as a
-#: control-system write from Python" — the docs list is written from it, and a
-#: library added here needs no other change to be enforced.
-#:
-#: The dotted target is resolved by importing its longest importable prefix and
-#: then walking attributes, so a module (``epics``), a module attribute
-#: (``epics.ca``) and a class (``p4p.client.thread.Context``) are all spelled
-#: the same way. Attributes that do not exist on the resolved object are
-#: skipped, which is what makes listing several client flavours free: an
-#: uninstalled or older library simply contributes nothing.
-#:
-#: Patching the object in ``sys.modules`` — rather than inspecting the source —
-#: is what makes this immune to spelling. ``importlib.import_module("epics")``,
-#: ``from epics import caput as _w`` and ``getattr(epics, "ca" + "put")`` all
-#: end up holding the refusing function, because they all resolve through the
-#: one module object this mutates.
-_READONLY_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    # --- EPICS Channel Access (pyepics) ---
-    ("epics", ("caput", "caput_many")),
-    ("epics.PV", ("put",)),
-    ("epics.ca", ("put", "put_complete")),
-    # --- PVAccess (p4p): one client Context per concurrency flavour, plus the
-    # server-side SharedPV, which puts values on the wire when it is opened or
-    # posted to.
-    ("p4p.client.thread.Context", ("put", "rpc")),
-    ("p4p.client.asyncio.Context", ("put", "rpc")),
-    ("p4p.client.cothread.Context", ("put", "rpc")),
-    ("p4p.server.raw.SharedPV", ("post", "open")),
-    ("p4p.server.thread.SharedPV", ("post", "open")),
-    ("p4p.server.asyncio.SharedPV", ("post", "open")),
-    # --- Channel Access (caproto) ---
-    ("caproto.sync.client", ("write", "write_read")),
-    ("caproto.threading.client.PV", ("write", "write_all")),
-    ("caproto.threading.client.Batch", ("write",)),
-    ("caproto.asyncio.client.PV", ("write",)),
-    # --- PVAccess (pvaPy). Its ``Channel`` carries one typed setter per scalar
-    # and array type, so the ``put`` prefix is swept dynamically below rather
-    # than enumerated here; ``put`` itself is listed so the table still names
-    # the library.
-    ("pvaccess.Channel", ("put", "putGet")),
-    # --- Tango. ``command_inout`` is included because a Tango command is an
-    # action on the device, not a read — refusing it is the readonly reading.
-    # ``PyTango`` is the legacy alias for the same package; when both import,
-    # they resolve to the same class object and the second patch is a no-op.
-    (
-        "tango.DeviceProxy",
-        (
-            "write_attribute",
-            "write_attributes",
-            "write_attribute_asynch",
-            "write_attributes_asynch",
-            "write_read_attribute",
-            "write_read_attributes",
-            "write_pipe",
-            "put_property",
-            "command_inout",
-            "command_inout_asynch",
-        ),
-    ),
-    ("tango.AttributeProxy", ("write", "write_asynch", "write_read")),
-    (
-        "PyTango.DeviceProxy",
-        (
-            "write_attribute",
-            "write_attributes",
-            "write_read_attribute",
-            "command_inout",
-        ),
-    ),
-    # --- Routes out of Python. A readonly run has no legitimate use for these:
-    # ``import subprocess`` is already refused in every mode by the static
-    # import check, so anything reaching the process-spawning surface at
-    # runtime got there by an evasion. ``os.fork`` is deliberately absent —
-    # forking alone cannot run a new program, and refusing it would break
-    # ordinary multiprocessing for no security gain, since the exec half of
-    # every fork+exec is refused here.
-    (
-        "subprocess",
-        (
-            "run",
-            "Popen",
-            "call",
-            "check_call",
-            "check_output",
-            "getoutput",
-            "getstatusoutput",
-        ),
-    ),
-    ("_posixsubprocess", ("fork_exec",)),
-    # ``os`` re-exports these from ``posix``; patching only ``os`` would leave
-    # ``import posix; posix.system(...)`` open, so both modules are swept.
-    (
-        "os",
-        (
-            "system",
-            "popen",
-            "execl",
-            "execle",
-            "execlp",
-            "execlpe",
-            "execv",
-            "execve",
-            "execvp",
-            "execvpe",
-            "spawnl",
-            "spawnle",
-            "spawnlp",
-            "spawnlpe",
-            "spawnv",
-            "spawnve",
-            "spawnvp",
-            "spawnvpe",
-            "posix_spawn",
-            "posix_spawnp",
-        ),
-    ),
-    (
-        "posix",
-        (
-            "system",
-            "popen",
-            "execv",
-            "execve",
-            "posix_spawn",
-            "posix_spawnp",
-        ),
-    ),
-    # --- Loading a shared library sidesteps every Python-level guard above:
-    # ``ctypes.CDLL("libca")`` reaches Channel Access without importing a
-    # single client package. ``LibraryLoader.__getattr__`` is patched too,
-    # because ``ctypes.cdll.libca`` never goes through ``CDLL`` by that name.
-    ("ctypes", ("CDLL", "PyDLL", "WinDLL", "OleDLL")),
-    ("ctypes.LibraryLoader", ("LoadLibrary", "__getattr__")),
-)
 
 
 class ExecutionWrapper:

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -483,6 +483,143 @@ if not _execution_dir.exists():
                     )
                 except Exception as _p4p_error:
                     print(f"⚠️  p4p.client.cothread guard failed: {{_p4p_error}}")
+
+                # --- Tango. Its writes carry the attribute name only; the
+                # channel a limits database is keyed by is the full
+                # ``device/attribute`` address, so it is rebuilt from the
+                # proxy's own device name. Each client below gets its OWN
+                # try/except for the same reason the p4p flavours do: one
+                # client absent or broken must not skip the ones after it.
+                try:
+                    import tango as _tango
+
+                    def _tango_channel(_proxy, _attr):
+                        return f"{{_proxy.dev_name()}}/{{_attr}}"
+
+                    def _tango_pairs(_name_val):
+                        '''Normalise write_attributes' argument to (name, value) pairs.
+
+                        A shape that cannot be paired up fails CLOSED — the
+                        write raises rather than reaching the device
+                        unvalidated, which is the same trade the p4p batch
+                        guard makes.
+                        '''
+                        _pairs = []
+                        for _item in _name_val:
+                            try:
+                                _attr, _value = _item
+                            except (TypeError, ValueError) as _shape_error:
+                                raise ValueError(
+                                    "tango write_attributes requires (attribute, value) "
+                                    "pairs so each write can be limits-checked"
+                                ) from _shape_error
+                            _pairs.append((_attr, _value))
+                        return _pairs
+
+                    if hasattr(_tango, "DeviceProxy"):
+                        if hasattr(_tango.DeviceProxy, "write_attribute"):
+                            _orig_tango_write = _tango.DeviceProxy.write_attribute
+
+                            def _checked_tango_write(self, attr_name, value, *args, **kwargs):
+                                '''Limits-checked wrapper for DeviceProxy.write_attribute().'''
+                                _limits_validator.validate(
+                                    _tango_channel(self, attr_name), value
+                                )
+                                return _orig_tango_write(self, attr_name, value, *args, **kwargs)
+
+                            _tango.DeviceProxy.write_attribute = _checked_tango_write
+
+                        if hasattr(_tango.DeviceProxy, "write_attributes"):
+                            _orig_tango_write_many = _tango.DeviceProxy.write_attributes
+
+                            def _checked_tango_write_many(self, name_val, *args, **kwargs):
+                                '''Limits-checked wrapper for DeviceProxy.write_attributes().'''
+                                _pairs = _tango_pairs(name_val)
+                                for _attr, _value in _pairs:
+                                    _limits_validator.validate(
+                                        _tango_channel(self, _attr), _value
+                                    )
+                                # The materialised pairs, not the argument: a
+                                # generator was consumed by the check above, and
+                                # forwarding it would write nothing at all.
+                                return _orig_tango_write_many(self, _pairs, *args, **kwargs)
+
+                            _tango.DeviceProxy.write_attributes = _checked_tango_write_many
+
+                    print("✅ Monkeypatched tango DeviceProxy.write_attribute(s)()")
+                except ImportError:
+                    print("ℹ️  tango not available - Tango limits checking disabled")
+                except Exception as _tango_error:
+                    print(f"⚠️  tango guard failed: {{_tango_error}}")
+
+                # --- DOOCS. ``doocs4py.set`` is the call the shipped DOOCS
+                # connector writes through, so a readwrite script naming it
+                # reaches the same hardware the mediated path does.
+                try:
+                    import doocs4py as _doocs4py
+
+                    if hasattr(_doocs4py, "set"):
+                        _orig_doocs_set = _doocs4py.set
+
+                        def _checked_doocs_set(address, value, *args, **kwargs):
+                            '''Limits-checked wrapper for doocs4py.set().'''
+                            _limits_validator.validate(address, value)
+                            return _orig_doocs_set(address, value, *args, **kwargs)
+
+                        _doocs4py.set = _checked_doocs_set
+
+                    print("✅ Monkeypatched doocs4py.set()")
+                except ImportError:
+                    print("ℹ️  doocs4py not available - DOOCS limits checking disabled")
+                except Exception as _doocs_error:
+                    print(f"⚠️  doocs4py guard failed: {{_doocs_error}}")
+
+                # --- caproto. Two entry points, in two modules: the sync
+                # client's module-level write() and the threading client's
+                # PV.write(), which knows its own channel name.
+                try:
+                    import caproto.sync.client as _caproto_sync
+
+                    if hasattr(_caproto_sync, "write"):
+                        _orig_caproto_write = _caproto_sync.write
+
+                        def _checked_caproto_write(pv_name, data, *args, **kwargs):
+                            '''Limits-checked wrapper for caproto.sync.client.write().'''
+                            _limits_validator.validate(pv_name, data)
+                            return _orig_caproto_write(pv_name, data, *args, **kwargs)
+
+                        _caproto_sync.write = _checked_caproto_write
+
+                    print("✅ Monkeypatched caproto.sync.client.write()")
+                except ImportError:
+                    print(
+                        "ℹ️  caproto.sync.client not available - "
+                        "caproto limits checking disabled"
+                    )
+                except Exception as _caproto_error:
+                    print(f"⚠️  caproto.sync.client guard failed: {{_caproto_error}}")
+
+                try:
+                    from caproto.threading.client import PV as _CaprotoPV
+
+                    if hasattr(_CaprotoPV, "write"):
+                        _orig_caproto_pv_write = _CaprotoPV.write
+
+                        def _checked_caproto_pv_write(self, data, *args, **kwargs):
+                            '''Limits-checked wrapper for caproto threading PV.write().'''
+                            _limits_validator.validate(self.name, data)
+                            return _orig_caproto_pv_write(self, data, *args, **kwargs)
+
+                        _CaprotoPV.write = _checked_caproto_pv_write
+
+                    print("✅ Monkeypatched caproto.threading.client PV.write()")
+                except ImportError:
+                    print(
+                        "ℹ️  caproto.threading.client not available - "
+                        "caproto limits checking disabled"
+                    )
+                except Exception as _caproto_error:
+                    print(f"⚠️  caproto.threading.client guard failed: {{_caproto_error}}")
             except Exception as e:
                 print(f"⚠️  Limits checking setup failed: {{e}}")
                 import traceback

--- a/src/osprey/services/python_executor/write_surface.py
+++ b/src/osprey/services/python_executor/write_surface.py
@@ -1,0 +1,219 @@
+"""The one table of Python entry points that reach a control system.
+
+Every gate that has to answer "is this a control-system write?" for *Python
+source* reads this module rather than spelling a client library's name itself:
+
+* the readonly runtime guard emitted into the execution subprocess
+  (:mod:`osprey.services.python_executor.execution.wrapper`) patches every
+  entry point here with a refusing function;
+* the readonly import denylist
+  (:mod:`osprey.services.python_executor.analysis.safety_checks`) is derived
+  from :data:`_CLIENT_WRITE_TARGETS` — the two can no longer drift apart,
+  because there is only one producer;
+* the write-surface section of ``docs/source/architecture/python-executor.rst``
+  is written from it.
+
+The dotted target is resolved by importing its longest importable prefix and
+then walking attributes, so a module (``epics``), a module attribute
+(``epics.ca``) and a class (``p4p.client.thread.Context``) are all spelled the
+same way. Attributes that do not exist on the resolved object are skipped,
+which is what makes listing several client flavours free: an uninstalled or
+older library simply contributes nothing. Over-listing is therefore safe and
+under-listing is not.
+
+Patching the object in ``sys.modules`` — rather than inspecting the source —
+is what makes the guard immune to spelling. ``importlib.import_module("epics")``,
+``from epics import caput as _w`` and ``getattr(epics, "ca" + "put")`` all end
+up holding the refusing function, because they all resolve through the one
+module object the guard mutates.
+
+The table is split three ways because the three groups are answered
+differently by the *static* import check:
+
+* :data:`_CLIENT_WRITE_TARGETS` — control-system client libraries. A readonly
+  run may not even import one: reads go through ``read_channel()``, so an
+  import is only ever a route around the write gates.
+* :data:`_FRAMEWORK_WRITE_TARGETS` — acquisition frameworks that can drive
+  hardware but are also ordinary document/analysis libraries. Their *writes*
+  refuse at runtime; their import stays allowed, which is why they are kept
+  out of the denylist.
+* :data:`_ESCAPE_ROUTES` — routes out of Python that reach a control system
+  without importing a client at all.
+"""
+
+#: Control-system client libraries, as ``(dotted target, attributes)``. Also
+#: the producer of :data:`READONLY_DENIED_IMPORTS`: a readonly run refuses to
+#: import any top-level package named here.
+_CLIENT_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # --- EPICS Channel Access (pyepics) ---
+    ("epics", ("caput", "caput_many")),
+    ("epics.PV", ("put",)),
+    ("epics.ca", ("put", "put_complete")),
+    # --- EPICS Channel Access (aioca). Not an optional extra: ophyd-async's
+    # [ca] backend pulls it into every environment OSPREY builds, so a readonly
+    # script can reach ``aioca.caput`` with nothing else installed.
+    ("aioca", ("caput", "caput_many")),
+    # --- PVAccess (p4p): one client Context per concurrency flavour, plus the
+    # server-side SharedPV, which puts values on the wire when it is opened or
+    # posted to.
+    ("p4p.client.thread.Context", ("put", "rpc")),
+    ("p4p.client.asyncio.Context", ("put", "rpc")),
+    ("p4p.client.cothread.Context", ("put", "rpc")),
+    ("p4p.server.raw.SharedPV", ("post", "open")),
+    ("p4p.server.thread.SharedPV", ("post", "open")),
+    ("p4p.server.asyncio.SharedPV", ("post", "open")),
+    # --- Channel Access (caproto) ---
+    ("caproto.sync.client", ("write", "write_read")),
+    ("caproto.threading.client.PV", ("write", "write_all")),
+    ("caproto.threading.client.Batch", ("write",)),
+    ("caproto.asyncio.client.PV", ("write",)),
+    # --- PVAccess (pvaPy). Its ``Channel`` carries one typed setter per scalar
+    # and array type, so the ``put`` prefix is swept dynamically by the guard
+    # rather than enumerated here; ``put`` itself is listed so the table still
+    # names the library.
+    ("pvaccess.Channel", ("put", "putGet")),
+    # --- DOOCS (doocs4py). The client the shipped DOOCS connector writes
+    # through (``osprey_connectors.control_system.doocs_connector``), so a
+    # readonly script on a DOOCS deployment can reach the machine with the one
+    # library that deployment is guaranteed to have.
+    ("doocs4py", ("set",)),
+    # --- Tango. ``command_inout`` is included because a Tango command is an
+    # action on the device, not a read — refusing it is the readonly reading.
+    # ``PyTango`` is the legacy alias for the same package; when both import,
+    # they resolve to the same class object and the second patch is a no-op.
+    (
+        "tango.DeviceProxy",
+        (
+            "write_attribute",
+            "write_attributes",
+            "write_attribute_asynch",
+            "write_attributes_asynch",
+            "write_read_attribute",
+            "write_read_attributes",
+            "write_pipe",
+            "put_property",
+            "command_inout",
+            "command_inout_asynch",
+        ),
+    ),
+    ("tango.AttributeProxy", ("write", "write_asynch", "write_read")),
+    (
+        "PyTango.DeviceProxy",
+        (
+            "write_attribute",
+            "write_attributes",
+            "write_read_attribute",
+            "command_inout",
+        ),
+    ),
+)
+
+#: Acquisition frameworks that can drive hardware through a client below them.
+#: Deliberately NOT in :data:`READONLY_DENIED_IMPORTS`: both are also ordinary
+#: document and analysis libraries, and a readonly script reading a Tiled
+#: catalog or introspecting a device tree has a legitimate reason to import
+#: them. What it may not do is *move* anything, so the write entry points
+#: refuse at runtime.
+_FRAMEWORK_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    # ophyd-async signals: ``set`` is the one method that puts a value on a
+    # device, whichever backend is under it. The write-capable signal classes
+    # are listed rather than the base ``Signal``, so a read-only ``SignalR``
+    # keeps working.
+    ("ophyd_async.core.SignalW", ("set",)),
+    ("ophyd_async.core.SignalRW", ("set",)),
+    ("ophyd_async.core.SignalX", ("trigger", "execute")),
+    # Running a plan is how the Bluesky stack moves hardware. Patching
+    # ``__call__`` on the class is enough: Python resolves a dunder on the
+    # type, so ``RE(plan)`` on any instance lands here.
+    ("bluesky.RunEngine", ("__call__",)),
+    ("bluesky.run_engine.RunEngine", ("__call__",)),
+)
+
+#: Routes out of Python. A readonly run has no legitimate use for these:
+#: ``import subprocess`` is already refused in every mode by the static import
+#: check, so anything reaching the process-spawning surface at runtime got
+#: there by an evasion. ``os.fork`` is deliberately absent — forking alone
+#: cannot run a new program, and refusing it would break ordinary
+#: multiprocessing for no security gain, since the exec half of every
+#: fork+exec is refused here.
+_ESCAPE_ROUTES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "subprocess",
+        (
+            "run",
+            "Popen",
+            "call",
+            "check_call",
+            "check_output",
+            "getoutput",
+            "getstatusoutput",
+        ),
+    ),
+    ("_posixsubprocess", ("fork_exec",)),
+    # ``os`` re-exports these from ``posix``; patching only ``os`` would leave
+    # ``import posix; posix.system(...)`` open, so both modules are swept.
+    (
+        "os",
+        (
+            "system",
+            "popen",
+            "execl",
+            "execle",
+            "execlp",
+            "execlpe",
+            "execv",
+            "execve",
+            "execvp",
+            "execvpe",
+            "spawnl",
+            "spawnle",
+            "spawnlp",
+            "spawnlpe",
+            "spawnv",
+            "spawnve",
+            "spawnvp",
+            "spawnvpe",
+            "posix_spawn",
+            "posix_spawnp",
+        ),
+    ),
+    (
+        "posix",
+        (
+            "system",
+            "popen",
+            "execv",
+            "execve",
+            "posix_spawn",
+            "posix_spawnp",
+        ),
+    ),
+    # --- Loading a shared library sidesteps every Python-level guard above:
+    # ``ctypes.CDLL("libca")`` reaches Channel Access without importing a
+    # single client package. ``LibraryLoader.__getattr__`` is patched too,
+    # because ``ctypes.cdll.libca`` never goes through ``CDLL`` by that name.
+    ("ctypes", ("CDLL", "PyDLL", "WinDLL", "OleDLL")),
+    ("ctypes.LibraryLoader", ("LoadLibrary", "__getattr__")),
+)
+
+#: Every entry point a readonly run refuses. The canonical machine-readable
+#: answer to "what counts as a control-system write from Python" — the docs
+#: list is written from it, and a library added above needs no other change to
+#: be enforced.
+_READONLY_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    _CLIENT_WRITE_TARGETS + _FRAMEWORK_WRITE_TARGETS + _ESCAPE_ROUTES
+)
+
+#: Top-level packages a readonly run may not import, derived from
+#: :data:`_CLIENT_WRITE_TARGETS` so the denylist cannot fall behind the guard.
+READONLY_DENIED_IMPORTS: frozenset[str] = frozenset(
+    dotted.split(".")[0] for dotted, _attrs in _CLIENT_WRITE_TARGETS
+)
+
+__all__ = [
+    "READONLY_DENIED_IMPORTS",
+    "_CLIENT_WRITE_TARGETS",
+    "_ESCAPE_ROUTES",
+    "_FRAMEWORK_WRITE_TARGETS",
+    "_READONLY_WRITE_TARGETS",
+]

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -284,15 +284,16 @@ deployed_services: []
 #   only — under `selective` every other tool is treated as `always`), skip (no
 #   approval).
 # Scope: applied by the osprey_approval PreToolUse hook, so these policies reach
-# only tools whose matcher runs that hook — in this app exactly three: ARIEL
-# `entry_create`, workspace `setup_patch`, and facility-knowledge
-# `draft_concept`. Everything else is gated by the rendered settings.json
-# permissions instead.
+# only tools whose matcher runs that hook — in this app exactly four: ARIEL
+# `entry_create` and `entry_publish`, workspace `setup_patch`, and
+# facility-knowledge `draft_concept`. Everything else is gated by the rendered
+# settings.json permissions instead.
 approval:
   enabled: true
   default_policy: "always"        # Fail-closed for hook-wired tools not listed below
   tools:
     entry_create: always           # ARIEL logbook entry creation requires approval
+    entry_publish: always          # Publishing it to the logbook does too
 
 # ── Hook observability ──────────────────────────────────────────────
 # Shipped ON. This drives three things, not just a debug print: one line per

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -390,6 +390,7 @@ approval:
     execute: selective             # Content-aware: checks write patterns + exec mode
     setup_patch: always            # Config mutation needs approval
     entry_create: always           # ARIEL logbook write
+    entry_publish: always          # ARIEL logbook write-through
 
 # ── Hook observability ──────────────────────────────────────────────
 # Shipped ON. This drives three things, not just a debug print:

--- a/src/osprey/templates/apps/hello_world/config.yml.j2
+++ b/src/osprey/templates/apps/hello_world/config.yml.j2
@@ -224,6 +224,8 @@ approval:
     setup_patch: always            # Config mutation needs approval
     entry_create: always           # ARIEL logbook write (inert here: the
                                    # ariel server is disabled below)
+    entry_publish: always          # ARIEL logbook write-through (inert
+                                   # here for the same reason)
 
 # ── Hook observability ──────────────────────────────────────────────
 # Shipped OFF here (the readers default to false when the section is absent).

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -134,7 +134,7 @@ except Exception:  # pragma: no cover - older render without the reader
     _target_state = None
 
 # Fallback write patterns: used when osprey is not importable (e.g., standalone hook).
-# Must stay in sync with get_framework_standard_patterns()["write"] (19 patterns).
+# Must stay in sync with get_framework_standard_patterns()["write"] (20 patterns).
 # The parity test in test_approval_hook.py enforces this.
 _FALLBACK_WRITE_PATTERNS = [
     # osprey.runtime unified API
@@ -158,6 +158,9 @@ _FALLBACK_WRITE_PATTERNS = [
     r"\.write_attribute\s*\(",
     r"\.write_attribute_asynch\s*\(",
     r"tango\.DeviceProxy\([^)]*\)\.write",
+    # DOOCS (doocs4py) - anchored to doocs4py; a bare r"\.set\s*\(" would
+    # flag every set() call in ordinary analysis code
+    r"\bdoocs4py\b[\s\S]*?\.set\s*\(",
     # LabVIEW
     r"labview\.set_control\(",
     r"\.SetControlValue\(",
@@ -165,7 +168,7 @@ _FALLBACK_WRITE_PATTERNS = [
     r"connector\.write_channel\(",
 ]
 
-# Pattern detection: prefer framework module (regex-based, config-driven, 19 patterns)
+# Pattern detection: prefer framework module (regex-based, config-driven, 20 patterns)
 # with graceful fallback to regex matching against _FALLBACK_WRITE_PATTERNS
 try:
     from osprey.services.python_executor.analysis.pattern_detection import (

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -5,7 +5,7 @@ name: Human Approval Gate
 description: Requires human approval for dangerous operations based on per-tool policy
 summary: Requires human approval for dangerous operations
 event: PreToolUse
-tools: channel_write, execute, setup_patch, entry_create, queue_add, queue_start, queue_stop, queue_remove, stop_run
+tools: channel_write, execute, setup_patch, entry_create, entry_publish, queue_add, queue_start, queue_stop, queue_remove, stop_run
 safety_layer: 2
 ---
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_config_drift.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_config_drift.py
@@ -19,7 +19,7 @@ SessionStart ──► stat config.yml & .claude/settings.json
    (b) exactly one writes_enabled key?  ── no ─► claim nothing about writes
                      │ yes
                      ▼
-       its value  vs  channel_write in deny? ──► precise drift
+    its value vs this render's write_tools in deny? ──► precise drift
                      │
                      ▼
    drift?  ── yes ─► warn (stderr + additionalContext) ─► exit 0
@@ -29,11 +29,21 @@ SessionStart ──► stat config.yml & .claude/settings.json
 ## Details
 
 `config.yml` is a build-time input: safety-critical fields (notably the write
-posture, which bakes ``mcp__controls__channel_write`` into ``settings.json``'s
+posture, which bakes this render's write tools into ``settings.json``'s
 ``permissions.deny``) only take effect once the artifacts are re-rendered by
 ``osprey build``. The web and CLI entry points auto-regenerate, but a
 hand-edited config.yml launched via raw ``claude`` would otherwise run stale
 settings with no signal. This hook is that signal.
+
+The tools check (b) looks for come from this render's own
+``.claude/hooks/hook_config.json`` — the same ``write_tools`` list the
+writes-check hook and the MCP audit middleware read — not from a literal spelled
+here. A deployment whose controls server is an ``extends`` clone denies
+``mcp__<clone>__channel_write`` and nothing named ``controls``, so a hook probing
+the framework literal claimed nothing while looking like it had checked. Entries
+naming a whole server (``mcp__<name>__.*``) and tools whose reads survive the
+kill switch (``mixed_read_write_tools``) are dropped: neither is denied outright,
+so neither says anything about the posture. An empty list abstains.
 
 Check (b) covers one shape of deployment only: the one whose whole posture is
 ``control_system.writes_enabled``. Posture is per connector type, and a config
@@ -73,7 +83,16 @@ from pathlib import Path
 # reads the single key. Even a mis-parse cannot weaken the write-block gate.
 _WRITES_ENABLED_KEY = re.compile(r"^\s*writes_enabled:", re.MULTILINE | re.IGNORECASE)
 _WRITES_ENABLED = re.compile(r"^\s*writes_enabled:\s*(true|false)\b", re.MULTILINE | re.IGNORECASE)
-_CHANNEL_WRITE = "mcp__controls__channel_write"
+#: Suffix marking a `mcp__<server>__.*` entry in `write_tools` — a whole server
+#: gated by the writes-check hook, whose tool names are unknown at render time.
+#: Such an entry names no tool that could appear in `permissions.deny`, so the
+#: kill-switch comparison skips it.
+_MATCHER_WILDCARD = ".*"
+
+#: Read when `hook_config.json` cannot be, so this check keeps working on a
+#: render that predates the file. It is the framework's own controls tool: the
+#: literal this hook used to be written against.
+_FALLBACK_WRITE_TOOLS = ("mcp__controls__channel_write",)
 
 _REGEN_HINT = "run 'osprey build' and restart for changes to take effect"
 
@@ -92,8 +111,55 @@ def _writes_enabled_in_config(config_path: Path) -> bool | None:
     return match.group(1).lower() == "true"
 
 
-def _channel_write_denied(settings_path: Path) -> bool | None:
-    """Whether channel_write is in permissions.deny (None if undeterminable)."""
+def _kill_switch_tools(hook_config_path: Path) -> tuple[str, ...]:
+    """The tools the writes kill switch renders into ``permissions.deny``.
+
+    Read from this render's own ``hook_config.json`` rather than spelled here,
+    because the answer is per deployment: an ``extends`` clone of the controls
+    server contributes ``mcp__<clone>__channel_write``, and a facility-custom
+    server that opts into the writes-check hook contributes an
+    ``mcp__<name>__.*`` matcher. A hook that probes one framework literal claims
+    nothing about either — and on a deployment whose only write tool is a clone
+    it claimed nothing at all while looking like it had checked.
+
+    Two kinds of entry are dropped:
+
+    * wildcard matchers — they name no tool that could be in ``permissions.deny``;
+    * ``mixed_read_write_tools`` — tools whose reads stay available with writes
+      off, so they are not denied outright and their absence from ``deny`` says
+      nothing about the posture.
+
+    An unreadable or malformed file falls back to the framework's own controls
+    tool, which is what this check was written against before there was a file
+    to read. An empty result means "claim nothing", which the caller handles.
+    """
+    try:
+        data = json.loads(hook_config_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return _FALLBACK_WRITE_TOOLS
+    if not isinstance(data, dict):
+        return _FALLBACK_WRITE_TOOLS
+    tools = data.get("write_tools")
+    if not isinstance(tools, list):
+        return _FALLBACK_WRITE_TOOLS
+    mixed = data.get("mixed_read_write_tools")
+    mixed_set = {t for t in mixed if isinstance(t, str)} if isinstance(mixed, list) else set()
+    return tuple(
+        tool
+        for tool in tools
+        if isinstance(tool, str) and not tool.endswith(_MATCHER_WILDCARD) and tool not in mixed_set
+    )
+
+
+def _write_tools_denied(settings_path: Path, tools: tuple[str, ...]) -> bool | None:
+    """Whether *tools* are in permissions.deny (None if undeterminable).
+
+    All-or-nothing on purpose: the kill switch renders the whole set together,
+    so a partial overlap is not a posture — it is a hand-edited settings.json,
+    and check (a) is the signal for that.
+    """
+    if not tools:
+        return None
     try:
         data = json.loads(settings_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
@@ -106,17 +172,22 @@ def _channel_write_denied(settings_path: Path) -> bool | None:
     deny = perms.get("deny", [])
     if not isinstance(deny, list):
         return None
-    return _CHANNEL_WRITE in deny
+    denied = {tool for tool in tools if tool in deny}
+    if not denied:
+        return False
+    if len(denied) == len(tools):
+        return True
+    return None
 
 
-def _detect_drift(config_path: Path, settings_path: Path) -> str | None:
+def _detect_drift(config_path: Path, settings_path: Path, hook_config_path: Path) -> str | None:
     """Return a drift warning message, or None when artifacts look in sync."""
     if not config_path.exists() or not settings_path.exists():
         return None
 
     # (b) Targeted, high-signal check: does the kill-switch match the config?
     writes_enabled = _writes_enabled_in_config(config_path)
-    denied = _channel_write_denied(settings_path)
+    denied = _write_tools_denied(settings_path, _kill_switch_tools(hook_config_path))
     if writes_enabled is not None and denied is not None:
         if writes_enabled and denied:
             return (
@@ -144,8 +215,9 @@ def main() -> int:
         project_dir = Path(os.environ.get("CLAUDE_PROJECT_DIR", "."))
         config_path = project_dir / "config.yml"
         settings_path = project_dir / ".claude" / "settings.json"
+        hook_config_path = project_dir / ".claude" / "hooks" / "hook_config.json"
 
-        message = _detect_drift(config_path, settings_path)
+        message = _detect_drift(config_path, settings_path, hook_config_path)
         if not message:
             return 0
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_error_guidance.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_error_guidance.py
@@ -181,6 +181,8 @@ ERROR_CLASS_MAP = {
     "configuration_error": "Internal",
     "not_configured": "Internal",
     "server_not_initialised": "Internal",
+    "bundle_not_configured": "Internal",
+    "bundle_load_failed": "Internal",
     "dependency_missing": "Internal",
     "conversion_error": "Internal",
     "capture_error": "Internal",

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_limits.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_limits.py
@@ -111,7 +111,14 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from osprey_hook_log import AUDIT_DECISION_REFUSED, emit_audit, get_hook_input, log_hook
+from osprey_hook_log import (
+    AUDIT_DECISION_REFUSED,
+    emit_audit,
+    get_hook_input,
+    load_hook_config,
+    log_hook,
+    short_tool_name,
+)
 
 # The shared, stdlib-only reader for the control-system target state, imported
 # while this file's own directory is still the first `sys.path` entry the line
@@ -150,6 +157,26 @@ def _control_target(hook_input):
         return None
 
 
+def _server_prefixes():
+    """Every MCP server prefix this render generated into hook_config.
+
+    Resolved the way `osprey_writes_check._server_prefixes` resolves it, and
+    for the same reason: an ``extends`` clone of the controls server renames
+    only the prefix, so a check written against the full tool name would miss
+    every clone. Never raises — `short_tool_name` still resolves a short name
+    from the ``mcp__<server>__<tool>`` shape with no prefixes at all.
+    """
+    try:
+        hook_config = load_hook_config()
+        return [
+            prefix
+            for key in ("server_prefixes", "approval_prefixes")
+            for prefix in hook_config.get(key) or ()
+        ]
+    except Exception:
+        return []
+
+
 def _supports_per_target_postures(validator_cls):
     """Whether the installed framework can resolve a limits posture per target.
 
@@ -183,8 +210,13 @@ def main():
 
     tool_name = hook_input.get("tool_name", "")
 
-    # Only validate channel_write
-    if tool_name != "mcp__controls__channel_write":
+    # Only validate channel_write — matched on the SHORT name, so a clone of
+    # the controls server (`extends: controls`) is validated too. The registry
+    # rewrites this hook's matcher to `mcp__<clone>__channel_write`, so the
+    # hook already fired on those calls; keying on the framework server's own
+    # literal name made it exit 0 and report nothing, which reads in the
+    # transcript exactly like a write that passed its limits check.
+    if short_tool_name(tool_name, _server_prefixes()) != "channel_write":
         sys.exit(0)
 
     tool_input = hook_input.get("tool_input", {})

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -90,6 +90,7 @@ approval:
     execute: selective             # Content-aware: checks write patterns + exec mode
     setup_patch: always            # Config mutation needs approval
     entry_create: always           # ARIEL logbook write
+    entry_publish: always          # ARIEL logbook write-through
 
 # ── Hook observability ──────────────────────────────────────────────
 # Shipped OFF here (the readers default to false when the section is absent).

--- a/tests/agent_runner/test_write_tools.py
+++ b/tests/agent_runner/test_write_tools.py
@@ -236,12 +236,18 @@ def test_read_only_disallowed_tools_no_duplicates(tmp_path: Path) -> None:
 def test_read_only_disallowed_tools_blocks_approval_required_actions(tmp_path: Path) -> None:
     """Approval-required side-effect tools that are NOT in the hardware-write
     kill-switch list must still be blocked (the round-5 escape hatch):
-    execute_file, entry_create, draft_concept, setup_patch."""
+    execute_file, entry_create, entry_publish, draft_concept, setup_patch.
+
+    entry_publish is the one that actually reaches the facility's logbook, so a
+    headless read-only query that could call it would write to the logbook with
+    no gate anywhere in its path.
+    """
     result = read_only_disallowed_tools(tmp_path)
 
     for tool in (
         "mcp__python__execute_file",
         "mcp__ariel__entry_create",
+        "mcp__ariel__entry_publish",
         "mcp__osprey_facility_knowledge__draft_concept",
         "mcp__osprey_workspace__setup_patch",
     ):

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -36,7 +36,14 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # `startup|resume|clear`), which is what lets a view switch wait until the
     # process is between turns. Deploy-visible, so the staleness advisory
     # firing on already-deployed projects is the correct signal.
-    "ariel-standalone": "sha256:878c0f09885509f0d7e6866d8603da3f571dfe26ec3aa5293cc437145543136a",
+    # Moved again — with control-assistant-logbook and no other preset, which
+    # is the signature of a change to the two tiers that spell an ARIEL
+    # approval policy. Both gained `approval.tools.entry_publish: always`
+    # beside their existing `entry_create` line: publishing an entry is the
+    # half that reaches the facility's logbook, and it was gated nowhere. A
+    # rebuilt project prompts before a publish, so the staleness advisory
+    # firing on already-deployed projects is the correct signal.
+    "ariel-standalone": "sha256:4b0e696201139c0b712a6f1477897680e4ad87c21ddcccc4faee24a3a3320857",
     # Moved with the shared hook list above: `turn-state`.
     "channel-finder-standalone": (
         "sha256:ead6c626c7f5a539f21110b827f2eb2e3d15e42522aafb02db0c4c72acc08883"
@@ -245,8 +252,9 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # Moved with the base above: the plan queue comes up armed.
     # Moved with the base above: the JUPYTER tab.
     # Moved with the shared hook list above: `turn-state`.
+    # Moved with ariel-standalone, not with the base: `approval.tools.entry_publish`.
     "control-assistant-logbook": (
-        "sha256:1d3091e9a09c4c6d83136ffdc5b4e1553cdbba5d419843c644d4e4dad6650e8d"
+        "sha256:3e40020a955c085e9df080ea8439b2907b192069bac57965804584b2ddc74251"
     ),
     # New: the second standalone persona. The facility knowledge graph, the
     # graph-mode channel finder and the knowledge bundle behind one shared

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -1216,6 +1216,64 @@ def test_failed_round_trip_after_mkdir_removes_the_target(
     assert not target.exists()
 
 
+def test_failed_round_trip_discards_the_env_it_seeded(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shell-exported provider key seeds `.env`, and a failed run owns it.
+
+    `.env` is an operator file, so cleanup leaves one it finds; but this run
+    wrote it, and leaving it behind both contradicts "Nothing was materialized"
+    and leaves the operator's key in a directory the next attempt then finds
+    non-empty. Whether the run's shell happens to export a key must not decide
+    what a failed init leaves on disk.
+    """
+    from osprey.cli import build_profile
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-not-a-real-key")
+
+    real = build_profile.resolve_build_profile
+
+    def fail_on_round_trip(profile_path, preset, *args, **kwargs):
+        if profile_path is not None:
+            raise BuildProfileError("simulated round-trip failure")
+        return real(profile_path, preset, *args, **kwargs)
+
+    monkeypatch.setattr(build_profile, "resolve_build_profile", fail_on_round_trip)
+    target = tmp_path / "p-facility"
+
+    result = _new(runner, target, "hello-world")
+
+    assert result.exit_code == 2
+    assert "Nothing was materialized" in result.output
+    assert not target.exists()
+
+
+def test_failed_round_trip_keeps_an_env_it_did_not_write(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half: an operator's own `.env` survives the failure."""
+    from osprey.cli import build_profile
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-not-a-real-key")
+
+    real = build_profile.resolve_build_profile
+
+    def fail_on_round_trip(profile_path, preset, *args, **kwargs):
+        if profile_path is not None:
+            raise BuildProfileError("simulated round-trip failure")
+        return real(profile_path, preset, *args, **kwargs)
+
+    monkeypatch.setattr(build_profile, "resolve_build_profile", fail_on_round_trip)
+    target = tmp_path / "p-facility"
+    target.mkdir()
+    (target / ".env").write_text("OPERATOR_SECRET=keep-me\n", encoding="utf-8")
+
+    result = _new(runner, target, "hello-world")
+
+    assert result.exit_code == 2
+    assert "OPERATOR_SECRET=keep-me" in (target / ".env").read_text(encoding="utf-8")
+
+
 def test_round_trip_failure_without_layers_does_not_blame_overrides(
     runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -852,8 +852,10 @@ config:
   # must not drift if the base's default ever changes.
   control_system.writes_enabled: false
   # Creating a logbook entry is this agent's only write of any kind, and it is
-  # approval-gated like every other write in OSPREY.
+  # approval-gated like every other write in OSPREY. Publishing it is the half
+  # that actually reaches the facility's logbook, so it is gated too.
   approval.tools.entry_create: always
+  approval.tools.entry_publish: always
   # Full split-pane layout: the ARIEL search panel is the point of this tier, so
   # it needs the panel area. Pinned rather than left to the server default for
   # the same reason the other two tiers pin theirs.

--- a/tests/hooks/test_approval_hook.py
+++ b/tests/hooks/test_approval_hook.py
@@ -949,6 +949,59 @@ def test_entry_create_always_asks(tmp_path, hook_runner, make_config):
     assert output["permissionDecision"] == "ask"
 
 
+@pytest.mark.unit
+def test_entry_publish_always_asks(tmp_path, hook_runner, make_config):
+    """Publishing an entry reaches the facility's logbook, so it prompts.
+
+    It falls to `default_policy` rather than naming a policy of its own, which
+    is fail-closed and is what the shipped presets state explicitly.
+    """
+    config = make_config({"approval": DEFAULT_TOOLS_CONFIG})
+
+    result = hook_runner(
+        "osprey_approval.py",
+        "mcp__ariel__entry_publish",
+        {"entry_id": "e-1"},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config=DEFAULT_APPROVAL_CONFIG,
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "tool_name",
+    ["mcp__ring__channel_write", "mcp__ring__control_target_set"],
+    ids=["channel_write", "control_target_set"],
+)
+def test_clone_approval_gated_tools_still_ask(tmp_path, hook_runner, make_config, tool_name):
+    """A clone renames only the server prefix, never the tool.
+
+    The registry rewrites each rule's matcher to `mcp__<clone>__<tool>`, so the
+    hook fires; the policy has to be resolved from the SHORT name or every
+    approval-gated controls tool on a clone falls through unrecognised.
+    """
+    config = make_config({"approval": DEFAULT_TOOLS_CONFIG})
+
+    result = hook_runner(
+        "osprey_approval.py",
+        tool_name,
+        {"channel": "TEST:PV", "value": 1.0},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config={
+            "server_prefixes": ["mcp__ring__"],
+            "approval_prefixes": ["mcp__ring__"],
+        },
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
 # ============================================================================
 # Pattern parity — fallback patterns must match framework patterns
 # ============================================================================

--- a/tests/hooks/test_approval_hook.py
+++ b/tests/hooks/test_approval_hook.py
@@ -1001,6 +1001,21 @@ def test_fallback_covers_p4p_write_idioms(hook_module):
 
 
 @pytest.mark.unit
+def test_fallback_covers_the_doocs_write_idiom(hook_module):
+    """The fallback list must carry the DOOCS write spelling.
+
+    ``doocs4py.set`` is what the shipped DOOCS connector writes through, so a
+    deployment on that connector is guaranteed to have the library. Anchored
+    to ``doocs4py`` on purpose: a bare ``.set(`` would flag every set() call in
+    ordinary analysis code.
+    """
+    fallback_patterns = hook_module("osprey_approval")._FALLBACK_WRITE_PATTERNS
+
+    assert r"\bdoocs4py\b[\s\S]*?\.set\s*\(" in fallback_patterns
+    assert r"\.set\s*\(" not in fallback_patterns
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "code",
     [

--- a/tests/hooks/test_config_drift_hook.py
+++ b/tests/hooks/test_config_drift_hook.py
@@ -3,9 +3,9 @@
 The hook warns (never blocks) when config.yml has drifted from the rendered
 .claude/settings.json. Two layers of coverage:
 
-* The pure helpers (``_writes_enabled_in_config``, ``_channel_write_denied``,
-  ``_detect_drift``) are imported and called directly, one test per documented
-  return branch. The hook is stdlib-only and imports nothing at module scope, so
+* The pure helpers (``_writes_enabled_in_config``, ``_kill_switch_tools``,
+  ``_write_tools_denied``, ``_detect_drift``) are imported and called directly,
+  one test per documented return branch. The hook is stdlib-only and imports nothing at module scope, so
   a plain import is safe — it is still written inside the test bodies so that
   importing this file stays free of side effects (tests/README.md §5).
 * The end-to-end behaviour goes through the shared ``hook_runner_raw`` harness,
@@ -29,6 +29,12 @@ HOOK_SCRIPT = "osprey_config_drift.py"
 # Spelled out here rather than imported: the tests state the contract the hook is
 # supposed to implement, independently of the constant the hook happens to use.
 CHANNEL_WRITE = "mcp__controls__channel_write"
+
+# What the same tool is called on an `extends: controls` clone. A deployment
+# whose controls server is a clone denies THIS and nothing named `controls`, so
+# a hook keyed on the framework literal claims nothing about its posture while
+# looking like it had checked.
+CLONE_CHANNEL_WRITE = "mcp__ring__channel_write"
 
 # Channel-write states a rendered settings.json can be in.
 DENIED = "denied"
@@ -69,7 +75,9 @@ class _RaisingPath:
 # --------------------------------------------------------------------------- #
 
 
-def _make_project(project_dir, *, writes_enabled: bool | None, channel_write: str):
+def _make_project(
+    project_dir, *, writes_enabled: bool | None, channel_write: str, write_tool: str = CHANNEL_WRITE
+):
     """Write config.yml + .claude/settings.json in a chosen (possibly drifted) state.
 
     ``writes_enabled=None`` omits the key entirely; ``channel_write=NO_PERMISSIONS``
@@ -79,24 +87,37 @@ def _make_project(project_dir, *, writes_enabled: bool | None, channel_write: st
     if writes_enabled is not None:
         lines.append(f"  writes_enabled: {'true' if writes_enabled else 'false'}")
     return _make_project_from_text(
-        project_dir, "\n".join(lines) + "\n", channel_write=channel_write
+        project_dir,
+        "\n".join(lines) + "\n",
+        channel_write=channel_write,
+        write_tool=write_tool,
     )
 
 
-def _make_project_from_text(project_dir, config_text: str, *, channel_write: str):
-    """Same, for a config.yml whose exact text matters (shapes a bool cannot express)."""
-    (project_dir / ".claude").mkdir(parents=True, exist_ok=True)
+def _make_project_from_text(
+    project_dir, config_text: str, *, channel_write: str, write_tool: str = CHANNEL_WRITE
+):
+    """Same, for a config.yml whose exact text matters (shapes a bool cannot express).
+
+    ``write_tool`` names the deployment's own write tool: the framework's by
+    default, a clone's when the test is about a clone. It is written into both
+    ``hook_config.json`` (where the hook reads the set from) and
+    ``permissions.deny`` (where the kill switch puts it).
+    """
+    (project_dir / ".claude" / "hooks").mkdir(parents=True, exist_ok=True)
     config_path = project_dir / "config.yml"
     settings_path = project_dir / ".claude" / "settings.json"
+    hook_config_path = project_dir / ".claude" / "hooks" / "hook_config.json"
 
     config_path.write_text(config_text, encoding="utf-8")
+    hook_config_path.write_text(json.dumps({"write_tools": [write_tool]}), encoding="utf-8")
 
     if channel_write == NO_PERMISSIONS:
         settings = {"hooks": {}}
     else:
         deny = ["Bash", "Edit"]
         if channel_write == DENIED:
-            deny.append(CHANNEL_WRITE)
+            deny.append(write_tool)
         settings = {"permissions": {"deny": deny}}
     settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
     return config_path, settings_path
@@ -185,7 +206,63 @@ def test_writes_enabled_in_config_is_none_when_unreadable(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# _channel_write_denied — JSON read of permissions.deny
+# _kill_switch_tools — which tools this render's kill switch denies
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (json.dumps({"write_tools": [CLONE_CHANNEL_WRITE]}), (CLONE_CHANNEL_WRITE,)),
+        (
+            json.dumps({"write_tools": [CHANNEL_WRITE, CLONE_CHANNEL_WRITE]}),
+            (CHANNEL_WRITE, CLONE_CHANNEL_WRITE),
+        ),
+        # A whole facility-custom server names no tool that could be in deny.
+        (json.dumps({"write_tools": [CHANNEL_WRITE, "mcp__site__.*"]}), (CHANNEL_WRITE,)),
+        # A mixed read/write tool keeps its reads with writes off, so it is not
+        # denied outright and says nothing about the posture.
+        (
+            json.dumps(
+                {
+                    "write_tools": [CHANNEL_WRITE, "mcp__bluesky__queue_add"],
+                    "mixed_read_write_tools": ["mcp__bluesky__queue_add"],
+                }
+            ),
+            (CHANNEL_WRITE,),
+        ),
+        (json.dumps({"write_tools": []}), ()),
+        (json.dumps({"write_tools": [1, None]}), ()),
+    ],
+    ids=["clone-only", "framework-and-clone", "wildcard-dropped", "mixed-dropped", "empty", "junk"],
+)
+def test_kill_switch_tools(tmp_path, payload, expected):
+    hook_config_path = tmp_path / "hook_config.json"
+    hook_config_path.write_text(payload, encoding="utf-8")
+
+    assert _hook()._kill_switch_tools(hook_config_path) == expected
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, "{ this is not json", json.dumps(["not", "a", "mapping"]), json.dumps({})],
+    ids=["file-missing", "malformed-json", "top-level-not-a-mapping", "key-absent"],
+)
+def test_kill_switch_tools_falls_back_to_the_framework_tool(tmp_path, payload):
+    """A render without a readable hook_config still gets the old check.
+
+    Falling back to nothing would silently retire the check on exactly the
+    deployments least likely to notice.
+    """
+    hook_config_path = tmp_path / "hook_config.json"
+    if payload is not None:
+        hook_config_path.write_text(payload, encoding="utf-8")
+
+    assert _hook()._kill_switch_tools(hook_config_path) == (CHANNEL_WRITE,)
+
+
+# --------------------------------------------------------------------------- #
+# _write_tools_denied — JSON read of permissions.deny
 # --------------------------------------------------------------------------- #
 
 
@@ -212,15 +289,38 @@ def test_writes_enabled_in_config_is_none_when_unreadable(tmp_path):
         "malformed-json",
     ],
 )
-def test_channel_write_denied(tmp_path, payload, expected):
+def test_write_tools_denied(tmp_path, payload, expected):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(payload, encoding="utf-8")
 
-    assert _hook()._channel_write_denied(settings_path) is expected
+    assert _hook()._write_tools_denied(settings_path, (CHANNEL_WRITE,)) is expected
 
 
-def test_channel_write_denied_is_none_when_file_missing(tmp_path):
-    assert _hook()._channel_write_denied(tmp_path / "settings.json") is None
+def test_write_tools_denied_is_none_when_file_missing(tmp_path):
+    assert _hook()._write_tools_denied(tmp_path / "settings.json", (CHANNEL_WRITE,)) is None
+
+
+def test_write_tools_denied_abstains_on_an_empty_tool_set(tmp_path):
+    """Nothing to compare is not "writes are allowed"."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(json.dumps({"permissions": {"deny": []}}), encoding="utf-8")
+
+    assert _hook()._write_tools_denied(settings_path, ()) is None
+
+
+def test_write_tools_denied_abstains_on_a_partial_deny(tmp_path):
+    """The kill switch renders the whole set together, so half of it is not a posture.
+
+    A hand-edited settings.json is what produces this, and the mtime check is
+    the signal for that — warning about the write posture would name the wrong
+    control.
+    """
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps({"permissions": {"deny": [CHANNEL_WRITE]}}), encoding="utf-8"
+    )
+
+    assert _hook()._write_tools_denied(settings_path, (CHANNEL_WRITE, CLONE_CHANNEL_WRITE)) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -234,12 +334,13 @@ def test_detect_drift_is_none_when_an_artifact_is_missing(tmp_path, missing):
     config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
     (config_path if missing == "config" else settings_path).unlink()
 
-    assert _hook()._detect_drift(config_path, settings_path) is None
+    hook_config_path = tmp_path / ".claude" / "hooks" / "hook_config.json"
+    assert _hook()._detect_drift(config_path, settings_path, hook_config_path) is None
 
 
 def test_detect_drift_fails_open_when_stat_raises():
     # Both signals blow up on IO: the hook returns no message rather than guessing.
-    assert _hook()._detect_drift(_RaisingPath(), _RaisingPath()) is None
+    assert _hook()._detect_drift(_RaisingPath(), _RaisingPath(), _RaisingPath()) is None
 
 
 def test_detect_drift_prefers_the_targeted_check_over_mtime(tmp_path):
@@ -248,9 +349,29 @@ def test_detect_drift_prefers_the_targeted_check_over_mtime(tmp_path):
     config_path, settings_path = _make_project(tmp_path, writes_enabled=True, channel_write=DENIED)
     _set_mtimes(config_path, settings_path, config_newer=True)
 
-    message = _hook()._detect_drift(config_path, settings_path)
+    hook_config_path = tmp_path / ".claude" / "hooks" / "hook_config.json"
+    message = _hook()._detect_drift(config_path, settings_path, hook_config_path)
     assert "still blocks writes" in message
     assert "changed since" not in message
+
+
+def test_detect_drift_sees_a_clone_the_framework_literal_would_miss(tmp_path):
+    """The #244 case on a deployment whose controls server is an `extends` clone.
+
+    Its kill switch denies `mcp__ring__channel_write`; nothing named `controls`
+    appears anywhere in the render. Probing the framework literal read that as
+    "not denied", so a config that had turned writes back ON matched a settings
+    file that still blocked them, and the operator was told nothing.
+    """
+    config_path, settings_path = _make_project(
+        tmp_path, writes_enabled=True, channel_write=DENIED, write_tool=CLONE_CHANNEL_WRITE
+    )
+    _set_mtimes(config_path, settings_path, config_newer=False)
+    hook_config_path = tmp_path / ".claude" / "hooks" / "hook_config.json"
+
+    message = _hook()._detect_drift(config_path, settings_path, hook_config_path)
+    assert message is not None
+    assert "still blocks writes" in message
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/hooks/test_error_guidance_hook.py
+++ b/tests/hooks/test_error_guidance_hook.py
@@ -733,6 +733,8 @@ EXPECTED_ERROR_CLASSES = {
     "configuration_error": "Internal",
     "not_configured": "Internal",
     "server_not_initialised": "Internal",
+    "bundle_not_configured": "Internal",
+    "bundle_load_failed": "Internal",
     "dependency_missing": "Internal",
     "conversion_error": "Internal",
     "capture_error": "Internal",

--- a/tests/hooks/test_limits_hook.py
+++ b/tests/hooks/test_limits_hook.py
@@ -125,6 +125,78 @@ def test_non_write_tools_pass(tmp_path, hook_runner):
 
 
 @pytest.mark.unit
+def test_clone_channel_write_is_validated(tmp_path, hook_runner):
+    """An `extends: controls` clone's channel_write is limits-checked too.
+
+    `build_extended_server` rewrites this hook's matcher to
+    `mcp__<clone>__channel_write`, so the hook already ran on these calls. Keyed
+    on the framework server's own literal name it exited 0 and reported nothing
+    — which in a transcript is indistinguishable from a write that passed.
+    """
+    config = _make_limits_config(
+        tmp_path,
+        {"TEST:PV": {"min_value": 0.0, "max_value": 100.0, "writable": True}},
+    )
+
+    result = hook_runner(
+        "osprey_limits.py",
+        "mcp__ring__channel_write",
+        {"operations": [{"channel": "TEST:PV", "value": 999.0}]},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config={"server_prefixes": ["mcp__ring__"]},
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.unit
+def test_clone_channel_read_still_passes(tmp_path, hook_runner):
+    """Short-name keying must not start denying a clone's reads."""
+    config = _make_limits_config(
+        tmp_path,
+        {"TEST:PV": {"min_value": 0.0, "max_value": 100.0, "writable": True}},
+    )
+
+    result = hook_runner(
+        "osprey_limits.py",
+        "mcp__ring__channel_read",
+        {"channels": ["TEST:PV"]},
+        config_path=config,
+        cwd=tmp_path,
+        hook_config={"server_prefixes": ["mcp__ring__"]},
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+def test_clone_is_validated_without_a_hook_config(tmp_path, hook_runner):
+    """No prefixes to read still resolves a short name from the tool's shape.
+
+    `short_tool_name` falls back to the `mcp__<server>__<tool>` split, so a
+    render whose hook_config could not be read still validates the write rather
+    than waving it through.
+    """
+    config = _make_limits_config(
+        tmp_path,
+        {"TEST:PV": {"min_value": 0.0, "max_value": 100.0, "writable": True}},
+    )
+
+    result = hook_runner(
+        "osprey_limits.py",
+        "mcp__ring__channel_write",
+        {"operations": [{"channel": "TEST:PV", "value": 999.0}]},
+        config_path=config,
+        cwd=tmp_path,
+    )
+
+    assert result is not None
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.unit
 def test_unlisted_channel_blocked_by_default(tmp_path, hook_runner):
     """Unlisted channels are blocked when allow_unlisted_channels is false (default)."""
     config = _make_limits_config(

--- a/tests/mcp_server/test_facility_knowledge_capabilities.py
+++ b/tests/mcp_server/test_facility_knowledge_capabilities.py
@@ -89,7 +89,6 @@ class TestCapabilities:
         assert "bundle_path" in result
         assert "count" in result
         assert "types" in result
-        assert "write_enabled" in result
 
     @pytest.mark.asyncio
     async def test_count_matches_concepts(self, fixture_bundle: Path):
@@ -131,12 +130,18 @@ class TestCapabilities:
         assert len(types) == len(set(types))
 
     @pytest.mark.asyncio
-    async def test_write_enabled_is_true(self):
+    async def test_no_write_enabled_field(self):
+        """The field was a constant `True` that no consumer read.
+
+        It described nothing: the shipped knowledge persona denies
+        `draft_concept` outright, so on that deployment the manifest said writes
+        were enabled while every write was refused.
+        """
         from osprey.mcp_server.facility_knowledge.server import capabilities
 
         result = json.loads(await get_tool_fn(capabilities)())
 
-        assert result["write_enabled"] is True
+        assert "write_enabled" not in result
 
     @pytest.mark.asyncio
     async def test_bundle_path_is_string(self, fixture_bundle: Path):
@@ -171,8 +176,54 @@ class TestCapabilities:
         from osprey.mcp_server.facility_knowledge.server import capabilities
 
         monkeypatch.setattr(srv, "_bundle", None)
+        monkeypatch.setattr(srv, "_bundle_error", None)
 
         with assert_raises_error(error_type="server_not_initialised"):
+            await get_tool_fn(capabilities)()
+
+    @pytest.mark.asyncio
+    async def test_an_unconfigured_bundle_names_the_config_key(self, monkeypatch):
+        """ "Start the server" is the wrong remedy for a config that names no bundle.
+
+        The server IS started; what is missing is `facility_knowledge.bundle_path`.
+        One error code for three causes sent the operator to restart something
+        that was already running.
+        """
+        import osprey.mcp_server.facility_knowledge.server as srv
+        from osprey.mcp_server.facility_knowledge.server import capabilities
+
+        monkeypatch.setattr(srv, "_bundle", None)
+        monkeypatch.setattr(
+            srv,
+            "_bundle_error",
+            (
+                "bundle_not_configured",
+                "This deployment names no facility knowledge bundle.",
+                ["Set `facility_knowledge.bundle_path` ..."],
+            ),
+        )
+
+        with assert_raises_error(error_type="bundle_not_configured"):
+            await get_tool_fn(capabilities)()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_load_names_the_resolved_path(self, monkeypatch):
+        """A bundle that would not load is a third fault with a third fix."""
+        import osprey.mcp_server.facility_knowledge.server as srv
+        from osprey.mcp_server.facility_knowledge.server import capabilities
+
+        monkeypatch.setattr(srv, "_bundle", None)
+        monkeypatch.setattr(
+            srv,
+            "_bundle_error",
+            (
+                "bundle_load_failed",
+                "The facility knowledge bundle at /srv/okf could not be loaded: no index.md",
+                ["Check that /srv/okf exists ..."],
+            ),
+        )
+
+        with assert_raises_error(error_type="bundle_load_failed"):
             await get_tool_fn(capabilities)()
 
     @pytest.mark.asyncio
@@ -205,3 +256,59 @@ class TestRegistryPermissions:
             "'capabilities' is missing from osprey_facility_knowledge.permissions_allow "
             f"(current: {sdef.permissions_allow!r})"
         )
+
+
+# ---------------------------------------------------------------------------
+# create_server records WHICH fault left the bundle unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestBundleFailureCause:
+    """Three faults, three fixes — so three error codes, decided at startup.
+
+    ``_get_bundle`` runs long after the config was read and cannot tell an
+    absent ``bundle_path`` from one that would not load. ``create_server`` can,
+    and is the only place that can, so it records the cause there.
+    """
+
+    def _run_create_server(self, monkeypatch, tmp_path: Path, config: dict):
+        import osprey.mcp_server.facility_knowledge.server as srv
+        import osprey.utils.workspace as workspace
+
+        monkeypatch.setattr(workspace, "resolve_config_path", lambda: tmp_path / "config.yml")
+        monkeypatch.setattr(workspace, "load_osprey_config", lambda: config)
+        monkeypatch.setattr(srv, "_bundle", None)
+        monkeypatch.setattr(srv, "_bundle_error", None)
+
+        srv.create_server()
+        return srv
+
+    def test_absent_bundle_path_is_recorded_as_not_configured(self, monkeypatch, tmp_path):
+        srv = self._run_create_server(monkeypatch, tmp_path, {})
+
+        assert srv._bundle is None
+        assert srv._bundle_error is not None
+        code, message, remedies = srv._bundle_error
+        assert code == "bundle_not_configured"
+        assert any("facility_knowledge.bundle_path" in r for r in remedies), remedies
+        assert "start" not in message.lower()
+
+    def test_unloadable_bundle_is_recorded_with_its_resolved_path(self, monkeypatch, tmp_path):
+        missing = tmp_path / "not-a-bundle"
+        srv = self._run_create_server(
+            monkeypatch, tmp_path, {"facility_knowledge": {"bundle_path": str(missing)}}
+        )
+
+        assert srv._bundle is None
+        assert srv._bundle_error is not None
+        code, message, _remedies = srv._bundle_error
+        assert code == "bundle_load_failed"
+        assert str(missing) in message
+
+    def test_a_loadable_bundle_records_no_cause(self, monkeypatch, tmp_path, fixture_bundle):
+        srv = self._run_create_server(
+            monkeypatch, tmp_path, {"facility_knowledge": {"bundle_path": str(fixture_bundle)}}
+        )
+
+        assert srv._bundle is not None
+        assert srv._bundle_error is None

--- a/tests/mcp_server/test_python_execute_safety.py
+++ b/tests/mcp_server/test_python_execute_safety.py
@@ -186,6 +186,10 @@ def _readonly_import_issues(code):
         pytest.param("import pvaccess", id="pvaccess"),
         pytest.param("import tango", id="tango"),
         pytest.param("from PyTango import DeviceProxy", id="pytango"),
+        pytest.param("import doocs4py", id="doocs4py"),
+        pytest.param("from doocs4py import set as _w", id="doocs4py-alias"),
+        pytest.param("import aioca", id="aioca"),
+        pytest.param("from aioca import caput", id="aioca-from-import"),
         pytest.param("def f():\n    import epics\n    return epics", id="nested-in-function"),
     ],
 )
@@ -193,6 +197,25 @@ def test_readonly_imports_denied(code):
     issues = _readonly_import_issues(code)
     assert issues, code
     assert all("readonly" in i for i in issues), issues
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param("from ophyd_async.core import SignalRW", id="ophyd-async"),
+        pytest.param("import bluesky", id="bluesky"),
+        pytest.param("from bluesky import RunEngine", id="bluesky-run-engine"),
+    ],
+)
+def test_readonly_allows_framework_imports(code):
+    """Frameworks are not import-denied; only their write calls refuse.
+
+    ophyd-async and Bluesky are how a readonly script reads a device tree or a
+    catalog. Denying the import would refuse legitimate analysis; the runtime
+    guard refuses the calls that move hardware instead.
+    """
+    assert _readonly_import_issues(code) == []
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/test_python_execute_safety.py
+++ b/tests/mcp_server/test_python_execute_safety.py
@@ -162,6 +162,57 @@ def test_quick_safety_check_standalone():
 
 
 # ============================================================================
+# eval / exec matching — a CALL of a bare name, not a substring
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param("retrieval(query)", id="name-contains-eval"),
+        pytest.param("df.eval('a + b')", id="pandas-expression"),
+        pytest.param("model.eval()", id="torch-inference-mode"),
+        pytest.param("s = 'eval('", id="inside-a-string"),
+        pytest.param("# eval(x)\nprint(1)", id="inside-a-comment"),
+        pytest.param("executor(job)", id="name-contains-exec"),
+        pytest.param("ctx.exec(stmt)", id="attribute-exec"),
+    ],
+)
+def test_ordinary_code_is_not_flagged_as_dynamic_evaluation(code):
+    """``pattern in code`` refused ordinary analysis for containing ``eval(``.
+
+    None of these runs caller-supplied code, and every one of them is code an
+    operator has a real reason to submit — so refusing them trains people to
+    work around the executor rather than through it.
+    """
+    from osprey.services.python_executor.analysis.safety_checks import quick_safety_check
+
+    passed, issues = quick_safety_check(code)
+    assert passed is True, issues
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param("exec('print(1)')", id="exec"),
+        pytest.param("result = eval('2 + 2')", id="eval"),
+        pytest.param("__import__('os').system('ls')", id="dunder-import"),
+        pytest.param("compile('x = 1', '<s>', 'exec')", id="compile"),
+        pytest.param("def f():\n    return eval(user_input)", id="nested-in-function"),
+    ],
+)
+def test_dynamic_evaluation_calls_are_still_refused(code):
+    """Narrowing the match must not let the real thing through."""
+    from osprey.services.python_executor.analysis.safety_checks import quick_safety_check
+
+    passed, issues = quick_safety_check(code)
+    assert passed is False
+    assert any("Security risk" in i for i in issues), issues
+
+
+# ============================================================================
 # readonly import denylist — control-system client libraries
 # ============================================================================
 

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -426,6 +426,51 @@ class TestResolveServers:
         # Warning should have been logged
         assert any("bogus" in r.message for r in caplog.records)
 
+    def test_limits_preset_warns_that_it_only_knows_channel_write(self, caplog):
+        """`limits` on a custom server reads like a guarantee it cannot give.
+
+        The rendered rule matches every tool on the server, but the hook only
+        understands a channel_write-shaped call — a `channel`/`value` pair or an
+        `operations` list — and abstains on anything else. Abstaining is right
+        (denying would deny reads), which is exactly why the config line has to
+        be told about at build time rather than discovered from an unchecked
+        write.
+        """
+        ctx = _base_ctx()
+        cfg = {
+            "servers": {
+                "my-plc": {
+                    "command": "python",
+                    "args": ["-m", "my_plc_server"],
+                    "hooks": {"pre_tool_use": ["limits"]},
+                    "permissions": {"ask": ["set_output"]},
+                }
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            resolve_servers(cfg, ctx)
+
+        assert "channel_write-shaped" in caplog.text
+        assert "my-plc" in caplog.text
+
+    def test_no_limits_warning_without_the_limits_preset(self, caplog):
+        """The warning names a real risk, so it must not fire on every server."""
+        ctx = _base_ctx()
+        cfg = {
+            "servers": {
+                "my-plc": {
+                    "command": "python",
+                    "args": ["-m", "my_plc_server"],
+                    "hooks": {"pre_tool_use": ["approval"]},
+                    "permissions": {"ask": ["set_output"]},
+                }
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            resolve_servers(cfg, ctx)
+
+        assert "channel_write-shaped" not in caplog.text
+
     def test_custom_server_no_hooks_key(self):
         """Custom server without hooks key gets no pre-tool-use hooks."""
         ctx = _base_ctx()

--- a/tests/registry/test_tool_classification_drift.py
+++ b/tests/registry/test_tool_classification_drift.py
@@ -1,0 +1,132 @@
+"""Every framework MCP tool must be classified by the registry.
+
+The registry is where a tool is told apart from a write: ``permissions_allow``
+and ``permissions_ask`` decide what the rendered ``settings.json`` auto-approves
+and what it prompts for, and ``hooks_pre`` decides which gate runs first.
+``agent_runner.write_tools`` derives the headless read-only block list from those
+same lists, so a tool in none of them is a tool the headless path will happily
+call — which is exactly how ``entry_publish`` shipped able to write through to a
+facility logbook with no gate at all.
+
+This test walks the *live* servers rather than any list of names, so a tool
+added to a ``tools/`` module and forgotten in the registry fails here.
+
+The known gaps are recorded rather than waved through: the assertion is
+equality, so closing one shows up as a failure too, and nothing can be added
+to the baseline by accident.
+"""
+
+import asyncio
+import importlib
+import pkgutil
+
+import pytest
+
+from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+pytestmark = pytest.mark.unit
+
+
+#: Tools registered by a framework server but named nowhere in its registry
+#: entry, as of this test's introduction. Pre-existing, and not this test's
+#: business to fix — recorded so that a NEW one is a failure rather than an
+#: eleventh line in a list nobody reads.
+_UNCLASSIFIED_BASELINE: dict[str, set[str]] = {
+    "osprey_workspace": {
+        "add_panel_to_rail",
+        "artifact_pin",
+        "lattice_clear_baseline",
+        "lattice_get_data",
+        "lattice_get_figure",
+        "lattice_get_settings",
+        "lattice_update_settings",
+        "register_panel",
+        "remove_panel_from_rail",
+    },
+}
+
+
+def _registered_tool_names(module: str) -> set[str]:
+    """Tool names the live FastMCP singleton of *module* registers.
+
+    Importing the server module and every module under its ``tools`` package is
+    what runs the ``@mcp.tool()`` decorators; ``create_server()`` is deliberately
+    not called, since it does heavy config and workspace startup. A server whose
+    tools live in ``server.py`` itself has no ``tools`` package, which is not an
+    error.
+    """
+    server_mod = importlib.import_module(f"{module}.server")
+    try:
+        tools_pkg = importlib.import_module(f"{module}.tools")
+    except ModuleNotFoundError:
+        tools_pkg = None
+    if tools_pkg is not None:
+        for found in pkgutil.iter_modules(tools_pkg.__path__):
+            importlib.import_module(f"{module}.tools.{found.name}")
+    # ``list_tools`` is FastMCP's public listing; the private
+    # ``_list_tools`` an upgrade may rename would turn this safety guard
+    # into a collection error instead of a verdict.
+    tools = asyncio.run(server_mod.mcp.list_tools())
+    return {getattr(tool, "name", tool) for tool in tools}
+
+
+def _classified_tool_names(server) -> set[str]:
+    """Every tool name this server's registry entry accounts for.
+
+    A tool counts as classified when a permission list names it *or* a
+    ``hooks_pre`` matcher does: ``channel_read`` and ``archiver_read`` sit in no
+    permission list on purpose — they are governed by the approval hook's own
+    per-tool policy — and that is a decision, not a gap.
+    """
+    names = {
+        *server.permissions_allow,
+        *server.permissions_ask,
+        *server.fixed_allow,
+        *server.fixed_ask,
+    }
+    prefix = f"mcp__{server.name}__"
+    for rule in server.hooks_pre:
+        if rule.matcher.startswith(prefix):
+            names.add(rule.matcher[len(prefix) :])
+    return names
+
+
+_WALKABLE = sorted(name for name, s in FRAMEWORK_SERVERS.items() if "{" not in s.module)
+
+
+def test_every_framework_server_is_walkable_or_templated():
+    """The walk must not go quiet because a module path stopped resolving."""
+    assert set(_WALKABLE) | {"channel-finder"} == set(FRAMEWORK_SERVERS)
+
+
+@pytest.mark.parametrize("server_name", _WALKABLE)
+def test_registered_tools_are_classified_by_the_registry(server_name):
+    server = FRAMEWORK_SERVERS[server_name]
+    registered = _registered_tool_names(server.module)
+    assert registered, f"{server_name} registered no tools — the walk found nothing to check"
+
+    unclassified = registered - _classified_tool_names(server)
+    expected = _UNCLASSIFIED_BASELINE.get(server_name, set())
+
+    assert unclassified == expected, (
+        f"{server_name}: tools the registry does not classify changed.\n"
+        f"  newly unclassified: {sorted(unclassified - expected)}\n"
+        f"  newly classified (drop them from the baseline): {sorted(expected - unclassified)}"
+    )
+
+
+def test_ariel_gates_both_halves_of_a_logbook_write():
+    """entry_create drafts the entry; entry_publish is what reaches the logbook.
+
+    Gating only the draft prompts for the half that never leaves the deployment.
+    Pinned by name as well as by the walk above: parity alone would stay green
+    if both tools lost their gate together.
+    """
+    ariel = FRAMEWORK_SERVERS["ariel"]
+
+    assert "entry_create" in ariel.permissions_ask
+    assert "entry_publish" in ariel.permissions_ask
+
+    gated = {rule.matcher for rule in ariel.hooks_pre}
+    assert "mcp__ariel__entry_create" in gated
+    assert "mcp__ariel__entry_publish" in gated

--- a/tests/services/bluesky_bridge/test_capability_surface.py
+++ b/tests/services/bluesky_bridge/test_capability_surface.py
@@ -238,6 +238,23 @@ def test_health_fails_closed_on_an_unsupported_connector(connector, bridge) -> N
     assert capability["reason"] == qb.REASON_UNSUPPORTED_CONNECTOR
 
 
+def test_an_unsupported_connector_is_not_told_to_run_the_simulator(connector, bridge) -> None:
+    """A production deployment on another protocol is not a misconfiguration.
+
+    The flip command points a deployment at the simulator. Offering it to a
+    facility whose machine speaks DOOCS reads as "swap your control system for
+    a simulator" — the one remedy that cannot be right. State the condition
+    instead: the queue worker builds its devices over Channel Access.
+    """
+    connector("doocs")
+
+    with bridge(_ScriptedManager()) as client:
+        capability = _capability(client.get("/health"))
+
+    assert qb.FLIP_COMMAND not in capability["detail"]
+    assert "Channel Access" in capability["detail"]
+
+
 def test_health_fails_closed_without_a_configured_manager(connector, bridge) -> None:
     connector("virtual_accelerator")
 

--- a/tests/services/bluesky_bridge/test_plan_validation.py
+++ b/tests/services/bluesky_bridge/test_plan_validation.py
@@ -198,6 +198,17 @@ class TestVizSandboxRegression:
         assert ("write_channel", "write_channel()") in _DANGEROUS_PATTERNS
         assert ("ctypes", "ctypes module") in _DANGEROUS_PATTERNS
 
+    def test_dangerous_patterns_name_every_shipped_client(self):
+        """The blocklist names pyepics and Tango; it must name DOOCS too.
+
+        A sandbox that blocks the clients one facility uses and not the ones
+        another facility uses is not a blocklist, it is a coincidence.
+        ``aioca`` is here for a second reason: ophyd-async pulls it into every
+        environment, installed or not.
+        """
+        assert ("doocs4py", "doocs4py module") in _DANGEROUS_PATTERNS
+        assert ("aioca", "aioca module") in _DANGEROUS_PATTERNS
+
     def test_viz_single_arg_call_still_behaves_identically(self):
         """The pre-existing single-positional-arg call (the viz sandbox's own
         caller, `sandbox_executor.py`'s `execute_sandbox_code`) must see the

--- a/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
+++ b/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
@@ -1,0 +1,350 @@
+"""Limits parity for the non-EPICS clients in the generated wrapper monkeypatch.
+
+A readwrite run is limits-checked, but only for the clients the wrapper knows
+how to intercept. Tango, DOOCS and caproto were in the *readonly* write surface
+— so a readonly run refused them — while a readwrite run let them past the
+limits database that ``epics.caput`` and every p4p flavour are checked against.
+That asymmetry is what these tests pin shut.
+
+Like the p4p monkeypatch tests, they execute the generated *source text*
+against fake client modules injected into ``sys.modules``: the block is emitted
+to run inside the executor subprocess, so there is no object to patch here.
+"""
+
+import contextlib
+import io
+import sys
+from types import ModuleType
+
+import pytest
+
+from osprey.connectors.control_system.limits_validator import (
+    ChannelLimitsConfig,
+    LimitsValidator,
+)
+from osprey.errors import ChannelLimitsViolationError
+from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_epics():
+    """Keep the block's own epics branch off any real pyepics install."""
+    mod = ModuleType("epics")
+
+    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+        return 1
+
+    class PV:
+        def __init__(self, pvname):
+            self.pvname = pvname
+
+        def put(self, value, wait=False, timeout=60, **kwargs):
+            return 1
+
+    mod.caput = caput
+    mod.PV = PV
+    return mod
+
+
+def _install_fake_tango(monkeypatch, writes):
+    mod = ModuleType("tango")
+
+    class DeviceProxy:
+        def __init__(self, name):
+            self._name = name
+
+        def dev_name(self):
+            return self._name
+
+        def write_attribute(self, attr, value):
+            writes.append((attr, value))
+            return "written"
+
+        def write_attributes(self, name_val):
+            writes.extend(list(name_val))
+            return "written"
+
+        def read_attribute(self, attr):
+            return 1.0
+
+    mod.DeviceProxy = DeviceProxy
+    monkeypatch.setitem(sys.modules, "tango", mod)
+    return mod
+
+
+def _install_fake_doocs(monkeypatch, writes):
+    mod = ModuleType("doocs4py")
+
+    def _set(address, value):
+        writes.append((address, value))
+        return "written"
+
+    mod.set = _set
+    monkeypatch.setitem(sys.modules, "doocs4py", mod)
+    return mod
+
+
+def _install_fake_caproto(monkeypatch, writes):
+    """Inject a fake ``caproto`` with both write entry points."""
+    caproto_mod = ModuleType("caproto")
+    sync_mod = ModuleType("caproto.sync")
+    sync_client = ModuleType("caproto.sync.client")
+    threading_mod = ModuleType("caproto.threading")
+    threading_client = ModuleType("caproto.threading.client")
+
+    def write(pv_name, data, **kwargs):
+        writes.append((pv_name, data))
+        return "written"
+
+    class PV:
+        def __init__(self, name):
+            self.name = name
+
+        def write(self, data, **kwargs):
+            writes.append((self.name, data))
+            return "written"
+
+        def read(self):
+            return 1.0
+
+    sync_client.write = write
+    threading_client.PV = PV
+    sync_mod.client = sync_client
+    threading_mod.client = threading_client
+    caproto_mod.sync = sync_mod
+    caproto_mod.threading = threading_mod
+
+    for name, mod in (
+        ("caproto", caproto_mod),
+        ("caproto.sync", sync_mod),
+        ("caproto.sync.client", sync_client),
+        ("caproto.threading", threading_mod),
+        ("caproto.threading.client", threading_client),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+    return sync_client, threading_client
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _make_validator():
+    limits = {
+        "sys/tg_test/1/current": ChannelLimitsConfig(
+            channel_address="sys/tg_test/1/current", min_value=0.0, max_value=10.0
+        ),
+        "sys/tg_test/1/voltage": ChannelLimitsConfig(
+            channel_address="sys/tg_test/1/voltage", min_value=0.0, max_value=10.0
+        ),
+        "FACILITY/MAGNET/H1/CURRENT.SP": ChannelLimitsConfig(
+            channel_address="FACILITY/MAGNET/H1/CURRENT.SP",
+            min_value=0.0,
+            max_value=10.0,
+        ),
+        "TEST:MAG:SP": ChannelLimitsConfig(
+            channel_address="TEST:MAG:SP", min_value=0.0, max_value=10.0
+        ),
+    }
+    return LimitsValidator(limits, {"allow_unlisted_channels": False})
+
+
+def _run_monkeypatch(monkeypatch):
+    """Execute the generated monkeypatch block; return its stdout."""
+    monkeypatch.setitem(sys.modules, "epics", _make_fake_epics())
+
+    import osprey.runtime as runtime_module
+
+    monkeypatch.setattr(runtime_module, "_limits_validator", None, raising=False)
+
+    source = ExecutionWrapper(limits_validator=_make_validator())._get_limits_checking_monkeypatch()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        exec(compile(source, "<generated-wrapper>", "exec"), {})
+    out = buf.getvalue()
+    assert "Limits checking setup failed" not in out, out
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tango
+# ---------------------------------------------------------------------------
+
+
+def test_tango_write_attribute_within_limits_reaches_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attribute("current", 5.0) == "written"
+    assert writes == [("current", 5.0)]
+
+
+def test_tango_write_attribute_out_of_bounds_raises_before_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attribute("current", 99.0)
+    assert writes == []
+
+
+def test_tango_channel_is_the_full_device_attribute_address(monkeypatch):
+    """A limits database is keyed by ``device/attribute``, not by the attribute.
+
+    Validating the bare attribute name would look up a channel the database
+    has never heard of — which, on a deployment that allows unlisted channels,
+    is a write that passes without being checked at all.
+    """
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    # Another device with the same attribute name is not in the database.
+    other = mod.DeviceProxy("sys/tg_test/2")
+    with pytest.raises(ChannelLimitsViolationError):
+        other.write_attribute("current", 5.0)
+    assert writes == []
+
+
+def test_tango_write_attributes_checks_every_pair(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attributes([("current", 5.0), ("voltage", 4.0)]) == "written"
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+    writes.clear()
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attributes([("current", 5.0), ("voltage", 99.0)])
+    assert writes == []
+
+
+def test_tango_write_attributes_forwards_a_consumed_iterator(monkeypatch):
+    """A generator of pairs must still reach the device.
+
+    The guard has to materialise the argument to check every pair, which
+    exhausts an iterator. Forwarding the original then writes nothing at all —
+    silently, with the caller told the write succeeded.
+    """
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    pairs = iter([("current", 5.0), ("voltage", 4.0)])
+    assert proxy.write_attributes(pairs) == "written"
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+
+def test_tango_write_attributes_fails_closed_on_an_unpairable_shape(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ValueError, match="pairs"):
+        proxy.write_attributes([object()])
+    assert writes == []
+
+
+# ---------------------------------------------------------------------------
+# DOOCS
+# ---------------------------------------------------------------------------
+
+
+def test_doocs_set_within_limits_reaches_the_machine(monkeypatch):
+    writes: list = []
+    mod = _install_fake_doocs(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    address = "FACILITY/MAGNET/H1/CURRENT.SP"
+    assert mod.set(address, 5.0) == "written"
+    assert writes == [(address, 5.0)]
+
+
+def test_doocs_set_out_of_bounds_raises_before_the_machine(monkeypatch):
+    writes: list = []
+    mod = _install_fake_doocs(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.set("FACILITY/MAGNET/H1/CURRENT.SP", 99.0)
+    assert writes == []
+
+
+# ---------------------------------------------------------------------------
+# caproto
+# ---------------------------------------------------------------------------
+
+
+def test_caproto_sync_write_is_limits_checked(monkeypatch):
+    writes: list = []
+    sync_client, _ = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    assert sync_client.write("TEST:MAG:SP", 5.0) == "written"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+    writes.clear()
+    with pytest.raises(ChannelLimitsViolationError):
+        sync_client.write("TEST:MAG:SP", 99.0)
+    assert writes == []
+
+
+def test_caproto_threading_pv_write_is_limits_checked(monkeypatch):
+    writes: list = []
+    _, threading_client = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    pv = threading_client.PV("TEST:MAG:SP")
+    assert pv.write(5.0) == "written"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+    writes.clear()
+    with pytest.raises(ChannelLimitsViolationError):
+        pv.write(99.0)
+    assert writes == []
+    assert pv.read() == 1.0, "reads must survive the guard untouched"
+
+
+# ---------------------------------------------------------------------------
+# Absence
+# ---------------------------------------------------------------------------
+
+
+def test_absent_clients_do_not_stop_the_block(monkeypatch):
+    """One client missing must not skip the guards after it.
+
+    Each client gets its own try/except for the same reason the p4p flavours
+    do: the outer swallow-all handler would drop every guard that had not been
+    installed yet.
+    """
+    for name in (
+        "tango",
+        "doocs4py",
+        "caproto",
+        "caproto.sync",
+        "caproto.sync.client",
+        "caproto.threading",
+        "caproto.threading.client",
+    ):
+        monkeypatch.setitem(sys.modules, name, None)
+    writes: list = []
+    _install_fake_doocs(monkeypatch, writes)
+
+    out = _run_monkeypatch(monkeypatch)
+    assert "tango not available" in out
+    assert "✅ Monkeypatched doocs4py.set()" in out

--- a/tests/services/python_executor/execution/test_readonly_guard.py
+++ b/tests/services/python_executor/execution/test_readonly_guard.py
@@ -423,6 +423,99 @@ def test_readonly_refuses_tango_write_attribute(monkeypatch):
     assert proxy.read_attribute("current") == 1.0, "reads must survive the guard untouched"
 
 
+def test_readonly_refuses_doocs4py_set(monkeypatch):
+    """The DOOCS connector's own client is guarded like every other client.
+
+    A DOOCS deployment is guaranteed to have ``doocs4py`` importable, so a
+    readonly script naming it is not a hypothetical route to the machine — it
+    is the route the shipped connector itself writes through.
+    """
+    mod = ModuleType("doocs4py")
+    writes: list = []
+
+    def _set(address, value):
+        writes.append((address, value))
+
+    def _get(address):
+        return 1.0
+
+    mod.set = _set
+    mod.get = _get
+    monkeypatch.setitem(sys.modules, "doocs4py", mod)
+    _run_guard("readonly")
+
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        mod.set("FACILITY/MAGNET/H1/CURRENT.SP", 150)
+    assert writes == []
+    assert mod.get("FACILITY/MAGNET/H1/CURRENT.RBV") == 1.0, (
+        "reads must survive the guard untouched"
+    )
+
+
+def test_readonly_refuses_aioca_caput(monkeypatch):
+    """aioca is in every OSPREY environment via ``ophyd-async[ca]``.
+
+    Unlike pyepics it needs no facility-specific install, so it is the Channel
+    Access client a readonly script is most likely to actually find.
+    """
+    mod = ModuleType("aioca")
+    writes: list = []
+
+    async def caput(pv, value, **kwargs):
+        writes.append((pv, value))
+
+    async def caget(pv, **kwargs):
+        return 1.0
+
+    mod.caput = caput
+    mod.caget = caget
+    monkeypatch.setitem(sys.modules, "aioca", mod)
+    _run_guard("readonly")
+
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        mod.caput("SR:MAG:QF:01:CURRENT:SP", 150)
+    assert writes == []
+    assert asyncio.run(mod.caget("SR:MAG:QF:01:CURRENT")) == 1.0, (
+        "reads must survive the guard untouched"
+    )
+
+
+def test_every_client_package_is_also_denied_at_import():
+    """The runtime guard and the static denylist name the same libraries.
+
+    They are two halves of one gate — the denylist stops the import, the guard
+    stops the call — and a client present in only one of them is a client a
+    readonly script can still reach. Deriving both from one table is what makes
+    that impossible; this pins the derivation.
+    """
+    from osprey.services.python_executor.analysis.safety_checks import (
+        _READONLY_DENIED_IMPORTS,
+    )
+    from osprey.services.python_executor.write_surface import _CLIENT_WRITE_TARGETS
+
+    packages = {dotted.split(".")[0] for dotted, _attrs in _CLIENT_WRITE_TARGETS}
+    assert packages <= set(_READONLY_DENIED_IMPORTS)
+    assert {"doocs4py", "aioca"} <= packages
+
+
+def test_framework_write_targets_stay_importable():
+    """Acquisition frameworks refuse their writes but are not import-denied.
+
+    ophyd-async and Bluesky are document and analysis libraries as much as they
+    are hardware drivers; denying the import would refuse a readonly script
+    that only reads a catalog. Their write entry points are in the runtime
+    guard instead.
+    """
+    from osprey.services.python_executor.analysis.safety_checks import (
+        _READONLY_DENIED_IMPORTS,
+    )
+    from osprey.services.python_executor.write_surface import _FRAMEWORK_WRITE_TARGETS
+
+    packages = {dotted.split(".")[0] for dotted, _attrs in _FRAMEWORK_WRITE_TARGETS}
+    assert packages == {"ophyd_async", "bluesky"}
+    assert not packages & set(_READONLY_DENIED_IMPORTS)
+
+
 # ---------------------------------------------------------------------------
 # Routes out of Python
 #

--- a/tests/services/python_executor/test_p4p_patterns.py
+++ b/tests/services/python_executor/test_p4p_patterns.py
@@ -288,3 +288,53 @@ def test_requests_post_is_not_a_control_system_write():
     result = detect(code)
 
     assert result["has_writes"] is False
+
+
+# ============================================================================
+# DOOCS - the connector's own client, anchored the way p4p is
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            "import doocs4py\ndoocs4py.set('FACILITY/MAGNET/H1/CURRENT.SP', 1.5)\n",
+            id="doocs-qualified-set",
+        ),
+        pytest.param(
+            "import doocs4py as d\nd.set('FACILITY/MAGNET/H1/CURRENT.SP', 1.5)\n",
+            id="doocs-aliased-set",
+        ),
+    ],
+)
+def test_doocs_set_is_detected_as_a_write(code):
+    """doocs4py.set is what the shipped DOOCS connector writes through."""
+    result = detect(code)
+
+    assert result["has_writes"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param("settings = {}\nsettings.set('a', 1)\n", id="unrelated-set"),
+        pytest.param("frozenset().set\n", id="attribute-only"),
+    ],
+)
+def test_bare_set_is_not_a_doocs_write(code):
+    """The DOOCS entry is anchored, so ordinary set() calls stay quiet."""
+    result = detect(code)
+
+    assert result["has_writes"] is False
+
+
+@pytest.mark.unit
+def test_no_bare_set_pattern():
+    """A bare ``.set(`` would flag half of ordinary analysis code."""
+    patterns = get_framework_standard_patterns()
+
+    assert r"\.set\s*\(" not in patterns["write"]
+    assert r"\.set\s*\(" not in patterns["read"]


### PR DESCRIPTION
Closes the parity gaps in the Python write-guard tables, the hook gates and the tool wiring, so every write path derives its guard surface from what the deployment actually renders rather than from a hand-written list of client spellings.

Commits, in order:

1. `fix(python-executor): cover doocs4py, aioca and the scan-stack write entry points in the readonly write surface`
2. `fix(python-executor): limits-check Tango, caproto and DOOCS client writes like pyepics and p4p`
3. `fix(python-executor): name doocs4py in the write classifier, the hook fallback and the sandbox blocklist`
4. `fix(python-executor): match eval/exec on AST calls, not substrings`
5. `fix(python-executor): describe the execute tool's safety layers without naming one client`
6. `fix(registry): gate ariel entry_publish like entry_create`
7. `fix(hooks): key the limits and config-drift hooks on the rendered write_tools, not one literal`
8. `fix(facility-knowledge): drop the constant write_enabled and name the real bundle failure`
9. `fix(bluesky): stop prescribing the simulator on the unsupported-connector refusal`
10. `fix(cli): discard the .env a failed init seeded`

## Why

The guard tables hand-enumerated client spellings, so what a deployment was protected against depended on which libraries someone happened to think of. The shipped DOOCS connector's own client, `doocs4py`, was guarded nowhere — not in the readonly runtime guard, not in the import denylist, not in the write classifier, not in the viz sandbox blocklist. `aioca` was in none of them either, and ophyd-async's `[ca]` extra puts it in every environment OSPREY builds. The readonly guard and the static import denylist were two literals that had to agree with no producer making them agree; they now come from one table in `services/python_executor/write_surface.py`, so a client added there is enforced at import and at the call in the same change. Acquisition frameworks (ophyd-async signals, `bluesky.RunEngine`) refuse their writes at runtime while staying importable for analysis. In a readwrite run, Tango, caproto and DOOCS writes are now limits-checked the way pyepics and p4p already were.

The gate side had the same shape. `entry_publish` — the tool that writes an ARIEL entry through to the facility's logbook — sat in no permission list and carried no hook, while the agent brief and the standalone app's README both promised a gate on it; because the headless read-only block list is derived from `permissions_ask`, a headless query could publish to the logbook with nothing in its path. The limits and config-drift hooks were written against the literal `mcp__controls__channel_write`, so on an `extends` clone the limits hook fired and validated nothing (in a transcript that is indistinguishable from a write that passed) and the drift check claimed nothing about the write posture while looking like it had checked. Both now key on what this render generated: the short tool name, and the `write_tools` list in `hook_config.json`.

The result for a deployer: adding a control-system client to `write_surface.py` is the whole change needed to enforce it; a facility on DOOCS or Tango gets the same readonly refusals, the same limits checking and the same approval prompts an EPICS facility gets; and a deployment whose controls server is a clone gets its limits and drift checks back. Three refusals that gave advice a deployer could not act on — resubmit shell-out work as readwrite, restart a server whose config named no bundle, swap a production machine for the simulator — now name the condition and the key that moves it. A registry drift test walks every framework server's live tool surface and fails when a tool is classified nowhere, so the next write tool cannot ship unnoticed.

Commit 10 is a deflake, not part of the write-guard work. `test_failed_round_trip_after_mkdir_removes_the_target` passed or failed depending on whether the run's shell exported a provider API key: a key seeds the new repo's `.env`, cleanup leaves an `.env` alone because in a deployment repo that file is the operator's, and the leftover kept the repo root non-empty so the failed run could not undo the directory it had created. A failed init now discards an `.env` it seeded itself — tracked the way seeded write-once directories already are — and still leaves one it found. The refusal's "Nothing was materialized" is true again, and the next attempt no longer refuses a name nothing successfully used.

Every change moves in the refusing direction, with one deliberate exception: `check_security` matched `eval`/`exec` as substrings, so `retrieval(`, `df.eval("a + b")` and `model.eval()` were refused as dynamic evaluation. That is now an AST match on a call of the bare name, and `compile` joins the set.

## Not in this PR

- Connector write paths stay as they are: flipping them from fail-open to fail-closed is a separate change set in `packages/osprey-connectors`, and it changes a validator signature this PR's sandbox code consumes. It rebases onto this one.
- `entry_publish` is deliberately **not** writes-check gated. Whether a logbook write-through belongs under the hardware kill switch is one question for every non-hardware write, and it gets one answer elsewhere rather than an ad-hoc one here.
- The nine workspace-server tools the registry classifies nowhere are recorded as a named baseline in the new drift test, not fixed here.
- The `facility_knowledge.write_enabled` config key that `draft_concept` would also honour: the unread constant is deleted rather than replaced.

