### PR TITLE
fix(safety): fail closed on TLS, tier gate, secret dump and unvalidated config values

### DIFF
--- a/changelog.d/api-protocol.changed.md
+++ b/changelog.d/api-protocol.changed.md
@@ -1,0 +1,6 @@
+`api.providers.<name>.api_protocol` now accepts only `anthropic` and `openai`.
+Anything else — a capitalised `Anthropic`, a typo — is refused when the
+provider is resolved, naming the provider and the two accepted values. It
+previously read as "not Anthropic" and silently inserted the OpenAI
+translation proxy in front of a gateway that speaks Anthropic natively. An
+absent key still means OpenAI.

--- a/changelog.d/archiver-date.changed.md
+++ b/changelog.d/archiver-date.changed.md
@@ -1,0 +1,6 @@
+`archiver_read` no longer guesses at ambiguous dates. `start_time` and
+`end_time` accept ISO-8601, relative expressions like `2h ago`, and `now`; a
+dotted or slashed date such as `03.04.2026` — which reads as two dates a month
+apart depending on where you are — is now a validation error naming the
+accepted spellings, instead of being read month-first and stamped
+facility-local.

--- a/changelog.d/config-panel-gate.security.md
+++ b/changelog.d/config-panel-gate.security.md
@@ -1,0 +1,6 @@
+The ARIEL panel's settings editor now honours `web.config_panel.enabled`.
+A deployment that has taken the Config panel away gets `403` from both
+`GET` and `PUT /api/config` there, as it already did on the web terminal, and
+the Settings entry disappears from ARIEL's display menu. Previously the key
+hid the terminal's tab while ARIEL still served — and accepted — the whole
+document, provider base URLs included.

--- a/changelog.d/generate-source.changed.md
+++ b/changelog.d/generate-source.changed.md
@@ -1,0 +1,8 @@
+`osprey channel-finder generate` now requires you to say where the channels
+come from: `--source PATH` for your own hierarchical database, or `--demo` for
+the packaged one. It also refuses to overwrite database files that already
+exist unless you pass `--force`. A bare `generate` used to write the packaged
+demo machine's ~2900 channels straight into `data/channel_databases/` — the
+files the pipelines read — replacing a facility's own database. Generated
+`in_context.json` files now record the source they were expanded from in
+`_metadata`.

--- a/changelog.d/ingestion-adapter.changed.md
+++ b/changelog.d/ingestion-adapter.changed.md
@@ -1,0 +1,4 @@
+`ariel.ingestion.adapter` is now required. An `ingestion:` block that names no
+adapter is refused when the configuration loads, with the registered adapter
+names in the message, instead of defaulting to `generic` — a name no adapter
+was ever registered under, so the block failed at the first ingest anyway.

--- a/changelog.d/setup-inspect.security.md
+++ b/changelog.d/setup-inspect.security.md
@@ -1,0 +1,6 @@
+The `setup_inspect` agent tool now reports `config.yml` with its `${VAR}`
+placeholders intact instead of the values they resolved to, so an API key or a
+database password no longer lands in the transcript. Any literal value under a
+key named `*KEY*`, `*TOKEN*`, `*SECRET*` or `*PASSWORD*` — in the config or in
+`.mcp.json` — is masked on top of that. The unexpanded document is also the
+better diagnostic: it names the variable each key reads.

--- a/changelog.d/sidecar-names.changed.md
+++ b/changelog.d/sidecar-names.changed.md
@@ -1,0 +1,6 @@
+The sidecar-metadata step now takes its filenames from the ingestion adapter
+(`metadata_sidecar_names`, default `("metadata.json",)`) instead of matching
+that one name everywhere, so a logbook whose sidecar is spelled differently
+gets its metadata merged. The fetch also honours the ingestion block's
+`verify_ssl`, `ca_bundle` and `proxy_url`; it previously opened a plain
+connection that ignored all three.

--- a/changelog.d/sql-allowlist.security.md
+++ b/changelog.d/sql-allowlist.security.md
@@ -1,0 +1,5 @@
+ARIEL's `sql_query` tool now refuses a query that reads no allowlisted table.
+The table allowlist only ever ran over `FROM` and `JOIN` targets, so a query
+with neither — `SELECT pg_read_file(...)`, say — had nothing to check and
+passed; the read-only transaction around it stops writes, not server-side file
+reads.

--- a/changelog.d/trigger-edge.fixed.md
+++ b/changelog.d/trigger-edge.fixed.md
@@ -1,0 +1,4 @@
+An `epics_ca` dispatch trigger with an unrecognized `edge` value is now skipped
+with a warning naming the trigger, instead of being armed as if it had said
+`both`. Only `rising`, `falling` and `both` arm a monitor; sibling triggers in
+the same set are unaffected.

--- a/changelog.d/verify-ssl.security.md
+++ b/changelog.d/verify-ssl.security.md
@@ -1,0 +1,5 @@
+ARIEL logbook ingestion now verifies TLS certificates by default. A deployment
+that ingests from a logbook with a certificate the image cannot verify must
+either name its site CA with the new `ariel.ingestion.ca_bundle` key or opt out
+explicitly with `ariel.ingestion.verify_ssl: false`; the previous default
+silently accepted any certificate.

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -89,6 +89,22 @@ If neither is possible, ``verify_ssl: false`` turns verification off for this in
 
 Write it only as a deliberate choice. Nothing about the connection is authenticated afterwards.
 
