### PR TITLE
fix(control-target): a session can always come home

### DIFF
--- a/changelog.d/control-target-return-leg.fixed.md
+++ b/changelog.d/control-target-return-leg.fixed.md
@@ -1,0 +1,12 @@
+A session can always come home. Returning to the deployment's own baseline
+no longer fails the eligibility checks when that target's connector block
+carries no gateways, no selectable gateway role or no probe channel — the shape
+a block reached over Channel Access has, and one a baseline on another
+protocol, or a block still half authored, may never fill in. A deployment
+baselined on the live machine whose block leaves ``probe_channel`` commented
+out could otherwise rehearse on the simulator once and stay there until the
+controls server restarted. Coming home still requires the target's connector
+block, still refuses a stand-in block pointed anywhere but this deployment's
+own stand-in, and is proven with the baseline's probe channel wherever the
+block names one. A baseline whose block derives no endpoint at all is still
+refused as not probed while a controls server is live.

--- a/changelog.d/one-real-machine.changed.md
+++ b/changelog.d/one-real-machine.changed.md
@@ -1,0 +1,6 @@
+OSPREY says out loud that a deployment describes one real machine. The refusal
+for a `live` target that cannot be derived, the unknown-target refusal, and the
+how-tos for deploying a facility and switching the control target all name the
+limit, and a config that carries a second non-simulated connector block — one
+no control target can reach — is now warned about instead of passed over in
+silence. A complex with two real machines runs one deployment per machine.

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -62,6 +62,17 @@ deployment has the ones its config describes, which is often two:
        It is a machine of its own, not a relabelled ``live`` — and it is
        operated like the real one, which is what makes it worth rehearsing on.
 
+.. note::
+
+   **One real machine per deployment.** ``live`` names one machine, and the
+   connector blocks are keyed by connector type, so a second real one — the
+   injector beside the ring, a second complex's control system — cannot be
+   written into this config at all. A facility that operates two runs one
+   deployment per machine, each with its own targets, write posture, limits and
+   archive, behind the same login origin if that is convenient. A config that
+   does carry a second non-simulated connector block gets no target for it, and
+   the controls server's log names the block nothing reaches.
+
 Two tools move between them:
 
 ``control_target``
@@ -192,11 +203,25 @@ deployment's services, or drop ``virtual_accelerator.live_standin`` from the
 build profile — and rebuild. The archive belongs to the machine it records.
 
 There is one exemption. A deployment can always come **home** to its own
-baseline — whichever of the three that is — with neither the limits posture,
-the acknowledgment, nor the archive gate applied. The probe still runs: a target
-that cannot prove itself reachable is never switched to, in either direction.
-Stranding a deployment away from the machine it was built for is the less safe
-outcome of the two.
+baseline — whichever of the three that is — with none of the gates above
+applied: not the limits posture, not the acknowledgment, not the archive gate,
+and not the gateway and probe-channel checks either. Stranding a deployment away
+from the machine it was built for is the less safe outcome of the two, and a
+baseline whose block is half authored — no gateways yet, the probe channel still
+commented out, a machine reached over something other than Channel Access —
+would otherwise be a machine a session can leave and never come back to. Where
+the baseline names a probe channel the return is proven with it like any other
+switch; where it does not, the return is made unprobed and the controls server's
+log says so.
+
+Three things still refuse, coming home as much as going out: a target that
+resolves to no ``control_system.connector`` block at all, a ``standin`` block
+pointed at something other than the stand-in this deployment runs; and a
+baseline whose connector block derives no endpoint at all, which publishes no
+reachability row and so, while a controls server is live, is still refused as
+``reachability_unknown`` — the switch gate's reachability rung is
+direction-blind and has nothing to read. None of the three is a machine the
+switch can prove it came home to.
 
 Coming home
 -----------
@@ -316,10 +341,11 @@ channel the switch reads to prove that target is reachable:
        same machine model, so the channel that proves one proves the other. A
        deployment whose simulator names none gets none here either.
 
-A target with no ``probe_channel`` is never switched to, and the roster says so
-by name. Naming the live machine's probe channel is therefore a deliberate act
-by whoever knows the facility — the same posture as the acknowledgment key
-above.
+A target with no ``probe_channel`` is never switched to — except the
+deployment's own baseline, which is come home to unprobed rather than made
+unreachable — and the roster says so by name. Naming the live machine's probe
+channel is therefore a deliberate act by whoever knows the facility — the same
+posture as the acknowledgment key above.
 
 Two more keys bound the switch itself, both under
 ``control_system.target_switch:``: ``drain_timeout_s`` (default 5) is how long

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -153,6 +153,17 @@ simulator, so correctors move and BPMs read through exactly the approval and
 limit layers a live machine would use. The preset ships ``mock``, which touches
 nothing.
 
+A deployment describes **one real machine**. ``control_system.type`` names it,
+or — on a simulated baseline like this one — the single non-simulated block
+under ``control_system.connector`` does, and the three control targets
+(``live``, ``va``, ``standin``) name that machine, the simulator and the
+stand-in soft IOC. A complex that operates two real machines, an injector and a
+storage ring say, runs one deployment per machine rather than one deployment
+naming both: the write posture, the limits, the approvals and the archive all
+belong to a machine, and a second non-simulated connector block here would be a
+block no target ever reaches. See
+:doc:`control-systems/switch-control-target`.
+
 ``deployed_services`` looks too short, and is not. The ``virtual_accelerator:``
 block and the ``services:`` entry you add in Step 4 each append their own
 service to this list at build time. Naming ``openobserve`` explicitly is what

--- a/packages/osprey-connectors/src/osprey_connectors/types.py
+++ b/packages/osprey-connectors/src/osprey_connectors/types.py
@@ -48,8 +48,17 @@ nothing. Such a posture answers neither leaf, and a caller that must act blocks
 every write instead of waving them through unchecked.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger("osprey_connectors.types")
+
+#: Config shapes the second-real-block warning has already been said about, so
+#: a resolver asked on every roster render says it once. Keyed by the shape
+#: itself — a deployment has one, and a test that edits a config gets a fresh
+#: line for the shape it edited to.
+_SECOND_REAL_BLOCK_WARNED: set[tuple[str, tuple[str, ...]]] = set()
 
 # -- Control system connector types (have implementations) --
 MOCK = "mock"
@@ -93,6 +102,21 @@ TARGET_LIVE = "live"
 TARGET_VA = "va"
 TARGET_STANDIN = "standin"
 CONTROL_TARGETS = [TARGET_LIVE, TARGET_VA, TARGET_STANDIN]
+
+#: The topology those three names bound, spelled once and quoted by every
+#: answer that runs into it. One deployment describes one real machine: the
+#: target vocabulary has a single name for it, and the connector table is keyed
+#: by connector type, so a second machine on the same protocol cannot be written
+#: down at all. That is a product shape rather than an oversight — a complex
+#: whose sessions must reach two real machines runs one deployment per machine,
+#: which is also what keeps a session's posture, limits and archive about one
+#: machine each. Said here so a deployer meets it in the error and in the how-to
+#: rather than in the silence of a configured block nothing ever offers.
+ONE_REAL_MACHINE = (
+    "A deployment names one real machine — exactly one connector block that is "
+    "neither simulated nor the stand-in — and 'live' is that machine. A complex "
+    "with two real machines runs one deployment per machine."
+)
 
 # -- Write posture --
 #: The deployment-wide write posture, dotted as a caller spells it for
@@ -183,7 +207,10 @@ def resolve_target(section: Any, target: Any) -> str:
     - When the section's own type is a real control system, that is the live
       machine, and it is returned as written — including a value this module
       does not recognize, which reaches the factory's "Unknown … type" error
-      exactly as :func:`resolve_control_system_type` already lets it.
+      exactly as :func:`resolve_control_system_type` already lets it. A second
+      non-simulated block beside it is not a second target: no name reaches it
+      (:data:`ONE_REAL_MACHINE`), so it is warned about rather than skipped in
+      silence.
     - When the section's own type is simulated or is a stand-in (or absent,
       which resolves to the mock), the deployment has not named its real machine
       there, so the live type is taken from the connector table: exactly one
@@ -222,9 +249,9 @@ def resolve_target(section: Any, target: Any) -> str:
     raise ValueError(
         f"Unknown control target {target!r}. Valid targets are "
         f"{TARGET_LIVE!r}, {TARGET_VA!r} and {TARGET_STANDIN!r}, spelled "
-        "exactly. A control target is always stated, never defaulted — there is "
-        "no target a caller gets by saying nothing, because the one it would "
-        "get could be the real machine."
+        f"exactly. {ONE_REAL_MACHINE} A control target is always stated, never "
+        "defaulted — there is no target a caller gets by saying nothing, "
+        "because the one it would get could be the real machine."
     )
 
 