+The same settings cover the sidecar-metadata fetch described below, so one ingest never reaches the logbook host two different ways.
+
+Sidecar Metadata
+~~~~~~~~~~~~~~~~
+
+An entry can carry its structured metadata in a JSON attachment beside the prose --- session ids, model names, whatever the tooling that wrote the entry recorded. During ingestion that file is fetched and merged into the entry's ``metadata``.
+
+The filename is a facility convention, not a standard, so each adapter declares its own:
+
+.. code-block:: python
+
+   class MyLogbookAdapter(FacilityAdapter):
+       metadata_sidecar_names = ("entry-meta.json",)
+
+The default is ``("metadata.json",)``. Matching is case-insensitive, and a name that never appears is simply a no-op --- there is no switch to turn this off. If an entry has attachments and none of them matched, ingestion says so at debug level rather than staying silent about metadata it did not collect.
+
 
 .. _`Enhancement Pipeline`:
 

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -59,6 +59,37 @@ An adapter written and registered as described in :doc:`/contributing/extending-
    The adapters above reflect the logbook schemas we have had access to so far. If you implement an adapter for your facility and test it successfully, we encourage you to open a pull request to make it natively available in Osprey --- this makes it easier for other sites running similar logbook systems to get started.
 
 
+Connecting to Your Logbook
+==========================
+
+The ``ariel.ingestion`` block says which adapter runs and how it reaches the source system.
+
+.. code-block:: yaml
+
+   ariel:
+     ingestion:
+       adapter: als_logbook              # required
+       source_url: https://logbook.example.org/api/entries
+       ca_bundle: /etc/ssl/certs/site-ca.pem   # optional, for a site CA
+
+``adapter`` is required. There is no default: a block that names no adapter is refused when the configuration loads, with the registered adapter names in the message, rather than failing later on the first ingest.
+
+**TLS.** Certificates are verified. A logbook served over HTTPS whose certificate does not check out fails the ingest instead of being trusted --- credentials for a write-enabled logbook and the entry text itself both travel over that connection. Two ways to make a site certificate verifiable:
+
+* Install your site CA into the image's trust store. Nothing needs to be configured; verification just succeeds.
+* Point ``ca_bundle`` at the CA's PEM file when it lives beside the deployment rather than in the image. Verification then runs against that bundle.
+
+If neither is possible, ``verify_ssl: false`` turns verification off for this ingestion source:
+
+.. code-block:: yaml
+
+   ariel:
+     ingestion:
+       verify_ssl: false
+
+Write it only as a deliberate choice. Nothing about the connection is authenticated afterwards.
+
+
 .. _`Enhancement Pipeline`:
 
 Enhancement Pipeline

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -291,6 +291,12 @@ translation proxy:
 (The unmapped ``opus`` tier here falls back to the default model at build
 time, with a warning — map it to silence the substitution.)
 
+``api_protocol`` takes exactly two values, ``anthropic`` and ``openai``.
+Anything else — including a capitalised ``Anthropic`` — is refused when the
+provider is resolved, naming the provider and the two accepted values. Leave
+the key out and the provider is treated as OpenAI, which is what all but the
+Anthropic-native built-ins are.
+
 Spend Attribution on a LiteLLM Gateway
 --------------------------------------
 

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -732,9 +732,13 @@ Options: ``--project PATH``, ``-v, --verbose``
 ``osprey channel-finder preview``
    Preview a channel database with flexible display options.
 
-``osprey channel-finder generate [--output-dir DIR] [--source PATH] [--format in_context|hierarchical|middle_layer|all] [--tier 1|3|none] [--validate]``
+``osprey channel-finder generate (--source PATH | --demo) [--output-dir DIR] [--force] [--format in_context|hierarchical|middle_layer|all] [--tier 1|3|none] [--validate]``
    Generate channel databases from a hierarchical template. Produces one
    or more pipeline formats (default: all three) with optional tier filtering.
+   Name the source: ``--source`` for your own hierarchical database, ``--demo``
+   for the packaged demo one. Files already in the output directory are left
+   alone unless you pass ``--force`` --- the default output directory,
+   ``data/channel_databases/``, is the one the pipelines read.
 
 ``osprey channel-finder benchmark --model PROVIDER/WIRE_ID [--queries SPEC] [--runs-per-query N] [--concurrency N] [--output-dir DIR] [--queries-path PATH] [-v]``
    Run the benchmark harness against a channel-finder pipeline using a
@@ -753,7 +757,7 @@ and ``--pipeline`` does not offer ``graph`` for the same reason.
    osprey channel-finder build-database
    osprey channel-finder validate
    osprey channel-finder preview
-   osprey channel-finder generate --format hierarchical
+   osprey channel-finder generate --source my_channels.json --format hierarchical
    osprey channel-finder benchmark --model anthropic/claude-haiku-4-5
    osprey channel-finder web
 

--- a/docs/source/reference/contracts/channel-finder.rst
+++ b/docs/source/reference/contracts/channel-finder.rst
@@ -175,7 +175,7 @@ language via the agent, or invoke the CLI directly:
 
 .. code-block:: bash
 
-   osprey channel-finder generate     # build database from template
+   osprey channel-finder generate --source my_channels.json   # build database from template
    osprey channel-finder benchmark    # evaluate on a query dataset
 
 .. tip::

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -1068,6 +1068,21 @@ keys:
   ariel.ingestion: {covered-by: ariel}
   ariel.ingestion.adapter: {covered-by: ariel.ingestion}
   ariel.ingestion.source_url: {evidence: 'source_url'}
+  ariel.ingestion.verify_ssl:
+    rendered: false
+    evidence: 'data\.get\("verify_ssl", True\)'
+    note: >-
+      The default is spelled in the evidence because it is the safe posture: an
+      ingest that cannot verify the logbook's certificate must fail rather than
+      trust whatever answered, so a silent flip back to False has to red this
+      guard.
+  ariel.ingestion.ca_bundle:
+    rendered: false
+    evidence: 'data\.get\("ca_bundle"\)'
+    note: >-
+      Commented in both templates that carry an `ingestion:` block: a site CA
+      path is facility content, and the shipped default (the image trust store)
+      is the right answer for a deployment that has none.
   ariel.default_search_mode: {evidence: 'default_search_mode'}
   # The facility vocabulary: shorthand the operators type, mapped to the words
   # the logbook prose actually uses. Read ONCE at config parse — the file is

--- a/scripts/config_key_manifest.yml
+++ b/scripts/config_key_manifest.yml
@@ -1336,7 +1336,7 @@ keys:
       on line length, so a single-line pattern reds the guard when a rename
       pushes an unrelated call past the margin.
   web.config_panel:
-    evidence: '(?:get_config_value|resolve_config_flag)\(\s*"web\.config_panel\.'
+    evidence: '(?:get_config_value|resolve_config_flag|coerce_config_flag)\(\s*"web\.config_panel\.'
     note: >-
       The block is never read as a mapping — its single leaf below carries the
       whole read, so the evidence anchors on the prefix they share and this
@@ -1344,7 +1344,7 @@ keys:
       the four templates that carry a `web:` block; hello_world has none, so
       this is deliberately not all-templates, same as `web.docs_url`.
   web.config_panel.enabled:
-    evidence: '(?:get_config_value|resolve_config_flag)\(\s*"web\.config_panel\.enabled",\s*True'
+    evidence: '(?:get_config_value|resolve_config_flag|coerce_config_flag)\(\s*"web\.config_panel\.enabled",\s*(?:[^,)]+,\s*)?True'
     note: >-
       Tier gate for the Config panel, and a SERVER-side one: false makes
       /api/config and /api/claude-setup refuse every verb with 403 and takes

--- a/src/osprey/cli/channel_finder_cmd.py
+++ b/src/osprey/cli/channel_finder_cmd.py
@@ -502,7 +502,19 @@ def web(ctx, host: str, port: int | None):
     "--source",
     type=click.Path(exists=True, dir_okay=False),
     default=None,
-    help="Source hierarchical database (default: built-in template)",
+    help="Source hierarchical database to generate from",
+)
+@click.option(
+    "--demo",
+    is_flag=True,
+    default=False,
+    help="Generate from the packaged demo template instead of a --source file",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite database files that already exist in the output directory",
 )
 @click.option(
     "--format",
@@ -524,7 +536,15 @@ def web(ctx, host: str, port: int | None):
     default=False,
     help="Verify generated databases load correctly through pipeline database classes",
 )
-def generate(output_dir: str, source: str | None, fmt: str, tier: str, do_validate: bool):
+def generate(
+    output_dir: str,
+    source: str | None,
+    demo: bool,
+    force: bool,
+    fmt: str,
+    tier: str,
+    do_validate: bool,
+):
     """Generate channel databases from a hierarchical template.
 
     Produces database files from a hierarchical channel template.
@@ -536,18 +556,24 @@ def generate(output_dir: str, source: str | None, fmt: str, tier: str, do_valida
       - hierarchical.json  (tree format)
       - middle_layer.json  (MML-style with setup blocks)
 
+    Say where the channels come from: --source names your own hierarchical
+    database, --demo asks for the packaged demo one. Existing files in the
+    output directory are left alone unless you pass --force; the default
+    output directory is the one the pipelines read.
+
     Examples:
 
     \b
-      osprey channel-finder generate
-      osprey channel-finder generate --tier 1 --format in_context
       osprey channel-finder generate --source my_channels.json
-      osprey channel-finder generate --validate
+      osprey channel-finder generate --demo
+      osprey channel-finder generate --source my_channels.json --tier 1 --format in_context
+      osprey channel-finder generate --source my_channels.json --validate --force
     """
     import json
     from pathlib import Path
 
     from osprey.services.channel_finder.benchmarks.generator import (
+        TEMPLATE_DB_PATH,
         TIER_1,
         TIER_3,
         TierSpec,
@@ -557,10 +583,23 @@ def generate(output_dir: str, source: str | None, fmt: str, tier: str, do_valida
         load_template,
     )
 
+    # Where the channels come from is stated, never assumed. The old default
+    # wrote the demo machine's channels into the very directory the pipelines
+    # read, so a bare `generate` in a real deployment replaced that facility's
+    # database with somebody else's.
+    if source and demo:
+        raise click.ClickException("--source and --demo name two different sources; pass one.")
+    if not source and not demo:
+        raise click.ClickException(
+            "Say where the channels come from: --source PATH for your own "
+            "hierarchical database, or --demo for the packaged demo one."
+        )
+
+    source_path = Path(source) if source else TEMPLATE_DB_PATH
+
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
 
-    source_path = Path(source) if source else None
     tree_data, channels = load_template(source_path)
 
     if tier == "none":
@@ -577,7 +616,7 @@ def generate(output_dir: str, source: str | None, fmt: str, tier: str, do_valida
     # One writer per paradigm in FILE_DATABASE_PARADIGMS; Click has already
     # rejected any other --format before this point.
     format_map = {
-        "in_context.json": lambda: format_in_context(channels, tier_spec),
+        "in_context.json": lambda: format_in_context(channels, tier_spec, source=source_path),
         "hierarchical.json": lambda: format_hierarchical(tree_data, tier_spec),
         "middle_layer.json": lambda: format_middle_layer(channels, tier_spec),
     }
@@ -593,6 +632,13 @@ def generate(output_dir: str, source: str | None, fmt: str, tier: str, do_valida
     elif fmt != "all":
         filename = f"{fmt}.json"
         format_map = {filename: format_map[filename]}
+
+    existing = [name for name in format_map if (out / name).exists()]
+    if existing and not force:
+        raise click.ClickException(
+            f"{', '.join(sorted(existing))} already exist in {out}/. "
+            "Pass --force to overwrite them, or --output-dir to write elsewhere."
+        )
 
     for filename, builder in format_map.items():
         path = out / filename

--- a/src/osprey/dispatch/sources/epics_ca.py
+++ b/src/osprey/dispatch/sources/epics_ca.py
@@ -25,6 +25,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("osprey.dispatch.sources.epics_ca")
 
+#: The three edges ``_PvWatcher._detect_edge`` implements. An unrecognized
+#: spelling used to fall through to the widest of them, so ``edge: up`` armed a
+#: trigger that fired on both crossings — the opposite of what it asked for, and
+#: silently.
+VALID_EDGES = frozenset({"rising", "falling", "both"})
+
 
 class _PvWatcher:
     """Monitor one PV and fire a callback when its value crosses a threshold.
@@ -67,6 +73,12 @@ class _PvWatcher:
     # ------------------------------------------------------------------
 
     def _detect_edge(self, prev: float, curr: float) -> bool:
+        """Whether the step from *prev* to *curr* is the crossing this edge names.
+
+        Only the three edges in :data:`VALID_EDGES` reach here — ``start``
+        refuses anything else — so the final branch is ``both``, not a
+        catch-all for whatever the config said.
+        """
         if self._edge == "rising":
             return prev < self._threshold <= curr
         if self._edge == "falling":
@@ -160,6 +172,18 @@ class EpicsCaSource:
                 logger.warning(
                     "EPICS CA trigger '%s' has no 'pv' in source_config; skipping",
                     trigger.name,
+                )
+                continue
+            edge = trigger.source_config.get("edge", "rising")
+            if edge not in VALID_EDGES:
+                # Skip this one trigger, arm the rest: one mistyped edge must
+                # not take a dispatcher's whole trigger set down, and it must
+                # not quietly become "both" either.
+                logger.warning(
+                    "EPICS CA trigger '%s' has unknown 'edge' (%r); expected one of %s; skipping",
+                    trigger.name,
+                    edge,
+                    ", ".join(sorted(VALID_EDGES)),
                 )
                 continue
             watcher = _PvWatcher(trigger, fire_callback, loop)

--- a/src/osprey/infrastructure/proxy/lifecycle.py
+++ b/src/osprey/infrastructure/proxy/lifecycle.py
@@ -14,6 +14,12 @@ logger = logging.getLogger("osprey.infrastructure.proxy")
 # Everything else is assumed to be OpenAI-compatible and needs the proxy.
 _ANTHROPIC_NATIVE_PROVIDERS = frozenset({"anthropic", "cborg", "als-apg"})
 
+#: The two wire protocols a provider entry may declare. The comparison against
+#: ``"anthropic"`` is exact, so a misspelling — ``Anthropic``, ``antropic`` —
+#: used to read as "not Anthropic" and silently insert the translation hop the
+#: config template warns about. Two values, checked as an enum.
+VALID_API_PROTOCOLS = frozenset({"anthropic", "openai"})
+
 _state: dict[str, Any] = {
     "server": None,
     "thread": None,
@@ -34,15 +40,42 @@ def is_proxy_needed(
     1. Built-in Anthropic-native providers → False
     2. Explicit ``api_protocol: anthropic`` in config → False
     3. Everything else → True
+
+    An absent ``api_protocol`` means OpenAI, which is right for nine of the
+    twelve proxied built-ins. A PRESENT one is checked against
+    :data:`VALID_API_PROTOCOLS`: the old exact comparison meant a typo took the
+    step-3 branch, so a provider written ``api_protocol: Anthropic`` was routed
+    through the translation proxy the config template explicitly warns against
+    — with nothing said about it.
+
+    Args:
+        provider_name: The provider being resolved.
+        api_providers: The ``api.providers`` block, if the caller has one.
+
+    Returns:
+        Whether the translation proxy has to sit in front of this provider.
+
+    Raises:
+        ValueError: If this provider declares an ``api_protocol`` that is
+            neither ``anthropic`` nor ``openai``.
     """
-    if provider_name in _ANTHROPIC_NATIVE_PROVIDERS:
+    declared = None
+    if api_providers:
+        provider_conf = api_providers.get(provider_name) or {}
+        if isinstance(provider_conf, dict):
+            declared = provider_conf.get("api_protocol")
+
+    if declared is not None and declared not in VALID_API_PROTOCOLS:
+        raise ValueError(
+            f"api.providers.{provider_name}.api_protocol is {declared!r}; "
+            f"expected one of {', '.join(sorted(VALID_API_PROTOCOLS))}."
+        )
+
+    if provider_name in _ANTHROPIC_NATIVE_PROVIDERS or declared == "anthropic":
+        logger.info("Provider %r speaks Anthropic natively; no proxy", provider_name)
         return False
 
-    if api_providers:
-        provider_conf = api_providers.get(provider_name, {})
-        if provider_conf.get("api_protocol") == "anthropic":
-            return False
-
+    logger.info("Provider %r speaks OpenAI; routing through the translation proxy", provider_name)
     return True
 
 

--- a/src/osprey/interfaces/ariel/api/routes.py
+++ b/src/osprey/interfaces/ariel/api/routes.py
@@ -263,11 +263,16 @@ async def get_capabilities(request: Request) -> dict:
     remedy = getattr(request.app.state, "config_remedy", None)
     service = getattr(request.app.state, "ariel_service", None)
 
+    # The Config panel's server gate, reported so the frontend can take the
+    # Settings entry out of the display menu. The server refusal is the real
+    # gate; this is its other half, never the only half.
+    panel_enabled = bool(getattr(request.app.state, "config_panel_enabled", True))
+
     if status == CONFIG_STATUS_INVALID or (errors and status is None and service is None):
-        return _invalid_capabilities(errors, remedy)
+        return {**_invalid_capabilities(errors, remedy), "config_panel_enabled": panel_enabled}
 
     service = _require_service(request)
-    payload = _get_caps(service.config)
+    payload = {**_get_caps(service.config), "config_panel_enabled": panel_enabled}
     if errors:
         payload = {
             **payload,
@@ -925,7 +930,17 @@ def _config_path(request: Request) -> Path:
 
 @router.get("/config")
 async def get_config(request: Request) -> dict:
-    """Return the current config.yml as a dict and raw YAML."""
+    """Return the current config.yml as a dict and raw YAML.
+
+    Gated on ``web.config_panel.enabled`` before anything else, reads
+    included: the document this returns carries every provider ``base_url``
+    and the paths the safety layers derive their allow and deny areas from, so
+    a tier that may not edit the file may not read it out either.
+    """
+    from osprey.interfaces.web_terminal.routes.config import _require_config_panel
+
+    _require_config_panel(request)
+
     path = _config_path(request)
     if not path.exists():
         raise HTTPException(status_code=404, detail="config.yml not found")
@@ -971,7 +986,14 @@ async def update_config(request: Request, req: ConfigUpdateRequest) -> dict:
         _changed_protected_keys,
         _current_document,
         _refuse_protected_keys,
+        _require_config_panel,
     )
+
+    # The tier gate runs FIRST, ahead of the path check and ahead of the
+    # protected-set logic, exactly as it does on the terminal: a deployment
+    # that has taken this panel away never gets as far as having a key to
+    # judge, so it never reports a protected-key refusal instead.
+    _require_config_panel(request)
 
     path = _config_path(request)
     if not path.exists():

--- a/src/osprey/interfaces/ariel/app.py
+++ b/src/osprey/interfaces/ariel/app.py
@@ -190,6 +190,8 @@ class _ConfigState:
         errors: Every error to report, in the order they were collected.
         status: One of the ``CONFIG_STATUS_*`` values.
         remedy: The class-derived operator action, None when ok.
+        config_panel_enabled: Whether ``web.config_panel.enabled`` leaves the
+            Config panel reachable on this deployment.
     """
 
     config: Any
@@ -197,6 +199,43 @@ class _ConfigState:
     errors: list[str]
     status: str
     remedy: str | None
+    config_panel_enabled: bool = True
+
+
+def _resolve_config_panel_enabled(config_path: Path | None) -> bool:
+    """Whether this deployment lets its operators reach the Config panel.
+
+    ``web.config_panel.enabled`` is one key with one meaning across both
+    surfaces, so this reads the same file the panel edits — the config.yml the
+    loader actually resolved — and coerces it with the Web Terminal's own
+    :func:`coerce_config_flag`. Two readers of one key, never two keys.
+
+    Fails OPEN, exactly as the terminal's lifespan does: an unreadable or
+    unparseable config leaves the panel at the shipped posture rather than
+    silently taking an operator's config editor away.
+
+    Args:
+        config_path: The config.yml that was read, or None when none was found.
+
+    Returns:
+        The configured boolean, or True when the key is absent or unreadable.
+    """
+    from osprey.interfaces.web_terminal.app import coerce_config_flag
+
+    raw: object = None
+    if config_path is not None:
+        try:
+            document = yaml.safe_load(config_path.read_text()) or {}
+            web = document.get("web") if isinstance(document, dict) else None
+            panel = web.get("config_panel") if isinstance(web, dict) else None
+            raw = panel.get("enabled") if isinstance(panel, dict) else None
+        except Exception:  # noqa: BLE001 — never let config load block startup
+            logger.warning(
+                "Could not read web.config_panel.enabled; leaving the Config panel enabled",
+                exc_info=True,
+            )
+            raw = None
+    return coerce_config_flag("web.config_panel.enabled", raw, True)
 
 
 def _resolve_config_state(config_path: str | Path | None) -> _ConfigState:
@@ -249,6 +288,7 @@ def _resolve_config_state(config_path: str | Path | None) -> _ConfigState:
         errors=config_errors,
         status=status,
         remedy=remedy,
+        config_panel_enabled=_resolve_config_panel_enabled(resolved_path),
     )
 
 
@@ -330,6 +370,13 @@ def _create_lifespan(config_path: str | Path | None = None):
         app.state.config_errors = state.errors
         app.state.config_status = state.status
         app.state.config_remedy = state.remedy
+
+        # `web.config_panel.enabled: false` takes the settings editor's SERVER
+        # surface away, not just its entry in the display menu: GET and PUT
+        # /api/config both refuse with 403. GET is gated too — the document it
+        # returns carries the provider base_urls and every path the safety
+        # layers derive their allow and deny areas from.
+        app.state.config_panel_enabled = state.config_panel_enabled
 
         if state.errors:
             logger.warning(_config_banner(state.status, state.errors, state.remedy))

--- a/src/osprey/interfaces/ariel/static/js/advanced-options.js
+++ b/src/osprey/interfaces/ariel/static/js/advanced-options.js
@@ -64,6 +64,7 @@ import { escapeHtml } from '/design-system/js/dom.js';
  * @property {string[]} [config_errors]
  * @property {string|null} [remedy]
  * @property {VocabularyCapability} [vocabulary]
+ * @property {boolean} [config_panel_enabled]
  */
 
 // --- State ---

--- a/src/osprey/interfaces/ariel/static/js/app.js
+++ b/src/osprey/interfaces/ariel/static/js/app.js
@@ -104,7 +104,7 @@ async function init() {
     initEntries();
     initDashboard();
     initAdvancedOptions(capabilities);
-    initSettings();
+    initSettings(capabilities);
   } catch (e) {
     console.error('Module initialization failed (non-fatal):', e);
   }

--- a/src/osprey/interfaces/ariel/static/js/settings.js
+++ b/src/osprey/interfaces/ariel/static/js/settings.js
@@ -14,9 +14,36 @@ let configDirty = false;
 let originalRaw = '';
 
 /**
- * Initialize settings module.
+ * Take the Settings entry out of the display menu and drop the drawer.
+ *
+ * The server refusal is the gate — `GET` and `PUT /api/config` answer 403
+ * when `web.config_panel.enabled` is false — and this is its other half: a
+ * control an operator cannot use should not be on screen offering itself.
+ * Removing the drawer too means a stale `#settings-drawer` trigger elsewhere
+ * has nothing left to open.
  */