@@ -1104,6 +1131,44 @@ def _limits_leaf(value: Any) -> bool | None:
     return None
 
 
+def _real_blocks(section: Any, never_live: tuple[str, ...]) -> list[str]:
+    """The connector blocks that could describe a real machine, sorted."""
+    connector = section.get("connector") if isinstance(section, dict) else None
+    if not isinstance(connector, dict):
+        return []
+    return sorted(key for key in connector if isinstance(key, str) and key not in never_live)
+
+
+def _report_second_real_block(section: Any, baseline: str, never_live: tuple[str, ...]) -> None:
+    """Say so when a config describes a real machine no target can reach.
+
+    A deployment whose own type is its real machine never consults the connector
+    table for ``live``, so a second non-simulated block is not ambiguous here —
+    it is unreachable, and quietly so: no control target resolves to it, and the
+    roster it never appears in looks exactly like a roster for a deployment that
+    configured one machine. Nothing else in the stack will ever mention it, so
+    the resolver that skipped it is where a deployer has to hear about it.
+
+    Once per config shape, not once per call: this resolver answers every roster
+    render, and a line repeated at that rate is a line nobody reads.
+    """
+    others = [name for name in _real_blocks(section, never_live) if name != baseline]
+    if not others:
+        return
+    seen = (baseline, tuple(others))
+    if seen in _SECOND_REAL_BLOCK_WARNED:
+        return
+    _SECOND_REAL_BLOCK_WARNED.add(seen)
+    logger.warning(
+        "'control_system.connector' carries %s beside this deployment's own %r block, "
+        "and no control target reaches %s. %s",
+        ", ".join(repr(name) for name in others),
+        baseline,
+        "them" if len(others) > 1 else "it",
+        ONE_REAL_MACHINE,
+    )
+
+
 def _live_type(section: Any) -> str:
     """The control system type that reaches this deployment's real machine.
 
@@ -1113,18 +1178,19 @@ def _live_type(section: Any) -> str:
     deployment stands up itself; counting it would either answer ``live`` with
     the stand-in, or make ``live`` ambiguous on exactly the deployments that run
     the stand-in beside the block naming their facility's own machine.
+
+    Either way the answer is one machine — :data:`ONE_REAL_MACHINE` — and both
+    ways of missing it are said out loud: a baseline that cannot derive one
+    raises, and a baseline that *is* one, beside a second real block no target
+    can reach, is warned about.
     """
     never_live = _SIMULATED_TYPES + STANDIN_TYPES
     baseline = resolve_control_system_type(section)
     if baseline not in never_live:
+        _report_second_real_block(section, baseline, never_live)
         return baseline
 
-    connector = section.get("connector") if isinstance(section, dict) else None
-    candidates: list[str] = []
-    if isinstance(connector, dict):
-        candidates = sorted(
-            key for key in connector if isinstance(key, str) and key not in never_live
-        )
+    candidates = _real_blocks(section, never_live)
     if len(candidates) == 1:
         return candidates[0]
 
@@ -1133,8 +1199,7 @@ def _live_type(section: Any) -> str:
         f"Target {TARGET_LIVE!r} has no control system on this deployment: "
         f"'control_system.type' resolves to {baseline!r}, which is simulated, "
         f"and the live blocks under 'control_system.connector' are: {found}. "
-        "Exactly one non-simulated connector block is what names the real "
-        f"machine (an {EPICS!r} or {DOOCS!r} block, say); configure it there. "
-        "It is not inferred, so that no session reaches a real machine this "
-        "config never described."
+        f"{ONE_REAL_MACHINE} Configure exactly one such block (an {EPICS!r} or "
+        f"{DOOCS!r} block, say). It is not inferred, so that no session reaches "
+        "a real machine this config never described."
     )

--- a/src/osprey/mcp_server/control_system/connector_host_manager.py
+++ b/src/osprey/mcp_server/control_system/connector_host_manager.py
@@ -1401,7 +1401,7 @@ class ConnectorHostManager:
 
         fallback: dict[str, Any] | None = None
         try:
-            candidate = await self._launch(target, derivation, probe_channel)
+            candidate = await self._launch(target, derivation, probe_channel, first_child=not probe)
         except SwitchError as exc:
             read_derivation = self._read_role_fallback(derivation, exc)
             if read_derivation is None:
@@ -1421,7 +1421,11 @@ class ConnectorHostManager:
             derivation = read_derivation
             try:
                 candidate = await self._launch(
-                    target, derivation, probe_channel, without_write_gateway=True
+                    target,
+                    derivation,
+                    probe_channel,
+                    without_write_gateway=True,
+                    first_child=not probe,
                 )
             except SwitchError as retry_error:
                 if retry_error.stage != STAGE_PROBE:
@@ -1513,9 +1517,10 @@ class ConnectorHostManager:
 
         The fields describe the child that is already running rather than one
         that was just launched: its connector type, the role it reported having
-        connected on, and the channel it proved itself with — empty for the
-        deployment's first child, which was started without a probe, because
-        claiming a probe that never ran would be worse than saying so.
+        connected on, and the channel it proved itself with — empty for the two
+        children that start without one: the deployment's first, and a return to
+        a baseline whose block sets no ``probe_channel``. Claiming a probe that
+        never ran would be worse than saying so.
 
         Returns:
             The normal switch result for the running child, or ``None`` when
@@ -1665,10 +1670,27 @@ class ConnectorHostManager:
         Eligibility already reports a missing ``probe_channel``; re-checking it
         here costs one dictionary lookup and keeps the manager's own contract
         closed — a target with nothing to probe must never reach a spawn.
+
+        The deployment baseline is the exception, and it is the one eligibility
+        makes too: coming home is what a session does when nothing else can be
+        proven, so a baseline block that names no probe channel is returned to
+        unprobed rather than turned into a target a session can leave and never
+        come back to. Every other stage of the switch still applies.
         """
         block = _connector_block(self._config.raw, derivation.connector_type)
         channel = block.get(PROBE_CHANNEL_KEY)
         if not isinstance(channel, str) or not channel.strip():
+            if target == self._baseline:
+                logger.warning(
+                    "Returning to the deployment baseline %r without a readiness probe: "
+                    "'control_system.connector.%s.%s' is not set, so nothing reads a "
+                    "channel through the new connection before it goes active. Set that "
+                    "key to a channel this target serves.",
+                    target,
+                    derivation.connector_type,
+                    PROBE_CHANNEL_KEY,
+                )
+                return ""
             raise SwitchError(
                 target,
                 STAGE_PROBE_CHANNEL,
@@ -1687,6 +1709,7 @@ class ConnectorHostManager:
         probe_channel: str,
         *,
         without_write_gateway: bool = False,
+        first_child: bool = False,
     ) -> _Child:
         """Spawn, verify and probe a child — or leave nothing behind.
 
@@ -1695,6 +1718,9 @@ class ConnectorHostManager:
         ``connect()``'s documented absent-row fallback — ``read_only`` with a
         warning — and never even learns where the write gateway is. The caller
         passes a derivation whose selected role is ``read_only`` to match.
+
+        ``first_child`` is true only for the deployment's very first child,
+        which has no session to protect.
         """
         process = await self._spawn(target)
         channel = _LaunchChannel(target, process)
@@ -1741,11 +1767,26 @@ class ConnectorHostManager:
                     # refusal is the only thing the operator sees.
                     raise _name_probed_gateway(exc, derivation) from None
             else:
-                logger.info(
-                    "Connector host for target %r started without a readiness probe: "
-                    "this is the deployment's first child, so there is no session to protect",
-                    target,
-                )
+                # Two silences, and the operator has to be able to tell them
+                # apart: the deployment's very first child, which had no session
+                # to protect, and any later child, which is swapping a working
+                # session out. Which one this is the caller knows, not the
+                # liveness of the child being replaced.
+                if not first_child:
+                    logger.info(
+                        "Connector host for target %r started without a readiness probe: "
+                        "the deployment baseline's block names no probe channel, so the "
+                        "child now taking the session over read nothing through its new "
+                        "connection first",
+                        target,
+                    )
+                else:
+                    logger.info(
+                        "Connector host for target %r started without a readiness probe: "
+                        "this is the deployment's first child, so there is no session to "
+                        "protect",
+                        target,
+                    )
             channel.assert_stream_is_clean()
         except BaseException:
             # Nothing survives a failed launch: the previous child is still the

--- a/src/osprey/mcp_server/control_system/target_eligibility.py
+++ b/src/osprey/mcp_server/control_system/target_eligibility.py
@@ -61,7 +61,12 @@ by the ``virtual_accelerator.live_standin`` line that stood it up. Both are
 waived **except** when the target is the deployment's own baseline and the
 session is returning to it — stranding a session on the simulator is the less
 safe outcome, so coming home is never gated, and the baseline a deployment comes
-home to may be ``standin`` as readily as ``live``.
+home to may be ``standin`` as readily as ``live``. The exemption covers the
+Channel Access shape of a connector block too — its gateways, the role this
+deployment would select, its probe channel — for the same reason: a baseline
+that never filled that shape in, because its machine is reached over another
+protocol or because the block is half authored, would otherwise be a machine a
+session can leave and never come back to.
 :func:`target_availability` therefore reports two answers:
 
 * ``available_now`` — the predicate for the switch this deployment would make,

--- a/src/osprey/mcp_server/control_system/target_eligibility.py
+++ b/src/osprey/mcp_server/control_system/target_eligibility.py
@@ -691,12 +691,20 @@ def evaluate_eligibility(
        stand-in, and a real machine's readings must not land in that store
        (:data:`REASON_ARCHIVE_BELONGS_TO_STANDIN`).
 
+    A **return to the deployment baseline** waives checks 3 and 4 along with 7
+    and 8. Those two are the Channel Access shape of a connector block, and a
+    baseline that never filled it in — a machine reached over another protocol,
+    a block half authored — would otherwise be a target a session could leave
+    and never come back to. Coming home still has to pass 1, 2, 5 and 6: the
+    target resolves, its block exists, the stand-in is really this deployment's
+    stand-in, and an invented present is not paired with an invented past.
+
     Args:
         config: The full rendered config mapping.
         target: The control target being judged.
         direction: :data:`DIRECTION_AWAY` for a switch toward a target that is
             not the deployment baseline, :data:`DIRECTION_BACK` for a return to
-            the baseline. Only the FR-8 gates (checks 7 and 8) read it, and the
+            the baseline. Checks 3, 4, 7 and 8 read it, and the
             baseline a return exempts may be any of the three targets — a
             deployment whose own ``control_system.type`` is ``live_standin``
             comes home to ``standin``.
@@ -741,28 +749,34 @@ def evaluate_eligibility(
             "gateways and probe_channel) to make the target switchable.",
         )
 
-    gateways = _sub(raw_block, "gateways")
-    if not gateways:
-        return Eligibility(
-            False,
-            REASON_GATEWAYS_MISSING,
-            f"'{block_key}.gateways' is empty or missing, so there is no endpoint "
-            f"to point a connector at for target {target!r}.",
-        )
-
+    # Returning to a deployment's own baseline is exempt — a session stranded on
+    # the simulator, unable to come home, is the less safe outcome of the two
+    # this gate can produce — and the baseline may be any of the three targets,
+    # so the exemption follows the direction rather than naming a target.
+    switching_away = direction != DIRECTION_BACK
     selected_role = derivation.selected_role
-    role_missing = _selected_role_missing(config, derivation, target)
-    if role_missing is not None:
-        return role_missing
 
-    if not _is_set(raw_block.get(PROBE_CHANNEL_KEY)):
-        return Eligibility(
-            False,
-            REASON_PROBE_CHANNEL_MISSING,
-            f"'{block_key}.{PROBE_CHANNEL_KEY}' is not set. The switch reads that "
-            f"channel to prove target {target!r} is reachable before making it "
-            "active, so a target without one is never switched to.",
-        )
+    if switching_away:
+        if not _sub(raw_block, "gateways"):
+            return Eligibility(
+                False,
+                REASON_GATEWAYS_MISSING,
+                f"'{block_key}.gateways' is empty or missing, so there is no endpoint "
+                f"to point a connector at for target {target!r}.",
+            )
+
+        role_missing = _selected_role_missing(config, derivation, target)
+        if role_missing is not None:
+            return role_missing
+
+        if not _is_set(raw_block.get(PROBE_CHANNEL_KEY)):
+            return Eligibility(
+                False,
+                REASON_PROBE_CHANNEL_MISSING,
+                f"'{block_key}.{PROBE_CHANNEL_KEY}' is not set. The switch reads that "
+                f"channel to prove target {target!r} is reachable before making it "
+                "active, so a target without one is never switched to.",
+            )
 
     if target == TARGET_STANDIN and not endpoint_is_live_standin(
         config, derivation.selected_endpoint()
@@ -795,13 +809,6 @@ def evaluate_eligibility(
                 "a real archiver — this deployment's own store — before switching a "
                 "session onto this target.",
             )
-
-    # Returning to a deployment's own baseline is exempt from FR-8 — a session
-    # stranded on the simulator, unable to come home, is the less safe outcome
-    # of the two this gate can produce — and the baseline may be either machine
-    # a session can be careful around, so the exemption follows the direction
-    # rather than naming a target.
-    switching_away = direction != DIRECTION_BACK
 
     if switching_away and target in (TARGET_LIVE, TARGET_STANDIN):
         # The strict limits posture guards both machines an operator meets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -656,6 +656,32 @@ def reset_health_offload_state():
 
 
 # ===================================================================
+# One-real-machine warning guard
+# ===================================================================
+
+
+@pytest.fixture(autouse=True, scope="function")
+def reset_second_real_block_warning():
+    """Forget which config shapes have already drawn the one-real-machine warning.
+
+    Leak guarded: ``osprey_connectors.types`` says once per process that a
+    config carries a second real connector block no control target reaches —
+    once, because the resolver behind it answers every roster render and a line
+    repeated at that rate is a line nobody reads. Held for the life of the
+    process, that set makes any test asserting the warning depend on whether an
+    earlier test on the same worker happened to resolve the same shape first,
+    which under xdist depends on how the files were distributed.
+    """
+    from osprey_connectors import types as connector_types
+
+    connector_types._SECOND_REAL_BLOCK_WARNED.clear()
+
+    yield
+
+    connector_types._SECOND_REAL_BLOCK_WARNED.clear()
+
+
+# ===================================================================
 # Marker-driven resource skip-gating
 # ===================================================================
 #

--- a/tests/connectors/test_target_resolver.py
+++ b/tests/connectors/test_target_resolver.py
@@ -16,6 +16,7 @@ on hardware nobody selected.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -28,6 +29,7 @@ from osprey_connectors.types import (
     INVENTED_HISTORY_TYPES,
     LIVE_STANDIN,
     MOCK,
+    ONE_REAL_MACHINE,
     STANDIN_TYPES,
     TARGET_LIVE,
     TARGET_STANDIN,
@@ -221,6 +223,59 @@ def test_live_refuses_when_two_live_blocks_leave_it_ambiguous():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "connector",
+    [
+        {"virtual_accelerator": {"timeout": 5.0}},
+        {"epics": {"address": "gw"}, "doocs": {"address": "gw"}},
+    ],
+    ids=["no-live-block", "two-live-blocks"],
+)
+def test_a_live_that_cannot_be_derived_names_the_one_real_machine_limit(connector: Any):
+    """Both halves of the refusal are the same topology: a deployment describes
+    one real machine, so nought and two are equally underivable. A deployer who
+    reads only the error still learns what the product's shape is."""
+    with pytest.raises(ValueError) as excinfo:
+        resolve_target(_section(VIRTUAL_ACCELERATOR, connector), TARGET_LIVE)
+
+    assert ONE_REAL_MACHINE in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_a_second_real_block_beside_a_real_baseline_is_reported(caplog: Any):
+    """A facility that writes a second real machine down gets no target for it:
+    the baseline is its own live type, so the connector table is never consulted.
+    Silence would leave that to be discovered by never being offered the machine."""
+    section = _section(EPICS, {"epics": {"address": "ring"}, DOOCS: {"address": "injector"}})
+
+    with caplog.at_level(logging.WARNING, logger="osprey_connectors.types"):
+        assert resolve_target(section, TARGET_LIVE) == EPICS
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert DOOCS in message
+    assert ONE_REAL_MACHINE in message
+
+
+@pytest.mark.unit
+def test_the_stand_in_and_the_simulator_are_not_a_second_real_machine(caplog: Any):
+    """The shape every stand-in deployment has, and it is within the limit."""
+    section = _section(
+        EPICS,
+        {
+            "epics": {"address": "gw"},
+            "virtual_accelerator": {"timeout": 5.0},
+            "live_standin": {"address": "127.0.0.1"},
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="osprey_connectors.types"):
+        assert resolve_target(section, TARGET_LIVE) == EPICS
+
+    assert caplog.records == []
+
+
+@pytest.mark.unit
 def test_live_never_falls_back_to_hardware_on_a_bare_config():
     """An empty config resolves to the mock baseline; live has to raise, not guess."""
     for section in ({}, None, _section(), _section(None)):
@@ -311,6 +366,7 @@ def test_an_unrecognized_target_raises_and_resolves_to_nothing(target: Any):
     assert TARGET_LIVE in message
     assert TARGET_VA in message
     assert TARGET_STANDIN in message
+    assert ONE_REAL_MACHINE in message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/test_switch_lifecycle.py
+++ b/tests/mcp_server/test_switch_lifecycle.py
@@ -32,6 +32,7 @@ give the two targets different postures and have both children act on them.
 import asyncio
 import contextlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -2106,15 +2107,15 @@ class TestServingFromTheChild:
             assert isinstance(archiver, _FakeArchiver)
             assert await context.archiver() is archiver
 
-    async def test_the_baseline_starts_unprobed_but_a_switch_to_it_still_needs_a_probe(
-        self, make_manager
-    ):
+    async def test_the_baseline_starts_unprobed_and_is_returned_to_unprobed(self, make_manager):
         """The shipped posture: the live block carries no probe channel.
 
         Starting the deployment's own baseline is not a swap, so it does not
         need a channel to prove itself with — refusing to start would leave the
-        server with no control system at all. Switching *to* that target later
-        is a swap, and is refused for exactly the missing channel.
+        server with no control system at all. Coming back to it is refused for
+        the same missing channel on no other target, because a baseline that
+        cannot be returned to is one a session leaves for good: it rehearses on
+        the simulator once and stays there until the server restarts.
         """
         manager = make_manager(raw=raw_config(live_probe=None))
         context = context_for(manager)
@@ -2124,11 +2125,37 @@ class TestServingFromTheChild:
         assert manager.active_target() == "live"
 
         await manager.switch("va")
-        with pytest.raises(SwitchError) as raised:
-            await manager.switch("live")
+        result = await manager.switch("live")
 
-        assert raised.value.reason == REASON_PROBE_CHANNEL_MISSING
-        assert manager.active_target() == "va"
+        assert manager.active_target() == "live"
+        assert result["probe_channel"] == ""
+        assert isinstance(
+            await manager.active_proxy().read_channel(LIVE_PROBE, timeout=10.0), ChannelValue
+        )
+
+    async def test_the_two_unprobed_launches_say_which_one_they_are(self, make_manager, caplog):
+        """Both silences are logged, and they are not logged as the same thing.
+
+        A first child and a return to an unprobed baseline both reach the launch
+        with no channel to read, but only one of them has a working session on
+        the other side of the swap. Telling an operator "there is no session to
+        protect" while one is being retired is a line that says the opposite of
+        what happened.
+        """
+        manager = make_manager(raw=raw_config(live_probe=None))
+        context = context_for(manager)
+
+        with caplog.at_level(logging.INFO, logger=connector_host_manager.__name__):
+            await context.control_system()
+            first_child = [record.getMessage() for record in caplog.records]
+            await manager.switch("va")
+            caplog.clear()
+            await manager.switch("live")
+            return_leg = [record.getMessage() for record in caplog.records]
+
+        assert any("deployment's first child" in line for line in first_child)
+        assert not any("first child" in line for line in return_leg)
+        assert any("names no probe channel" in line for line in return_leg)
 
 
 class TestNoChildRefusal:

--- a/tests/mcp_server/test_target_eligibility.py
+++ b/tests/mcp_server/test_target_eligibility.py
@@ -486,16 +486,54 @@ def test_returning_to_live_needs_neither_posture_nor_acknowledgment() -> None:
     assert _eligibility(config, LIVE, direction=te.DIRECTION_BACK).eligible is True
 
 
-def test_the_return_exemption_does_not_excuse_the_configuration_checks() -> None:
-    """It waives FR-8's posture, not the target's existence."""
-    block = _epics_block()
-    block.pop("probe_channel")
-    config = _config(limits="permissive", ack=False, connector={EPICS_TYPE: block})
+def test_the_return_exemption_does_not_excuse_the_targets_own_block() -> None:
+    """It waives what the block says, not that there is one: a return still has to
+    resolve to a connector type and find that type configured."""
+    config = _config(limits="permissive", ack=False, connector={VA_TYPE: _va_block()})
 
     verdict = _eligibility(config, LIVE, direction=te.DIRECTION_BACK)
 
     assert verdict.eligible is False
-    assert verdict.reason == te.REASON_PROBE_CHANNEL_MISSING
+    assert verdict.reason == te.REASON_CONNECTOR_BLOCK_MISSING
+
+
+def test_coming_home_to_a_baseline_with_no_gateways_is_not_refused() -> None:
+    """The gateways table is Channel Access's shape, and a baseline that does not
+    fill it in — a machine on another protocol, a block half written — is still the
+    machine this deployment was built for. Refusing the return leg over it strands
+    the session on whatever it switched to."""
+    config = _config(connector={EPICS_TYPE: _epics_block(gateways={}), VA_TYPE: _va_block()})
+
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_BACK).eligible is True
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_AWAY).reason == (
+        te.REASON_GATEWAYS_MISSING
+    )
+
+
+def test_coming_home_to_a_baseline_with_no_probe_channel_is_not_refused() -> None:
+    """A target that cannot prove itself reachable is never switched *to*; the
+    baseline is where a session that can prove nothing else belongs."""
+    block = _epics_block()
+    block.pop("probe_channel")
+    config = _config(connector={EPICS_TYPE: block, VA_TYPE: _va_block()})
+
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_BACK).eligible is True
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_AWAY).reason == (
+        te.REASON_PROBE_CHANNEL_MISSING
+    )
+
+
+def test_coming_home_to_a_baseline_missing_the_selected_role_is_not_refused() -> None:
+    """Writes unarmed selects ``read_only``, which a write-only table does not
+    carry. Away that is a refusal; home it is the read-only gateway the connector
+    would have fallen back to anyway."""
+    gateways = {"write_access": {"address": "gw.example.org", "port": 5084}}
+    config = _config(connector={EPICS_TYPE: _epics_block(gateways=gateways), VA_TYPE: _va_block()})
+
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_BACK).eligible is True
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_AWAY).reason == (
+        te.REASON_SELECTED_ROLE_MISSING
+    )
 
 
 def test_va_is_never_gated_on_posture_or_acknowledgment() -> None:


### PR DESCRIPTION
A session can always come home: the return leg to a deployment's own baseline no longer depends on that block carrying the Channel Access shape, and the one-real-machine-per-deployment limit is now stated where a deployer reads.

- `fix(control-target): let a session come home to an unfinished baseline block`
- `fix(control-target): return to a baseline that names no probe channel`
- `feat(connectors): name the one-real-machine limit where a deployer meets it`
- `docs(control-systems): say what a return leg waives and what one deployment holds`

## Why

Eligibility refused a return to the baseline whenever that target's connector block had no `gateways` table, no selectable gateway role or no `probe_channel`. Those three checks are written around the shape of a block reached over Channel Access, and they ran before the direction was ever read — so a deployment whose baseline is reached over another protocol, or whose block is still half authored, could switch to the simulator and never come back: the roster reported the baseline unavailable and the switch gate refused it. The connector-host manager re-checked the probe channel before spawning, which made the same door one-way on the *shipped* posture, where the live block ships its probe channel commented out.

The three checks now run only on a switch away from the baseline, beside the posture and archive gates that already did, and the manager returns to an unprobed baseline with a warning naming the key to set. Coming home still resolves the target, still requires its connector block, still refuses a `standin` block pointed anywhere but this deployment's own stand-in, and still refuses an invented present paired with an invented past.