-export function initSettings() {
+function removeConfigPanel() {
+  document.querySelectorAll('.display-menu-settings').forEach(btn => btn.remove());
+  document.querySelectorAll('osprey-display-menu[settings-drawer]')
+    .forEach(menu => menu.removeAttribute('settings-drawer'));
+  const drawer = document.getElementById('settings-drawer');
+  if (drawer) drawer.remove();
+}
+
+/**
+ * Initialize settings module.
+ *
+ * @param {{config_panel_enabled?: boolean} | null} [capabilities] The
+ *   `/api/capabilities` payload. Only an explicit `false` closes the panel —
+ *   a payload that never arrived (backend down) leaves it where the server's
+ *   own default leaves it, which is open.
+ */
+export function initSettings(capabilities) {
+  if (capabilities && capabilities.config_panel_enabled === false) {
+    removeConfigPanel();
+    return;
+  }
+
   // Mode bar (Form / Raw)
   const modeBtns = /** @type {NodeListOf<HTMLElement>} */ (
     document.querySelectorAll('.settings-mode-btn')

--- a/src/osprey/mcp_server/control_system/tools/archiver_read.py
+++ b/src/osprey/mcp_server/control_system/tools/archiver_read.py
@@ -60,10 +60,31 @@ def auto_bin_seconds(span: timedelta, target_points: int) -> int:
 def _parse_time(time_str: str) -> datetime:
     """Parse a time string into a timezone-aware datetime.
 
-    Supports ISO-8601 and simple relative expressions like "1h ago", "30m ago", "2d ago".
+    Accepts ``now``, simple relative expressions like ``1h ago``, ``30m ago``,
+    ``2d ago``, and ISO-8601 (``datetime.fromisoformat``, which since 3.11 also
+    takes the space-separated ``2026-04-03 14:00`` form).
+
+    Nothing else. A dotted or slashed date is AMBIGUOUS — ``03.04.2026`` is the
+    third of April to most of the world and the fourth of March in the US —
+    and a general-purpose parser resolves it silently, one way, and stamps the
+    result facility-local. An archiver window off by a month reads as "there is
+    no data" or, worse, as somebody else's shift. So an unrecognized spelling
+    raises here and the caller answers with the ``validation_error`` whose
+    hints already name ISO-8601, rather than guessing. This matches the sibling
+    entry point in :mod:`osprey.mcp_server.ariel.server`.
+
     Naive inputs (operator-provided wall-clock with no offset) are interpreted as
     facility-local — the agent rule promises operator times are facility-local, so the
     query window and the echoed range must honor the facility zone, not the box/UTC.
+
+    Args:
+        time_str: The operator's spelling of the instant.
+
+    Returns:
+        A timezone-aware datetime.
+
+    Raises:
+        ValueError: If *time_str* is not one of the accepted spellings.
     """
     tz = get_facility_timezone()
     if not time_str or time_str.strip().lower() == "now":
@@ -82,10 +103,7 @@ def _parse_time(time_str: str) -> datetime:
             except ValueError:
                 pass  # unparseable amount — fall through to dateutil below
 
-    # Fall back to dateutil for ISO / human strings
-    from dateutil import parser as dateutil_parser
-
-    dt = dateutil_parser.parse(time_str)
+    dt = datetime.fromisoformat(time_str.strip())
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=tz)
     return dt
@@ -272,8 +290,10 @@ async def archiver_read(
 
     Args:
         channels: List of PV/channel addresses to query.
-        start_time: Start of the time range — ISO-8601 or relative (e.g. "2h ago").
-        end_time: End of the time range (default "now").
+        start_time: Start of the time range — ISO-8601 ("2026-04-03T14:00") or
+            relative (e.g. "2h ago"). Nothing else: a dotted or slashed date is
+            ambiguous and is refused rather than read one way.
+        end_time: End of the time range (default "now"), same spellings.
         processing: Aggregation within each bin — one of "raw", "mean", "min",
             "max", "median", "std", "count".
         bin_size: Bin size in seconds. ``None`` (the default) picks a
@@ -336,7 +356,11 @@ async def archiver_read(
         return make_error(
             "validation_error",
             f"Could not parse start_time '{start_time}': {exc}",
-            ["Use ISO-8601 format or relative expressions like '2h ago'."],
+            [
+                "Use ISO-8601 (2026-04-03, 2026-04-03T14:00) or a relative "
+                "expression like '2h ago'.",
+                "A dotted or slashed date (03.04.2026) is ambiguous and is not read.",
+            ],
         )
 
     try:
@@ -345,7 +369,11 @@ async def archiver_read(
         return make_error(
             "validation_error",
             f"Could not parse end_time '{end_time}': {exc}",
-            ["Use ISO-8601 format or 'now'."],
+            [
+                "Use ISO-8601 (2026-04-03, 2026-04-03T14:00), a relative "
+                "expression like '2h ago', or 'now'.",
+                "A dotted or slashed date (03.04.2026) is ambiguous and is not read.",
+            ],
         )
 
     async with connector_error_handler("archiver_read", connector_name="archiver"):

--- a/src/osprey/mcp_server/workspace/tools/setup.py
+++ b/src/osprey/mcp_server/workspace/tools/setup.py
@@ -11,6 +11,7 @@ import re
 from pathlib import Path
 from typing import NoReturn
 
+import yaml
 from fastmcp.exceptions import ToolError
 
 from osprey.cli.profile_conventions import RESERVED_PATH_CHANNELS, is_protected_key
@@ -110,6 +111,75 @@ def _mask_env(env: dict[str, str]) -> dict[str, str]:
     return masked
 
 
+def _mask_document(value: object, key: str | None = None) -> object:
+    """Return *value* with literal secrets under sensitive key names masked.
+
+    Walks a parsed document — the config, the ``.mcp.json`` blob — and replaces
+    the value of any key matching :data:`_SENSITIVE_PATTERNS` with ``***``.
+    A ``${VAR}`` placeholder survives: it names the variable a secret comes
+    from, which is the diagnostic, not the secret.
+
+    This is the second line, not the first. The document reported here is the
+    UNEXPANDED one, so a well-formed deployment has nothing but placeholders
+    under those keys already; this catches a secret somebody typed straight
+    into ``config.yml`` or ``.mcp.json``.
+
+    Args:
+        value: The node being walked.
+        key: The mapping key *value* was found under, or None at the root and
+            inside sequences.
+
+    Returns:
+        The masked copy.
+    """
+    if isinstance(value, dict):
+        return {k: _mask_document(v, str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_mask_document(item, key) for item in value]
+    if (
+        key is not None
+        and isinstance(value, str)
+        and value
+        and _SENSITIVE_PATTERNS.search(key)
+        and "${" not in value
+    ):
+        return "***"
+    return value
+
+
+def _unexpanded_config(config_path: Path) -> dict:
+    """The config document with its ``${VAR}`` placeholders still in place.
+
+    ``load_osprey_config`` returns the EXPANDED document — every placeholder
+    replaced by the value the environment holds — which is the right input for
+    resolving a path and the wrong thing to hand back to an agent transcript.
+    The unexpanded copy is the better diagnostic anyway: it shows which
+    variable each key references, and the environment section beside it already
+    reports whether that variable is set.
+
+    Falls back to a plain YAML read of the same file, which is unexpanded by
+    construction, so no failure here can turn into an expanded document.
+
+    Args:
+        config_path: The config.yml this deployment resolved.
+
+    Returns:
+        The unexpanded document, or an empty dict when it cannot be read.
+    """
+    try:
+        from osprey.utils.config import get_config_builder
+
+        return get_config_builder(config_path=str(config_path)).get_unexpanded_config()
+    except Exception:
+        logger.warning("Could not load %s through ConfigBuilder; reading it as YAML", config_path)
+
+    try:
+        return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        logger.warning("Could not read %s", config_path)
+        return {}
+
+
 def _read_json_file(path: Path) -> dict | list | None:
     """Read and parse a JSON file, returning None if missing or invalid."""
     if not path.exists():
@@ -152,21 +222,27 @@ async def setup_inspect() -> str:
     including config.yml, MCP servers, settings, hooks, rules, agents, skills,
     environment variables, and workspace structure.
 
-    Environment variables containing KEY, TOKEN, SECRET, or PASSWORD in their
-    names have their values masked.
+    The config is reported UNEXPANDED --- ``${VAR}`` placeholders intact ---
+    so a resolved secret never reaches the transcript. Environment variables
+    and any literal value in the config or ``.mcp.json`` whose key contains
+    KEY, TOKEN, SECRET or PASSWORD are masked on top of that.
 
     Returns:
         JSON object with all configuration sections.
     """
     try:
-        project_root = resolve_config_path().parent
+        config_path = resolve_config_path()
+        project_root = config_path.parent
         claude_dir = project_root / ".claude"
 
-        # Config
+        # Config. Two copies with two jobs: the expanded one resolves the
+        # agent-data path below and is never reported; the unexpanded one is
+        # what the caller sees.
         config = load_osprey_config()
+        reported_config = _mask_document(_unexpanded_config(config_path))
 
         # MCP servers (.mcp.json)
-        mcp_servers = _read_json_file(project_root / ".mcp.json")
+        mcp_servers = _mask_document(_read_json_file(project_root / ".mcp.json"))
 
         # Settings (.claude/settings.json)
         settings = _read_json_file(claude_dir / "settings.json")
@@ -198,9 +274,7 @@ async def setup_inspect() -> str:
         # deployment REPO root, not beside the render `project_root` points at —
         # so resolve it from the config's own `agent_data.base_dir` anchored on
         # the repo, the same derivation every writer uses.
-        ws_dir = anchored_path(
-            agent_data_base_dir(config), repo_root_for_config(resolve_config_path())
-        )
+        ws_dir = anchored_path(agent_data_base_dir(config), repo_root_for_config(config_path))
         workspace = {
             "exists": ws_dir.is_dir(),
             "subdirs": _list_dirs_in(ws_dir) if ws_dir.is_dir() else [],
@@ -208,7 +282,7 @@ async def setup_inspect() -> str:
 
         return json.dumps(
             {
-                "config": config,
+                "config": reported_config,
                 "mcp_servers": mcp_servers,
                 "settings": settings,
                 "hooks": hooks,

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -335,6 +335,35 @@ class WriteConfig:
         )
 
 
+def _known_ingestion_adapters() -> list[str]:
+    """Adapter names to offer an operator who named none.
+
+    The live registry first — a deployment that registered its own adapter must
+    see it here — and the framework's built-in registrations as the fallback,
+    since a config can be parsed outside a project, where there is no registry
+    to ask.
+
+    Returns:
+        Sorted adapter names, or an empty list if neither source can answer.
+    """
+    try:
+        from osprey.registry.manager import get_registry
+
+        names = get_registry().list_ariel_ingestion_adapters()
+        if names:
+            return sorted(names)
+    except Exception:  # noqa: BLE001 — the refusal matters more than the list
+        pass
+
+    try:
+        from osprey.registry.builtins import FrameworkRegistryProvider
+
+        registrations = FrameworkRegistryProvider().get_registry_config()
+        return sorted(r.name for r in registrations.ariel_ingestion_adapters)
+    except Exception:  # noqa: BLE001 — same
+        return []
+
+
 @dataclass
 class IngestionConfig:
     """Configuration for logbook ingestion.
@@ -372,7 +401,29 @@ class IngestionConfig:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "IngestionConfig":
-        """Create IngestionConfig from dictionary."""
+        """Create IngestionConfig from dictionary.
+
+        Args:
+            data: The ``ariel.ingestion`` block.
+
+        Returns:
+            The parsed configuration.
+
+        Raises:
+            ConfigurationError: If ``adapter`` is absent. There is no sensible
+                default — the old one, ``"generic"``, is not a registered name
+                at all, so an ingestion block without an adapter never worked;
+                it just failed later, at the first ingest, instead of here.
+        """
+        if not data.get("adapter"):
+            available = ", ".join(_known_ingestion_adapters())
+            suffix = f" Registered adapters: {available}." if available else ""
+            raise ConfigurationError(
+                "ariel.ingestion.adapter is required: name the adapter that reads "
+                f"your logbook.{suffix}",
+                config_key="ingestion.adapter",
+            )
+
         proxy_url = data.get("proxy_url") or os.environ.get("ARIEL_SOCKS_PROXY")
 
         watch = WatchConfig()
@@ -384,7 +435,7 @@ class IngestionConfig:
             write = WriteConfig.from_dict(data["write"])
 
         return cls(
-            adapter=data.get("adapter", "generic"),
+            adapter=data["adapter"],
             source_url=data.get("source_url"),
             poll_interval_seconds=data.get("poll_interval_seconds", 3600),
             proxy_url=proxy_url,

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -344,7 +344,11 @@ class IngestionConfig:
         source_url: URL for source system API (optional)
         poll_interval_seconds: Polling interval for incremental ingestion
         proxy_url: SOCKS proxy URL (e.g., "socks5://localhost:1080")
-        verify_ssl: Whether to verify SSL certificates (default: False for internal servers)
+        verify_ssl: Whether to verify TLS certificates (default: True). Set false
+            only as a deliberate opt-out for a logbook whose certificate cannot
+            be verified any other way.
+        ca_bundle: Path to a PEM bundle to verify against, for a site CA that is
+            not in the image trust store (optional)
         chunk_days: Days per API request for time windowing (default: 365)
         request_timeout_seconds: Timeout for HTTP requests (default: 60)
         max_retries: Maximum retry attempts for failed requests (default: 3)
@@ -357,7 +361,8 @@ class IngestionConfig:
     source_url: str | None = None
     poll_interval_seconds: int = 3600
     proxy_url: str | None = None
-    verify_ssl: bool = False
+    verify_ssl: bool = True
+    ca_bundle: str | None = None
     chunk_days: int = 365
     request_timeout_seconds: int = 60
     max_retries: int = 3
@@ -383,7 +388,8 @@ class IngestionConfig:
             source_url=data.get("source_url"),
             poll_interval_seconds=data.get("poll_interval_seconds", 3600),
             proxy_url=proxy_url,
-            verify_ssl=data.get("verify_ssl", False),
+            verify_ssl=data.get("verify_ssl", True),
+            ca_bundle=data.get("ca_bundle"),
             chunk_days=data.get("chunk_days", 365),
             request_timeout_seconds=data.get("request_timeout_seconds", 60),
             max_retries=data.get("max_retries", 3),

--- a/src/osprey/services/ariel_search/ingestion/adapters/als.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/als.py
@@ -23,6 +23,7 @@ from osprey.services.ariel_search.exceptions import (
     IngestionError,
 )
 from osprey.services.ariel_search.ingestion.base import FacilityAdapter
+from osprey.services.ariel_search.ingestion.http import build_ssl_context
 from osprey.services.ariel_search.models import AttachmentInfo, EnhancedLogbookEntry
 from osprey.utils.logger import get_logger
 
@@ -105,6 +106,7 @@ class ALSLogbookAdapter(FacilityAdapter):
 
         self.proxy_url = config.ingestion.proxy_url or os.environ.get("ARIEL_SOCKS_PROXY")
         self.verify_ssl = config.ingestion.verify_ssl
+        self.ca_bundle = config.ingestion.ca_bundle
         self.chunk_days = config.ingestion.chunk_days or 365
         self.request_timeout = config.ingestion.request_timeout_seconds or 60
         self.max_retries = config.ingestion.max_retries or 3
@@ -296,13 +298,7 @@ class ALSLogbookAdapter(FacilityAdapter):
         """
         connector = self._create_connector()
 
-        ssl_context: ssl.SSLContext | bool
-        if self.verify_ssl:
-            ssl_context = True
-        else:
-            ssl_context = ssl.create_default_context()
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+        ssl_context = build_ssl_context(self.verify_ssl, self.ca_bundle)
 
         timeout = aiohttp.ClientTimeout(total=self.request_timeout)
         last_error: Exception | None = None
@@ -400,13 +396,7 @@ class ALSLogbookAdapter(FacilityAdapter):
 
         connector = self._create_connector()
 
-        ssl_context: ssl.SSLContext | bool
-        if self.verify_ssl:
-            ssl_context = True
-        else:
-            ssl_context = ssl.create_default_context()
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
+        ssl_context = build_ssl_context(self.verify_ssl, self.ca_bundle)
 
         timeout = aiohttp.ClientTimeout(total=self.request_timeout)
 

--- a/src/osprey/services/ariel_search/ingestion/base.py
+++ b/src/osprey/services/ariel_search/ingestion/base.py
@@ -25,7 +25,17 @@ class FacilityAdapter(ABC):
 
     Attributes:
         config: ARIEL configuration
+        metadata_sidecar_names: Attachment filenames this facility uses for the
+            JSON sidecar that carries an entry's structured metadata. Declared
+            per adapter because ``metadata.json`` is one facility's convention,
+            not a standard; a logbook that spells it differently would
+            otherwise get no metadata at all and say nothing about it. A name
+            that never matches is simply a no-op, so this needs no enable
+            switch beside it.
     """
+
+    #: See the class docstring. Lower-case comparison, so case does not matter.
+    metadata_sidecar_names: tuple[str, ...] = ("metadata.json",)
 
     def __init__(self, config: "ARIELConfig") -> None:
         """Initialize the adapter with configuration.

--- a/src/osprey/services/ariel_search/ingestion/http.py
+++ b/src/osprey/services/ariel_search/ingestion/http.py
@@ -1,0 +1,43 @@
+"""HTTP transport helpers shared by ingestion adapters.
+
+One place decides what TLS verification an ingestion request gets, so an
+adapter cannot ship its own quieter answer to that question.
+"""
+
+import ssl
+
+__all__ = ["build_ssl_context"]
+
+
+def build_ssl_context(verify_ssl: bool, ca_bundle: str | None = None) -> ssl.SSLContext | bool:
+    """Return the ``ssl=`` argument for an ingestion request.
+
+    Three outcomes, in the order a deployment meets them:
+
+    * ``verify_ssl`` true and no ``ca_bundle`` — ``True``, which leaves aiohttp
+      on the trust store the image ships. A site that installs its CA into that
+      store therefore needs no ARIEL key at all.
+    * ``verify_ssl`` true with a ``ca_bundle`` — a default context pinned to
+      that file, for a site CA that lives beside the config rather than in the
+      image.
+    * ``verify_ssl`` false — verification off. This is an explicit opt-out an
+      operator has to write; it is never what an unconfigured deployment gets.
+
+    Args:
+        verify_ssl: Whether certificates are verified at all.
+        ca_bundle: Path to a PEM bundle to verify against, or ``None`` to use
+            the trust store already present.
+
+    Returns:
+        ``True``, a verifying context built from *ca_bundle*, or a context with
+        hostname checking and verification disabled.
+    """
+    if verify_ssl:
+        if ca_bundle:
+            return ssl.create_default_context(cafile=ca_bundle)
+        return True
+
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context

--- a/src/osprey/services/ariel_search/ingestion/metadata_attachment.py
+++ b/src/osprey/services/ariel_search/ingestion/metadata_attachment.py
@@ -1,63 +1,131 @@
-"""Extract metadata from metadata.json attachments.
+"""Extract entry metadata from a sidecar JSON attachment.
 
-Scans an entry's attachments for files named ``metadata.json``, fetches the
-content (local file or HTTP), and merges the result into the entry's metadata
-dict.  All failures are non-fatal — logged as warnings.
+Scans an entry's attachments for the sidecar filenames its adapter declares,
+fetches the content (local file or HTTP), and merges the result into the
+entry's metadata dict. All failures are non-fatal --- logged as warnings.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from osprey.services.ariel_search.models import EnhancedLogbookEntry
 from osprey.utils.logger import get_logger
 
+if TYPE_CHECKING:
+    from osprey.services.ariel_search.config import IngestionConfig
+    from osprey.services.ariel_search.ingestion.base import FacilityAdapter
+
 logger = get_logger("ariel.ingestion")
+
+#: The filename the step matched before adapters could declare their own. Used
+#: when no adapter is supplied, so a direct caller behaves as it always did.
+DEFAULT_SIDECAR_NAMES: tuple[str, ...] = ("metadata.json",)
 
 
 async def extract_metadata_from_attachments(
     entry: EnhancedLogbookEntry,
     *,
     fetch_timeout: int = 5,
+    adapter: FacilityAdapter | None = None,
+    ingestion: IngestionConfig | None = None,
 ) -> None:
-    """Scan attachments for ``metadata.json`` and merge into entry metadata.
+    """Merge an entry's sidecar metadata attachment into its metadata dict.
 
-    The function modifies *entry* in place.  If no matching attachment is
-    found, or if fetching / parsing fails, the entry is left unchanged.
+    The function modifies *entry* in place. If no attachment matches, or if
+    fetching or parsing fails, the entry is left unchanged.
+
+    Which filenames count is the ADAPTER's answer, not this module's:
+    ``metadata.json`` is one facility's convention, and a logbook that names
+    its sidecar anything else was silently getting no metadata at all. An
+    adapter declares its own through
+    :attr:`~osprey.services.ariel_search.ingestion.base.FacilityAdapter.metadata_sidecar_names`.
+
+    The HTTP fetch honours the ingestion config it is given --- the same TLS
+    verification, site CA and SOCKS proxy the adapter itself uses. Without
+    that, this step reached the logbook host over a connection configured
+    differently from every other request in the same ingest: unverified where
+    the adapter verified, and direct where the adapter went through a proxy
+    (so, on an air-gapped site, not at all).
 
     Args:
         entry: The logbook entry to enrich.
         fetch_timeout: HTTP request timeout in seconds.
+        adapter: The adapter that produced *entry*, for its sidecar filenames
+            and its proxy connector. ``None`` falls back to
+            :data:`DEFAULT_SIDECAR_NAMES` and a plain session.
+        ingestion: The ingestion config, for ``verify_ssl`` and ``ca_bundle``.
     """
-    for att in entry.get("attachments", []):
-        filename = att.get("filename") or ""
-        if filename.lower() != "metadata.json":
+    names = _sidecar_names(adapter)
+    attachments = entry.get("attachments", [])
+
+    matched = False
+    for att in attachments:
+        filename = (att.get("filename") or "").lower()
+        if filename not in names:
             continue
+        matched = True
 
         url = att.get("url", "")
         if not url:
             continue
 
         try:
-            data = await _fetch_metadata(url, fetch_timeout)
+            data = await _fetch_metadata(url, fetch_timeout, adapter, ingestion)
         except Exception:
-            logger.warning("Failed to fetch metadata.json from %s", url, exc_info=True)
+            logger.warning("Failed to fetch sidecar metadata from %s", url, exc_info=True)
             continue
 
         if isinstance(data, dict):
             entry["metadata"].update(data)
-            logger.debug("Merged metadata.json from %s into entry %s", url, entry["entry_id"])
+            logger.debug("Merged sidecar metadata from %s into entry %s", url, entry["entry_id"])
+
+    if attachments and not matched:
+        logger.debug(
+            "Entry %s has %d attachment(s) but none named %s",
+            entry["entry_id"],
+            len(attachments),
+            ", ".join(sorted(names)),
+        )
 
 
-async def _fetch_metadata(url: str, timeout: int) -> Any:
-    """Fetch and parse a metadata.json file from a URL or local path."""
+def _sidecar_names(adapter: FacilityAdapter | None) -> set[str]:
+    """The lower-cased filenames that count as a sidecar for *adapter*."""
+    declared = getattr(adapter, "metadata_sidecar_names", None) or DEFAULT_SIDECAR_NAMES
+    return {str(name).lower() for name in declared}
+
+
+async def _fetch_metadata(
+    url: str,
+    timeout: int,
+    adapter: FacilityAdapter | None = None,
+    ingestion: IngestionConfig | None = None,
+) -> Any:
+    """Fetch and parse a sidecar metadata file from a URL or local path."""
     if url.startswith(("http://", "https://")):
         import aiohttp
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout)) as resp:
+        from osprey.services.ariel_search.ingestion.http import build_ssl_context
+
+        ssl_context: Any = True
+        if ingestion is not None:
+            ssl_context = build_ssl_context(ingestion.verify_ssl, ingestion.ca_bundle)
+
+        # The adapter's own connector, so a SOCKS proxy the ingest goes
+        # through carries this request too.
+        connector = None
+        make_connector = getattr(adapter, "_create_connector", None)
+        if callable(make_connector):
+            connector = make_connector()
+
+        async with aiohttp.ClientSession(connector=connector) as session:
+            async with session.get(
+                url,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+                ssl=ssl_context,
+            ) as resp:
                 resp.raise_for_status()
                 return await resp.json()
     else:
@@ -65,4 +133,4 @@ async def _fetch_metadata(url: str, timeout: int) -> Any:
         path = Path(url)
         if path.exists():
             return json.loads(path.read_text())
-        raise FileNotFoundError(f"metadata.json not found at {url}")
+        raise FileNotFoundError(f"sidecar metadata not found at {url}")

--- a/src/osprey/services/ariel_search/ingestion/scheduler.py
+++ b/src/osprey/services/ariel_search/ingestion/scheduler.py
@@ -198,7 +198,11 @@ class IngestionScheduler:
         try:
             async for entry in adapter.fetch_entries(since=since, limit=limit):
                 try:
-                    await extract_metadata_from_attachments(entry)
+                    await extract_metadata_from_attachments(
+                        entry,
+                        adapter=adapter,
+                        ingestion=self.config.ingestion,
+                    )
                     await self.repository.upsert_entry(entry)
                     entries_added += 1
 

--- a/src/osprey/services/ariel_search/search/sql_query.py
+++ b/src/osprey/services/ariel_search/search/sql_query.py
@@ -58,11 +58,20 @@ class SqlQueryInput(BaseModel):
 def validate_sql_query(query: str) -> None:
     """Validate that a SQL query is safe to execute.
 
-    Uses an allowlist approach:
-    - Must start with SELECT or WITH (for CTEs)
-    - No multi-statement injection (semicolons)
-    - No DML/DDL/DCL keywords
-    - Only allowed tables
+    Four rules, all of which must hold:
+
+    - starts with SELECT or WITH (for CTEs);
+    - one statement — no semicolons in the body;
+    - no DML/DDL/DCL keyword anywhere;
+    - reads at least one allowlisted table, and no table outside the
+      allowlist.
+
+    That last rule is why the check is an allowlist rather than a denylist, and
+    why "names none" is a refusal rather than a pass. A query with no FROM or
+    JOIN at all — ``SELECT pg_read_file('/etc/passwd')`` — has nothing to
+    check against the allowlist, and the read-only transaction the caller opens
+    stops writes, not server-side file reads. So a query that resolves to no
+    allowlisted table is refused on that ground alone.
 
     Args:
         query: The SQL query to validate.
@@ -112,11 +121,13 @@ def validate_sql_query(query: str) -> None:
     table_pattern = r"\b(?:FROM|JOIN)\s+([a-zA-Z_][a-zA-Z0-9_]*)"
     table_refs = re.findall(table_pattern, normalized, re.IGNORECASE)
 
-    for table_ref in table_refs:
+    # Only the references that survive CTE resolution are real tables; a name
+    # a WITH clause defined is a query of its own, already checked by whatever
+    # IT reads.
+    resolved_refs = [ref for ref in table_refs if ref.lower() not in cte_names]
+
+    for table_ref in resolved_refs:
         table_lower = table_ref.lower()
-        # Skip CTE-defined names
-        if table_lower in cte_names:
-            continue
         # Check exact match or prefix match (for text_embeddings_* tables)
         if not any(
             table_lower == allowed or table_lower.startswith(f"{allowed}_")
@@ -126,6 +137,14 @@ def validate_sql_query(query: str) -> None:
                 f"Table '{table_ref}' is not in the allowlist. "
                 f"Allowed tables: enhanced_entries, text_embeddings_*"
             )
+
+    # Nothing to check IS the failure: the loop above passes vacuously for a
+    # query that reads no table, which is exactly the shape a server-side file
+    # read takes.
+    if not resolved_refs:
+        raise ValueError(
+            "Query reads no allowlisted table. Allowed tables: enhanced_entries, text_embeddings_*"
+        )
 
 
 async def sql_query(

--- a/src/osprey/services/channel_finder/benchmarks/generator.py
+++ b/src/osprey/services/channel_finder/benchmarks/generator.py
@@ -32,7 +32,9 @@ def load_template(source_path: Path | None = None) -> tuple[dict, list[dict]]:
     """Load a hierarchical template and expand to flat channels.
 
     Args:
-        source_path: Path to hierarchical JSON. Defaults to built-in template.
+        source_path: Path to hierarchical JSON. Defaults to the packaged demo
+            template — callers that write into a deployment's own database
+            directory name the source explicitly rather than relying on it.
 
     Returns:
         (tree_data, expanded_channels) tuple.
@@ -332,7 +334,9 @@ _HWUNITS_BY_FIELD: dict[str, str] = {
 _DEFAULT_HWUNITS = ""
 
 
-def format_in_context(channels: list[dict], tier_spec: TierSpec) -> dict:
+def format_in_context(
+    channels: list[dict], tier_spec: TierSpec, source: Path | str | None = None
+) -> dict:
     """Format channels for the in-context (flat) database paradigm.
 
     Filters *channels* by *tier_spec* and returns a dict with
@@ -343,6 +347,9 @@ def format_in_context(channels: list[dict], tier_spec: TierSpec) -> dict:
         channels: Full list of expanded channel dicts from
             :func:`expand_hierarchy`.
         tier_spec: Tier specification controlling which channels to include.
+        source: The hierarchical database these channels were expanded from,
+            recorded in ``_metadata`` so a generated file says which machine's
+            channels it holds. Omitted when the caller did not name one.
 
     Returns:
         Dict with ``_metadata`` and ``channels`` keys, loadable by
@@ -357,13 +364,16 @@ def format_in_context(channels: list[dict], tier_spec: TierSpec) -> dict:
         }
         for ch in filtered
     ]
+    metadata = {
+        "version": "1.0",
+        "tier": tier_spec.name,
+        "total_channels": len(channel_entries),
+        "generated_by": "osprey-benchmark-generator",
+    }
+    if source is not None:
+        metadata["source"] = str(source)
     return {
-        "_metadata": {
-            "version": "1.0",
-            "tier": tier_spec.name,
-            "total_channels": len(channel_entries),
-            "generated_by": "osprey-benchmark-generator",
-        },
+        "_metadata": metadata,
         "channels": channel_entries,
     }
 

--- a/src/osprey/templates/apps/ariel_standalone/config.yml.j2
+++ b/src/osprey/templates/apps/ariel_standalone/config.yml.j2
@@ -351,6 +351,17 @@ ariel:
     adapter: generic_json
     source_url: data/logbook_seed/demo_logbook.json
 
+    # TLS on the logbook fetch. Verification is ON — an ingest that cannot
+    # verify the logbook's certificate fails rather than trusting whatever
+    # answered. Two ways out, in order of preference:
+    #   ca_bundle: point at your site CA's PEM when it is not in the image
+    #     trust store (a CA installed into the image needs no key here);
+    #   verify_ssl: false — the deliberate opt-out for a certificate that
+    #     cannot be verified at all. Credentials and entry text then travel
+    #     over a connection nobody has authenticated.
+    # ca_bundle: /etc/ssl/certs/site-ca.pem
+    # verify_ssl: false
+
   # Which module answers a search that names no mode — the web interface's
   # opening tab, `osprey ariel search` without `--mode`, and the service API.
   # Naming a module that is not enabled below is refused at startup rather

--- a/src/osprey/templates/apps/control_assistant/config.yml.j2
+++ b/src/osprey/templates/apps/control_assistant/config.yml.j2
@@ -1035,6 +1035,14 @@ ariel:
   # scenarios and seeds their logbook entries into Postgres (see the
   # sim-scenarios skill). For production, add an `ingestion` block pointing at
   # your logbook system (adapter + source_url) and use `osprey ariel ingest`.
+  # That block's TLS keys default to verifying the logbook's certificate; name
+  # your site CA with `ca_bundle` when it is not in the image trust store, and
+  # keep `verify_ssl: false` for a certificate that cannot be verified at all.
+  # ingestion:
+  #   adapter: generic_json
+  #   source_url: https://logbook.example.org/api/entries
+  #   ca_bundle: /etc/ssl/certs/site-ca.pem
+  #   verify_ssl: false
 
   # osprey:panel-port ariel
   # ARIEL tab: the search UI is a web server of its own, configured under this

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -765,6 +765,9 @@ api:
     #                                  # through the translation proxy to
     #                                  # /chat/completions. Copying this block
     #                                  # without it silently adds that hop.
+    #                                  # The key takes exactly two values,
+    #                                  # `anthropic` and `openai`; anything
+    #                                  # else is refused at build.
     # Then set claude_code.provider: my-proxy above.
 
 # ============================================================

--- a/tests/cli/test_channel_finder_generate.py
+++ b/tests/cli/test_channel_finder_generate.py
@@ -25,12 +25,92 @@ class TestGenerateSubcommand:
         assert "--output-dir" in result.output
         assert "--validate" in result.output
         assert "--source" in result.output
+        assert "--demo" in result.output
+        assert "--force" in result.output
         assert "--format" in result.output
         assert "--tier" in result.output
 
+    def test_bare_generate_is_refused(self, runner, tmp_path):
+        """Neither --source nor --demo means nobody said whose channels these are."""
+        result = runner.invoke(channel_finder, ["generate", "--output-dir", str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "--source" in result.output
+        assert "--demo" in result.output
+        assert not (tmp_path / "in_context.json").exists()
+
+    def test_source_and_demo_together_are_refused(self, runner, tmp_path):
+        """Two sources named is a mistake, not a precedence question."""
+        from osprey.services.channel_finder.benchmarks.generator import TEMPLATE_DB_PATH
+
+        result = runner.invoke(
+            channel_finder,
+            [
+                "generate",
+                "--demo",
+                "--source",
+                str(TEMPLATE_DB_PATH),
+                "--output-dir",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert not (tmp_path / "in_context.json").exists()
+
+    def test_existing_files_are_not_overwritten(self, runner, tmp_path):
+        """The default output directory is the one the pipelines read."""
+        existing = tmp_path / "in_context.json"
+        existing.write_text('{"_metadata": {}, "channels": []}')
+
+        result = runner.invoke(
+            channel_finder,
+            ["generate", "--demo", "--output-dir", str(tmp_path), "--format", "in_context"],
+        )
+
+        assert result.exit_code != 0
+        assert "--force" in result.output
+        assert existing.read_text() == '{"_metadata": {}, "channels": []}'
+
+    def test_force_overwrites(self, runner, tmp_path):
+        """--force is how a deliberate regeneration says so."""
+        existing = tmp_path / "in_context.json"
+        existing.write_text('{"_metadata": {}, "channels": []}')
+
+        result = runner.invoke(
+            channel_finder,
+            [
+                "generate",
+                "--demo",
+                "--output-dir",
+                str(tmp_path),
+                "--format",
+                "in_context",
+                "--force",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(existing.read_text())["channels"]
+
+    def test_metadata_records_the_source(self, runner, tmp_path):
+        """A generated file says which hierarchical database it came from."""
+        from osprey.services.channel_finder.benchmarks.generator import TEMPLATE_DB_PATH
+
+        result = runner.invoke(
+            channel_finder,
+            ["generate", "--demo", "--output-dir", str(tmp_path), "--format", "in_context"],
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads((tmp_path / "in_context.json").read_text())
+        assert data["_metadata"]["source"] == str(TEMPLATE_DB_PATH)
+
     def test_generates_three_files(self, runner, tmp_path):
         """Running generate creates 3 database files."""
-        result = runner.invoke(channel_finder, ["generate", "--output-dir", str(tmp_path)])
+        result = runner.invoke(
+            channel_finder, ["generate", "--demo", "--output-dir", str(tmp_path)]
+        )
         assert result.exit_code == 0, f"Failed: {result.output}"
 
         assert (tmp_path / "in_context.json").exists()
@@ -43,7 +123,7 @@ class TestGenerateSubcommand:
 
         _, all_channels = load_template()
 
-        runner.invoke(channel_finder, ["generate", "--output-dir", str(tmp_path)])
+        runner.invoke(channel_finder, ["generate", "--demo", "--output-dir", str(tmp_path)])
 
         data = json.loads((tmp_path / "in_context.json").read_text())
         assert isinstance(data, dict)
@@ -63,7 +143,7 @@ class TestGenerateSubcommand:
 
         runner.invoke(
             channel_finder,
-            ["generate", "--output-dir", str(tmp_path), "--tier", "1"],
+            ["generate", "--demo", "--output-dir", str(tmp_path), "--tier", "1"],
         )
 
         data = json.loads((tmp_path / "in_context.json").read_text())
@@ -78,7 +158,7 @@ class TestGenerateSubcommand:
 
         _, all_channels = load_template()
 
-        runner.invoke(channel_finder, ["generate", "--output-dir", str(tmp_path)])
+        runner.invoke(channel_finder, ["generate", "--demo", "--output-dir", str(tmp_path)])
 
         data = json.loads((tmp_path / "hierarchical.json").read_text())
         channels = expand_hierarchy(data)
@@ -93,7 +173,7 @@ class TestGenerateSubcommand:
 
         _, all_channels = load_template()
 
-        runner.invoke(channel_finder, ["generate", "--output-dir", str(tmp_path)])
+        runner.invoke(channel_finder, ["generate", "--demo", "--output-dir", str(tmp_path)])
 
         data = json.loads((tmp_path / "middle_layer.json").read_text())
         pvs = collect_middle_layer_pvs(data)
@@ -102,14 +182,14 @@ class TestGenerateSubcommand:
     def test_output_dir_flag(self, runner, tmp_path):
         """--output-dir creates files in specified directory."""
         custom = tmp_path / "custom_output"
-        result = runner.invoke(channel_finder, ["generate", "--output-dir", str(custom)])
+        result = runner.invoke(channel_finder, ["generate", "--demo", "--output-dir", str(custom)])
         assert result.exit_code == 0
         assert (custom / "in_context.json").exists()
 
     def test_validate_flag(self, runner, tmp_path):
         """--validate produces validation output."""
         result = runner.invoke(
-            channel_finder, ["generate", "--output-dir", str(tmp_path), "--validate"]
+            channel_finder, ["generate", "--demo", "--output-dir", str(tmp_path), "--validate"]
         )
         assert result.exit_code == 0
         assert "validated" in result.output.lower() or "OK" in result.output
@@ -118,7 +198,7 @@ class TestGenerateSubcommand:
         """--format in_context generates only one file."""
         result = runner.invoke(
             channel_finder,
-            ["generate", "--output-dir", str(tmp_path), "--format", "in_context"],
+            ["generate", "--demo", "--output-dir", str(tmp_path), "--format", "in_context"],
         )
         assert result.exit_code == 0
         assert (tmp_path / "in_context.json").exists()
@@ -138,7 +218,7 @@ class TestGenerateSubcommand:
 
         result = runner.invoke(
             channel_finder,
-            ["generate", "--output-dir", str(tmp_path), "--tier", "1"],
+            ["generate", "--demo", "--output-dir", str(tmp_path), "--tier", "1"],
         )
         assert result.exit_code == 0
 
@@ -154,7 +234,16 @@ class TestGenerateSubcommand:
         """--tier 1 with a non-in_context --format is refused."""
         result = runner.invoke(
             channel_finder,
-            ["generate", "--output-dir", str(tmp_path), "--tier", "1", "--format", "hierarchical"],
+            [
+                "generate",
+                "--demo",
+                "--output-dir",
+                str(tmp_path),
+                "--tier",
+                "1",
+                "--format",
+                "hierarchical",
+            ],
         )
         assert result.exit_code != 0
         assert "in_context" in result.output
@@ -191,6 +280,7 @@ class TestGenerateSubcommand:
             channel_finder,
             [
                 "generate",
+                "--demo",
                 "--output-dir",
                 str(tmp_path),
                 "--format",

--- a/tests/cli/test_claude_code_resolver.py
+++ b/tests/cli/test_claude_code_resolver.py
@@ -128,6 +128,47 @@ class TestAlsApgProvider:
         assert spec.default_model_tier == "haiku"
 
 
+class TestUnrecognisedApiProtocol:
+    """A misspelled api_protocol is refused where an unknown provider is."""
+
+    def test_resolve_surfaces_the_refusal(self):
+        api_providers = {
+            "my-gateway": {
+                "base_url": "https://gateway.example.org/v1",
+                "api_protocol": "Anthropic",
+                "models": {"haiku": "h", "sonnet": "s", "opus": "o"},
+            }
+        }
+        with pytest.raises(ValueError, match="api.providers.my-gateway.api_protocol"):
+            ClaudeCodeModelResolver.resolve({"provider": "my-gateway"}, api_providers)
+
+    def test_a_valid_protocol_resolves(self):
+        """The check refuses spellings, not the two values themselves."""
+        api_providers = {
+            "my-gateway": {
+                "base_url": "https://gateway.example.org/v1",
+                "api_protocol": "anthropic",
+                "models": {"haiku": "h", "sonnet": "s", "opus": "o"},
+            }
+        }
+        spec = ClaudeCodeModelResolver.resolve({"provider": "my-gateway"}, api_providers)
+        assert spec is not None
+        assert spec.needs_proxy is False
+        assert spec.upstream_base_url is None
+
+    def test_an_absent_protocol_still_routes_through_the_proxy(self):
+        api_providers = {
+            "my-gateway": {
+                "base_url": "https://gateway.example.org/v1",
+                "models": {"haiku": "h", "sonnet": "s", "opus": "o"},
+            }
+        }
+        spec = ClaudeCodeModelResolver.resolve({"provider": "my-gateway"}, api_providers)
+        assert spec is not None
+        assert spec.needs_proxy is True
+        assert spec.upstream_base_url == "https://gateway.example.org/v1"
+
+
 class TestUnsupportedProvider:
     """Unknown provider without api_providers entry raises ValueError."""
 

--- a/tests/dispatch/test_epics_ca_source.py
+++ b/tests/dispatch/test_epics_ca_source.py
@@ -439,6 +439,76 @@ class TestEpicsCaSourceLifecycle:
         assert len(source._watchers) == 0
 
     @pytest.mark.asyncio
+    async def test_start_skips_trigger_with_unknown_edge(self, caplog) -> None:
+        """`edge: up` used to arm a both-edges monitor; it is now refused."""
+        source = EpicsCaSource()
+        fire_cb = AsyncMock(return_value=None)
+
+        with (
+            caplog.at_level("WARNING", logger="osprey.dispatch.sources.epics_ca"),
+            patch("osprey.dispatch.sources.epics_ca.epics.PV") as mock_pv,
+        ):
+            await source.start([_trigger(name="typo", edge="up")], fire_cb)
+
+        mock_pv.assert_not_called()
+        assert len(source._watchers) == 0
+        assert "typo" in caplog.text
+        assert "'up'" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_sibling_triggers_stay_armed(self) -> None:
+        """One mistyped edge takes down that trigger, not the dispatcher's set."""
+        source = EpicsCaSource()
+        fire_cb = AsyncMock(return_value=None)
+        triggers = [
+            _trigger(name="typo", pv="SIM:PV:1", edge="up"),
+            _trigger(name="good", pv="SIM:PV:2", edge="falling"),
+        ]
+
+        created = []
+
+        def _fake_pv(pvname, callback=None, **kw):
+            pv = _FakePV(pvname, callback)
+            created.append(pv)
+            return pv
+
+        with patch("osprey.dispatch.sources.epics_ca.epics.PV", side_effect=_fake_pv):
+            await source.start(triggers, fire_cb)
+
+        assert len(source._watchers) == 1
+        assert [pv.pvname for pv in created] == ["SIM:PV:2"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("edge", ["rising", "falling", "both"])
+    async def test_every_valid_edge_arms(self, edge) -> None:
+        """The three edges _detect_edge implements are all accepted."""
+        source = EpicsCaSource()
+        fire_cb = AsyncMock(return_value=None)
+
+        with patch("osprey.dispatch.sources.epics_ca.epics.PV", side_effect=_FakePV):
+            await source.start([_trigger(edge=edge)], fire_cb)
+
+        assert len(source._watchers) == 1
+
+    @pytest.mark.asyncio
+    async def test_absent_edge_defaults_to_rising(self) -> None:
+        """A trigger that never mentions `edge` keeps the documented default."""
+        source = EpicsCaSource()
+        fire_cb = AsyncMock(return_value=None)
+        trigger = TriggerConfig(
+            name="no-edge",
+            source="epics_ca",
+            action={"prompt": "test"},
+            source_config={"pv": "SIM:PV"},
+        )
+
+        with patch("osprey.dispatch.sources.epics_ca.epics.PV", side_effect=_FakePV):
+            await source.start([trigger], fire_cb)
+
+        assert len(source._watchers) == 1
+        assert source._watchers[0]._edge == "rising"
+
+    @pytest.mark.asyncio
     async def test_stop_clears_watchers(self) -> None:
         source = EpicsCaSource()
         triggers = [_trigger(name="t1", pv="SIM:PV:1")]

--- a/tests/infrastructure/proxy/test_proxy_lifecycle.py
+++ b/tests/infrastructure/proxy/test_proxy_lifecycle.py
@@ -84,6 +84,31 @@ class TestIsProxyNeeded:
         api = {"other": {"api_protocol": "anthropic"}}
         assert lifecycle.is_proxy_needed("custom", api_providers=api) is True
 
+    @pytest.mark.parametrize("value", ["Anthropic", "ANTHROPIC", "antropic", "openai-compatible"])
+    def test_unrecognised_protocol_is_refused(self, value):
+        """A typo used to read as "not Anthropic" and insert the translation hop."""
+        api = {"custom": {"api_protocol": value}}
+        with pytest.raises(ValueError, match="api.providers.custom.api_protocol"):
+            lifecycle.is_proxy_needed("custom", api_providers=api)
+
+    def test_the_refusal_names_the_accepted_values(self):
+        api = {"custom": {"api_protocol": "Anthropic"}}
+        with pytest.raises(ValueError) as exc_info:
+            lifecycle.is_proxy_needed("custom", api_providers=api)
+
+        assert "anthropic, openai" in str(exc_info.value)
+
+    def test_a_native_provider_with_a_bad_protocol_is_refused_too(self):
+        """The check is on the declaration, not on whether it would have mattered."""
+        api = {"anthropic": {"api_protocol": "Anthropic"}}
+        with pytest.raises(ValueError):
+            lifecycle.is_proxy_needed("anthropic", api_providers=api)
+
+    def test_an_absent_key_keeps_the_openai_default(self):
+        """Nine of the twelve proxied built-ins declare nothing and are OpenAI."""
+        api = {"custom": {"base_url": "https://gateway.example.org/v1"}}
+        assert lifecycle.is_proxy_needed("custom", api_providers=api) is True
+
 
 # ---------------------------------------------------------------------------
 # find_free_port

--- a/tests/interfaces/ariel/config-panel-gate.test.mjs
+++ b/tests/interfaces/ariel/config-panel-gate.test.mjs
@@ -1,0 +1,66 @@
+// @ts-check
+/**
+ * The client half of the Config panel's tier gate.
+ *
+ * `web.config_panel.enabled: false` reaches the browser as
+ * `config_panel_enabled: false` on `/api/capabilities`. The server refusal is
+ * the real gate — both `/api/config` verbs answer 403 — and this proves the
+ * other half: the Settings entry and the drawer it opens leave the page, and
+ * an absent flag (an older backend, a failed capabilities fetch) changes
+ * nothing.
+ *
+ *   npx vitest run tests/interfaces/ariel/config-panel-gate.test.mjs
+ */
+
+import { test, expect, describe, beforeEach } from 'vitest';
+
+import { initSettings } from '../../../src/osprey/interfaces/ariel/static/js/settings.js';
+
+/** The header's display menu plus the drawer it targets, as index.html lays them out. */
+function mountFixture() {
+  document.body.innerHTML = `
+    <osprey-display-menu settings-drawer="settings-drawer">
+      <button class="display-menu-settings" data-drawer="settings-drawer">Settings</button>
+    </osprey-display-menu>
+    <div id="settings-drawer">
+      <div class="settings-mode-bar">
+        <button class="settings-mode-btn active" data-mode="form">Form</button>
+      </div>
+      <textarea id="config-raw-editor"></textarea>
+      <button id="config-apply-btn">Apply</button>
+    </div>
+  `;
+}
+
+describe('initSettings config panel gate', () => {
+  beforeEach(() => mountFixture());
+
+  test('a disabled panel loses its Settings entry and its drawer', () => {
+    initSettings({ config_panel_enabled: false });
+
+    expect(document.querySelector('.display-menu-settings')).toBeNull();
+    expect(document.getElementById('settings-drawer')).toBeNull();
+    expect(
+      document.querySelector('osprey-display-menu')?.getAttribute('settings-drawer')
+    ).toBeNull();
+  });
+
+  test('an enabled panel is left alone', () => {
+    initSettings({ config_panel_enabled: true });
+
+    expect(document.querySelector('.display-menu-settings')).not.toBeNull();
+    expect(document.getElementById('settings-drawer')).not.toBeNull();
+  });
+
+  test('an absent flag leaves the panel where the server default leaves it', () => {
+    initSettings({});
+
+    expect(document.getElementById('settings-drawer')).not.toBeNull();
+  });
+
+  test('capabilities that never arrived leave the panel alone', () => {
+    initSettings(null);
+
+    expect(document.getElementById('settings-drawer')).not.toBeNull();
+  });
+});

--- a/tests/interfaces/ariel/test_routes.py
+++ b/tests/interfaces/ariel/test_routes.py
@@ -1077,3 +1077,59 @@ def test_put_config_allows_an_unprotected_edit(client, gated_config, audit_zone)
     assert gated_config.read_text() == updated
     assert config_backup_path(gated_config).read_text() == before
     assert _audit_records(audit_zone) == []
+
+
+class TestConfigPanelTierGate:
+    """``web.config_panel.enabled: false`` closes the settings editor's server surface."""
+
+    def test_get_config_is_refused_when_the_panel_is_disabled(self, client, gated_config):
+        """A read is gated too: the document carries the provider base_urls."""
+        client.app.state.config_panel_enabled = False
+
+        response = client.get("/api/config")
+
+        assert response.status_code == 403
+        assert "web.config_panel.enabled" in response.json()["detail"]
+
+    def test_put_config_is_refused_when_the_panel_is_disabled(self, client, gated_config):
+        """The write is refused before the file is read, so nothing changes."""
+        before = gated_config.read_bytes()
+        client.app.state.config_panel_enabled = False
+
+        response = client.put("/api/config", json={"content": "project_name: updated\n"})
+
+        assert response.status_code == 403
+        assert "web.config_panel.enabled" in response.json()["detail"]
+        assert gated_config.read_bytes() == before
+
+    def test_the_gate_runs_before_the_protected_set(self, client, gated_config):
+        """A disabled panel never gets as far as having a key to judge."""
+        client.app.state.config_panel_enabled = False
+
+        response = client.put(
+            "/api/config",
+            json={"content": "control_system:\n  writes_enabled: false\nproject_name: x\n"},
+        )
+
+        assert response.status_code == 403
+        assert "agent_data.base_dir" not in response.json()["detail"]
+
+    def test_an_absent_key_leaves_the_panel_open(self, client, gated_config):
+        """An app whose lifespan never set the flag behaves as it always did."""
+        assert not hasattr(client.app.state, "config_panel_enabled")
+
+        assert client.get("/api/config").status_code == 200
+
+    def test_capabilities_reports_the_gate(self, client):
+        """The frontend gets the flag it needs to drop the Settings entry."""
+        client.app.state.config_panel_enabled = False
+
+        payload = client.get("/api/capabilities").json()
+
+        assert payload["config_panel_enabled"] is False
+
+    def test_capabilities_reports_an_open_panel_by_default(self, client):
+        """No flag on app.state reads as open, matching the server's own default."""
+        payload = client.get("/api/capabilities").json()
+
+        assert payload["config_panel_enabled"] is True

--- a/tests/interfaces/ariel/test_routes_vocabulary.py
+++ b/tests/interfaces/ariel/test_routes_vocabulary.py
@@ -116,6 +116,7 @@ def test_capabilities_configuration_invalid_payload_is_service_independent():
         "default_mode": None,
         "shared_parameters": [],
         "vocabulary": {"enabled": False, "concepts": 0, "expand_by_default": False},
+        "config_panel_enabled": True,
     }
     assert "ariel.vocabulary.path" in response.json()["remedy"]
 
@@ -169,7 +170,13 @@ def test_capabilities_without_config_state_returns_the_normal_payload():
 
     assert response.status_code == 200
     payload = response.json()
-    assert set(payload) == {"categories", "default_mode", "shared_parameters", "vocabulary"}
+    assert set(payload) == {
+        "categories",
+        "default_mode",
+        "shared_parameters",
+        "vocabulary",
+        "config_panel_enabled",
+    }
     assert "status" not in payload
 
 

--- a/tests/mcp_server/ariel/test_sql_query.py
+++ b/tests/mcp_server/ariel/test_sql_query.py
@@ -28,6 +28,16 @@ class TestValidateSqlQuery:
             "SELECT * FROM recent"
         )
 
+    def test_reject_query_that_reads_no_table(self):
+        """A server-side file read names no table, so the allowlist saw nothing."""
+        with pytest.raises(ValueError, match="reads no allowlisted table"):
+            validate_sql_query("SELECT pg_read_file('/etc/passwd')")
+
+    def test_reject_cte_only_query(self):
+        """A query whose only references are its own CTEs reads no real table."""
+        with pytest.raises(ValueError, match="reads no allowlisted table"):
+            validate_sql_query("WITH x AS (SELECT 1 AS n) SELECT * FROM x")
+
     def test_reject_insert(self):
         """INSERT is rejected."""
         with pytest.raises(ValueError, match="INSERT"):

--- a/tests/mcp_server/test_archiver_read_tool.py
+++ b/tests/mcp_server/test_archiver_read_tool.py
@@ -244,41 +244,93 @@ def test_parse_time_relative_expressions(expression, expected_delta, monkeypatch
         "M ago",
     ],
 )
-def test_parse_time_unrecognized_relative_falls_through_to_dateutil(expression, monkeypatch):
-    """A "... ago" string the unit map cannot serve still reaches the dateutil branch.
+def test_parse_time_unrecognized_relative_falls_through_to_iso(expression, monkeypatch):
+    """A "... ago" string the unit map cannot serve still reaches the ISO branch.
 
-    dateutil rejects all of these, so ``ParserError`` proves the fall-through
-    happened.
+    None of these is ISO-8601, so the ``ValueError`` proves the fall-through
+    happened and that it ends in a refusal rather than a guess.
     """
     from datetime import UTC
-
-    from dateutil.parser import ParserError
 
     from osprey.mcp_server.control_system.tools import archiver_read as mod
 
     monkeypatch.setattr(mod, "get_facility_timezone", lambda: UTC)
 
-    with pytest.raises(ParserError):
+    with pytest.raises(ValueError):
         mod._parse_time(expression)
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("field", "kwargs"),
+    "expression",
     [
-        ("start_time", {"start_time": "not-a-timestamp"}),
-        # A bad end_time is caught after a good start_time.
-        ("end_time", {"start_time": "2024-01-15T10:00:00", "end_time": "not-a-timestamp"}),
+        "03.04.2026",  # third of April, or fourth of March? Nobody can tell.
+        "03/04/2026",
+        "4 March 2026",
+        "March 4, 2026",
+        "next tuesday",
     ],
 )
-async def test_archiver_read_unparseable_time(archiver_project, field, kwargs):
-    """A time even dateutil cannot parse errors cleanly, naming the failing field."""
+def test_parse_time_refuses_ambiguous_dates(expression, monkeypatch):
+    """A dotted or slashed date has two readings a month apart; guessing is worse."""
+    from datetime import UTC
+
+    from osprey.mcp_server.control_system.tools import archiver_read as mod
+
+    monkeypatch.setattr(mod, "get_facility_timezone", lambda: UTC)
+
+    with pytest.raises(ValueError):
+        mod._parse_time(expression)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "2026-04-03",
+        "2026-04-03T14:00:00",
+        "2026-04-03 14:00:00",  # the space form fromisoformat takes since 3.11
+        "2026-04-03T14:00:00+02:00",
+    ],
+)
+def test_parse_time_accepts_iso_spellings(expression, monkeypatch):
+    """Everything the contract advertises still parses."""
+    from datetime import UTC
+
+    from osprey.mcp_server.control_system.tools import archiver_read as mod
+
+    monkeypatch.setattr(mod, "get_facility_timezone", lambda: UTC)
+
+    parsed = mod._parse_time(expression)
+
+    assert parsed.tzinfo is not None
+    assert parsed.year == 2026
+    assert (parsed.month, parsed.day) == (4, 3)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "bad_value", "kwargs"),
+    [
+        ("start_time", "not-a-timestamp", {"start_time": "not-a-timestamp"}),
+        # An ambiguous date is a validation error, not a month-first guess.
+        ("start_time", "03.04.2026", {"start_time": "03.04.2026"}),
+        # A bad end_time is caught after a good start_time.
+        (
+            "end_time",
+            "not-a-timestamp",
+            {"start_time": "2024-01-15T10:00:00", "end_time": "not-a-timestamp"},
+        ),
+    ],
+)
+async def test_archiver_read_unparseable_time(archiver_project, field, bad_value, kwargs):
+    """A time outside the accepted spellings errors cleanly, naming the failing field."""
     fn = _get_archiver_read()
     with assert_raises_error(error_type="validation_error") as ctx:
         await fn(channels=["SR:CURRENT:RB"], **kwargs)
 
     assert field in ctx["envelope"]["error_message"]
-    assert "not-a-timestamp" in ctx["envelope"]["error_message"]
+    assert bad_value in ctx["envelope"]["error_message"]
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/workspace/test_setup_tools.py
+++ b/tests/mcp_server/workspace/test_setup_tools.py
@@ -494,3 +494,104 @@ async def test_patch_file_not_found(project_dir):
     (project_dir / ".mcp.json").unlink()
     with _patch_config_path(project_dir), assert_raises_error(error_type="not_found"):
         await fn(file=".mcp.json", key_path="foo", value="bar")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_inspect_reports_the_unexpanded_config(project_dir, monkeypatch):
+    """No resolved ``${VAR}`` value reaches the payload — the placeholder does."""
+    fn = _get_setup_inspect()
+    config_path = project_dir / "config.yml"
+    config_path.write_text(
+        "control_system:\n"
+        "  type: mock\n"
+        "ariel:\n"
+        "  database:\n"
+        "    uri: postgresql://ariel:${ARIEL_DB_PASSWORD}@db:5432/ariel\n"
+        "models:\n"
+        "  providers:\n"
+        "    anthropic:\n"
+        "      api_key: ${ANTHROPIC_API_KEY}\n"
+    )
+    monkeypatch.setenv("ARIEL_DB_PASSWORD", "hunter2-from-the-env")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-from-the-env")
+    # What ``load_osprey_config`` hands back, and what used to be reported
+    # verbatim: every placeholder already replaced by its environment value.
+    expanded = {
+        "control_system": {"type": "mock"},
+        "ariel": {"database": {"uri": "postgresql://ariel:hunter2-from-the-env@db:5432/ariel"}},
+        "models": {"providers": {"anthropic": {"api_key": "sk-ant-from-the-env"}}},
+    }
+
+    with _patch_config_path(project_dir), _patch_load_config(expanded):
+        payload = await fn()
+
+    result = json.loads(payload)
+
+    assert "hunter2-from-the-env" not in payload
+    assert "sk-ant-from-the-env" not in payload
+    assert "${ARIEL_DB_PASSWORD}" in result["config"]["ariel"]["database"]["uri"]
+    assert result["config"]["models"]["providers"]["anthropic"]["api_key"] == (
+        "${ANTHROPIC_API_KEY}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_inspect_masks_a_secret_typed_into_the_config(project_dir):
+    """A literal under a sensitive key name is masked, placeholders or not."""
+    fn = _get_setup_inspect()
+    (project_dir / "config.yml").write_text(
+        "control_system:\n"
+        "  type: mock\n"
+        "models:\n"
+        "  providers:\n"
+        "    anthropic:\n"
+        "      api_key: sk-ant-typed-straight-in\n"
+        "      base_url: https://api.anthropic.com\n"
+    )
+    config = yaml.safe_load((project_dir / "config.yml").read_text())
+
+    with _patch_config_path(project_dir), _patch_load_config(config):
+        payload = await fn()
+
+    result = json.loads(payload)
+    provider = result["config"]["models"]["providers"]["anthropic"]
+
+    assert "sk-ant-typed-straight-in" not in payload
+    assert provider["api_key"] == "***"
+    # Everything that is not a secret still reads as itself.
+    assert provider["base_url"] == "https://api.anthropic.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_inspect_masks_secrets_in_the_mcp_servers_blob(project_dir):
+    """`.mcp.json` gets the same walk: it carries per-server env blocks."""
+    fn = _get_setup_inspect()
+    (project_dir / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "workspace": {
+                        "command": "python",
+                        "env": {
+                            "SOME_TOKEN": "tok-typed-straight-in",
+                            "OSPREY_CONFIG": "/app/config.yml",
+                        },
+                    }
+                }
+            }
+        )
+    )
+    config = yaml.safe_load((project_dir / "config.yml").read_text())
+
+    with _patch_config_path(project_dir), _patch_load_config(config):
+        payload = await fn()
+
+    result = json.loads(payload)
+    env = result["mcp_servers"]["mcpServers"]["workspace"]["env"]
+
+    assert "tok-typed-straight-in" not in payload
+    assert env["SOME_TOKEN"] == "***"
+    assert env["OSPREY_CONFIG"] == "/app/config.yml"

--- a/tests/services/ariel_search/test_cli_operations_maintenance.py
+++ b/tests/services/ariel_search/test_cli_operations_maintenance.py
@@ -518,7 +518,10 @@ class TestRunQuickstart:
 
         messages: list[str] = []
         result = await ops.run_quickstart(
-            {**_DB, "ingestion": {"source_url": "file:///entries.json"}},
+            {
+                **_DB,
+                "ingestion": {"adapter": "generic_json", "source_url": "file:///entries.json"},
+            },
             source=None,
             progress=messages.append,
         )
@@ -545,7 +548,10 @@ class TestRunQuickstart:
         messages: list[str] = []
         with caplog.at_level(logging.DEBUG, logger="ariel"):
             result = await ops.run_quickstart(
-                {**_DB, "ingestion": {"source_url": "file:///entries.json"}},
+                {
+                    **_DB,
+                    "ingestion": {"adapter": "generic_json", "source_url": "file:///entries.json"},
+                },
                 source=None,
                 progress=messages.append,
             )

--- a/tests/services/ariel_search/test_cli_operations_pipeline.py
+++ b/tests/services/ariel_search/test_cli_operations_pipeline.py
@@ -66,10 +66,14 @@ _SOURCE = "file:///entries.json"
 
 
 def _config(**ingestion: Any) -> dict[str, Any]:
-    """Fresh config dict; ``ingestion`` kwargs become the ``ingestion`` block."""
+    """Fresh config dict; ``ingestion`` kwargs become the ``ingestion`` block.
+
+    An ingestion block always names an adapter — the key is required — so one
+    is filled in unless the caller named its own.
+    """
     cfg: dict[str, Any] = {"database": dict(_DB["database"])}
     if ingestion:
-        cfg["ingestion"] = dict(ingestion)
+        cfg["ingestion"] = {"adapter": "generic_json", **ingestion}
     return cfg
 
 
@@ -235,20 +239,23 @@ class TestRunSync:
             "max_consecutive_failures": 3,
         }
 
-    async def test_missing_ingestion_block_gets_the_override_too(
+    async def test_missing_ingestion_block_is_refused(
         self, monkeypatch, mock_repository, fake_pool
     ):
+        """A sync with nothing to ingest from is refused, naming the missing key."""
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
         _patch_pool(monkeypatch, fake_pool)
         _patch_migrations(monkeypatch, applied=[])
-        schedulers = _patch_scheduler(monkeypatch, _poll_result(added=0))
+        _patch_scheduler(monkeypatch, _poll_result(added=0))
         _patch_service(monkeypatch, _StubService(mock_repository))
         _patch_enhancers(monkeypatch, [])
 
         config_dict = dict(_DB)
 
-        await ops.run_sync(config_dict)
+        with pytest.raises(ConfigurationError, match="ariel.ingestion.adapter is required"):
+            await ops.run_sync(config_dict)
 
-        assert schedulers[0].config.ingestion.watch.require_initial_ingest is False
         # The synthesized block never leaks back to the caller.
         assert "ingestion" not in config_dict
 
@@ -591,11 +598,14 @@ class TestRunWatchOnce:
         assert config_dict["ingestion"]["poll_interval_seconds"] == 30
         assert schedulers[0].config.ingestion.poll_interval_seconds == 30
 
-    async def test_interval_without_a_source_is_recorded_then_rejected(self, monkeypatch):
+    async def test_interval_without_an_ingestion_block_is_recorded_then_rejected(self, monkeypatch):
+        """An interval alone is not a configuration: the adapter is still required."""
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
         _forbid_service(monkeypatch)
 
         config_dict = dict(_DB)
-        with pytest.raises(ValueError, match="No ingestion source configured"):
+        with pytest.raises(ConfigurationError, match="ariel.ingestion.adapter is required"):
             await ops.run_watch(
                 config_dict,
                 source=None,
@@ -605,9 +615,25 @@ class TestRunWatchOnce:
                 dry_run=False,
             )
 
-        # The override is applied before the source check, so the synthesized
-        # block is left behind even though the call is rejected.
+        # The override is applied before the config is parsed, so the
+        # synthesized block is left behind even though the call is rejected.
         assert config_dict["ingestion"] == {"poll_interval_seconds": 45}
+
+    async def test_source_without_an_adapter_is_still_refused(self, monkeypatch):
+        """--source names where, not what reads it; the adapter is a separate answer."""
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
+        _forbid_service(monkeypatch)
+
+        with pytest.raises(ConfigurationError, match="ariel.ingestion.adapter is required"):
+            await ops.run_watch(
+                dict(_DB),
+                source=_SOURCE,
+                adapter=None,
+                once=True,
+                interval=None,
+                dry_run=False,
+            )
 
     async def test_the_updated_count_survives_the_projection(self, monkeypatch, mock_repository):
         """``entries_updated`` reaches the CLI result, not just the poll result.

--- a/tests/services/ariel_search/test_config.py
+++ b/tests/services/ariel_search/test_config.py
@@ -150,6 +150,38 @@ class TestIngestionConfig:
         assert config.source_url == "https://als.example.com/api"
         assert config.poll_interval_seconds == 1800
 
+    def test_tls_defaults(self) -> None:
+        """Verification is on and no site CA is assumed."""
+        config = IngestionConfig.from_dict({"adapter": "als_logbook"})
+        assert config.verify_ssl is True
+        assert config.ca_bundle is None
+
+    def test_ca_bundle_threads_through(self) -> None:
+        """A named site CA reaches the config the adapter reads."""
+        config = IngestionConfig.from_dict(
+            {"adapter": "als_logbook", "ca_bundle": "/etc/ssl/certs/site-ca.pem"}
+        )
+        assert config.ca_bundle == "/etc/ssl/certs/site-ca.pem"
+
+    def test_missing_adapter_is_refused(self) -> None:
+        """There is no default adapter: the old one was not a registered name."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            IngestionConfig.from_dict({"source_url": "https://als.example.com/api"})
+
+        assert "ariel.ingestion.adapter is required" in str(exc_info.value)
+
+    def test_the_refusal_lists_the_registered_adapters(self) -> None:
+        """An operator who meets it is told what to write instead."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            IngestionConfig.from_dict({})
+
+        assert "generic_json" in str(exc_info.value)
+
+    def test_an_empty_adapter_is_refused_too(self) -> None:
+        """`adapter:` with nothing after it names no adapter."""
+        with pytest.raises(ConfigurationError):
+            IngestionConfig.from_dict({"adapter": ""})
+
     def test_watch_defaults(self) -> None:
         """IngestionConfig has default WatchConfig."""
         config = IngestionConfig(adapter="generic_json")

--- a/tests/services/ariel_search/test_ingestion.py
+++ b/tests/services/ariel_search/test_ingestion.py
@@ -724,6 +724,21 @@ class TestALSLogbookAdapterHTTP:
         adapter = ALSLogbookAdapter(config)
         assert adapter.verify_ssl is True
 
+    def test_verify_ssl_defaults_on(self):
+        """An ingestion block that says nothing about TLS still verifies."""
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://test"},
+                "ingestion": {
+                    "adapter": "als_logbook",
+                    "source_url": "https://example.com/api",
+                },
+            }
+        )
+        adapter = ALSLogbookAdapter(config)
+        assert adapter.verify_ssl is True
+        assert adapter.ca_bundle is None
+
     def test_config_chunk_days(self):
         """Chunk days setting is read from config."""
         config = self._make_config(chunk_days=30)
@@ -1134,7 +1149,8 @@ class TestALSLogbookAdapterHTTPConfigParsing:
         config = IngestionConfig.from_dict({"adapter": "als_logbook"})
 
         assert config.proxy_url is None
-        assert config.verify_ssl is False
+        assert config.verify_ssl is True
+        assert config.ca_bundle is None
         assert config.chunk_days == 365
         assert config.request_timeout_seconds == 60
         assert config.max_retries == 3
@@ -1163,6 +1179,24 @@ class TestALSLogbookAdapterHTTPConfigParsing:
         assert config.request_timeout_seconds == 120
         assert config.max_retries == 5
         assert config.retry_delay_seconds == 10
+
+    def test_ingestion_config_verify_ssl_opt_out_is_explicit(self):
+        """Verification is only off when the config says so in words."""
+        from osprey.services.ariel_search.config import IngestionConfig
+
+        config = IngestionConfig.from_dict({"adapter": "als_logbook", "verify_ssl": False})
+
+        assert config.verify_ssl is False
+
+    def test_ingestion_config_ca_bundle(self):
+        """A site CA bundle path is carried through to the adapter."""
+        from osprey.services.ariel_search.config import IngestionConfig
+
+        config = IngestionConfig.from_dict(
+            {"adapter": "als_logbook", "ca_bundle": "/etc/ssl/certs/site-ca.pem"}
+        )
+
+        assert config.ca_bundle == "/etc/ssl/certs/site-ca.pem"
 
     def test_ingestion_config_env_fallback(self):
         """Proxy URL falls back to ARIEL_SOCKS_PROXY env var."""
@@ -1490,3 +1524,51 @@ class TestALSLogbookAdapterWrite:
 
         with pytest.raises(AuthenticationRequiredError, match="credentials"):
             await adapter.create_entry(request)
+
+
+class TestBuildSSLContext:
+    """Tests for the shared ingestion TLS helper."""
+
+    def test_verifying_default_uses_the_image_trust_store(self):
+        """No bundle named means aiohttp's own default, not a hand-built one."""
+        from osprey.services.ariel_search.ingestion.http import build_ssl_context
+
+        assert build_ssl_context(True, None) is True
+
+    def test_ca_bundle_builds_a_verifying_context(self, tmp_path):
+        """A named bundle produces a context that still verifies."""
+        import ssl
+
+        from osprey.services.ariel_search.ingestion.http import build_ssl_context
+
+        bundle = tmp_path / "site-ca.pem"
+        bundle.write_bytes(Path(ssl.get_default_verify_paths().openssl_cafile).read_bytes())
+
+        context = build_ssl_context(True, str(bundle))
+
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_opt_out_disables_verification(self):
+        """verify_ssl false is the one path that turns checking off."""
+        import ssl
+
+        from osprey.services.ariel_search.ingestion.http import build_ssl_context
+
+        context = build_ssl_context(False, None)
+
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_NONE
+        assert context.check_hostname is False
+
+    def test_adapter_builds_its_context_through_the_helper(self):
+        """The ALS adapter has no private copy of the TLS decision."""
+        import inspect
+
+        from osprey.services.ariel_search.ingestion.adapters import als
+
+        source = inspect.getsource(als)
+
+        assert "build_ssl_context(" in source
+        assert "ssl.CERT_NONE" not in source

--- a/tests/services/ariel_search/test_ingestion_branches.py
+++ b/tests/services/ariel_search/test_ingestion_branches.py
@@ -376,7 +376,7 @@ class TestALSPostEntry:
 
     @pytest.mark.asyncio
     async def test_verify_ssl_true_passes_certificate_verification(self):
-        """verify_ssl=True hands aiohttp its default verifying context."""
+        """verify_ssl=True, the default, hands aiohttp its default verifying context."""
         adapter = _als_write_adapter(verify_ssl=True)
         session = _http_session(post=_http_response(text="<response><id>7</id></response>"))
 
@@ -387,12 +387,12 @@ class TestALSPostEntry:
 
     @pytest.mark.asyncio
     async def test_verify_ssl_false_builds_permissive_context(self):
-        """verify_ssl=False (the default) disables hostname and certificate checks.
+        """verify_ssl=False disables hostname and certificate checks.
 
-        Internal olog servers carry self-signed certificates; the default is
-        permissive so ingestion works, and this pins exactly how permissive.
+        The written opt-out for an olog whose certificate cannot be verified at
+        all. This pins exactly how permissive it is; the default is on.
         """
-        adapter = _als_write_adapter()
+        adapter = _als_write_adapter(verify_ssl=False)
         session = _http_session(post=_http_response(text="<response><id>7</id></response>"))
 
         with _patched_session(adapter, session):

--- a/tests/services/ariel_search/test_metadata_attachment.py
+++ b/tests/services/ariel_search/test_metadata_attachment.py
@@ -3,10 +3,13 @@
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from osprey.services.ariel_search.config import IngestionConfig
 from osprey.services.ariel_search.ingestion.metadata_attachment import (
     extract_metadata_from_attachments,
 )
@@ -193,3 +196,158 @@ class TestAdapterMetadataMerge:
 
         entry = adapter._convert_entry(data)
         assert "not-a-dict" not in entry["metadata"].values()
+
+
+class TestAdapterDeclaredSidecarNames:
+    """Which filenames count is the adapter's answer, not this module's."""
+
+    @pytest.mark.asyncio
+    async def test_default_name_still_matches_without_an_adapter(self, tmp_path: Path):
+        """A caller that names no adapter behaves exactly as before."""
+        meta_file = tmp_path / "metadata.json"
+        meta_file.write_text(json.dumps({"a": 1}))
+        entry = _make_entry(attachments=[{"url": str(meta_file), "filename": "metadata.json"}])
+
+        await extract_metadata_from_attachments(entry)
+
+        assert entry["metadata"] == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_adapter_declared_name_is_matched(self, tmp_path: Path):
+        """A facility whose sidecar is not metadata.json now gets its metadata."""
+        meta_file = tmp_path / "entry-meta.json"
+        meta_file.write_text(json.dumps({"operator": "jane"}))
+        entry = _make_entry(attachments=[{"url": str(meta_file), "filename": "entry-meta.json"}])
+
+        adapter = SimpleNamespace(metadata_sidecar_names=("entry-meta.json",))
+        await extract_metadata_from_attachments(entry, adapter=adapter)
+
+        assert entry["metadata"] == {"operator": "jane"}
+
+    @pytest.mark.asyncio
+    async def test_a_name_the_adapter_does_not_declare_is_ignored(self, tmp_path: Path):
+        """Declaring names narrows as well as widens."""
+        meta_file = tmp_path / "metadata.json"
+        meta_file.write_text(json.dumps({"a": 1}))
+        entry = _make_entry(attachments=[{"url": str(meta_file), "filename": "metadata.json"}])
+
+        adapter = SimpleNamespace(metadata_sidecar_names=("entry-meta.json",))
+        await extract_metadata_from_attachments(entry, adapter=adapter)
+
+        assert entry["metadata"] == {}
+
+    @pytest.mark.asyncio
+    async def test_matching_is_case_insensitive(self, tmp_path: Path):
+        """Facilities are not consistent about case; the match should not care."""
+        meta_file = tmp_path / "Metadata.JSON"
+        meta_file.write_text(json.dumps({"a": 1}))
+        entry = _make_entry(attachments=[{"url": str(meta_file), "filename": "Metadata.JSON"}])
+
+        await extract_metadata_from_attachments(entry)
+
+        assert entry["metadata"] == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_unmatched_attachments_are_logged_at_debug(self, tmp_path: Path, caplog):
+        """An entry with attachments and no sidecar says so rather than staying silent."""
+        entry = _make_entry(attachments=[{"url": "/files/plot.png", "filename": "plot.png"}])
+
+        with caplog.at_level("DEBUG", logger="ariel.ingestion"):
+            await extract_metadata_from_attachments(entry)
+
+        assert "none named metadata.json" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_every_builtin_adapter_declares_the_default(self):
+        """The shipped adapters keep the convention they already had."""
+        from osprey.services.ariel_search.ingestion.base import FacilityAdapter
+
+        assert FacilityAdapter.metadata_sidecar_names == ("metadata.json",)
+
+
+class TestSidecarFetchHonoursIngestionSettings:
+    """The sidecar fetch uses the same transport as every other request in the ingest."""
+
+    @staticmethod
+    def _mock_session():
+        mock_resp = AsyncMock()
+        mock_resp.raise_for_status = lambda: None
+        mock_resp.json = AsyncMock(return_value={"operator": "jane"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        calls: dict[str, Any] = {}
+
+        mock_session = AsyncMock()
+
+        def _get(*args, **kwargs):
+            calls["get"] = kwargs
+            return mock_resp
+
+        mock_session.get = _get
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        return mock_session, calls
+
+    @pytest.mark.asyncio
+    async def test_ca_bundle_reaches_the_request(self, tmp_path: Path):
+        """A site CA configured for ingestion verifies the sidecar fetch too."""
+        import ssl
+
+        bundle = tmp_path / "site-ca.pem"
+        bundle.write_bytes(Path(ssl.get_default_verify_paths().openssl_cafile).read_bytes())
+
+        entry = _make_entry(
+            attachments=[{"url": "https://example.com/metadata.json", "filename": "metadata.json"}],
+        )
+        ingestion = IngestionConfig.from_dict({"adapter": "generic_json", "ca_bundle": str(bundle)})
+        session, calls = self._mock_session()
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            await extract_metadata_from_attachments(entry, ingestion=ingestion)
+
+        context = calls["get"]["ssl"]
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert entry["metadata"] == {"operator": "jane"}
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_opt_out_reaches_the_request(self):
+        """The opt-out applies here as well; nothing is verified twice-over."""
+        import ssl
+
+        entry = _make_entry(
+            attachments=[{"url": "https://example.com/metadata.json", "filename": "metadata.json"}],
+        )
+        ingestion = IngestionConfig.from_dict({"adapter": "generic_json", "verify_ssl": False})
+        session, calls = self._mock_session()
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            await extract_metadata_from_attachments(entry, ingestion=ingestion)
+
+        context = calls["get"]["ssl"]
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_NONE
+
+    @pytest.mark.asyncio
+    async def test_the_adapters_proxy_connector_is_used(self):
+        """A SOCKS proxy the ingest goes through carries this request too."""
+        entry = _make_entry(
+            attachments=[{"url": "https://example.com/metadata.json", "filename": "metadata.json"}],
+        )
+        sentinel = object()
+        adapter = SimpleNamespace(
+            metadata_sidecar_names=("metadata.json",),
+            _create_connector=lambda: sentinel,
+        )
+        session, _calls = self._mock_session()
+        seen: dict[str, Any] = {}
+
+        def _make_session(**kwargs):
+            seen.update(kwargs)
+            return session
+
+        with patch("aiohttp.ClientSession", side_effect=_make_session):
+            await extract_metadata_from_attachments(entry, adapter=adapter)
+
+        assert seen["connector"] is sentinel

--- a/tests/services/ariel_search/test_qmd_resync.py
+++ b/tests/services/ariel_search/test_qmd_resync.py
@@ -538,7 +538,10 @@ class TestWatchWiring:
         monkeypatch.setattr(sched_mod, "IngestionScheduler", _Scheduler)
         monkeypatch.setattr(ops, "resync_qmd_mirror_best_effort", _resync)
 
-        config_dict = {**_DB, "ingestion": {"source_url": "https://logbook.example/api"}}
+        config_dict = {
+            **_DB,
+            "ingestion": {"adapter": "generic_json", "source_url": "https://logbook.example/api"},
+        }
         await ops.run_watch(config_dict, None, None, False, None, False)
 
         assert order == ["resync", "poll", "resync", "poll"]

--- a/tests/services/ariel_search/test_scheduler.py
+++ b/tests/services/ariel_search/test_scheduler.py
@@ -764,3 +764,48 @@ class TestIngestionRunTracking:
 
         result = await repository.get_last_successful_run("als_elog")
         assert result is None
+
+
+class TestSidecarMetadataWiring:
+    """The scheduler hands the sidecar step the adapter and the ingestion config."""
+
+    @pytest.mark.asyncio
+    async def test_the_step_receives_the_adapter_and_the_ingestion_config(self) -> None:
+        """Without both, the step matches one hard-coded name over a bare session."""
+        config = _make_config()
+        adapter = _mock_adapter([_make_entry("e1")])
+
+        repository = MagicMock()
+        repository.pool = MagicMock()
+        repository.pool.connection = MagicMock(return_value=AsyncMock())
+        repository.start_ingestion_run = AsyncMock(return_value=1)
+        repository.complete_ingestion_run = AsyncMock()
+        repository.fail_ingestion_run = AsyncMock()
+        repository.get_last_successful_run = AsyncMock(
+            return_value=datetime(2026, 1, 1, tzinfo=UTC)
+        )
+        repository.upsert_entry = AsyncMock()
+
+        extract = AsyncMock()
+        with (
+            patch(
+                "osprey.services.ariel_search.ingestion.get_adapter",
+                return_value=adapter,
+            ),
+            patch(
+                "osprey.services.ariel_search.enhancement.create_enhancers_from_config",
+                return_value=[],
+            ),
+            patch(
+                "osprey.services.ariel_search.ingestion.metadata_attachment."
+                "extract_metadata_from_attachments",
+                extract,
+            ),
+        ):
+            scheduler = IngestionScheduler(config=config, repository=repository)
+            await scheduler.poll_once()
+
+        extract.assert_awaited_once()
+        kwargs = extract.await_args.kwargs
+        assert kwargs["adapter"] is adapter
+        assert kwargs["ingestion"] is config.ingestion

--- a/tests/services/ariel_search/test_sql_query.py
+++ b/tests/services/ariel_search/test_sql_query.py
@@ -162,6 +162,27 @@ class TestValidateSqlQueryRejects:
         with pytest.raises(ValueError, match="Table 'pg_stat_activity'"):
             validate_sql_query("WITH x AS (SELECT * FROM pg_stat_activity) SELECT * FROM x")
 
+    def test_server_side_file_read_names_no_table(self):
+        """A query with no FROM at all had nothing to check, so it used to pass."""
+        with pytest.raises(ValueError, match="reads no allowlisted table"):
+            validate_sql_query("SELECT pg_read_file('/etc/passwd')")
+
+    def test_tableless_select_is_refused(self):
+        """Same shape without the file read: a SELECT that reads nothing is refused."""
+        with pytest.raises(ValueError, match="reads no allowlisted table"):
+            validate_sql_query("SELECT version()")
+
+    def test_cte_only_query_is_refused(self):
+        """Every reference resolving to a CTE leaves no real table behind."""
+        with pytest.raises(ValueError, match="reads no allowlisted table"):
+            validate_sql_query("WITH x AS (SELECT 1 AS n) SELECT * FROM x")
+
+    def test_the_refusal_names_the_allowed_tables(self):
+        """The message an agent reads says what it may query instead."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_sql_query("SELECT pg_read_file('/etc/passwd')")
+        assert "enhanced_entries" in str(exc_info.value)
+
 
 class TestValidateSqlQueryVariantSets:
     """The two constants are read at call time — swap in copies, never mutate."""

--- a/tests/services/ariel_search/test_sync_watch.py
+++ b/tests/services/ariel_search/test_sync_watch.py
@@ -43,10 +43,10 @@ _SOURCE = "file:///entries.json"
 
 
 def _config(**ingestion: Any) -> dict[str, Any]:
-    """Config dict with a reachable-looking ingestion source."""
+    """Config dict with a reachable-looking ingestion source and its adapter."""
     return {
         "database": {"uri": "postgresql://localhost/test"},
-        "ingestion": {"source_url": _SOURCE, **ingestion},
+        "ingestion": {"adapter": "generic_json", "source_url": _SOURCE, **ingestion},
     }
 
 


### PR DESCRIPTION
Ten places where a shipped default failed open or guessed at an ambiguous input. Same fix shape throughout: flip the default to the safe value, or refuse the input at load time using the hint text that already exists.

## Commits

- `security(ariel): verify TLS on logbook ingestion by default; add ca_bundle`
- `fix(ariel): gate the panel's config routes on web.config_panel.enabled`
- `security(workspace): keep resolved secrets out of setup_inspect`
- `security(ariel): refuse SQL that names no allowlisted table`
- `fix(channel-finder): generate requires --source and refuses to overwrite`
- `fix(dispatch): reject an unknown edge value on channel triggers`
- `fix(archiver): refuse ambiguous non-ISO dates instead of guessing month-first`
- `fix(ariel): ingestion adapter is required, not defaulted to an unregistered name`
- `fix(ariel): sidecar-metadata step declares its filenames per adapter and honours TLS/proxy`
- `fix(proxy): reject an unrecognised api_protocol value`

## Why

Each of these coupled a deployment to one site's assumptions, and each did it silently.

Logbook ingestion verified no certificates because one facility's olog is self-signed, so every other deployment inherited an unauthenticated connection carrying its operators' credentials; verification is now on, with `ariel.ingestion.ca_bundle` for a site CA and `verify_ssl: false` as a written opt-out. `web.config_panel.enabled: false` took the Config panel away on the web terminal only, so a tier that may not re-render this deployment's agent could still read and replace the whole document — provider base URLs included — through ARIEL's copy of the route. `setup_inspect` handed the agent transcript the env-expanded config, every resolved secret with it. The SQL allowlist ran only over `FROM`/`JOIN` targets, so a query naming no table at all — `SELECT pg_read_file(...)` — had nothing to check and passed. `channel-finder generate` defaulted its source to the packaged demo machine and its output to the directory the pipelines read, so a bare `generate` replaced a facility's own channel database with ~2900 channels from a machine it has never seen. A dispatch trigger written `edge: up` was armed on both crossings. `03.04.2026` was read month-first and stamped facility-local, putting an archiver window a month off. An `ingestion:` block without `adapter` defaulted to a name nothing is registered under. The sidecar-metadata step matched one facility's filename and opened a connection that ignored the TLS, CA and proxy settings every other request in the same ingest used. `api_protocol: Anthropic` read as "not Anthropic" and inserted the translation hop the config template warns against.

A deployer can now name a site CA instead of turning verification off, gate the config editor on both surfaces with one key, read `setup_inspect` output without leaking secrets, generate a channel database from their own source without overwriting anything, and have a typo in `edge`, `adapter` or `api_protocol` refused where they wrote it rather than silently reinterpreted.

Three default changes alter existing deployments, deliberately:

1. A deployment ingesting from a logbook whose certificate the image cannot verify must add `ca_bundle` or `verify_ssl: false`.
2. A bare `osprey channel-finder generate` stops working; `--source PATH` or `--demo` says where the channels come from, and `--force` is required to overwrite.
3. A hand-written `ingestion:` block without `adapter` now fails at config load rather than at first ingest. It never worked either way.

`web.config_panel.enabled` still defaults open when the key is absent, exactly as on the terminal.

## Not in this PR

- The read-only Postgres role behind the SQL surface — the structural half of the allowlist finding. It touches the postgresql service template, `.env` minting and the DSN resolver, and carries an open design choice; keeping it out leaves this run's CI signal attributable to the default flips.
- `threshold`'s `0.0` default on `epics_ca` triggers: documented behaviour, deliberately left.
- No `system.date_order` config key for the archiver: it would be a second producer beside `system.timezone` and still silent when set wrong.
- No `{enabled, filename}` config pair for the sidecar step: a filename that never matches is already a no-op.