Separately, nothing said that a deployment describes one real machine — the target vocabulary has one name for it and connector blocks are keyed by connector type, so a second machine cannot be written down. A deployer met that limit as a `ValueError`, or, with a real baseline and a second real block, not at all: the block was simply never a target. The limit is now one sentence quoted by both refusals, a warning when a real baseline carries a second real block, and a paragraph in each of the two how-tos.

A deployer can now run OSPREY against a baseline this framework did not author the connector shape for — a DOOCS or TANGO machine beside the shipped simulator — rehearse on the simulator, and get back, without restarting the controls server; and can find out that a two-machine complex runs one deployment per machine before building one that names both.

## Not in this PR

- The connector capability declaration itself. Whether a connector is simulated, speaks Channel Access, is switchable or is writable over PVA is still decided by name tuples in `osprey_connectors/types.py`; the honesty pass over those refusals and the class-declared capabilities behind it are separate work.
- N live targets (`live.<name>`) or a config-declared target roster. This states the one-real-machine topology rather than opening it.
- A baseline whose block derives no endpoint at all is still refused past the checks this PR moved, in two more places. The switch gate's reachability rung is direction-blind and has nothing to read: `EndpointProber` drops a target whose endpoints will not derive, so while a controls server is live the return is refused as `reachability_unknown`. And the manager's spawn path stays EPICS-shaped past eligibility — `verify_child_report` wants a derived endpoint and `_epics_configured`. What this PR fixes is the half of the door that was shut for no reason; serving such a baseline is the connector-capability work above.
