### PR TITLE
fix(providers): require an explicit ALS-APG gateway URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,17 @@ concurrency:
 # src/osprey/templates/services/openobserve/docker-compose.yml.j2 moves.
 env:
   OSPREY_OPENOBSERVE_IMAGE: ghcr.io/als-apg/openobserve:v0.14.4
-  # ALS-APG endpoint override: set the ALS_APG_BASE_URL repository variable
-  # to point every LLM-touching job (probes and pytest alike) at an
-  # alternate gateway. Empty/unset keeps the provider's default endpoint.
+  # ALS-APG endpoint. The provider ships no built-in host — the gateway it
+  # fronts belongs to whoever runs it — so every LLM-touching job (probes and
+  # pytest alike) has to be told one, and a job given nothing is refused by
+  # name instead of falling through. This line is where the fork's own gateway
+  # is named: the ALS_APG_BASE_URL repository variable, stated once here and
+  # read by the jobs below rather than repeated in each of them.
+  #
+  # No literal stands behind it. A fork that has not set the variable gets an
+  # empty endpoint and its LLM-touching lanes are refused by name, which is the
+  # honest outcome — a baked-in host would instead send that fork's traffic,
+  # and its API key, to somebody else's gateway.
   ALS_APG_BASE_URL: ${{ vars.ALS_APG_BASE_URL }}
 
 jobs:
@@ -1341,7 +1349,7 @@ jobs:
           echo "   (Check repo secrets; required for the agentic-per-preset job.)"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -1455,7 +1463,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -1653,7 +1661,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -1854,7 +1862,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -1946,7 +1954,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -2385,7 +2393,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -2804,7 +2812,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -2928,7 +2936,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \
@@ -4910,7 +4918,7 @@ jobs:
           echo "❌ ALS_APG_API_KEY secret is not set on this runner"
           exit 1
         fi
-        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+        ALS_APG_PROBE_BASE="${ALS_APG_BASE_URL}"
         ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/}"; ALS_APG_PROBE_BASE="${ALS_APG_PROBE_BASE%/v1}"
         HTTP_CODE=$(curl -sS -o /tmp/probe.txt -w "%{http_code}" --max-time 15 \
           -X POST "$ALS_APG_PROBE_BASE/v1/messages" \

--- a/changelog.d/als-apg-gateway-url.changed.md
+++ b/changelog.d/als-apg-gateway-url.changed.md
@@ -1,0 +1,10 @@
+The `als-apg` provider no longer ships a built-in endpoint. Its gateway is a
+site's own host, so the URL now comes from `api.providers.als-apg.base_url` in
+`providers.yml` (shipped as `${ALS_APG_BASE_URL}`) or from that variable
+directly; naming a provider with no endpoint anywhere is refused instead of
+falling back on someone else's host. Existing deployments that relied on the
+old default must export `ALS_APG_BASE_URL`.
+
+The generated `.env.example` now lists the endpoint variables that have no
+default, beside the provider API keys, so a deployment sees both halves of what
+`als-apg` needs before its first launch rather than after it.

--- a/changelog.d/coalesced-directory-frame.fixed.md
+++ b/changelog.d/coalesced-directory-frame.fixed.md
@@ -1,0 +1,7 @@
+A file created or deleted inside a watched directory now shows up in the web
+terminal's file panel and the artifacts gallery even when the operating system
+reports the change as a single event about the directory rather than about the
+file. Such a frame used to be forwarded with nothing in it (file panel) or
+dropped outright (artifacts), so on macOS a burst of writes could leave both
+listings stale until the next reload. The directory is now re-listed one level
+deep and what actually differs is what gets announced.

--- a/changelog.d/unresolved-base-url-placeholder.fixed.md
+++ b/changelog.d/unresolved-base-url-placeholder.fixed.md
@@ -1,0 +1,7 @@
+A provider's `base_url` left as an unresolved `${VAR}` — the variable is not
+exported — is now read as "no endpoint configured" instead of being sent to the
+HTTP client as a hostname, so the failure names the provider and the missing
+value. `osprey health` reports that missing endpoint by name too, instead of
+probing another vendor's API with the gateway's key, and the channel-finder
+benchmark's ReAct backend expands the reference — from the shell or the
+deployment's `.env` — rather than dialling it.

--- a/changelog.d/watcher-observer-backend.internal.md
+++ b/changelog.d/watcher-observer-backend.internal.md
@@ -1,0 +1,5 @@
+The workspace and store-index watchers take the watchdog observer they run on
+as a constructor argument, defaulting to the platform's native one. Tests that
+ask which filesystem change becomes which broadcast now run on a polling
+observer, which reports what is on disk rather than what a notification stream
+happened to carry; one test per watcher stays on the native backend.

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -33,7 +33,7 @@ Available Providers
      - ``CBORG_API_KEY``
      - Anthropic (native)
    * - ``als-apg``
-     - ALS Accelerator Physics Group AWS proxy
+     - ALS Accelerator Physics Group gateway
      - ``ALS_APG_API_KEY``
      - Anthropic (native)
    * - ``stanford``
@@ -100,6 +100,25 @@ Set the API key as an environment variable before running Osprey:
    export STANFORD_API_KEY="..."
 
 Ollama and vLLM run locally and do not require an API key.
+
+``als-apg`` needs one more variable: it fronts a gateway that each site hosts
+itself, so there is no endpoint to default to. Name it alongside the key, or
+put the URL straight into ``providers.yml``:
+
+.. code-block:: bash
+
+   export ALS_APG_BASE_URL="https://your-gateway.example.org/v1"
+
+Without it, every path that would place a call refuses rather than sending the
+gateway's token to another host. A launch — ``osprey chat``, ``osprey web``, an
+agent run — stops with::
+
+   Provider 'als-apg' has no base_url. It fronts models through a gateway that
+   has no default endpoint, so the URL has to be named: set ALS_APG_BASE_URL,
+   or api.providers.als-apg.base_url in config.yml.
+
+A direct model call and ``osprey health`` report the same thing more briefly,
+as ``Base URL required for als-apg``.
 
 .. note::
 

--- a/packages/osprey-connectors/src/osprey_connectors/config.py
+++ b/packages/osprey-connectors/src/osprey_connectors/config.py
@@ -142,6 +142,38 @@ def resolve_env_vars(data: Any, *, environ: "Mapping[str, str] | None" = None) -
     return resolved
 
 
+#: A string that is nothing but a single unresolved env-var placeholder, e.g.
+#: ``"${MISSING}"`` or ``"$MISSING"``. :func:`resolve_env_vars` leaves such a
+#: value verbatim when the variable is unset (there is nothing to substitute and
+#: no declared default), so every consumer that reads a config value has to know
+#: this shape to tell "not configured" from a value.
+#:
+#: The two branches are the two branches of the resolver's own pattern above,
+#: character class included: the braced form takes any name without ``}`` or
+#: ``:`` (a ``:-`` default always substitutes, so it never survives), the bare
+#: form the shell-style identifier. Narrowing either half here would fail to
+#: recognise a reference the resolver did leave verbatim.
+_LONE_PLACEHOLDER = re.compile(r"^\$\{[^}:]+\}$|^\$[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def is_unresolved_placeholder(value: object) -> bool:
+    """Whether *value* is an env-var reference :func:`resolve_env_vars` left alone.
+
+    The counterpart to :func:`resolve_env_vars`: it keeps ``${VAR}`` verbatim
+    when ``VAR`` is unset, so a consumer that treats what it reads as data sees
+    the literal string ``"${VAR}"`` where a URL or a key belongs. This is the
+    one producer of that test, so a caller never has to re-state the syntax the
+    resolver accepts.
+
+    Args:
+        value: A config value, of any type. Only a ``str`` can be a placeholder.
+
+    Returns:
+        True when the value is exactly one unsubstituted reference.
+    """
+    return isinstance(value, str) and bool(_LONE_PLACEHOLDER.match(value))
+
+
 # OSPREY runs agent Python code in exactly one backend: a subprocess on the host.
 # ``local`` is an accepted alias for that same backend; ``container`` names a
 # Jupyter kernel gateway OSPREY does not ship.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -573,7 +573,7 @@ markers = [
     "requires_anthropic: Tests that require Anthropic API key",
     "requires_google: Tests that require Google API key",
     "requires_cborg: Tests that require CBORG API key (local dev only — IP allowlist blocks GitHub Actions runners)",
-    "requires_als_apg: Tests that require ALS-APG API key (AWS Bedrock proxy; reachable from GitHub Actions runners)",
+    "requires_als_apg: Tests that require ALS-APG API key (the ALS-APG gateway; reachable from GitHub Actions runners)",
     "requires_ollama: Tests that require local Ollama service",
     "asyncio: Async test marker",
     "flaky: Rerun on failure to absorb nondeterminism outside the process — LLM sampling in e2e, OS event delivery in a couple of watcher tests (pytest-rerunfailures). Not for flaky unit tests; see tests/README.md",

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -47,7 +47,7 @@ the bash now lives in the config + launcher.
 providers:
   cborg:   { base_url: https://api.cborg.lbl.gov/v1, key_file: ~/.cborg_key,
              protocol: openai,    judge: { via: cborg,   model: google/claude-haiku-4-5 } }
-  als-apg: { base_url: https://llm.gianlucamartino.com, key_file: ~/.als_apg_key,
+  als-apg: { base_url: ${ALS_APG_BASE_URL}, key_file: ~/.als_apg_key,
              protocol: anthropic, judge: { via: als-apg, model: claude-haiku-4-5-20251001 } }
   ds4:     { base_url: http://127.0.0.1:8000/v1, keyless: true,
              protocol: openai,    judge: { via: cborg,   model: google/claude-haiku-4-5 } }

--- a/scripts/benchmark/matrix.py
+++ b/scripts/benchmark/matrix.py
@@ -19,6 +19,13 @@ or direct, judge endpoint, budget scale, grid order, resume); the worker
 ``pytest tests/e2e/`` invocation, and JUnit→JSON summarization). The functions
 below are pure and import-safe so they can be unit-tested without spawning a run
 (see tests/benchmark/test_matrix.py).
+
+Config fields accept ``${VAR}`` / ``${VAR:-default}`` environment references —
+``load_config`` resolves them through ``osprey_connectors.config.resolve_env_vars``,
+the same expander the deployment config uses, so an endpoint set in the
+environment wins over the literal written in the file. A reference with no
+default that resolves to nothing is refused by ``load_config`` rather than
+travelling on as a URL.
 """
 
 from __future__ import annotations
@@ -297,8 +304,20 @@ def _fmt_scale(value: float) -> str:
 def load_config(path: Path) -> MatrixConfig:
     import yaml
 
+    from osprey_connectors.config import is_unresolved_placeholder, resolve_env_vars
+
     raw = yaml.safe_load(path.read_text()) or {}
+    raw = resolve_env_vars(raw)
     providers = raw.get("providers") or {}
+    # A gateway with no default host is written as a bare ``${VAR}``, which the
+    # resolver leaves verbatim when the variable is unset. Refuse it here rather
+    # than handing the literal reference to an HTTP client one cell at a time.
+    for name, spec in providers.items():
+        if isinstance(spec, dict) and is_unresolved_placeholder(spec.get("base_url")):
+            raise ValueError(
+                f"{path}: provider '{name}' has no base_url — "
+                f"{spec['base_url']} is unset in this environment"
+            )
     models = raw.get("models") or []
     defaults = raw.get("defaults") or {}
     # a top-level judge becomes the default judge for providers that omit one

--- a/scripts/benchmark/matrix.yaml
+++ b/scripts/benchmark/matrix.yaml
@@ -28,9 +28,11 @@ providers:
     judge: { via: cborg, model: google/claude-haiku-4-5 }
 
   als-apg:
-    # Native als-apg endpoint (AWS Bedrock proxy, NO /v1 — the Anthropic SDK
+    # Native als-apg endpoint (the ALS-APG gateway, NO /v1 — the Anthropic SDK
     # appends /v1/messages). Same base_url backs both SUT routing and the judge.
-    base_url: https://llm.gianlucamartino.com
+    # The gateway is a deployment's own host and has no default: set
+    # ALS_APG_BASE_URL, or write the endpoint here.
+    base_url: ${ALS_APG_BASE_URL}
     key_env: ALS_APG_API_KEY
     key_file: ~/.als_apg_key
     protocol: anthropic

--- a/scripts/benchmark/run_focus.sh
+++ b/scripts/benchmark/run_focus.sh
@@ -22,7 +22,7 @@ NODES=("$@"); [ "${#NODES[@]}" -gt 0 ] || { echo "FATAL: pass test node(s)" >&2;
 [ -n "${ALS_APG_API_KEY:-}" ] || ALS_APG_API_KEY="$(cat "$HOME/.als_apg_key")"
 export ALS_APG_API_KEY
 export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$ALS_APG_API_KEY}"
-export ALS_APG_BASE_URL="${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com}"
+export ALS_APG_BASE_URL="${ALS_APG_BASE_URL:?set this to your als-apg gateway}"
 export OSPREY_E2E_JUDGE_MODEL="${OSPREY_E2E_JUDGE_MODEL:-claude-haiku-4-5-20251001}"
 export OSPREY_E2E_FORCE_PROVIDER=als-apg
 export OSPREY_E2E_FORCE_MODEL="$MODEL"

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -35,6 +35,7 @@ from osprey.models.spend_attribution import apply_attribution_env, gateway_for
 from osprey.models.tiers import VALID_TIERS
 from osprey.utils.dotenv import chain_files
 from osprey_connectors import yaml_loader
+from osprey_connectors.config import is_unresolved_placeholder
 
 logger = logging.getLogger("osprey.build.claude_code_resolver")
 
@@ -71,10 +72,17 @@ CLAUDE_CODE_PROVIDERS: dict[str, dict] = {
     "als-apg": {
         "auth_env_var": "ANTHROPIC_AUTH_TOKEN",  # Bearer auth for proxy
         "auth_secret_env": "ALS_APG_API_KEY",  # Shell env var holding the secret
-        "base_url": "https://llm.gianlucamartino.com",  # ALS-APG AWS proxy (no /v1)
-        # Break-glass redirect: a set env var beats config and the URL above,
-        # so a deployment with a baked-in config can be pointed at a fallback
-        # gateway at runtime (mirrors the provider adapter's base_url_env_var).
+        # No built-in URL: this gateway is a deployment's own host, so the
+        # endpoint is site data. `requires_base_url` turns "nobody named one"
+        # into a refusal instead of an unset ANTHROPIC_BASE_URL, which would
+        # send the gateway's key straight to api.anthropic.com.
+        "base_url": None,
+        "requires_base_url": True,
+        # The endpoint arrives from api.providers.als-apg.base_url (the shipped
+        # catalog entry reads ``${ALS_APG_BASE_URL}``) or from the env var
+        # directly, which also beats a baked-in config so an already-deployed
+        # system can be pointed at a fallback gateway without a rebuild
+        # (mirrors the provider adapter's base_url_env_var).
         "base_url_env_var": "ALS_APG_BASE_URL",
         "default_model_tier": "haiku",
         # Fallback model IDs (used when api.providers.als-apg.models is absent)
@@ -450,6 +458,39 @@ def inject_provider_env(
     return sorted(spec.env_block.keys())
 
 
+def _without_unresolved_base_urls(api_providers: dict) -> dict:
+    """Drop every ``base_url`` that is still an unexported ``${VAR}``.
+
+    This is the *runtime* path, where a placeholder is not a value: the config
+    resolver keeps ``${VAR}`` verbatim when the variable is unset, and the
+    shipped catalog spells gateway endpoints exactly that way
+    (``base_url: ${ALS_APG_BASE_URL}``). Left in place the literal would be
+    exported as ``ANTHROPIC_BASE_URL``, i.e. handed to the agent as a hostname.
+    Blanked, it falls through the same precedence chain a missing key does —
+    to the built-in URL, or to the refusal that names the variable.
+
+    Only a launch blanks them. The template-render callers stay on the pure
+    :class:`ClaudeCodeModelResolver` precisely because they *want* the literal
+    ``${VAR}`` written into ``settings.json`` for expansion at launch, and the
+    build's reachability check reads a render the same way — see
+    ``defer_unresolved_base_url`` on :func:`load_provider_spec`.
+
+    Args:
+        api_providers: The ``api.providers`` mapping, already env-resolved.
+
+    Returns:
+        The same mapping with unresolved ``base_url`` values set to ``None``.
+    """
+    return {
+        name: (
+            {**entry, "base_url": None}
+            if isinstance(entry, dict) and is_unresolved_placeholder(entry.get("base_url"))
+            else entry
+        )
+        for name, entry in (api_providers or {}).items()
+    }
+
+
 def load_provider_spec(
     project_dir: Path,
     *,
@@ -457,6 +498,7 @@ def load_provider_spec(
     provider: str | None = None,
     include_telemetry: bool = True,
     defer_unresolved_telemetry_creds: bool = False,
+    defer_unresolved_base_url: bool = False,
 ) -> ClaudeCodeModelSpec | None:
     """Read ``config.yml``, expand ``${VAR}`` placeholders, and resolve the spec.
 
@@ -476,8 +518,10 @@ def load_provider_spec(
     literal ``${VAR}`` written into ``settings.json`` for deferred runtime
     expansion, and the model-id-only readers (``benchmarks/sdk.py``,
     ``channel_finder_in_context/server_context.py``) consume only
-    ``tier_to_model`` wire ids, which never contain ``${VAR}``. See
-    ``benchmarks/backends/react_backend.py`` for the one genuine deferral.
+    ``tier_to_model`` wire ids, which never contain ``${VAR}``.
+    ``benchmarks/backends/react_backend.py`` keeps its own resolver — its
+    contract is a synthetic config plus litellm ``api_base``, not a spec — but
+    expands and refuses the same way this does.
 
     Args:
         project_dir: Directory holding the ``config.yml`` to resolve.
@@ -489,6 +533,14 @@ def load_provider_spec(
             ``project_dir`` — the flat layout, where the two coincide.
         provider: When given, overrides ``claude_code.provider`` in the loaded
             config before resolving — used by cross-provider model sweeps.
+        defer_unresolved_base_url: Keep a provider ``base_url`` that is still an
+            unexported ``${VAR}`` instead of reading it as "no endpoint". The
+            build's reachability check sets it: a render is an artifact that can
+            start on another host — a container image is built here and given
+            its gateway there — so a deferred reference is that render's
+            contract with its runtime, not a missing value. Every launch path
+            leaves it False, so the process about to call the gateway is the one
+            that refuses, by name.
 
     Returns:
         Resolved :class:`ClaudeCodeModelSpec` with ``${VAR}`` expanded in both
@@ -508,9 +560,12 @@ def load_provider_spec(
     cc_config = cfg.get("claude_code", {})
     if provider is not None:
         cc_config = {**cc_config, "provider": provider}
+    api_providers = cfg.get("api", {}).get("providers", {})
+    if not defer_unresolved_base_url:
+        api_providers = _without_unresolved_base_urls(api_providers)
     return ClaudeCodeModelResolver.resolve(
         cc_config,
-        cfg.get("api", {}).get("providers", {}),
+        api_providers,
         include_telemetry=include_telemetry,
         defer_unresolved_telemetry_creds=defer_unresolved_telemetry_creds,
         environ=lookup,
@@ -704,7 +759,11 @@ class ClaudeCodeModelResolver:
         consults ``os.environ``, because it also renders ``settings.json`` at
         build time, where an ambient read would bake the builder's endpoint
         into the artifact. The trailing ``/v1`` is stripped for
-        ``ANTHROPIC_BASE_URL`` either way (see below).
+        ``ANTHROPIC_BASE_URL`` either way (see below). A built-in that declares
+        ``requires_base_url`` — it fronts a gateway each site hosts itself, so
+        there is no endpoint to default to — is refused outright when no source
+        names one, rather than falling through to Claude Code's native backend
+        with the gateway's bearer token.
 
         A tier that all three sources leave unmapped falls back to the
         resolved default model, with a warning naming each substitution — the
@@ -739,8 +798,9 @@ class ClaudeCodeModelResolver:
 
         Raises:
             ValueError: If the provider name is not in CLAUDE_CODE_PROVIDERS
-                and not in api_providers, or if the provider maps no models
-                and no ``default_model`` is set to fall back on.
+                and not in api_providers, if a provider that declares
+                ``requires_base_url`` resolves no endpoint, or if the provider
+                maps no models and no ``default_model`` is set to fall back on.
         """
         provider_name = claude_code_config.get("provider")
         if not provider_name:
@@ -804,6 +864,20 @@ class ClaudeCodeModelResolver:
             or api_providers.get(provider_name, {}).get("base_url")
             or provider_def.get("base_url")
         )
+        # A provider that has no built-in endpoint must be told one. Left
+        # unresolved, `base_url` is simply absent from the env block below and
+        # Claude Code talks to its native backend — so a gateway's bearer token
+        # would be presented to api.anthropic.com, which reads as an auth error
+        # nowhere near its cause.
+        if provider_def.get("requires_base_url") and not base_url:
+            sources = f"api.providers.{provider_name}.base_url in config.yml"
+            if env_var:
+                sources = f"{env_var}, or {sources}"
+            raise ValueError(
+                f"Provider '{provider_name}' has no base_url. It fronts models "
+                f"through a gateway that has no default endpoint, so the URL has "
+                f"to be named: set {sources}."
+            )
 
         # ── Build tier → model mapping ───────────────────────────
         # Priority: built-in fallback < api.providers models < claude_code.models

--- a/src/osprey/cli/build_cmd.py
+++ b/src/osprey/cli/build_cmd.py
@@ -2367,7 +2367,17 @@ def _render_project(
         # raises ObservabilityCredentialError into this ValueError catch.
         # Pinned by test_deferred_var_credential_warns_not_raises_through_resolve
         # in tests/cli/test_telemetry_env.py.
-        load_provider_spec(render_dir, defer_unresolved_telemetry_creds=True)
+        #
+        # A provider base_url still spelled "${VAR}" is deferred for the same
+        # reason: this render may start on another host (a container image is
+        # built here and handed its gateway there), so the reference is the
+        # render's contract with its runtime. The launch paths resolve it for
+        # real and refuse by name when nothing supplies it.
+        load_provider_spec(
+            render_dir,
+            defer_unresolved_telemetry_creds=True,
+            defer_unresolved_base_url=True,
+        )
     except ValueError as e:
         raise BuildProfileError(str(e)) from e
 

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -972,7 +972,11 @@ def _write_secret_channel(
     """
     from osprey.utils.dotenv import append_profile_env
 
-    from .templates.scaffolding import provider_api_key_entries, service_token_var_entries
+    from .templates.scaffolding import (
+        provider_api_key_entries,
+        provider_base_url_entries,
+        service_token_var_entries,
+    )
 
     manager.render_template(
         _ENV_EXAMPLE_TEMPLATE,
@@ -986,6 +990,17 @@ def _write_secret_channel(
             "active_provider_vars": [
                 entry["var"]
                 for entry in provider_api_key_entries()
+                if entry["provider"] in providers
+            ],
+            # Endpoints no provider ships a default for: a deployment that
+            # picks one of these has to name its own gateway or the launch is
+            # refused, so the variable belongs in the file it is told to fill in.
+            "provider_base_urls": provider_base_url_entries(),
+            # Which of those this profile actually needs — the rest are
+            # commented, the same way the unused API keys are.
+            "active_provider_base_url_vars": [
+                entry["var"]
+                for entry in provider_base_url_entries()
                 if entry["provider"] in providers
             ],
             "service_token_vars": service_token_var_entries(),

--- a/src/osprey/cli/templates/manager.py
+++ b/src/osprey/cli/templates/manager.py
@@ -578,6 +578,13 @@ class TemplateManager:
             # Ordered list of {"provider", "var"} dicts; key-less providers
             # (ollama, vllm, …) are excluded.
             "provider_api_keys": scaffolding.provider_api_key_entries(),
+            # Providers that require a base_url and ship no default: their
+            # gateway is the deployment's own host, so .env.example names the
+            # variable rather than leaving it to the documentation.
+            "provider_base_urls": scaffolding.provider_base_url_entries(),
+            # As with the keys: empty here, so a caller with no profile renders
+            # them all uncommented; `osprey init` fills it in.
+            "active_provider_base_url_vars": [],
             # The subset of the above this profile actually uses. Empty here so
             # a caller with no profile still renders the whole list uncommented;
             # `osprey init` fills it in and the rest drop below a divider.

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -110,6 +110,46 @@ def provider_api_key_entries() -> list[dict[str, str]]:
     ]
 
 
+def provider_base_url_entries() -> list[dict[str, str]]:
+    """Env vars naming an endpoint the deployment has to supply, in registry order.
+
+    A provider that requires a ``base_url`` and ships no ``default_base_url``
+    has no host to fall back to: the gateway it fronts is the deployment's own,
+    and a launch that names none is refused. Those are the variables whose
+    absence stops a deployment, so ``.env.example`` lists them beside the keys
+    rather than leaving them to the documentation.
+
+    Derived from the provider classes themselves — the same three attributes
+    the launch paths read — so the file cannot drift from what is actually
+    required. Providers with a working default (cborg, argo, ollama, …) are
+    excluded: setting their variable redirects them, it does not enable them.
+
+    Returns:
+        List of ``{"provider": <name>, "var": <ENV_VAR>}`` dicts, in the
+        registry's own (alphabetical) provider order. Empty when every provider
+        ships an endpoint.
+    """
+    from osprey.models.provider_registry import get_provider_registry
+
+    registry = get_provider_registry()
+    entries: list[dict[str, str]] = []
+    for provider in registry.list_providers():
+        # A provider whose module will not import is not this function's
+        # problem — the registry reports that where it is actionable.
+        try:
+            cls = registry.get_provider(provider)
+        except Exception:  # noqa: BLE001 - see comment above
+            continue
+        if cls is None:
+            continue
+        if not cls.requires_base_url or cls.default_base_url:
+            continue
+        if not cls.base_url_env_var:
+            continue
+        entries.append({"provider": provider, "var": cls.base_url_env_var})
+    return entries
+
+
 # Human-readable blurbs for the deploy-minted variables, keyed by var name.
 # Prose only: the *list* of variables comes from ``_SERVICE_TOKEN_VARS``, so a
 # newly minted var still reaches ``.env.example`` (named by the services that

--- a/src/osprey/health/probes/provider_canary.py
+++ b/src/osprey/health/probes/provider_canary.py
@@ -35,7 +35,6 @@ contract that authentication is checked by ``check_health`` itself.
 from __future__ import annotations
 
 import os
-import re
 from collections.abc import Mapping
 from time import perf_counter
 from typing import TYPE_CHECKING, Any
@@ -43,7 +42,11 @@ from typing import TYPE_CHECKING, Any
 from osprey.health.models import CheckResult, Status
 from osprey.health.offload import run_sync
 from osprey.models.provider_registry import get_provider_registry
-from osprey.utils.config import get_config_value, resolve_env_vars
+from osprey_connectors.config import (
+    get_config_value,
+    is_unresolved_placeholder,
+    resolve_env_vars,
+)
 
 if TYPE_CHECKING:
     from osprey.health.probes import ProbeContext
@@ -53,10 +56,6 @@ if TYPE_CHECKING:
 #: ``timeout`` so ``check_health`` returns its own ``(False, "…timed out")`` row
 #: before the bridge abandons the thread on a hard hang.
 _OFFLOAD_MARGIN_S = 2.0
-
-#: A string that is nothing but a single unresolved env-var placeholder, e.g.
-#: ``"${MISSING}"`` or ``"$MISSING"``. Such a value collapses to ``""``.
-_LONE_PLACEHOLDER = re.compile(r"^\$\{[A-Za-z_][A-Za-z0-9_]*\}$|^\$[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _resolve_secret(value: str | None) -> str | None:
@@ -73,7 +72,7 @@ def _resolve_secret(value: str | None) -> str | None:
     resolved = resolve_env_vars(value, environ=os.environ)
     if not isinstance(resolved, str):
         return value
-    if _LONE_PLACEHOLDER.match(resolved):
+    if is_unresolved_placeholder(resolved):
         return ""
     return resolved
 

--- a/src/osprey/interfaces/artifacts/store_watcher.py
+++ b/src/osprey/interfaces/artifacts/store_watcher.py
@@ -17,30 +17,11 @@ from typing import Any
 
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver
+
+from osprey.interfaces.fs_watch import ChangeStamp, ObserverFactory, one_level_listing
 
 logger = logging.getLogger("osprey.interfaces.artifacts.store_watcher")
-
-
-def _one_level_listing(directory: Path) -> dict[str, tuple[int, int]]:
-    """One level of *directory* as ``{name: (mtime_ns, size)}``.
-
-    A change stamp, not metadata anyone reads: two listings of the same
-    directory differ at exactly the names that were added, removed, or written
-    to. A directory that is gone by the time the scan runs lists as empty
-    rather than raising — the frame is a report about the past.
-    """
-    listing: dict[str, tuple[int, int]] = {}
-    try:
-        entries = list(os.scandir(directory))
-    except OSError:
-        return listing
-    for entry in entries:
-        try:
-            stat = entry.stat()
-            listing[entry.name] = (stat.st_mtime_ns, stat.st_size)
-        except OSError:  # vanished mid-scan
-            continue
-    return listing
 
 
 def _change_stamp(path: Path) -> tuple[int, int] | None:
@@ -80,7 +61,7 @@ class _IndexFileHandler(FileSystemEventHandler):
         self._last_event: dict[str, float] = {}
         self._last_stamp: dict[str, tuple[int, int] | None] = {}
         self._debounce_seconds = 0.1
-        self._listings: dict[str, dict[str, tuple[int, int]]] = {}
+        self._listings: dict[str, dict[str, ChangeStamp]] = {}
         # Snapshot known entry IDs per store
         self._known_ids: dict[str, set] = {}
         for filename, cfg in index_configs.items():
@@ -98,6 +79,14 @@ class _IndexFileHandler(FileSystemEventHandler):
         if event.is_directory:
             return
         self._handle(event)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        # A directory that is gone keeps no listing. The rescan below evicts
+        # one only when a *frame* arrives for a path that has already gone;
+        # a directory removed the ordinary way is announced by this event and
+        # by no other, so without this the entry would outlive the directory.
+        if event.is_directory:
+            self._listings.pop(str(Path(os.fsdecode(event.src_path))), None)
 
     def on_moved(self, event: FileSystemEvent) -> None:
         if event.is_directory:
@@ -125,13 +114,14 @@ class _IndexFileHandler(FileSystemEventHandler):
         One level, because that is what the frame names: a write in a
         subdirectory produces its own frame for its own directory.
 
-        One listing is kept per directory that still exists; a directory that
-        has gone away is dropped rather than remembered as empty.
+        One listing is kept per directory that still exists: one found already
+        gone is dropped here rather than remembered as empty, and one removed
+        the ordinary way is dropped by :meth:`on_deleted`.
         """
         directory = Path(os.fsdecode(event.src_path))
         key = str(directory)
         previous = self._listings.get(key)
-        current = _one_level_listing(directory)
+        current = one_level_listing(directory)
         if directory.is_dir():
             self._listings[key] = current
         else:
@@ -222,10 +212,21 @@ class StoreIndexWatcher:
         workspace_root: Path,
         broadcaster: Any,
         artifact_store: Any,
+        *,
+        observer_factory: ObserverFactory = Observer,
     ) -> None:
+        """
+        Args:
+            workspace_root: Deployment workspace the index files live under.
+            broadcaster: SSE broadcaster the index diffs are published to.
+            artifact_store: Store whose index this watcher reloads.
+            observer_factory: Builds the watchdog observer — see
+                :data:`ObserverFactory`.
+        """
         self._workspace_root = workspace_root
         self._broadcaster = broadcaster
-        self._observer: Observer | None = None
+        self._observer_factory = observer_factory
+        self._observer: BaseObserver | None = None
 
         self._index_configs: dict[str, dict[str, Any]] = {
             "artifacts.json": {
@@ -244,7 +245,7 @@ class StoreIndexWatcher:
     def start(self) -> None:
         """Start watching index files for changes."""
         handler = _IndexFileHandler(self._index_configs, self._broadcaster)
-        self._observer = Observer()
+        self._observer = self._observer_factory()
 
         # Schedule a watch on each directory that contains an index file
         watched = set()

--- a/src/osprey/interfaces/artifacts/store_watcher.py
+++ b/src/osprey/interfaces/artifacts/store_watcher.py
@@ -10,6 +10,7 @@ the diff naturally produces nothing — no duplicate events.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,42 @@ from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 logger = logging.getLogger("osprey.interfaces.artifacts.store_watcher")
+
+
+def _one_level_listing(directory: Path) -> dict[str, tuple[int, int]]:
+    """One level of *directory* as ``{name: (mtime_ns, size)}``.
+
+    A change stamp, not metadata anyone reads: two listings of the same
+    directory differ at exactly the names that were added, removed, or written
+    to. A directory that is gone by the time the scan runs lists as empty
+    rather than raising — the frame is a report about the past.
+    """
+    listing: dict[str, tuple[int, int]] = {}
+    try:
+        entries = list(os.scandir(directory))
+    except OSError:
+        return listing
+    for entry in entries:
+        try:
+            stat = entry.stat()
+            listing[entry.name] = (stat.st_mtime_ns, stat.st_size)
+        except OSError:  # vanished mid-scan
+            continue
+    return listing
+
+
+def _change_stamp(path: Path) -> tuple[int, int] | None:
+    """``(mtime_ns, size)`` of *path*, or ``None`` when it is not there.
+
+    Enough to tell one write from the next without reading the file: two
+    reports of the same write carry the same stamp, and a second write moves
+    it.
+    """
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
 
 
 class _IndexFileHandler(FileSystemEventHandler):
@@ -41,7 +78,9 @@ class _IndexFileHandler(FileSystemEventHandler):
         self._index_configs = index_configs
         self._broadcaster = broadcaster
         self._last_event: dict[str, float] = {}
+        self._last_stamp: dict[str, tuple[int, int] | None] = {}
         self._debounce_seconds = 0.1
+        self._listings: dict[str, dict[str, tuple[int, int]]] = {}
         # Snapshot known entry IDs per store
         self._known_ids: dict[str, set] = {}
         for filename, cfg in index_configs.items():
@@ -51,6 +90,7 @@ class _IndexFileHandler(FileSystemEventHandler):
 
     def on_modified(self, event: FileSystemEvent) -> None:
         if event.is_directory:
+            self._rescan_directory(event)
             return
         self._handle(event)
 
@@ -69,6 +109,44 @@ class _IndexFileHandler(FileSystemEventHandler):
         dest_path = getattr(event, "dest_path", "")
         self._handle(event, path=str(dest_path) if dest_path else None)
 
+    def _rescan_directory(self, event: FileSystemEvent) -> None:
+        """Read a directory frame as the index write it stands for.
+
+        FSEvents coalesces: a write to ``artifacts.json`` can arrive as one
+        ``modified`` event on the directory holding it, with no per-file event
+        behind it. A directory frame carries no per-file event, so returning on
+        it drops the index write. The directory is listed one level deep
+        instead, compared with the listing last taken of it, and every name
+        that differs is routed through :meth:`_handle` exactly as a per-file
+        event would have been. Only the index filenames this watcher was given
+        do anything there, so the rescan cannot broadcast anything a per-file
+        event would not have.
+
+        One level, because that is what the frame names: a write in a
+        subdirectory produces its own frame for its own directory.
+
+        One listing is kept per directory that still exists; a directory that
+        has gone away is dropped rather than remembered as empty.
+        """
+        directory = Path(os.fsdecode(event.src_path))
+        key = str(directory)
+        previous = self._listings.get(key)
+        current = _one_level_listing(directory)
+        if directory.is_dir():
+            self._listings[key] = current
+        else:
+            self._listings.pop(key, None)
+
+        changed = [
+            name
+            for name, stamp in current.items()
+            if previous is None or previous.get(name) != stamp
+        ]
+        changed.extend(sorted((previous or {}).keys() - current.keys()))
+        for name in changed:
+            if name in self._index_configs:
+                self._handle(event, path=str(directory / name))
+
     def _handle(self, event: FileSystemEvent, path: str | None = None) -> None:
         src_path = Path(path) if path is not None else Path(event.src_path)
         filename = src_path.name
@@ -76,13 +154,19 @@ class _IndexFileHandler(FileSystemEventHandler):
         if filename not in self._index_configs:
             return
 
-        # Debounce: skip if same path fired within 100ms
+        # Debounce: skip a repeat report of the index this handler last read.
+        # A directory frame and the per-file event for one write arrive
+        # milliseconds apart and a frame delivered before the index is on disk
+        # reads it unchanged, so closing the window on the clock alone would
+        # drop the event that did carry the entry — and nothing follows it. The
+        # window closes on a change already read instead: same stamp, same
+        # read.
         now = time.monotonic()
         key = str(src_path)
-        last = self._last_event.get(key, 0)
-        if now - last < self._debounce_seconds:
+        stamp = _change_stamp(src_path)
+        within_window = now - self._last_event.get(key, 0) < self._debounce_seconds
+        if within_window and key in self._last_stamp and self._last_stamp[key] == stamp:
             return
-        self._last_event[key] = now
 
         cfg = self._index_configs[filename]
         store = cfg["store"]
@@ -95,8 +179,14 @@ class _IndexFileHandler(FileSystemEventHandler):
         try:
             store._load_index()
         except Exception:
+            # No slot claimed: a half-written index that parses on the next
+            # frame must not have been debounced away by the attempt that
+            # failed on it.
             logger.warning("Failed to reload %s index; skipping", filename, exc_info=True)
             return
+
+        self._last_event[key] = now
+        self._last_stamp[key] = stamp
 
         new_ids = {getattr(e, id_attr) for e in store._entries}
 

--- a/src/osprey/interfaces/fs_watch.py
+++ b/src/osprey/interfaces/fs_watch.py
@@ -1,0 +1,55 @@
+"""Watchdog primitives shared by the interface file watchers.
+
+Both the workspace watcher behind the file panel and the artifacts store-index
+watcher run on the same backend and read a coalesced directory frame the same
+way, so the observer seam and the listing they diff live here once rather than
+once per watcher.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+from watchdog.observers.api import BaseObserver
+
+#: Builds the watchdog observer a watcher runs on.
+#:
+#: The default is the platform's native observer — FSEvents on macOS, inotify on
+#: Linux — which is what a deployment runs and the only backend that delivers an
+#: atomic file replacement as ``on_moved``. A caller that needs delivery to be
+#: decided by the filesystem's contents rather than by a notification stream
+#: passes ``watchdog.observers.polling.PollingObserver`` instead: it compares two
+#: directory snapshots on a fixed interval, so a change is reported whenever it
+#: was made and never coalesced away, at the cost of the event class the native
+#: backend would have used.
+ObserverFactory = Callable[[], BaseObserver]
+
+#: One directory entry as ``(is_dir, mtime_ns, size)``.
+ChangeStamp = tuple[bool, int, int]
+
+
+def one_level_listing(directory: Path) -> dict[str, ChangeStamp]:
+    """One level of *directory* as ``{name: (is_dir, mtime_ns, size)}``.
+
+    The tuple is a change stamp, not metadata anyone reads: two listings of the
+    same directory differ at exactly the names that were added, removed, or
+    written to. A directory that has gone away between the frame and the scan
+    lists as empty rather than raising — the frame is a report about the past.
+
+    One ``scandir`` and the stats it already carries, so the cost of reading a
+    frame this way is one syscall plus the entries the directory holds.
+    """
+    listing: dict[str, ChangeStamp] = {}
+    try:
+        entries = list(os.scandir(directory))
+    except OSError:
+        return listing
+    for entry in entries:
+        try:
+            stat = entry.stat()
+            listing[entry.name] = (entry.is_dir(), stat.st_mtime_ns, stat.st_size)
+        except OSError:  # vanished mid-scan
+            continue
+    return listing

--- a/src/osprey/interfaces/web_terminal/file_watcher.py
+++ b/src/osprey/interfaces/web_terminal/file_watcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 import time
 from collections.abc import Sequence
@@ -52,6 +53,28 @@ class FileEventBroadcaster:
 # Patterns to ignore in file watching
 _IGNORE_PATTERNS = {".git", "__pycache__", ".DS_Store", "_notebook_cache"}
 _IGNORE_EXTENSIONS = {".pyc", ".pyo"}
+
+
+def _one_level_listing(directory: Path) -> dict[str, tuple[bool, int, int]]:
+    """One level of *directory* as ``{name: (is_dir, mtime_ns, size)}``.
+
+    The tuple is a change stamp, not metadata anyone reads: two listings of the
+    same directory differ at exactly the names that were added, removed, or
+    written to. A directory that has gone away between the frame and the scan
+    lists as empty rather than raising — the frame is a report about the past.
+    """
+    listing: dict[str, tuple[bool, int, int]] = {}
+    try:
+        entries = list(os.scandir(directory))
+    except OSError:
+        return listing
+    for entry in entries:
+        try:
+            stat = entry.stat()
+            listing[entry.name] = (entry.is_dir(), stat.st_mtime_ns, stat.st_size)
+        except OSError:  # vanished mid-scan
+            continue
+    return listing
 
 
 def filesystem_is_case_insensitive(directory: Path) -> bool:
@@ -189,24 +212,14 @@ class _WorkspaceHandler(FileSystemEventHandler):
         )
         self._last_event: dict[str, float] = {}
         self._debounce_seconds = 0.1
+        self._listings: dict[str, dict[str, tuple[bool, int, int]]] = {}
 
     def on_any_event(self, event: FileSystemEvent) -> None:
         src_path = Path(event.src_path)
 
         # Filter ignored paths
-        for part in src_path.parts:
-            if part in _IGNORE_PATTERNS:
-                return
-        if src_path.suffix in _IGNORE_EXTENSIONS:
+        if self._is_ignored(src_path):
             return
-
-        # Debounce: skip duplicate events for the same path within 100ms
-        now = time.monotonic()
-        key = str(src_path)
-        last = self._last_event.get(key, 0)
-        if now - last < self._debounce_seconds:
-            return
-        self._last_event[key] = now
 
         event_type_map = {
             "created": "created",
@@ -225,13 +238,27 @@ class _WorkspaceHandler(FileSystemEventHandler):
             return
 
         # Conceal the server-side stores: drop the event rather than broadcast it.
-        if self._concealed_parts:
-            parts = relative.parts
-            if self._fold_case:
-                parts = tuple(part.casefold() for part in parts)
-            for store_parts in self._concealed_parts:
-                if parts[: len(store_parts)] == store_parts:
-                    return
+        if self._is_concealed(relative):
+            return
+
+        # A coalesced frame: FSEvents may report a burst of writes inside a
+        # directory as one ``modified`` event on the directory itself, with no
+        # per-file event behind it. Forwarded as-is it says a directory changed
+        # and nothing about what is in it, so the listing on the other end
+        # never learns about the file. Say what changed instead.
+        #
+        # The frame skips the path debounce below: it is the whole report of
+        # the change, so a frame dropped on the clock is a change lost rather
+        # than a duplicate suppressed. What keeps a repeat frame quiet is the
+        # listing diff, which announces only names that differ, and every name
+        # it does announce claims its own slot.
+        if event.is_directory and simple_type == "modified":
+            self._broadcast_directory_diff(src_path, relative)
+            return
+
+        # Debounce: skip duplicate events for the same path within 100ms
+        if not self._claim_debounce_slot(str(src_path)):
+            return
 
         self._broadcaster.broadcast(
             {
@@ -240,6 +267,99 @@ class _WorkspaceHandler(FileSystemEventHandler):
                 "is_dir": event.is_directory,
             }
         )
+
+    def _is_ignored(self, path: Path) -> bool:
+        """Whether *path* is one of the paths the file panel never shows."""
+        return any(part in _IGNORE_PATTERNS for part in path.parts) or (
+            path.suffix in _IGNORE_EXTENSIONS
+        )
+
+    def _is_concealed(self, relative: Path) -> bool:
+        """Whether *relative* is at or below one of the server-side stores."""
+        if not self._concealed_parts:
+            return False
+        parts = relative.parts
+        if self._fold_case:
+            parts = tuple(part.casefold() for part in parts)
+        return any(parts[: len(store)] == store for store in self._concealed_parts)
+
+    def _broadcast_directory_diff(self, directory: Path, relative: Path) -> None:
+        """Broadcast what one level of *directory* holds that it did not before.
+
+        The rescan stops at one level because that is what the frame names: a
+        write deeper in the tree produces its own frame for its own directory,
+        and recursing here would turn a single coalesced event into a walk of
+        the whole workspace.
+
+        The first frame for a directory has no earlier listing to compare
+        against, so its contents are announced as ``created``. A file panel
+        converges on what is there either way, and re-announcing a file that
+        was already listed costs a redundant frame — where staying silent
+        would lose the change the frame was reporting.
+
+        One listing is kept per directory that still exists: a directory that
+        has gone away is dropped after its contents are announced as deleted,
+        so a workspace that churns cannot grow the map without bound.
+        """
+        key = str(directory)
+        previous = self._listings.get(key)
+        current = _one_level_listing(directory)
+        if directory.is_dir():
+            self._listings[key] = current
+        else:
+            self._listings.pop(key, None)
+
+        if previous is None:
+            for name, stamp in current.items():
+                self._broadcast_child(directory, relative, name, "created", stamp[0])
+            return
+
+        for name, stamp in current.items():
+            if name not in previous:
+                self._broadcast_child(directory, relative, name, "created", stamp[0])
+            elif previous[name] != stamp:
+                self._broadcast_child(directory, relative, name, "modified", stamp[0])
+        for name in sorted(previous.keys() - current.keys()):
+            self._broadcast_child(directory, relative, name, "deleted", previous[name][0])
+
+    def _broadcast_child(
+        self, directory: Path, relative: Path, name: str, simple_type: str, is_dir: bool
+    ) -> None:
+        """Broadcast one child of a rescanned directory, ignore rules applied.
+
+        The rescan reaches children the per-file path never filtered, so the
+        same two predicates run again here — a rescan is not a way past the
+        ignore list or past concealment.
+
+        The child shares one debounce slot with its own per-file event: a write
+        delivers both that event and a frame for the parent directory, and
+        whichever arrives first is the one that announces the change.
+        """
+        child = directory / name
+        if self._is_ignored(child):
+            return
+        child_relative = relative / name
+        if self._is_concealed(child_relative):
+            return
+        if not self._claim_debounce_slot(str(child)):
+            return
+        self._broadcaster.broadcast(
+            {"type": simple_type, "path": str(child_relative), "is_dir": is_dir}
+        )
+
+    def _claim_debounce_slot(self, key: str) -> bool:
+        """Whether *key* may be announced now, claiming its slot if so.
+
+        One slot per path, held for the debounce window: the pair of events a
+        single write produces — the per-file event and the frame for its parent
+        directory — describes one change, and the first of the two to arrive is
+        the one that announces it.
+        """
+        now = time.monotonic()
+        if now - self._last_event.get(key, 0) < self._debounce_seconds:
+            return False
+        self._last_event[key] = now
+        return True
 
 
 class WorkspaceWatcher:

--- a/src/osprey/interfaces/web_terminal/file_watcher.py
+++ b/src/osprey/interfaces/web_terminal/file_watcher.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import threading
 import time
 from collections.abc import Sequence
@@ -16,6 +15,9 @@ from pathlib import Path, PurePath
 
 from watchdog.events import FileSystemEvent, FileSystemEventHandler
 from watchdog.observers import Observer
+from watchdog.observers.api import BaseObserver
+
+from osprey.interfaces.fs_watch import ChangeStamp, ObserverFactory, one_level_listing
 
 logger = logging.getLogger(__name__)
 
@@ -53,28 +55,6 @@ class FileEventBroadcaster:
 # Patterns to ignore in file watching
 _IGNORE_PATTERNS = {".git", "__pycache__", ".DS_Store", "_notebook_cache"}
 _IGNORE_EXTENSIONS = {".pyc", ".pyo"}
-
-
-def _one_level_listing(directory: Path) -> dict[str, tuple[bool, int, int]]:
-    """One level of *directory* as ``{name: (is_dir, mtime_ns, size)}``.
-
-    The tuple is a change stamp, not metadata anyone reads: two listings of the
-    same directory differ at exactly the names that were added, removed, or
-    written to. A directory that has gone away between the frame and the scan
-    lists as empty rather than raising — the frame is a report about the past.
-    """
-    listing: dict[str, tuple[bool, int, int]] = {}
-    try:
-        entries = list(os.scandir(directory))
-    except OSError:
-        return listing
-    for entry in entries:
-        try:
-            stat = entry.stat()
-            listing[entry.name] = (entry.is_dir(), stat.st_mtime_ns, stat.st_size)
-        except OSError:  # vanished mid-scan
-            continue
-    return listing
 
 
 def filesystem_is_case_insensitive(directory: Path) -> bool:
@@ -212,7 +192,7 @@ class _WorkspaceHandler(FileSystemEventHandler):
         )
         self._last_event: dict[str, float] = {}
         self._debounce_seconds = 0.1
-        self._listings: dict[str, dict[str, tuple[bool, int, int]]] = {}
+        self._listings: dict[str, dict[str, ChangeStamp]] = {}
 
     def on_any_event(self, event: FileSystemEvent) -> None:
         src_path = Path(event.src_path)
@@ -256,6 +236,14 @@ class _WorkspaceHandler(FileSystemEventHandler):
             self._broadcast_directory_diff(src_path, relative)
             return
 
+        # A directory that is gone keeps no listing. This is the ordinary way
+        # one leaves: a deletion is delivered as its own event, and only a
+        # *frame* for a path that no longer exists is answered by the diff
+        # above. Evicting here rather than only there is what keeps the map
+        # bounded by the tree rather than by the watcher's lifetime.
+        if event.is_directory and simple_type == "deleted":
+            self._listings.pop(str(src_path), None)
+
         # Debounce: skip duplicate events for the same path within 100ms
         if not self._claim_debounce_slot(str(src_path)):
             return
@@ -297,13 +285,15 @@ class _WorkspaceHandler(FileSystemEventHandler):
         was already listed costs a redundant frame — where staying silent
         would lose the change the frame was reporting.
 
-        One listing is kept per directory that still exists: a directory that
-        has gone away is dropped after its contents are announced as deleted,
-        so a workspace that churns cannot grow the map without bound.
+        One listing is kept per directory that still exists: a directory whose
+        frame finds it already gone is dropped after its contents are announced
+        as deleted, and one that leaves the ordinary way is dropped by its own
+        deletion event, so a workspace that churns cannot grow the map without
+        bound.
         """
         key = str(directory)
         previous = self._listings.get(key)
-        current = _one_level_listing(directory)
+        current = one_level_listing(directory)
         if directory.is_dir():
             self._listings[key] = current
         else:
@@ -376,11 +366,22 @@ class WorkspaceWatcher:
         broadcaster: FileEventBroadcaster,
         *,
         concealed: Sequence[PurePath] = (),
+        observer_factory: ObserverFactory = Observer,
     ) -> None:
+        """
+        Args:
+            workspace_dir: Tree whose changes reach the file panel.
+            broadcaster: SSE broadcaster the frames are published to.
+            concealed: Workspace-relative paths of the server-side stores whose
+                events are dropped.
+            observer_factory: Builds the watchdog observer — see
+                :data:`ObserverFactory`.
+        """
         self._workspace_dir = workspace_dir
         self._broadcaster = broadcaster
         self._concealed = tuple(concealed)
-        self._observer: Observer | None = None
+        self._observer_factory = observer_factory
+        self._observer: BaseObserver | None = None
 
     def start(self) -> None:
         """Start watching the workspace directory."""
@@ -390,7 +391,7 @@ class WorkspaceWatcher:
         handler = _WorkspaceHandler(
             self._workspace_dir, self._broadcaster, concealed=self._concealed
         )
-        self._observer = Observer()
+        self._observer = self._observer_factory()
         self._observer.schedule(handler, str(self._workspace_dir), recursive=True)
         self._observer.daemon = True
         self._observer.start()

--- a/src/osprey/models/providers/als_apg.py
+++ b/src/osprey/models/providers/als_apg.py
@@ -1,8 +1,10 @@
 """ALS-APG Provider Adapter Implementation.
 
 This provider uses LiteLLM as the backend for unified API access.
-ALS-APG is an OpenAI-compatible proxy service hosted on AWS for the
-Advanced Light Source Accelerator Physics Group.
+ALS-APG is an OpenAI-compatible gateway that fronts Anthropic models. It has no
+public endpoint: a deployment supplies its own, through
+``api.providers.als-apg.base_url`` or the ``ALS_APG_BASE_URL`` environment
+variable.
 """
 
 from .litellm_adapter import check_litellm_health, execute_litellm_completion
@@ -16,19 +18,22 @@ class ALSAPGProviderAdapter(LiteLLMDelegatingProvider):
 
     # Metadata (single source of truth)
     name = "als-apg"
-    description = "ALS Accelerator Physics Group AWS proxy (supports Anthropic models)"
+    description = "ALS Accelerator Physics Group gateway (supports Anthropic models)"
     requires_api_key = True
     requires_base_url = True
     requires_model_id = True
     supports_proxy = True
-    default_base_url = "https://llm.gianlucamartino.com"
-    # Break-glass redirect: a set ALS_APG_BASE_URL beats config and the default,
-    # so deployments with a baked-in URL can be pointed at a fallback gateway
-    # at runtime (accepts the URL with or without a trailing /v1).
+    # No built-in endpoint: this proxy is a deployment's own gateway, so its URL
+    # is site data and there is nothing generic to fall back to. A config that
+    # names none is refused by the ``requires_base_url`` gate in
+    # osprey.models.completion rather than resolving to somebody else's host.
+    default_base_url = None
+    # Break-glass redirect: a set ALS_APG_BASE_URL beats config, so deployments
+    # with a baked-in URL can be pointed at a fallback gateway at runtime
+    # (accepts the URL with or without a trailing /v1). It is also the ordinary
+    # way to supply the endpoint, since the shipped catalog entry reads
+    # ``base_url: ${ALS_APG_BASE_URL}``.
     base_url_env_var = "ALS_APG_BASE_URL"
-    # als-apg routes openai-compatible; without a base_url litellm would fall
-    # through to api.openai.com, so a missing base_url resolves to the default.
-    apply_default_base_url_fallback = True
     default_model_id = "claude-haiku-4-5-20251001"
     health_check_model_id = "claude-haiku-4-5-20251001"
     available_models = [
@@ -42,6 +47,7 @@ class ALSAPGProviderAdapter(LiteLLMDelegatingProvider):
     api_key_instructions = [
         "Contact the ALS Accelerator Physics Group for API access.",
         "Set ALS_APG_API_KEY in your environment.",
+        "Set ALS_APG_BASE_URL to the gateway endpoint — there is no default.",
     ]
     api_key_note = "Internal ALS-APG proxy — requires group membership."
 

--- a/src/osprey/models/providers/base.py
+++ b/src/osprey/models/providers/base.py
@@ -4,6 +4,8 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any
 
+from osprey_connectors.config import is_unresolved_placeholder
+
 
 class BaseProvider(ABC):
     """Abstract base class for AI model providers.
@@ -106,6 +108,13 @@ class BaseProvider(ABC):
         validation for "missing" base_url, and the default it declared was
         unreachable — visible only once the env override was removed.
 
+        A ``base_url`` that is still an unresolved ``${VAR}`` reference counts as
+        no value at all. :func:`~osprey_connectors.config.resolve_env_vars` keeps
+        such a reference verbatim when the variable is unset, so a config
+        declaring ``base_url: ${MY_GATEWAY}`` with nothing exported would
+        otherwise hand the literal string to the HTTP client and fail somewhere
+        far from the cause.
+
         Args:
             base_url: The caller's value, usually from deployment config. May be
                 ``None``.
@@ -119,6 +128,8 @@ class BaseProvider(ABC):
             override = os.environ.get(cls.base_url_env_var)
             if override:
                 return override
+        if is_unresolved_placeholder(base_url):
+            base_url = None
         if cls.apply_default_base_url_fallback:
             return base_url or cls.default_base_url
         return base_url

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -629,6 +629,20 @@ def check_litellm_health(
     if api_key and (api_key.startswith("${") or "YOUR_API_KEY" in api_key.upper()):
         return False, "API key not configured (placeholder value detected)"
 
+    if not base_url:
+        # The endpoint is checked the same way the key is. A provider that
+        # declares requires_base_url fronts a gateway with no default host and
+        # routes openai-compatible, so litellm would resolve `openai/<model>`
+        # with no api_base and send the call — carrying the gateway's key — to
+        # api.openai.com. The failure that comes back names authentication,
+        # nowhere near its cause. Lazy import: provider_registry imports the
+        # provider modules, which import this adapter.
+        from osprey.models.provider_registry import get_provider_registry
+
+        provider_class = get_provider_registry().get_provider(provider)
+        if getattr(provider_class, "requires_base_url", False):
+            return False, f"Base URL required for {provider}"
+
     if not model_id:
         return False, "Model ID required for health check"
 

--- a/src/osprey/profiles/providers.yml
+++ b/src/osprey/profiles/providers.yml
@@ -82,7 +82,11 @@ providers:
       opus: claudeopus41
   als-apg:
     api_key: ${ALS_APG_API_KEY}
-    base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
+    # Set this to your gateway. There is no default — this proxy is a
+    # deployment's own host — so export ALS_APG_BASE_URL, or replace the
+    # reference below with the endpoint's /v1 URL. A launch that names
+    # neither is refused rather than reaching somebody else's gateway.
+    base_url: ${ALS_APG_BASE_URL}
     models:
       haiku: claude-haiku-4-5-20251001
       sonnet: claude-sonnet-4-6

--- a/src/osprey/services/channel_finder/benchmarks/backends/react_backend.py
+++ b/src/osprey/services/channel_finder/benchmarks/backends/react_backend.py
@@ -29,6 +29,22 @@ _PROVIDER_RATE_LIMIT_RPM: dict[str, int | None] = {
 logger = logging.getLogger(__name__)
 
 
+def _project_dotenv(project_dir: Path) -> dict[str, str]:
+    """Read the project's ``.env``, so a benchmark run needs no exported shell vars.
+
+    Returns an empty mapping when there is no file, or when ``python-dotenv``
+    is not installed — the caller falls back to the process environment.
+    """
+    env_file = project_dir / ".env"
+    if not env_file.is_file():
+        return {}
+    try:
+        from dotenv import dotenv_values
+    except ImportError:
+        return {}
+    return {key: value for key, value in dotenv_values(env_file).items() if value is not None}
+
+
 def _resolve_litellm_endpoint(project_dir: Path, provider: str) -> dict | None:
     """Resolve provider routing kwargs for a non-ollama provider.
 
@@ -42,13 +58,14 @@ def _resolve_litellm_endpoint(project_dir: Path, provider: str) -> dict | None:
     and for direct Anthropic (LiteLLM's default routing is correct).
 
     NOTE (#307 follow-up): this benchmark-only path still does a raw
-    ``yaml.safe_load`` + ``ClaudeCodeModelResolver.resolve`` and so does NOT
-    expand ``${VAR}`` placeholders in a custom provider's ``base_url``. The
-    model matrix uses native literal-URL providers, so this is deferred rather
-    than switched to ``load_provider_spec`` — the contract differs (synthetic
-    ``{"provider": provider}`` config + litellm ``api_base``). Migrate to
-    ``load_provider_spec`` if a ``${VAR}``-based custom provider is ever
-    benchmarked.
+    ``yaml.safe_load`` + ``ClaudeCodeModelResolver.resolve`` rather than going
+    through ``load_provider_spec``, because the contract differs (synthetic
+    ``{"provider": provider}`` config + litellm ``api_base``). It does expand
+    ``${VAR}`` in a provider's ``base_url``, against the same
+    ``os.environ`` + project ``.env`` overlay the auth secret is read from, and
+    refuses a reference that resolves to nothing rather than handing litellm a
+    placeholder as a hostname — the shipped catalog spells gateway endpoints
+    that way.
     """
     if provider == "ollama":
         return None
@@ -56,32 +73,32 @@ def _resolve_litellm_endpoint(project_dir: Path, provider: str) -> dict | None:
     import yaml
 
     from osprey.build.claude_code_resolver import ClaudeCodeModelResolver
+    from osprey_connectors.config import is_unresolved_placeholder, resolve_env_vars
 
     config_path = project_dir / "config.yml"
     if not config_path.exists():
         return None
     config = yaml.safe_load(config_path.read_text()) or {}
-    api_providers = config.get("api", {}).get("providers", {})
+    # os.environ wins over the project .env, so a sweep can redirect a provider
+    # for one run without editing the deployment's file.
+    dotenv = _project_dotenv(project_dir)
+    overlay = {**dotenv, **os.environ}
+    api_providers = resolve_env_vars(config.get("api", {}).get("providers", {}), environ=overlay)
     spec = ClaudeCodeModelResolver.resolve({"provider": provider}, api_providers)
     if spec is None:
         return None
 
     base_url = spec.env_block.get("ANTHROPIC_BASE_URL")
+    if is_unresolved_placeholder(base_url):
+        raise ValueError(
+            f"Provider '{provider}' names its endpoint as {base_url}, and that variable "
+            f"is not set. Export it, or put it in {project_dir / '.env'}, before "
+            "benchmarking this provider."
+        )
     if not base_url:
         return None  # direct Anthropic — LiteLLM default routing works
 
-    secret = os.environ.get(spec.auth_secret_env)
-    if not secret:
-        # Fall back to project .env so users don't need to export shell vars
-        env_file = project_dir / ".env"
-        if env_file.is_file():
-            try:
-                from dotenv import dotenv_values
-
-                secret = dotenv_values(env_file).get(spec.auth_secret_env)
-            except ImportError:
-                pass
-
+    secret = os.environ.get(spec.auth_secret_env) or dotenv.get(spec.auth_secret_env)
     if not secret:
         logger.warning(
             "No %s found in env or project .env; LiteLLM auth will likely fail",

--- a/src/osprey/services/channel_finder/benchmarks/evaluation.py
+++ b/src/osprey/services/channel_finder/benchmarks/evaluation.py
@@ -116,7 +116,8 @@ def llm_judge_coverage(response_text: str, expected: list[str]) -> tuple[list[st
 
     # Resolve provider. Preference order: direct Anthropic, then ALS-APG
     # (works off-VPN), then CBORG (LBLnet/VPN-only — last resort because
-    # off-VPN traffic gets IP-blocked).
+    # off-VPN traffic gets IP-blocked). ALS-APG has no default endpoint, so it
+    # is only a candidate when its gateway URL is exported alongside its key.
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     provider = "anthropic"
     model_id = "claude-haiku-4-5-20251001"
@@ -124,11 +125,12 @@ def llm_judge_coverage(response_text: str, expected: list[str]) -> tuple[list[st
 
     if not api_key:
         als_apg_key = os.environ.get("ALS_APG_API_KEY")
-        if als_apg_key:
+        als_apg_base_url = os.environ.get("ALS_APG_BASE_URL")
+        if als_apg_key and als_apg_base_url:
             provider = "als-apg"
             api_key = als_apg_key
             model_id = "claude-haiku-4-5-20251001"
-            base_url = os.environ.get("ALS_APG_BASE_URL") or "https://llm.gianlucamartino.com"
+            base_url = als_apg_base_url
         else:
             cborg_key = os.environ.get("CBORG_API_KEY")
             auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")

--- a/src/osprey/templates/project/env.example.j2
+++ b/src/osprey/templates/project/env.example.j2
@@ -42,6 +42,19 @@
 {{ entry.var }}=your-{{ entry.provider }}-api-key-here
 {% endfor %}
 {%- endif %}
+{%- if provider_base_urls %}
+# Gateway endpoints. These providers front a gateway that is your own host, so
+# OSPREY ships no default: switch to one of them and it will not start until
+# its endpoint is set here.
+{% for entry in provider_base_urls -%}
+# {{ entry.provider }}
+{% if active_provider_vars and entry.var not in active_provider_base_url_vars -%}
+# {{ entry.var }}=
+{% else -%}
+{{ entry.var }}=
+{% endif -%}
+{% endfor %}
+{%- endif %}
 {%- set minted = service_token_vars | map(attribute='var') | list %}
 {%- if env_required | reject('in', minted) | list %}
 # Required by this profile. Its `env.required` names these, and the agent

--- a/tests/_env_scope_guard.py
+++ b/tests/_env_scope_guard.py
@@ -1,0 +1,120 @@
+"""Scope-aware ``os.environ`` restoration, used by ``tests/conftest.py``.
+
+Two guards there snapshot and restore the environment: one per test, one per
+test *module*. The module-scoped one exists because a module-scoped fixture --
+a real ``osprey build`` over a seeded repo, which loads that repo's ``.env``
+with override semantics -- is set up *before* the per-test snapshot is taken,
+so its writes land inside the copy every later test is restored to.
+
+Restoring a module's snapshot wholesale would be wrong, though: pytest sets a
+fixture up on first request, so a *session*-scoped fixture can be created
+part-way through a module. Its writes are made after that module's snapshot,
+and the fixture instance outlives the module -- rolling them back at module
+teardown leaves a live fixture whose environment is gone, and the next module
+runs against it without the variables it published.
+
+The environment alone cannot say which fixture wrote a value, so this module
+asks pytest instead: :func:`pytest_fixture_setup` measures the setup of every
+fixture that outlives a module, and :func:`restore_module_environment` replays
+what it recorded on top of the snapshot it puts back.
+
+``tests/conftest.py`` registers this as a *plugin* rather than keeping the hook
+in its own body. ``pytest_fixture_setup`` is dispatched on the node that owns
+the fixture's scope, and a session-scoped fixture's node is the Session --
+whose hook proxy carries only the conftests above it, which ``tests/conftest.py``
+is not. A plainly registered plugin is in scope for every node, which is exactly
+the set this has to see.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+import pytest
+
+#: Env writes made while a fixture that outlives a test module was being set
+#: up: key -> the value that setup left behind, or ``None`` when it removed the
+#: key. Reset on the way into every guarded region, so it only ever holds
+#: writes made after the snapshot that region is restored to.
+LONG_LIVED_ENV_WRITES: dict[str, str | None] = {}
+
+#: Fixture scopes whose instances outlive the module that first requests them.
+SCOPES_OUTLIVING_A_MODULE = frozenset({"session", "package"})
+
+#: The guarded regions currently open, outermost first. Each entry is the record
+#: its region set aside on the way in. Only :func:`restore_module_environment`
+#: touches it; it is what tells an exiting region whether anything encloses it.
+_OPEN_REGIONS: list[dict[str, str | None]] = []
+
+
+def record_env_delta(before: Mapping[str, str]) -> None:
+    """Record every environment key that changed since *before*.
+
+    Args:
+        before: The environment as it stood before the setup being measured.
+    """
+    for key in set(before) | set(os.environ):
+        if before.get(key) != os.environ.get(key):
+            LONG_LIVED_ENV_WRITES[key] = os.environ.get(key)
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    """Measure the environment across the setup of a longer-lived fixture.
+
+    A pluggy *wrapper*: it does not produce the fixture value, it brackets
+    whoever does. Only scopes that outlive a module are measured -- recording a
+    module-scoped fixture's writes here would mark them long-lived and defeat
+    :func:`restore_module_environment` entirely.
+    """
+    if fixturedef.scope not in SCOPES_OUTLIVING_A_MODULE:
+        return (yield)
+    before = dict(os.environ)
+    try:
+        return (yield)
+    finally:
+        record_env_delta(before)
+
+
+@contextmanager
+def restore_module_environment() -> Iterator[None]:
+    """Restore ``os.environ`` at module teardown, minus the long-lived writes.
+
+    Snapshots the environment on the way in and puts that snapshot back on the
+    way out, then re-applies everything :func:`record_env_delta` attributed to a
+    fixture that outlives this module. A module-scoped fixture's writes are in
+    neither set, so they are the ones that go away.
+
+    Re-entrant, because the autouse fixture wraps every test in this repo and a
+    test of this guard therefore opens a second region inside it. The record is
+    a single module-level dict, so an inner region borrows it: it sets the
+    record aside on the way in and puts it back on the way out, with its own
+    long-lived writes folded in -- those keys belong to a fixture that outlives
+    the *enclosing* region too, and clearing the record outright would leave
+    that region rolling a live fixture's environment back under it.
+
+    A region that encloses nothing hands its record to nobody: one module's
+    long-lived writes are not the next module's to replay, and carrying them
+    would grow the record for the length of the run.
+    """
+    saved = dict(os.environ)
+    _OPEN_REGIONS.append(dict(LONG_LIVED_ENV_WRITES))
+    LONG_LIVED_ENV_WRITES.clear()
+    try:
+        yield
+    finally:
+        own = dict(LONG_LIVED_ENV_WRITES)
+        enclosing = _OPEN_REGIONS.pop()
+        os.environ.clear()
+        os.environ.update(saved)
+        for key, value in own.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        LONG_LIVED_ENV_WRITES.clear()
+        if _OPEN_REGIONS:
+            LONG_LIVED_ENV_WRITES.update(enclosing)
+            LONG_LIVED_ENV_WRITES.update(own)

--- a/tests/agent_runner/test_primitives.py
+++ b/tests/agent_runner/test_primitives.py
@@ -59,6 +59,9 @@ def test_provider_override_propagates_raw_secret(
     raw secret for the overridden provider, not the config's."""
     _write_config(tmp_path, "anthropic")
     monkeypatch.setenv("ALS_APG_API_KEY", "sk-als-secret")
+    # als-apg ships no endpoint of its own, so a deployment names one; here the
+    # break-glass variable stands in for the deployment's providers.yml entry.
+    monkeypatch.setenv("ALS_APG_BASE_URL", "https://gw.test/v1")
 
     env = provider_env_for_project(tmp_path, provider="als-apg")
 

--- a/tests/audit/test_dedup_contract.py
+++ b/tests/audit/test_dedup_contract.py
@@ -102,6 +102,14 @@ def project(tmp_path, monkeypatch):
     am.reset_audit_state()
     dedup.clear_recorded()
 
+    # The redirect is process-global — the writer is imported at call time, so
+    # anything else recording in this process lands here too. A web server left
+    # running by an earlier test answers a probe with a `GET /` refusal, and the
+    # zone this fixture promises to hand over empty is not. Hand over what the
+    # docstring says: whatever arrived before the test began is not the test's.
+    for stray in audit_root.rglob("*.jsonl"):
+        stray.unlink()
+
     yield audit_root
 
     am.reset_audit_state()

--- a/tests/benchmark/test_matrix.py
+++ b/tests/benchmark/test_matrix.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from tests.conftest import GATEWAY_ORIGIN
 
 # import-time required because scripts/ is not a package: matrix.py is loaded
 # by path and registered in sys.modules before exec so @dataclass can resolve
@@ -35,7 +36,7 @@ def _cfg() -> matrix.MatrixConfig:
                 "judge": {"via": "cborg", "model": "google/claude-haiku-4-5"},
             },
             "als-apg": {
-                "base_url": "https://llm.gianlucamartino.com",
+                "base_url": GATEWAY_ORIGIN,
                 "key_env": "ALS_APG_API_KEY",
                 "protocol": "anthropic",
                 "judge": {"via": "als-apg", "model": "claude-haiku-4-5-20251001"},
@@ -211,7 +212,7 @@ def test_cell_env_alsapg_reference_is_direct(keys):
     # proxy"); blanking overrides any stale ambient value run_cell copies down.
     assert env["OSPREY_E2E_PROXY_UPSTREAM"] == ""
     assert env["OSPREY_E2E_PROXY_KEY"] == ""
-    assert env["ALS_APG_BASE_URL"] == "https://llm.gianlucamartino.com"
+    assert env["ALS_APG_BASE_URL"] == GATEWAY_ORIGIN
     assert env["OSPREY_E2E_JUDGE_MODEL"] == "claude-haiku-4-5-20251001"
     assert env["ALS_APG_API_KEY"] == "apg-key"  # judge key == als-apg routing key
     assert "CBORG_API_KEY" not in env
@@ -333,6 +334,61 @@ def test_load_config_top_level_judge_becomes_default(tmp_path):
     cfg = matrix.load_config(p)
     cell = matrix.build_cell(cfg, cfg.models[0], 1)
     assert cell.judge_model == "g/h"
+
+
+def test_load_config_expands_env_references(tmp_path, monkeypatch):
+    """Provider fields honour ``${VAR:-default}``: the environment wins, the
+    literal after ``:-`` is only the fallback."""
+    pytest.importorskip("yaml")
+    p = tmp_path / "m.yaml"
+    p.write_text(
+        "providers:\n"
+        "  als-apg:\n"
+        "    base_url: ${ALS_APG_BASE_URL:-https://fallback.example}\n"
+        "    key_env: ALS_APG_API_KEY\n"
+        "    protocol: anthropic\n"
+        "    judge: { via: als-apg, model: m }\n"
+        "models:\n"
+        "  - { id: claude-sonnet-4-6, provider: als-apg }\n"
+    )
+
+    monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+    cfg = matrix.load_config(p)
+    assert cfg.providers["als-apg"]["base_url"] == "https://fallback.example"
+
+    monkeypatch.setenv("ALS_APG_BASE_URL", GATEWAY_ORIGIN)
+    cfg = matrix.load_config(p)
+    assert cfg.providers["als-apg"]["base_url"] == GATEWAY_ORIGIN
+
+
+def test_load_config_refuses_an_unresolved_base_url(tmp_path, monkeypatch):
+    """A provider whose endpoint is named by an unset variable is refused.
+
+    ``resolve_env_vars`` leaves ``${VAR}`` verbatim when ``VAR`` is unset, and
+    the shipped matrix names the als-apg gateway that way because it has no
+    default host. Without the refusal the literal reference travels on as a URL
+    and every cell fails at the first request, far from the cause.
+    """
+    pytest.importorskip("yaml")
+    p = tmp_path / "m.yaml"
+    p.write_text(
+        "providers:\n"
+        "  als-apg:\n"
+        "    base_url: ${ALS_APG_BASE_URL}\n"
+        "    key_env: ALS_APG_API_KEY\n"
+        "    protocol: anthropic\n"
+        "    judge: { via: als-apg, model: m }\n"
+        "models:\n"
+        "  - { id: claude-sonnet-4-6, provider: als-apg }\n"
+    )
+
+    monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+    with pytest.raises(ValueError, match="ALS_APG_BASE_URL"):
+        matrix.load_config(p)
+
+    monkeypatch.setenv("ALS_APG_BASE_URL", GATEWAY_ORIGIN)
+    cfg = matrix.load_config(p)
+    assert cfg.providers["als-apg"]["base_url"] == GATEWAY_ORIGIN
 
 
 # --- orchestration (drive): resume + matrix.log markers ---------------------

--- a/tests/cli/test_base_url_override.py
+++ b/tests/cli/test_base_url_override.py
@@ -36,7 +36,7 @@ class TestBuiltInProviderOverride:
     @pytest.mark.parametrize("provider", sorted(CLAUDE_CODE_PROVIDERS))
     def test_override_does_not_mutate_the_builtin_table(self, provider):
         """The built-in dict is module-level shared state — resolve() must not write to it."""
-        before = CLAUDE_CODE_PROVIDERS[provider]["base_url"]
+        before = CLAUDE_CODE_PROVIDERS[provider].get("base_url")
         ClaudeCodeModelResolver.resolve(
             {"provider": provider},
             api_providers={provider: {"base_url": FACILITY_GATEWAY}},
@@ -45,10 +45,22 @@ class TestBuiltInProviderOverride:
 
     def test_builtin_url_survives_when_config_names_no_base_url(self):
         spec = ClaudeCodeModelResolver.resolve(
-            {"provider": "als-apg"},
-            api_providers={"als-apg": {"api_key": "k"}},
+            {"provider": "cborg"},
+            api_providers={"cborg": {"api_key": "k"}},
         )
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov"
+
+    def test_a_provider_with_no_builtin_url_is_refused_when_config_names_none(self):
+        """als-apg fronts a site's own gateway, so nothing can stand in for it.
+
+        Falling through would leave ANTHROPIC_BASE_URL unset, i.e. Claude Code
+        talking to its native backend with the gateway's bearer token.
+        """
+        with pytest.raises(ValueError, match="ALS_APG_BASE_URL"):
+            ClaudeCodeModelResolver.resolve(
+                {"provider": "als-apg"},
+                api_providers={"als-apg": {"api_key": "k"}},
+            )
 
     def test_anthropic_gains_a_base_url_only_when_config_gives_one(self):
         """The built-in anthropic entry has no URL; config is the only source."""
@@ -79,20 +91,16 @@ class TestV1StripSurvivesTheOverride:
         )
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
 
-    def test_shipped_template_urls_are_unchanged_by_the_override(self):
-        """cborg/als-apg templates ship the built-in URL + /v1 — the override is a no-op."""
-        for provider, shipped, expected in (
-            ("cborg", "https://api.cborg.lbl.gov/v1", "https://api.cborg.lbl.gov"),
-            (
-                "als-apg",
-                "https://llm.gianlucamartino.com/v1",
-                "https://llm.gianlucamartino.com",
-            ),
+    def test_catalog_urls_are_stripped_the_same_way_for_every_provider(self):
+        """The catalog spells endpoints with /v1; the env var must never carry it."""
+        for provider, configured in (
+            ("cborg", "https://api.cborg.lbl.gov/v1"),
+            ("als-apg", FACILITY_GATEWAY + "/v1"),
         ):
             spec = ClaudeCodeModelResolver.resolve(
-                {"provider": provider}, api_providers={provider: {"base_url": shipped}}
+                {"provider": provider}, api_providers={provider: {"base_url": configured}}
             )
-            assert spec.env_block["ANTHROPIC_BASE_URL"] == expected
+            assert spec.env_block["ANTHROPIC_BASE_URL"] == configured.removesuffix("/v1")
 
 
 class TestProxyUpstreamFollowsTheOverride:
@@ -153,6 +161,68 @@ class TestEndToEndThroughLoadProviderSpec:
         spec = load_provider_spec(tmp_path, include_telemetry=False)
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
 
+    def test_unexported_placeholder_is_refused_by_name(self, tmp_path, monkeypatch):
+        """The shipped catalog form with nothing exported must not travel on.
+
+        ``providers.yml`` spells the endpoint ``${ALS_APG_BASE_URL}``. Unset,
+        the config resolver keeps the reference verbatim, so without this the
+        literal reaches the env block and Claude Code is handed
+        ``ANTHROPIC_BASE_URL="${ALS_APG_BASE_URL}"`` as a hostname.
+        """
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        (tmp_path / "config.yml").write_text(
+            "api:\n"
+            "  providers:\n"
+            "    als-apg:\n"
+            "      base_url: ${ALS_APG_BASE_URL}\n"
+            "claude_code:\n"
+            "  provider: als-apg\n"
+        )
+
+        with pytest.raises(ValueError, match="ALS_APG_BASE_URL"):
+            load_provider_spec(tmp_path, include_telemetry=False)
+
+    def test_a_render_may_defer_the_placeholder_to_its_runtime(self, tmp_path, monkeypatch):
+        """The build's reachability check reads a render, not a launch.
+
+        A container image is built on one host and given its gateway on
+        another, so ``${VAR}`` there is the render's contract with its runtime.
+        Only the paths that are about to call the gateway refuse.
+        """
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        (tmp_path / "config.yml").write_text(
+            "api:\n"
+            "  providers:\n"
+            "    als-apg:\n"
+            "      base_url: ${ALS_APG_BASE_URL}\n"
+            "claude_code:\n"
+            "  provider: als-apg\n"
+        )
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False, defer_unresolved_base_url=True)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "${ALS_APG_BASE_URL}"
+
+    def test_unexported_placeholder_leaves_a_builtin_url_in_charge(self, tmp_path, monkeypatch):
+        """Blanking happens before the fallback chain, not instead of it."""
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.delenv("FACILITY_GATEWAY_URL", raising=False)
+        (tmp_path / "config.yml").write_text(
+            "api:\n"
+            "  providers:\n"
+            "    cborg:\n"
+            "      base_url: ${FACILITY_GATEWAY_URL}\n"
+            "claude_code:\n"
+            "  provider: cborg\n"
+        )
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://api.cborg.lbl.gov"
+
 
 class TestEnvVarBreakGlassOverride:
     """A supplied ``base_url_env_var`` value beats config and the built-in URL.
@@ -165,7 +235,8 @@ class TestEnvVarBreakGlassOverride:
     ``resolve()`` refuses to read the process environment itself.
     """
 
-    def test_supplied_value_wins_over_builtin_url(self):
+    def test_supplied_value_is_enough_on_its_own(self):
+        """For a provider with no built-in URL the variable is the whole source."""
         spec = ClaudeCodeModelResolver.resolve(
             {"provider": "als-apg"},
             environ={"ALS_APG_BASE_URL": f"{FACILITY_GATEWAY}/v1"},
@@ -180,16 +251,22 @@ class TestEnvVarBreakGlassOverride:
         )
         assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY
 
-    def test_absent_value_preserves_existing_behavior(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, environ={})
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+    def test_absent_value_leaves_config_in_charge(self):
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            api_providers={"als-apg": {"base_url": "https://baked.example.org/v1"}},
+            environ={},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://baked.example.org"
 
     def test_empty_value_is_ignored(self):
-        """An empty export must not blank the URL — fall through to the default."""
+        """An empty export must not blank the URL — fall through to config."""
         spec = ClaudeCodeModelResolver.resolve(
-            {"provider": "als-apg"}, environ={"ALS_APG_BASE_URL": ""}
+            {"provider": "als-apg"},
+            api_providers={"als-apg": {"base_url": "https://baked.example.org/v1"}},
+            environ={"ALS_APG_BASE_URL": ""},
         )
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://baked.example.org"
 
     def test_provider_without_the_declaration_ignores_the_value(self):
         """The override is opt-in per provider, so it cannot leak across them."""
@@ -246,8 +323,11 @@ class TestResolveNeverReadsAmbientEnviron:
 
     def test_process_env_does_not_reach_the_env_block(self, monkeypatch):
         monkeypatch.setenv("ALS_APG_BASE_URL", "https://build-machine.example.org/v1")
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            api_providers={"als-apg": {"base_url": "https://baked.example.org/v1"}},
+        )
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://baked.example.org"
 
     def test_process_env_does_not_override_a_config_base_url(self, monkeypatch):
         monkeypatch.setenv("ALS_APG_BASE_URL", "https://build-machine.example.org/v1")
@@ -312,3 +392,21 @@ class TestOverrideReachesTheRuntimePath:
 
         spec = load_provider_spec(tmp_path, include_telemetry=False)
         assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://baked.example.org"
+
+    def test_the_catalog_placeholder_resolves_once_the_variable_is_exported(
+        self, tmp_path, monkeypatch
+    ):
+        from osprey.build.claude_code_resolver import load_provider_spec
+
+        monkeypatch.setenv("ALS_APG_BASE_URL", f"{FACILITY_GATEWAY}/v1")
+        (tmp_path / "config.yml").write_text(
+            "api:\n"
+            "  providers:\n"
+            "    als-apg:\n"
+            "      base_url: ${ALS_APG_BASE_URL}\n"
+            "claude_code:\n"
+            "  provider: als-apg\n"
+        )
+
+        spec = load_provider_spec(tmp_path, include_telemetry=False)
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == FACILITY_GATEWAY

--- a/tests/cli/test_claude_code_resolver.py
+++ b/tests/cli/test_claude_code_resolver.py
@@ -12,6 +12,23 @@ from osprey.build.claude_code_resolver import (
     ClaudeCodeModelSpec,
     inject_provider_env,
 )
+from tests.conftest import GATEWAY_BASE_URL, GATEWAY_ORIGIN
+
+
+def _resolve_builtin(provider_name: str):
+    """Resolve a built-in provider, naming a gateway for the ones that need one.
+
+    A provider with no built-in endpoint (``requires_base_url``) is refused
+    unless config or the environment names one, so a sweep over the whole table
+    has to supply it — otherwise the sweep would only ever pass for the
+    providers that ship a URL.
+    """
+    api_providers = (
+        {provider_name: {"base_url": GATEWAY_BASE_URL}}
+        if CLAUDE_CODE_PROVIDERS[provider_name].get("requires_base_url")
+        else {}
+    )
+    return ClaudeCodeModelResolver.resolve({"provider": provider_name}, api_providers)
 
 
 class TestResolveReturnsNone:
@@ -99,32 +116,51 @@ class TestCBORGProvider:
 
 
 class TestAlsApgProvider:
-    """ALS-APG (LBL AWS proxy) provider configuration."""
+    """ALS-APG (gateway) provider configuration.
+
+    The gateway is a site's own host, so every case here has to name the
+    endpoint the way a deployment does — there is nothing built in to fall
+    back on, and :meth:`test_a_missing_base_url_is_refused` pins that.
+    """
+
+    ENVIRON = {"ALS_APG_BASE_URL": GATEWAY_BASE_URL}
+
+    def _spec(self):
+        return ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, environ=self.ENVIRON)
 
     def test_env_block_has_base_url_but_no_auth(self):
         """Auth is handled via shell exports, not env block."""
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        spec = self._spec()
         assert "ANTHROPIC_AUTH_TOKEN" not in spec.env_block
         assert "ANTHROPIC_API_KEY" not in spec.env_block
         assert "ANTHROPIC_BASE_URL" in spec.env_block
 
-    def test_base_url_is_correct(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
-        assert spec.env_block["ANTHROPIC_BASE_URL"] == "https://llm.gianlucamartino.com"
+    def test_base_url_is_the_configured_gateway(self):
+        spec = self._spec()
+        assert spec.env_block["ANTHROPIC_BASE_URL"] == GATEWAY_ORIGIN
+
+    def test_a_missing_base_url_is_refused(self):
+        """No endpoint anywhere must not silently mean "Anthropic direct".
+
+        Without a base_url the env block simply omits ANTHROPIC_BASE_URL, and
+        the gateway's bearer token would be presented to api.anthropic.com.
+        """
+        with pytest.raises(ValueError, match="ALS_APG_BASE_URL"):
+            ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, environ={})
 
     def test_shell_exports_use_als_apg_api_key(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        spec = self._spec()
         assert len(spec.shell_exports) == 1
         assert 'ANTHROPIC_AUTH_TOKEN="$ALS_APG_API_KEY"' in spec.shell_exports[0]
 
     def test_model_tiers(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        spec = self._spec()
         assert spec.tier_to_model["haiku"] == "claude-haiku-4-5-20251001"
         assert spec.tier_to_model["sonnet"] == "claude-sonnet-4-6"
         assert spec.tier_to_model["opus"] == "claude-opus-4-6"
 
     def test_default_model_tier_is_haiku(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        spec = self._spec()
         assert spec.default_model_tier == "haiku"
 
 
@@ -405,7 +441,7 @@ class TestApiProvidersModelAuthority:
             {"provider": "als-apg"},
             api_providers={
                 "als-apg": {
-                    "base_url": "https://llm.gianlucamartino.com/v1",
+                    "base_url": GATEWAY_BASE_URL,
                     "models": {
                         "haiku": "claude-haiku-4-5-20251001",
                         "sonnet": "claude-sonnet-4-6",
@@ -526,7 +562,7 @@ class TestEnvBlockTierModels:
 
     def test_all_three_vars_always_present(self):
         for provider_name in CLAUDE_CODE_PROVIDERS:
-            spec = ClaudeCodeModelResolver.resolve({"provider": provider_name})
+            spec = _resolve_builtin(provider_name)
             for var in (
                 "ANTHROPIC_DEFAULT_HAIKU_MODEL",
                 "ANTHROPIC_DEFAULT_SONNET_MODEL",
@@ -615,7 +651,7 @@ class TestAuthVarSeparation:
     def test_env_block_never_contains_auth_keys(self):
         """Auth keys must not be in env block (Claude Code doesn't expand ${VAR})."""
         for provider_name in CLAUDE_CODE_PROVIDERS:
-            spec = ClaudeCodeModelResolver.resolve({"provider": provider_name})
+            spec = _resolve_builtin(provider_name)
             assert "ANTHROPIC_API_KEY" not in spec.env_block
             assert "ANTHROPIC_AUTH_TOKEN" not in spec.env_block
 

--- a/tests/cli/test_env_templates_registry_driven.py
+++ b/tests/cli/test_env_templates_registry_driven.py
@@ -14,9 +14,14 @@ which renders a template.
 from __future__ import annotations
 
 from osprey.cli.templates.manager import TemplateManager
-from osprey.cli.templates.scaffolding import provider_api_key_entries, service_token_var_entries
+from osprey.cli.templates.scaffolding import (
+    provider_api_key_entries,
+    provider_base_url_entries,
+    service_token_var_entries,
+)
 from osprey.deployment.container_lifecycle import _SERVICE_TOKEN_VARS
 from osprey.models.provider_registry import PROVIDER_API_KEYS
+from osprey_connectors.dotenv import parse_dotenv_text
 
 
 def _render(template_name: str, ctx: dict) -> str:
@@ -36,6 +41,8 @@ def _base_ctx(env: dict) -> dict:
         # undefined name emits nothing — and the assertions below would then be
         # testing the fixture rather than the template.
         "service_token_vars": service_token_var_entries(),
+        "provider_base_urls": provider_base_url_entries(),
+        "active_provider_base_url_vars": [],
         "env_required": [],
         "env_defaults": {},
     }
@@ -53,11 +60,81 @@ class TestProviderApiKeyEntries:
         assert "vllm" not in providers
 
 
+class TestProviderBaseUrlEntries:
+    def test_names_every_provider_that_ships_no_endpoint(self):
+        """A provider that requires a base_url and defaults none is listed.
+
+        Derived from the classes rather than a hand-written list, so a gateway
+        adapter added later cannot quietly omit the one variable without which
+        it refuses to start.
+        """
+        from osprey.models.provider_registry import get_provider_registry
+
+        registry = get_provider_registry()
+        expected = set()
+        for name in registry.list_providers():
+            cls = registry.get_provider(name)
+            if cls is None:
+                continue
+            if cls.requires_base_url and not cls.default_base_url and cls.base_url_env_var:
+                expected.add(cls.base_url_env_var)
+
+        assert expected  # the assertion below must not pass vacuously
+        assert {e["var"] for e in provider_base_url_entries()} == expected
+
+    def test_providers_with_a_working_default_are_excluded(self):
+        """Setting their variable redirects them; it does not enable them."""
+        providers = {e["provider"] for e in provider_base_url_entries()}
+        assert "cborg" not in providers
+        assert "ollama" not in providers
+
+
 class TestEnvExampleJ2:
     def test_lists_every_registry_provider(self):
         rendered = _render("project/env.example.j2", _base_ctx({}))
         for entry in provider_api_key_entries():
             assert f"{entry['var']}=" in rendered
+
+    def test_names_the_endpoint_a_deployment_has_to_supply(self):
+        """The one file a deployment is told to fill in names the variable.
+
+        A provider with no default endpoint refuses to start until its gateway
+        is named, so an example that lists only the API key sends a deployer
+        through a launch failure to find the second half.
+        """
+        entries = provider_base_url_entries()
+        assert entries  # the loop below must not pass vacuously
+        rendered = _render("project/env.example.j2", _base_ctx({}))
+        for entry in entries:
+            assert f"{entry['var']}=" in rendered
+
+    def test_the_endpoint_line_reads_back_as_an_empty_value(self):
+        """A note on the same line would be the value, not a comment.
+
+        ``.env`` has no inline comments: ``ALS_APG_BASE_URL=  # als-apg`` sets
+        the endpoint to ``# als-apg``, and a deployer who fills in the file
+        below that line never sees why the gateway is unreachable. The provider
+        name goes on a line of its own.
+        """
+        entries = provider_base_url_entries()
+        assert entries
+        rendered = _render("project/env.example.j2", _base_ctx({}))
+        parsed = parse_dotenv_text(rendered)
+        for entry in entries:
+            assert parsed[entry["var"]] == ""
+
+    def test_comments_out_the_endpoints_this_profile_does_not_use(self):
+        """Same treatment as the unused API keys: present, but not to fill in."""
+        entries = provider_base_url_entries()
+        assert entries
+        ctx = _base_ctx({})
+        # A profile-aware render (non-empty active key list) that uses none of
+        # the gateway providers.
+        ctx["active_provider_vars"] = ["ANTHROPIC_API_KEY"]
+        ctx["active_provider_base_url_vars"] = []
+        rendered = _render("project/env.example.j2", ctx)
+        for entry in entries:
+            assert f"# {entry['var']}=" in rendered
 
     def test_no_stale_langfuse_block(self):
         rendered = _render("project/env.example.j2", _base_ctx({}))

--- a/tests/cli/test_preset_provider_parity.py
+++ b/tests/cli/test_preset_provider_parity.py
@@ -18,13 +18,19 @@ through ``ClaudeCodeModelResolver`` (no half-wired provider that builds but
 cannot route).
 """
 
+import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 import osprey
-from osprey.build.claude_code_resolver import ClaudeCodeModelResolver
+from osprey.build.claude_code_resolver import (
+    ClaudeCodeModelResolver,
+    _without_unresolved_base_urls,
+)
 from osprey.profiles.providers import packaged_catalog_path
+from osprey_connectors.config import resolve_env_vars
 
 TEMPLATES = Path(osprey.__file__).parent / "templates"
 
@@ -33,6 +39,31 @@ def _api_providers() -> dict:
     """The provider stanzas a build renders into ``api.providers``."""
     catalog = yaml.safe_load(packaged_catalog_path().read_text(encoding="utf-8")) or {}
     return catalog.get("providers") or {}
+
+
+#: ``${VAR}`` / ``${VAR:-default}`` — the two forms ``resolve_env_vars`` accepts,
+#: read here only to name the variables a catalog entry's endpoint comes from.
+_ENDPOINT_VAR = re.compile(r"\$\{([^}:]+)(?::-[^}]*)?\}")
+
+#: Any endpoint will do: these tests ask whether a stanza routes, not where to.
+PLACEHOLDER_ENDPOINT = "https://gateway.example.org/v1"
+
+
+def _endpoint_env_vars() -> set[str]:
+    """The env vars the catalog's ``base_url`` values are spelled in terms of.
+
+    A gateway that each site hosts itself ships as a reference rather than a
+    host (``base_url: ${ALS_APG_BASE_URL}``), so a deployment that exports
+    nothing has no endpoint for it. Naming the variables here lets the routing
+    test supply one, instead of resolving against a literal ``"${VAR}"`` that
+    is not a URL at all.
+    """
+    return {
+        var
+        for entry in _api_providers().values()
+        if isinstance(entry, dict)
+        for var in _ENDPOINT_VAR.findall(str(entry.get("base_url") or ""))
+    }
 
 
 def test_the_catalog_includes_ds4():
@@ -75,14 +106,54 @@ def test_only_one_template_renders_the_catalog_and_it_restates_no_entry():
         )
 
 
-def test_every_declared_provider_resolves():
+def test_every_declared_provider_resolves(monkeypatch):
     """No half-wired provider: each entry must route via the Claude Code
-    resolver (built-in or custom-proxy with a base_url)."""
-    providers = _api_providers()
+    resolver (built-in or custom-proxy with a base_url).
+
+    The catalog is expanded first, with every endpoint variable exported, so
+    what each stanza is judged on is the config a deployment actually runs. On
+    the raw text a stanza that ships ``base_url: ${VAR}`` resolves either way —
+    the literal is a non-empty string, so it passes for a URL and the guard
+    goes quiet exactly where an unexported variable would have broken the
+    launch.
+    """
+    for var in _endpoint_env_vars():
+        monkeypatch.setenv(var, PLACEHOLDER_ENDPOINT)
+    providers = resolve_env_vars(_api_providers())
     assert providers, "the packaged catalog declares no providers"
     for name in providers:
         spec = ClaudeCodeModelResolver.resolve({"provider": name}, providers)
         assert spec is not None, f"provider {name!r} resolved to None"
+        endpoints = (spec.upstream_base_url, spec.env_block.get("ANTHROPIC_BASE_URL"))
+        for endpoint in endpoints:
+            assert "${" not in (endpoint or ""), (
+                f"provider {name!r} routes to {endpoint!r} — an expanded "
+                "catalog still carries a variable reference where the endpoint "
+                "belongs"
+            )
+
+
+def test_a_gateway_with_no_endpoint_exported_is_refused_rather_than_routed(monkeypatch):
+    """The other half: nothing exported must not become a hostname.
+
+    ``resolve_env_vars`` keeps ``${VAR}`` verbatim when the variable is unset,
+    so the value a launch reads is the reference itself. The launch path blanks
+    it before resolving, which turns "nobody named an endpoint" into the
+    refusal that names the variable — rather than a spec that would hand
+    Claude Code the string ``"${ALS_APG_BASE_URL}"`` as its base URL.
+    """
+    for var in _endpoint_env_vars():
+        monkeypatch.delenv(var, raising=False)
+    providers = resolve_env_vars(_api_providers())
+    assert providers["als-apg"]["base_url"] == "${ALS_APG_BASE_URL}", (
+        "the catalog no longer spells the als-apg endpoint as a variable "
+        "reference — this guard is aimed at the wrong shape"
+    )
+
+    with pytest.raises(ValueError, match="ALS_APG_BASE_URL"):
+        ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"}, _without_unresolved_base_urls(providers)
+        )
 
 
 def test_ds4_stanza_resolves_to_deepseek_tiers():

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -21,6 +21,11 @@ from osprey.build.claude_code_resolver import (
     inject_provider_env,
 )
 from osprey.models.tiers import VALID_TIERS
+from tests.conftest import GATEWAY_BASE_URL, GATEWAY_ORIGIN
+
+#: ``als-apg`` ships no endpoint of its own, so every case that resolves it has
+#: to name one the way a deployment's ``providers.yml`` does.
+_ALS_APG = {"als-apg": {"base_url": GATEWAY_BASE_URL}}
 
 # ── MANAGED_ENV_VARS ─────────────────────────────────────────────
 
@@ -194,7 +199,7 @@ class TestAuthFieldPassthrough:
         assert spec.auth_secret_env == "ANTHROPIC_API_KEY"
 
     def test_als_apg(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, _ALS_APG)
         assert spec.auth_env_var == "ANTHROPIC_AUTH_TOKEN"
         assert spec.auth_secret_env == "ALS_APG_API_KEY"
 
@@ -342,7 +347,7 @@ class TestManagedListsAgree:
 
     @pytest.mark.parametrize("provider", ["anthropic", "cborg", "als-apg"])
     def test_lists_agree_resolve_env_block_subset_of_managed(self, provider):
-        spec = ClaudeCodeModelResolver.resolve({"provider": provider})
+        spec = ClaudeCodeModelResolver.resolve({"provider": provider}, _ALS_APG)
         leaked = set(spec.env_block) - MANAGED_ENV_VARS
         assert not leaked, (
             f"{provider} env_block escapes MANAGED_ENV_VARS (would survive a "
@@ -434,9 +439,14 @@ class TestResolveEnvBlockRegression:
         }
 
     def test_env_block_regression_als_apg(self):
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        # No built-in endpoint for this one: the gateway is site infrastructure,
+        # so config names it the way a deployment's providers.yml does.
+        spec = ClaudeCodeModelResolver.resolve(
+            {"provider": "als-apg"},
+            {"als-apg": {"base_url": GATEWAY_BASE_URL}},
+        )
         assert spec.env_block == {
-            "ANTHROPIC_BASE_URL": "https://llm.gianlucamartino.com",
+            "ANTHROPIC_BASE_URL": GATEWAY_ORIGIN,
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5-20251001",
             "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
             "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
@@ -663,7 +673,9 @@ class TestSpendAttributionEnv:
     ``ANTHROPIC_CUSTOM_HEADERS`` alone otherwise."""
 
     def test_builtin_litellm_providers_carry_gateway(self):
-        assert ClaudeCodeModelResolver.resolve({"provider": "als-apg"}).gateway == "litellm"
+        assert ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, _ALS_APG).gateway == (
+            "litellm"
+        )
         assert ClaudeCodeModelResolver.resolve({"provider": "cborg"}).gateway == "litellm"
 
     def test_direct_provider_has_no_gateway(self):
@@ -682,7 +694,7 @@ class TestSpendAttributionEnv:
 
     def test_inject_sets_identity_headers_for_gateway(self, monkeypatch):
         monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
-        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"})
+        spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, _ALS_APG)
         environ = {"ALS_APG_API_KEY": "sk-secret"}
 
         inject_provider_env(environ, spec)

--- a/tests/cli/test_render_is_not_the_repo_root.py
+++ b/tests/cli/test_render_is_not_the_repo_root.py
@@ -377,6 +377,10 @@ def test_the_repo_root_regen_derives_is_the_one_the_build_recorded(built_repo: P
 #: which value travelled rather than only that something did.
 PROBE_PROVIDER = "als-apg"
 PROBE_SECRET_ENV = "ALS_APG_API_KEY"
+#: That provider fronts a site's own gateway and ships no endpoint, so a
+#: deployment using it names one — here in the repo's ``.env``, the zone these
+#: tests are about.
+PROBE_BASE_URL_ENV = "ALS_APG_BASE_URL"
 
 
 def _synthetic_deployment(root: Path, *, flat: bool = False) -> Path:
@@ -391,7 +395,10 @@ def _synthetic_deployment(root: Path, *, flat: bool = False) -> Path:
         yaml.dump({"project_name": root.name, "claude_code": {"provider": PROBE_PROVIDER}}),
         encoding="utf-8",
     )
-    (root / ".env").write_text(f"{PROBE_SECRET_ENV}=from-the-repos-dotenv\n", encoding="utf-8")
+    (root / ".env").write_text(
+        f"{PROBE_SECRET_ENV}=from-the-repos-dotenv\n{PROBE_BASE_URL_ENV}=https://gw.test/v1\n",
+        encoding="utf-8",
+    )
     return render
 
 
@@ -400,6 +407,7 @@ def _no_ambient_matrix_overrides(monkeypatch):
     """Keep the benchmark matrix's env overrides out of these resolutions."""
     monkeypatch.delenv("OSPREY_E2E_FORCE_MODEL", raising=False)
     monkeypatch.delenv("OSPREY_E2E_PROXY_BASE_URL", raising=False)
+    monkeypatch.delenv(PROBE_BASE_URL_ENV, raising=False)
 
 
 def test_the_sdk_provider_env_resolves_from_the_repos_secrets_zone(tmp_path, monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,23 @@ def pytest_collection_finish(session):
 
 
 # ===================================================================
+# Provider gateway stand-in
+# ===================================================================
+
+#: The endpoint every test uses when a gateway-backed provider needs a URL.
+#:
+#: Providers that front a site's own gateway (``als-apg``) ship no default
+#: endpoint, so a test that exercises one has to supply the URL the same way a
+#: deployment does. One shared value means no test states a real deployment's
+#: host, and a reader can tell "this is the fixture endpoint" at a glance.
+GATEWAY_BASE_URL = "https://gateway.example.org/v1"
+
+#: :data:`GATEWAY_BASE_URL` as Claude Code receives it — no trailing ``/v1``,
+#: which the resolver strips because Claude Code appends ``/v1/messages``.
+GATEWAY_ORIGIN = "https://gateway.example.org"
+
+
+# ===================================================================
 # Environment guard
 # ===================================================================
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,8 @@ import pytest
 from rich.logging import RichHandler
 
 from osprey.utils.logger import QUIET_THIRD_PARTY_LOGGERS
-from tests import ci_diagnostics
+from tests import _env_scope_guard, ci_diagnostics
+from tests._env_scope_guard import restore_module_environment
 
 #: Repo root — the fallback when a test leaves the process in a deleted cwd.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -139,6 +140,9 @@ def restore_environ():
     ``OSPREY_CONFIG`` and ``CONFIG_FILE`` are additionally cleared on the way in,
     so a developer who exports either in their shell still gets a pristine run.
     ``TZ`` is handled once per session instead -- see ``_clear_dotenv_timezone``.
+
+    This snapshot cannot see writes made by a *module*-scoped fixture, which is
+    set up before it — ``restore_environ_per_module`` below covers those.
     """
     saved = dict(os.environ)
 
@@ -150,6 +154,27 @@ def restore_environ():
     finally:
         os.environ.clear()
         os.environ.update(saved)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def restore_environ_per_module():
+    """Snapshot and restore ``os.environ`` around every test *module*.
+
+    Module-scoped fixtures — a real ``osprey build`` over a seeded exemplar repo,
+    which loads that repo's ``.env`` with override semantics — are set up before
+    the function-scoped snapshot above is taken, so their writes land inside that
+    snapshot's ``saved`` copy and are restored, not removed, by every later test.
+    This restores the environment at module teardown so they cannot outlive the
+    module that created them.
+
+    A fixture that outlives the module keeps its writes: the plugin registered
+    in :func:`pytest_configure` records them, and :func:`~tests._env_scope_guard.restore_module_environment` replays
+    them on top of the snapshot. Without that, a session-scoped fixture first
+    requested by this module's second test would be left alive with its
+    environment rolled back under it.
+    """
+    with restore_module_environment():
+        yield
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -981,6 +1006,13 @@ _CI_DIAGNOSTICS: ci_diagnostics.DiagnosticsRecorder | None = None
 
 def pytest_configure(config):
     """Open the per-worker records and arm the stack dumper."""
+    # Registered as a plugin rather than left as a hook in this file: a
+    # session-scoped fixture's ``pytest_fixture_setup`` is dispatched on the
+    # Session node, whose hook proxy carries only the conftests above it — this
+    # one is not among them. See tests/_env_scope_guard.py.
+    if not config.pluginmanager.is_registered(_env_scope_guard):
+        config.pluginmanager.register(_env_scope_guard, "osprey-env-scope-guard")
+
     # Registered here rather than in pyproject.toml so the seam and its opt-out
     # marker live in one file; `--strict-markers` would otherwise reject it.
     config.addinivalue_line(

--- a/tests/deployment/goldens/exemplar-profile/.env.example
+++ b/tests/deployment/goldens/exemplar-profile/.env.example
@@ -19,6 +19,12 @@ ARGO_API_KEY=your-argo-api-key-here
 STANFORD_API_KEY=your-stanford-api-key-here
 ALS_APG_API_KEY=your-als-apg-api-key-here
 
+# Gateway endpoints. These providers front a gateway that is your own host, so
+# OSPREY ships no default: switch to one of them and it will not start until
+# its endpoint is set here.
+# als-apg
+# ALS_APG_BASE_URL=
+
 # Required by this profile — the profile's `env.required` names these, and
 # the agent cannot run without them.
 DEMO_REGISTRY_TOKEN=

--- a/tests/deployment/goldens/exemplar-profile/providers.yml
+++ b/tests/deployment/goldens/exemplar-profile/providers.yml
@@ -77,7 +77,9 @@ providers:
       opus: claudeopus41
   als-apg:
     api_key: ${ALS_APG_API_KEY}
-    base_url: ${ALS_APG_BASE_URL:-https://llm.gianlucamartino.com/v1}
+    # No default: this gateway is a deployment's own host. Export
+    # ALS_APG_BASE_URL, or replace this line with the endpoint's /v1 URL.
+    base_url: ${ALS_APG_BASE_URL}
     models:
       haiku: claude-haiku-4-5-20251001
       sonnet: claude-sonnet-4-6

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -2072,12 +2072,20 @@ def _als_apg_probe_steps(wf: dict[str, Any]) -> list[tuple[str, str, str]]:
 def test_workflow_exports_the_als_apg_base_url_override(workflow: dict[str, Any]) -> None:
     """The workflow-level ``env:`` block is what lets a single repository
     variable retarget every LLM-touching job at once. Without it the probes
-    below would each fall back to the baked-in default and the override would
-    silently do nothing — green locally, wrong in CI."""
+    below would each need their own endpoint and the override would silently
+    do nothing — green locally, wrong in CI.
+
+    The exported value is pinned exactly, not merely searched for the
+    variable: the endpoint is repository data, and a ``|| 'https://…'`` tail
+    added beside the variable would point every fork that has not set it at
+    somebody else's gateway while still reading ``vars.``. ci.yml is outside
+    the roots the shipped-literal guard walks, so this assertion is the only
+    thing standing between that tail and a merge."""
     env = workflow.get("env") or {}
-    assert env.get(ALS_APG_BASE_URL_ENV) == "${{ vars.ALS_APG_BASE_URL }}", (
+    exported = env.get(ALS_APG_BASE_URL_ENV)
+    assert exported == "${{ vars." + ALS_APG_BASE_URL_ENV + " }}", (
         f"ci.yml must export {ALS_APG_BASE_URL_ENV} from the repository variable "
-        f"at workflow level; found {env.get(ALS_APG_BASE_URL_ENV)!r}"
+        f"at workflow level, with no fallback behind it; found {exported!r}"
     )
 
 
@@ -2085,6 +2093,17 @@ def test_workflow_exports_the_als_apg_base_url_override__mutation_drops_export()
     mutated = copy.deepcopy(_load_workflow())
     (mutated.get("env") or {}).pop(ALS_APG_BASE_URL_ENV, None)
     with pytest.raises(AssertionError, match="must export"):
+        test_workflow_exports_the_als_apg_base_url_override(mutated)
+
+
+def test_workflow_exports_the_als_apg_base_url_override__mutation_adds_a_fallback() -> None:
+    """A fallback behind the variable is the regression that matters: it reads
+    ``vars.`` and still bakes an endpoint into every fork of the workflow."""
+    mutated = copy.deepcopy(_load_workflow())
+    (mutated.get("env") or {})[ALS_APG_BASE_URL_ENV] = (
+        "${{ vars." + ALS_APG_BASE_URL_ENV + " || 'https://gateway.example.org' }}"
+    )
+    with pytest.raises(AssertionError, match="no fallback"):
         test_workflow_exports_the_als_apg_base_url_override(mutated)
 
 

--- a/tests/docs/test_shipped_identity_literals.py
+++ b/tests/docs/test_shipped_identity_literals.py
@@ -107,6 +107,12 @@ DENIED: tuple[Denied, ...] = (
         ),
         sample="  epics_gateway: cagw-alsdmz.example-site.org:5064",
     ),
+    Denied(
+        name="maintainers' gateway host",
+        pattern=re.compile(r"gianluca[-.]?martino", re.IGNORECASE),
+        why="a maintainer's own gateway endpoint is not one another deployment can call",
+        sample="  base_url: https://llm.gianluca-martino.com/v1",
+    ),
 )
 
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -252,7 +252,7 @@ als-apg/haiku in 2026-04 — if the model or provider changes, re-tune
 E2E tests require API access. Set the appropriate environment variable:
 
 ```bash
-# For ALS-APG (CI default — AWS Bedrock proxy reachable from anywhere)
+# For ALS-APG (CI default — the ALS-APG gateway, reachable from anywhere)
 export ALS_APG_API_KEY="your-key"
 
 # For CBORG (local dev only — IP allowlist blocks GitHub Actions runners)

--- a/tests/e2e/judge.py
+++ b/tests/e2e/judge.py
@@ -23,11 +23,13 @@ def _default_provider_config(provider: str) -> dict[str, str] | None:
     """
     if provider == "als-apg":
         api_key = os.environ.get("ALS_APG_API_KEY")
-        if not api_key:
+        # The gateway has no built-in endpoint — it is a deployment's own host,
+        # named by ALS_APG_BASE_URL. Without both halves there is nothing to
+        # call, so the judge has no self-contained config and falls back to
+        # whatever config.yml the run supplies.
+        base_url = os.environ.get("ALS_APG_BASE_URL")
+        if not api_key or not base_url:
             return None
-        # base_url overridable so the judge can follow a redirected provider
-        # (e.g. a cborg-only box). Unset -> unchanged default, so CI is unaffected.
-        base_url = os.environ.get("ALS_APG_BASE_URL") or "https://llm.gianlucamartino.com/v1"
         return {"api_key": api_key, "base_url": base_url}
     return None
 

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -152,9 +152,9 @@ def has_anthropic_api_key() -> bool:
 def has_als_apg_api_key() -> bool:
     """Check if ALS_APG_API_KEY is set.
 
-    The CI-default Bedrock proxy at llm.gianlucamartino.com authenticates
-    with this token; the safety/SDK E2E suite skip-gates on it because the
-    Claude Code CLI subprocess uses the proxy via the project's `.env` and
+    The als-apg gateway (named by `ALS_APG_BASE_URL`) authenticates with this
+    token; the safety/SDK E2E suite skip-gates on it because the Claude Code
+    CLI subprocess reaches the gateway via the project's `.env` and
     `provider=als-apg` defaults landed in 8c541cc9.
     """
     return bool(os.environ.get("ALS_APG_API_KEY"))

--- a/tests/e2e/test_ariel_search.py
+++ b/tests/e2e/test_ariel_search.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 TEST_DATA_PATH = Path(__file__).parent.parent / "fixtures" / "ariel" / "test_logbook_entries.jsonl"
 
 # Path to config file for LLM access (RAG tests need this)
-# Uses minimal test config with ALS-APG API access (AWS Bedrock proxy)
+# Uses minimal test config with ALS-APG API access (gateway)
 CONFIG_FILE_PATH = Path(__file__).parent.parent / "fixtures" / "ariel" / "test_config.yml"
 
 # Dev database URL - uses port 5432 (ariel-postgres container)

--- a/tests/e2e/test_dispatch_tutorial.py
+++ b/tests/e2e/test_dispatch_tutorial.py
@@ -2,8 +2,8 @@
 
 Proves the bundled ``tutorial_triggers.yml`` triggers actually work end to end
 ACROSS PROCESSES with a real Claude Agent SDK run, using the provider named by
-``OSPREY_E2E_PROVIDER`` (defaulting to the Bedrock proxy reachable from GitHub
-Actions runners). For each token trigger this:
+``OSPREY_E2E_PROVIDER`` (defaulting to the ALS-APG gateway, reachable from
+GitHub Actions runners). For each token trigger this:
 
   1. Builds a real control-assistant deployment repo once (module-scoped fixture).
   2. Loads the REAL shipped ``tutorial_triggers.yml`` and overrides ONLY

--- a/tests/e2e/test_in_context_backend.py
+++ b/tests/e2e/test_in_context_backend.py
@@ -68,21 +68,22 @@ _TEST_CHANNELS = [
     },
 ]
 
-# Provider preference: als-apg first (AWS Bedrock proxy — IP-unrestricted, works
+# Provider preference: als-apg first (the ALS-APG gateway — IP-unrestricted, works
 # in CI and off-VPN), then CBORG (LBLnet-gated, faster locally), then anthropic
 # direct. Matches the CI auth choice in commit 5d0dcd72.
 _ALS_APG_KEY = os.environ.get("ALS_APG_API_KEY", "")
+# The gateway has no built-in endpoint; without one it is not a usable route.
+_ALS_APG_BASE_URL = os.environ.get("ALS_APG_BASE_URL", "")
 _CBORG_KEY = os.environ.get("CBORG_API_KEY", "")
 _ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_API_KEY_o", "")
 
-if _ALS_APG_KEY:
+if _ALS_APG_KEY and _ALS_APG_BASE_URL:
     _PROVIDER = "als-apg"
     _PROVIDER_API_KEY = _ALS_APG_KEY
     _SUBAGENT_MODEL = "claude-haiku-4-5-20251001"  # bare wire id; gateway rejects prefixed slugs
-    # Overridable so a run can be aimed at another gateway; same convention as
-    # judge.py. The value is written into the generated project's config, which
-    # is what the MCP subprocess reads — it does not inherit this process's env.
-    _PROVIDER_BASE_URL = os.environ.get("ALS_APG_BASE_URL") or "https://llm.gianlucamartino.com"
+    # Written into the generated project's config, which is what the MCP
+    # subprocess reads — it does not inherit this process's env.
+    _PROVIDER_BASE_URL = _ALS_APG_BASE_URL
     _BACKEND_MODEL = "als-apg/claude-haiku-4-5-20251001"
     _EXPECTED_WIRE = "claude-haiku-4-5-20251001"
 elif _CBORG_KEY:

--- a/tests/e2e/test_llm_channel_namer.py
+++ b/tests/e2e/test_llm_channel_namer.py
@@ -29,16 +29,18 @@ def get_available_providers() -> dict[str, dict]:
 
     available = {}
 
-    # Provider preference: als-apg first (AWS Bedrock proxy — IP-unrestricted,
-    # works in CI and off-VPN). CBORG is LBLnet-gated and would 403 from GitHub
-    # Actions runners or off-VPN laptops.
-    providers_to_check = [
-        (
-            "als-apg",
-            ["ALS_APG_API_KEY"],
-            os.environ.get("ALS_APG_BASE_URL") or "https://llm.gianlucamartino.com",
-            "claude-haiku-4-5-20251001",
-        ),
+    # Provider preference: als-apg first (the ALS-APG gateway — IP-unrestricted,
+    # works in CI and off-VPN), but only once its endpoint is named: the gateway
+    # has no built-in host, so ALS_APG_BASE_URL is what makes it a route at all.
+    # CBORG is LBLnet-gated and would 403 from GitHub Actions runners or
+    # off-VPN laptops.
+    als_apg_base_url = os.environ.get("ALS_APG_BASE_URL")
+    providers_to_check = []
+    if als_apg_base_url:
+        providers_to_check.append(
+            ("als-apg", ["ALS_APG_API_KEY"], als_apg_base_url, "claude-haiku-4-5-20251001")
+        )
+    providers_to_check += [
         ("cborg", ["CBORG_API_KEY"], "https://api.cborg.lbl.gov", "anthropic/claude-haiku"),
         (
             "amsc-i2",

--- a/tests/e2e/test_llm_providers.py
+++ b/tests/e2e/test_llm_providers.py
@@ -170,13 +170,21 @@ def get_available_providers_raw() -> dict[str, dict[str, Any]]:
             "https://api.i2-core.american-science-cloud.org",
             "claude-haiku",
         ),
-        (
-            "als-apg",
-            ["ALS_APG_API_KEY"],
-            os.environ.get("ALS_APG_BASE_URL") or "https://llm.gianlucamartino.com",
-            "claude-haiku-4-5-20251001",
-        ),
     ]
+
+    # The als-apg gateway has no built-in endpoint: it is a deployment's own
+    # host, named by ALS_APG_BASE_URL. With nothing to call there is no provider
+    # to detect, so the entry is only offered once the variable is set.
+    als_apg_base_url = os.environ.get("ALS_APG_BASE_URL")
+    if als_apg_base_url:
+        providers_to_check.append(
+            (
+                "als-apg",
+                ["ALS_APG_API_KEY"],
+                als_apg_base_url,
+                "claude-haiku-4-5-20251001",
+            )
+        )
 
     for provider_name, env_vars, default_base_url, default_model in providers_to_check:
         api_key = None

--- a/tests/fixtures/ariel/test_config.yml
+++ b/tests/fixtures/ariel/test_config.yml
@@ -12,7 +12,10 @@ api:
   providers:
     als-apg:
       api_key: ${ALS_APG_API_KEY}
-      base_url: https://llm.gianlucamartino.com/v1
+      # No default endpoint: the gateway is the running site's own host, named
+      # the same way a deployment names it. Export the full /v1 URL alongside
+      # the key before running this suite.
+      base_url: ${ALS_APG_BASE_URL}
     ollama:
       api_key: ollama
       base_url: http://localhost:11434

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -2081,6 +2081,12 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 # STANFORD_API_KEY=your-stanford-api-key-here
 # ALS_APG_API_KEY=your-als-apg-api-key-here
 
+# Gateway endpoints. These providers front a gateway that is your own host, so
+# OSPREY ships no default: switch to one of them and it will not start until
+# its endpoint is set here.
+# als-apg
+# ALS_APG_BASE_URL=
+
 # Declared by this profile with a default (`env.defaults`). Override only if
 # your facility needs a different value.
 OSPREY_AUTH_PW_ALICE=alice

--- a/tests/interfaces/artifacts/test_store_watcher.py
+++ b/tests/interfaces/artifacts/test_store_watcher.py
@@ -14,15 +14,35 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from watchdog.events import DirModifiedEvent, FileModifiedEvent
+from watchdog.events import DirDeletedEvent, DirModifiedEvent, FileModifiedEvent
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
 
 from osprey.interfaces.artifacts.store_watcher import StoreIndexWatcher, _IndexFileHandler
 from osprey.stores.artifact_store import ArtifactStore
-from tests.interfaces.fsevents_wait import poke_until
+from tests.interfaces.fsevents_wait import poke_until, wait_for, wait_for_polling_baseline
 
 
-def _make_watcher(tmp_path):
-    """Create a StoreIndexWatcher with real stores and a mock broadcaster."""
+def _polling_observer() -> PollingObserver:
+    """A polling observer that re-reads its watch several times a second.
+
+    watchdog's default polling interval is a second, which is four wasted
+    seconds in a test that only needs the emitter to look again.
+    """
+    return PollingObserver(timeout=0.05)
+
+
+def _make_watcher(tmp_path, *, observer_factory=_polling_observer):
+    """Create a StoreIndexWatcher with real stores and a mock broadcaster.
+
+    Polling by default: a test that asks which change becomes which broadcast is
+    asking about the handler, and a polling emitter re-reads the directory on
+    every interval, so the answer is decided by what is on disk rather than by
+    whether the platform's notification stream was armed and uncoalesced at the
+    moment of the write. The native backend keeps one test of its own, which is
+    also the only one that can exercise the ``on_moved`` route an atomic index
+    replace takes on Linux.
+    """
     artifact_store = ArtifactStore(workspace_root=tmp_path)
     broadcaster = MagicMock()
 
@@ -30,6 +50,7 @@ def _make_watcher(tmp_path):
         workspace_root=tmp_path,
         broadcaster=broadcaster,
         artifact_store=artifact_store,
+        observer_factory=observer_factory,
     )
     return watcher, broadcaster, artifact_store
 
@@ -73,16 +94,33 @@ def _wait_for_broadcast(broadcaster, external_store, expected_calls=1, *, what):
 class TestStoreWatcher:
     """Tests for StoreIndexWatcher."""
 
-    # No ``flaky`` marker any more. These two used to carry ``reruns=2`` because
-    # the OS occasionally missed the change event entirely, and a rerun was the
-    # only way to get a freshly armed observer. ``_wait_for_broadcast`` now
-    # re-applies the stimulus instead, which arms in-test and converges without
-    # a second attempt — so a red here is a real regression again, not weather.
+    def test_the_observer_backend_is_injectable(self, tmp_path):
+        """The seam every routing test below stands on.
+
+        Without it a test can only ask the platform's own notification stream
+        for a change and hope it was listening.
+        """
+        built = []
+
+        def factory() -> PollingObserver:
+            observer = _polling_observer()
+            built.append(observer)
+            return observer
+
+        watcher, _, _ = _make_watcher(tmp_path, observer_factory=factory)
+        watcher.start()
+        try:
+            assert built == [watcher._observer]
+        finally:
+            watcher.stop()
+
     def test_detects_new_artifact_entry(self, tmp_path):
         """External write to artifacts.json triggers SSE broadcast."""
         watcher, broadcaster, artifact_store = _make_watcher(tmp_path)
         watcher.start()
         try:
+            wait_for_polling_baseline(watcher._observer)
+
             # Simulate external process saving an artifact
             external_store = ArtifactStore(workspace_root=tmp_path)
             external_store.save_file(
@@ -95,6 +133,38 @@ class TestStoreWatcher:
                 tool_source="test",
             )
 
+            wait_for(
+                lambda: broadcaster.broadcast.call_count >= 1,
+                what="the broadcast for an externally saved artifact",
+            )
+            call_data = broadcaster.broadcast.call_args_list[0][0][0]
+            assert call_data["type"] == "artifact"
+            assert call_data["title"] == "External Plot"
+        finally:
+            watcher.stop()
+
+    def test_an_external_save_reaches_the_broadcast_under_the_live_backend(self, tmp_path):
+        """The one test here that runs the observer a deployment runs.
+
+        Everything else in this class is settled on a polling observer, which
+        cannot say whether the platform's own notification stream reaches the
+        handler — and on Linux an atomic index replace reaches it as
+        ``on_moved`` and as nothing else, a route no snapshot diff produces.
+        """
+        watcher, broadcaster, _ = _make_watcher(tmp_path, observer_factory=Observer)
+        watcher.start()
+        try:
+            external_store = ArtifactStore(workspace_root=tmp_path)
+            external_store.save_file(
+                file_content=b"<html>live</html>",
+                filename="live.html",
+                artifact_type="plot_html",
+                title="Saved Under The Live Backend",
+                description="externally saved",
+                mime_type="text/html",
+                tool_source="test",
+            )
+
             _wait_for_broadcast(
                 broadcaster,
                 external_store,
@@ -102,7 +172,7 @@ class TestStoreWatcher:
             )
             call_data = broadcaster.broadcast.call_args_list[0][0][0]
             assert call_data["type"] == "artifact"
-            assert call_data["title"] == "External Plot"
+            assert call_data["title"] == "Saved Under The Live Backend"
         finally:
             watcher.stop()
 
@@ -123,13 +193,14 @@ class TestStoreWatcher:
         watcher, broadcaster, artifact_store = _make_watcher(tmp_path)
         watcher.start()
         try:
+            wait_for_polling_baseline(watcher._observer)
+
             # Simulate external process deleting the entry
             external_store = ArtifactStore(workspace_root=tmp_path)
             external_store.delete_entry(entry.id)
 
-            _wait_for_broadcast(
-                broadcaster,
-                external_store,
+            wait_for(
+                lambda: broadcaster.broadcast.call_count >= 1,
                 what="the broadcast for an externally deleted artifact",
             )
             call_data = broadcaster.broadcast.call_args_list[0][0][0]
@@ -143,6 +214,8 @@ class TestStoreWatcher:
         watcher, broadcaster, _ = _make_watcher(tmp_path)
         watcher.start()
         try:
+            wait_for_polling_baseline(watcher._observer)
+
             # Write the index file rapidly 3 times
             artifacts_dir = tmp_path / "artifacts"
             artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -169,6 +242,8 @@ class TestStoreWatcher:
         watcher, broadcaster, _ = _make_watcher(tmp_path)
         watcher.start()
         try:
+            wait_for_polling_baseline(watcher._observer)
+
             artifacts_dir = tmp_path / "artifacts"
             artifacts_dir.mkdir(parents=True, exist_ok=True)
             (artifacts_dir / "random_file.json").write_text('{"data": "test"}')
@@ -183,6 +258,8 @@ class TestStoreWatcher:
         watcher, broadcaster, _ = _make_watcher(tmp_path)
         watcher.start()
         try:
+            wait_for_polling_baseline(watcher._observer)
+
             artifacts_dir = tmp_path / "artifacts"
             artifacts_dir.mkdir(parents=True, exist_ok=True)
             index_file = artifacts_dir / "artifacts.json"
@@ -286,6 +363,21 @@ class TestACoalescedDirectoryFrame:
 
         shutil.rmtree(artifacts_dir)
         handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+
+        assert str(artifacts_dir) not in handler._listings
+
+    def test_a_deleted_directory_drops_its_listing(self, tmp_path):
+        """A directory removed the ordinary way is announced by a deletion and
+        by nothing else — no later frame arrives to evict its listing."""
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+        assert str(artifacts_dir) in handler._listings
+
+        shutil.rmtree(artifacts_dir)
+        handler.on_deleted(DirDeletedEvent(str(artifacts_dir)))
 
         assert str(artifacts_dir) not in handler._listings
 

--- a/tests/interfaces/artifacts/test_store_watcher.py
+++ b/tests/interfaces/artifacts/test_store_watcher.py
@@ -9,12 +9,14 @@ Covers:
 """
 
 import json
+import shutil
 import time
 from unittest.mock import MagicMock
 
 import pytest
+from watchdog.events import DirModifiedEvent, FileModifiedEvent
 
-from osprey.interfaces.artifacts.store_watcher import StoreIndexWatcher
+from osprey.interfaces.artifacts.store_watcher import StoreIndexWatcher, _IndexFileHandler
 from osprey.stores.artifact_store import ArtifactStore
 from tests.interfaces.fsevents_wait import poke_until
 
@@ -190,3 +192,150 @@ class TestStoreWatcher:
             # Should not crash — watcher logs warning and skips
         finally:
             watcher.stop()
+
+
+@pytest.mark.unit
+class TestACoalescedDirectoryFrame:
+    """The index write can arrive as a frame about its directory.
+
+    macOS FSEvents coalesces: writes inside a directory can reach watchdog as
+    one ``modified`` event on the directory itself. The handler used to return
+    on every directory event, so an ``artifacts.json`` written that way was
+    never reloaded and the artifact it announced never reached a browser. The
+    directory is listed one level deep instead, and every index file that
+    changed takes the path a per-file event would have taken.
+    """
+
+    def _handler(self, tmp_path, broadcaster):
+        watcher = StoreIndexWatcher(
+            workspace_root=tmp_path,
+            broadcaster=broadcaster,
+            artifact_store=ArtifactStore(workspace_root=tmp_path),
+        )
+        handler = _IndexFileHandler(watcher._index_configs, broadcaster)
+        # The 100 ms debounce keys on the path; these tests deliver frames back
+        # to back on purpose.
+        handler._debounce_seconds = 0
+        return handler
+
+    def test_a_bare_directory_frame_announces_the_new_entry(self, tmp_path):
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+        broadcaster.reset_mock()
+
+        ArtifactStore(workspace_root=tmp_path).save_file(
+            file_content=b"<html>coalesced</html>",
+            filename="coalesced.html",
+            artifact_type="plot_html",
+            title="Written Behind A Directory Frame",
+            description="the per-file event never arrived",
+            mime_type="text/html",
+            tool_source="test",
+        )
+
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+
+        announced = [call.args[0] for call in broadcaster.broadcast.call_args_list]
+        assert [e for e in announced if e.get("title") == "Written Behind A Directory Frame"]
+
+    def test_an_unchanged_directory_announces_nothing(self, tmp_path):
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+        broadcaster.reset_mock()
+
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+
+        assert broadcaster.broadcast.call_count == 0
+
+    def test_a_directory_frame_ignores_files_that_are_not_the_index(self, tmp_path):
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+        broadcaster.reset_mock()
+
+        (artifacts_dir / "random_file.json").write_text('{"data": "test"}')
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+
+        assert broadcaster.broadcast.call_count == 0
+
+    def test_a_frame_for_a_vanished_directory_is_survivable(self, tmp_path):
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+
+        handler.on_modified(DirModifiedEvent(str(tmp_path / "never_existed")))
+
+        assert broadcaster.broadcast.call_count == 0
+
+    def test_the_listing_of_a_directory_that_is_gone_is_dropped(self, tmp_path):
+        """One entry per directory that still exists, so the map cannot grow
+        for the life of the watcher."""
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+        assert str(artifacts_dir) in handler._listings
+
+        shutil.rmtree(artifacts_dir)
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+
+        assert str(artifacts_dir) not in handler._listings
+
+    def test_a_stale_frame_does_not_swallow_the_write_behind_it(self, tmp_path):
+        """A frame that found nothing new must not spend the write's slot.
+
+        The directory frame and the per-file event for one write arrive
+        milliseconds apart, and a frame delivered before the index is on disk
+        reads it unchanged and announces nothing. Debouncing on the clock alone
+        would then drop the event that did carry the entry, and no third event
+        follows to make up for it. The window closes on a change already read,
+        not on the reader.
+        """
+        broadcaster = MagicMock()
+        watcher = StoreIndexWatcher(
+            workspace_root=tmp_path,
+            broadcaster=broadcaster,
+            artifact_store=ArtifactStore(workspace_root=tmp_path),
+        )
+        handler = _IndexFileHandler(watcher._index_configs, broadcaster)
+        # Both events below land inside one window by construction, rather than
+        # by being fast enough on the day.
+        handler._debounce_seconds = 30.0
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        index = artifacts_dir / "artifacts.json"
+        index.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "updated": "2024-01-01T00:00:00",
+                    "entry_count": 0,
+                    "entries": [],
+                    "created": "2024-01-01T00:00:00",
+                }
+            )
+        )
+        handler.on_modified(DirModifiedEvent(str(artifacts_dir)))
+        assert broadcaster.broadcast.call_count == 0
+
+        ArtifactStore(workspace_root=tmp_path).save_file(
+            file_content=b"<html>behind a stale frame</html>",
+            filename="behind.html",
+            artifact_type="plot_html",
+            title="Behind A Stale Frame",
+            description="the frame ahead of it read nothing",
+            mime_type="text/html",
+            tool_source="test",
+        )
+        handler.on_modified(FileModifiedEvent(str(index)))
+
+        announced = [call.args[0] for call in broadcaster.broadcast.call_args_list]
+        assert [e for e in announced if e.get("title") == "Behind A Stale Frame"]

--- a/tests/interfaces/fsevents_wait.py
+++ b/tests/interfaces/fsevents_wait.py
@@ -35,6 +35,16 @@ the wait itself hold out for the right kind of frame.
 Budget exhaustion is reported as a failure naming what never arrived. It is not
 absorbed and it is not retried at the test level: an observer that never
 delivers in :data:`ARM_BUDGET` seconds of repeated stimulus is broken, not slow.
+
+**A watcher running on a ``PollingObserver`` needs none of that**, and the
+wait-side functions for it live here too so a test module still imports one
+module for "wait until the watcher has said something". A polling emitter has
+no stream to arm and nothing to coalesce: it re-reads the watched directory on
+every interval and diffs it against the snapshot it took last, so a change made
+after that baseline is reported whether or not anything re-applies it. What a
+polling test does have to wait for is the *baseline itself* —
+:func:`wait_for_polling_baseline` — because a change already on disk when the
+snapshot is taken is inside it and is never a difference.
 """
 
 from __future__ import annotations
@@ -43,6 +53,9 @@ import asyncio
 import time
 from collections.abc import Callable
 from typing import Any
+
+from watchdog.observers.api import BaseObserver
+from watchdog.utils.dirsnapshot import EmptyDirectorySnapshot
 
 #: Overall ceiling on "this observer is delivering". Generous on purpose: it is
 #: only ever spent on a run that is already failing, and the poke loop returns
@@ -67,7 +80,7 @@ DRAIN_CEILING = 2.0
 
 def poke_until(
     check: Callable[[], bool],
-    poke: Callable[[], Any],
+    poke: Callable[[], Any] | None,
     *,
     what: str,
     budget: float = ARM_BUDGET,
@@ -81,6 +94,8 @@ def poke_until(
         check: True once the delivery under test has been observed. Called
             first, before any poke, so an already-delivered event costs nothing.
         poke: Reproduces the stimulus. Must not change what the test asserts.
+            ``None`` for a polling observer, which re-reads the directory itself
+            and so has nothing for a poke to fix — see :func:`wait_for`.
         what: Named in the failure message — say what never arrived.
         budget: Seconds of repeated stimulus before giving up.
 
@@ -96,12 +111,18 @@ def poke_until(
             return
         now = time.monotonic()
         if now >= deadline:
+            if poke is None:
+                raise AssertionError(
+                    f"{what} was never delivered in {budget:.0f}s of a polling "
+                    f"observer — the watcher is not reporting the change, rather "
+                    f"than reporting it late"
+                )
             raise AssertionError(
                 f"{what} was never delivered in {budget:.0f}s of a live observer, "
                 f"across {pokes} re-applications of the stimulus — the observer is "
                 f"not delivering, rather than delivering late"
             )
-        if now >= next_poke:
+        if poke is not None and now >= next_poke:
             poke()
             pokes += 1
             next_poke = now + POKE_INTERVAL
@@ -145,7 +166,7 @@ def collect_frames_matching(
     queue: asyncio.Queue,
     *,
     matches: Callable[[dict], bool],
-    poke: Callable[[], Any],
+    poke: Callable[[], Any] | None,
     what: str,
     budget: float = ARM_BUDGET,
 ) -> list[dict]:
@@ -199,7 +220,7 @@ def collect_frames(
     queue: asyncio.Queue,
     *,
     until: str,
-    poke: Callable[[], Any],
+    poke: Callable[[], Any] | None,
     until_type: str | None = None,
     budget: float = ARM_BUDGET,
 ) -> list[dict]:
@@ -247,3 +268,64 @@ def collect_paths(
     whether a particular kind of change did — those must read the frames.
     """
     return [frame["path"] for frame in collect_frames(queue, until=until, poke=poke, budget=budget)]
+
+
+# ── polling observers ──────────────────────────────────────────────────────
+
+
+def wait_for_polling_baseline(observer: BaseObserver, *, budget: float = ARM_BUDGET) -> None:
+    """Block until every emitter of a ``PollingObserver`` has snapshotted its watch.
+
+    ``PollingEmitter`` reports what differs from the snapshot it takes in
+    ``on_thread_start``, and ``Observer.start()`` returns once that thread
+    exists rather than once it has run. A file created in between is inside the
+    baseline and is therefore not a difference — the polling counterpart of the
+    arming window above, except that it is *observable* rather than only
+    provokable, so it is waited for directly instead of poked at.
+
+    The emitter's snapshot attribute is private to watchdog. It is read anyway
+    because the alternative is a sleep, and a sleep long enough to be safe on a
+    loaded box is a tax every green run pays for a condition that is plainly
+    visible.
+
+    Args:
+        observer: A started ``PollingObserver``.
+        budget: Seconds to wait before failing.
+
+    Raises:
+        AssertionError: No emitter ever took a baseline snapshot.
+    """
+    deadline = time.monotonic() + budget
+    while True:
+        emitters = list(observer.emitters)
+        if emitters and all(
+            not isinstance(emitter._snapshot, EmptyDirectorySnapshot) for emitter in emitters
+        ):
+            return
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"a polling observer took no baseline snapshot in {budget:.0f}s — "
+                f"its emitter thread never ran"
+            )
+        time.sleep(POLL)
+
+
+def wait_for(check: Callable[[], bool], *, what: str, budget: float = ARM_BUDGET) -> None:
+    """:func:`poke_until` for a polling watcher: the same wait, with no stimulus.
+
+    A polling emitter re-reads the directory itself, so there is nothing for a
+    poke to fix and a poke would only add a second change to the stream the test
+    is reading.
+    """
+    poke_until(check, None, what=what, budget=budget)
+
+
+def polled_frames(
+    queue: asyncio.Queue,
+    *,
+    until: str,
+    until_type: str | None = None,
+    budget: float = ARM_BUDGET,
+) -> list[dict]:
+    """:func:`collect_frames` for a polling watcher: the same wait, with no stimulus."""
+    return collect_frames(queue, until=until, until_type=until_type, poke=None, budget=budget)

--- a/tests/interfaces/web_terminal/test_file_watcher.py
+++ b/tests/interfaces/web_terminal/test_file_watcher.py
@@ -10,14 +10,24 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from watchdog.events import DirModifiedEvent, FileCreatedEvent, FileModifiedEvent
+from watchdog.events import (
+    DirDeletedEvent,
+    DirModifiedEvent,
+    FileCreatedEvent,
+    FileModifiedEvent,
+)
+from watchdog.observers.polling import PollingObserver
 
 from osprey.interfaces.web_terminal.file_watcher import (
     FileEventBroadcaster,
     WorkspaceWatcher,
     _WorkspaceHandler,
 )
-from tests.interfaces.fsevents_wait import collect_frames
+from tests.interfaces.fsevents_wait import (
+    collect_frames,
+    polled_frames,
+    wait_for_polling_baseline,
+)
 
 #: Tighter than the unit lane's 600 s cap, because this file is the one that
 #: has actually hung: ``test_start_creates_directory_if_missing`` sat inside
@@ -31,6 +41,15 @@ from tests.interfaces.fsevents_wait import collect_frames
 #: A timeout failure is ``Failed``, not ``AssertionError``, so a
 #: ``flaky(only_rerun=["AssertionError"])`` marker would not rerun it.
 pytestmark = pytest.mark.timeout(60)
+
+
+def _polling_observer() -> PollingObserver:
+    """A polling observer that re-reads its watch several times a second.
+
+    watchdog's default polling interval is a second, which is four wasted
+    seconds in a test that only needs the emitter to look again.
+    """
+    return PollingObserver(timeout=0.05)
 
 
 class TestFileEventBroadcaster:
@@ -97,7 +116,62 @@ class TestWorkspaceWatcher:
         # Should not raise on double stop
         watcher.stop()
 
+    def test_the_observer_backend_is_injectable(self, tmp_path):
+        """The seam every routing test below stands on.
+
+        Without it a test can only ask the platform's own notification stream
+        for a change and hope it was listening.
+        """
+        built = []
+
+        def factory() -> PollingObserver:
+            observer = _polling_observer()
+            built.append(observer)
+            return observer
+
+        watcher = WorkspaceWatcher(tmp_path, FileEventBroadcaster(), observer_factory=factory)
+        watcher.start()
+        try:
+            assert built == [watcher._observer]
+        finally:
+            watcher.stop()
+
     def test_detects_file_creation(self, tmp_path):
+        """Routing: a file that appears reaches the panel as ``created``.
+
+        On a polling observer, because the subject is what the handler does
+        with the change rather than whether a notification stream happened to
+        be carrying it. Polling re-reads the directory on every interval, so
+        the frame is decided by what is on disk — no arming window, no
+        coalescing, and nothing to re-apply. The live backend keeps its own
+        test below.
+        """
+        broadcaster = FileEventBroadcaster()
+        q = broadcaster.subscribe()
+        watcher = WorkspaceWatcher(tmp_path, broadcaster, observer_factory=_polling_observer)
+        watcher.start()
+
+        try:
+            wait_for_polling_baseline(watcher._observer)
+            (tmp_path / "new_file.txt").write_text("hello")
+
+            # Same requirement as the live test below: a ``created`` frame, not
+            # merely a frame naming the path.
+            frames = polled_frames(q, until="new_file.txt", until_type="created", budget=30)
+
+            assert {"created"} <= {
+                frame["type"] for frame in frames if frame["path"] == "new_file.txt"
+            }, f"no created frame for new_file.txt among {frames}"
+        finally:
+            watcher.stop()
+
+    def test_a_file_created_under_the_live_backend_reaches_the_panel(self, tmp_path):
+        """The one test here that runs the observer a deployment runs.
+
+        Everything above about routing is settled on a polling observer, which
+        cannot say whether the platform's own notification stream reaches the
+        handler at all. This one does, and only that.
+        """
         broadcaster = FileEventBroadcaster()
         q = broadcaster.subscribe()
         watcher = WorkspaceWatcher(tmp_path, broadcaster)
@@ -694,6 +768,23 @@ class TestACoalescedDirectoryFrame:
         assert {"type": "deleted", "path": str(Path("sub") / "note.txt"), "is_dir": False} in (
             self._events(broadcaster)
         ), "what the directory held is still announced as deleted"
+        assert str(sub) not in handler._listings
+
+    def test_a_deleted_directory_drops_its_listing(self, tmp_path):
+        """A directory removed the ordinary way is announced by a deletion and
+        by nothing else — no later frame arrives to evict its listing."""
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "note.txt").write_text("hello")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(sub)))
+        assert str(sub) in handler._listings
+
+        (sub / "note.txt").unlink()
+        sub.rmdir()
+        handler.on_any_event(DirDeletedEvent(str(sub)))
+
         assert str(sub) not in handler._listings
 
     def test_a_frame_inside_the_debounce_window_still_announces_what_it_carries(self, tmp_path):

--- a/tests/interfaces/web_terminal/test_file_watcher.py
+++ b/tests/interfaces/web_terminal/test_file_watcher.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from watchdog.events import FileCreatedEvent, FileModifiedEvent
+from watchdog.events import DirModifiedEvent, FileCreatedEvent, FileModifiedEvent
 
 from osprey.interfaces.web_terminal.file_watcher import (
     FileEventBroadcaster,
@@ -530,3 +530,192 @@ class TestBarItemVocabulary:
 
         assert items["logo"]["options"] == {}
         assert items["separator"]["options"] == {}
+
+
+class TestACoalescedDirectoryFrame:
+    """A directory-modified frame names the directory, not the file.
+
+    macOS FSEvents coalesces: a burst of writes inside a directory can reach
+    watchdog as one ``modified`` event on the directory itself, with no
+    per-file event behind it. Forwarded as-is that frame says a directory
+    changed and nothing about what is in it, so a file panel showing that
+    directory never learns the new file exists. The handler lists the
+    directory one level deep instead and broadcasts what actually differs.
+    """
+
+    def _handler(self, root: Path, broadcaster: MagicMock, **kwargs) -> _WorkspaceHandler:
+        handler = _WorkspaceHandler(root, broadcaster, **kwargs)
+        # The 100 ms debounce keys on the path, and these tests deliver two
+        # frames for the same directory back to back on purpose.
+        handler._debounce_seconds = 0
+        return handler
+
+    def _events(self, broadcaster: MagicMock) -> list[dict]:
+        return [call.args[0] for call in broadcaster.broadcast.call_args_list]
+
+    def test_the_first_frame_announces_what_the_directory_holds(self, tmp_path):
+        """Nothing to diff against yet, so the frame is read as "resync this
+        directory": its one level of contents is announced rather than dropped."""
+        (tmp_path / "already_here.txt").write_text("hello")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert {"type": "created", "path": "already_here.txt", "is_dir": False} in self._events(
+            broadcaster
+        )
+
+    def test_a_file_added_between_two_frames_is_announced_created(self, tmp_path):
+        (tmp_path / "already_here.txt").write_text("hello")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+        broadcaster.reset_mock()
+
+        (tmp_path / "new_file.txt").write_text("world")
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        events = self._events(broadcaster)
+        assert {"type": "created", "path": "new_file.txt", "is_dir": False} in events
+        assert [e for e in events if e["path"] == "already_here.txt"] == [], (
+            "an unchanged file was re-announced: the frame is diffed against the "
+            "last listing, not replayed"
+        )
+
+    def test_a_file_removed_between_two_frames_is_announced_deleted(self, tmp_path):
+        victim = tmp_path / "gone.txt"
+        victim.write_text("hello")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+        broadcaster.reset_mock()
+
+        victim.unlink()
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert {"type": "deleted", "path": "gone.txt", "is_dir": False} in self._events(broadcaster)
+
+    def test_a_subdirectory_that_appears_is_announced_as_one(self, tmp_path):
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+        broadcaster.reset_mock()
+
+        (tmp_path / "sub").mkdir()
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert {"type": "created", "path": "sub", "is_dir": True} in self._events(broadcaster)
+
+    def test_the_rescan_stops_at_one_level(self, tmp_path):
+        """Bounded: the frame names one directory, so one directory is listed."""
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+        broadcaster.reset_mock()
+
+        (nested / "deep.txt").write_text("hello")
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert [e for e in self._events(broadcaster) if "deep.txt" in e["path"]] == []
+
+    def test_ignored_children_stay_ignored(self, tmp_path):
+        """The rescan is not a way around the ignore list."""
+        (tmp_path / "__pycache__").mkdir()
+        (tmp_path / "module.pyc").write_bytes(b"\x00")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert self._events(broadcaster) == []
+
+    def test_concealed_children_stay_concealed(self, tmp_path):
+        """Nor around concealment: a store the tree happens to contain is a
+        store however its change was delivered."""
+        (tmp_path / "feedback").mkdir()
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster, concealed=(PurePath("feedback"),))
+
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert self._events(broadcaster) == []
+
+    def test_a_frame_for_a_vanished_directory_is_survivable(self, tmp_path):
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+
+        handler.on_any_event(DirModifiedEvent(str(tmp_path / "never_existed")))
+
+        assert self._events(broadcaster) == []
+
+    def test_a_child_its_own_event_announced_is_not_announced_again(self, tmp_path):
+        """A write delivers both a per-file event and a frame for the parent —
+        the ordinary inotify pair — and the two describe one change. The child's
+        debounce slot is shared between the two paths, so whichever arrives
+        first is the one that speaks."""
+        child = tmp_path / "note.txt"
+        child.write_text("hello")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))  # a listing to diff against
+        broadcaster.reset_mock()
+        # Nothing has been announced recently any more, and the window is the
+        # shipped one: the two events below are a genuine pair, not a repeat.
+        handler._last_event.clear()
+        handler._debounce_seconds = 0.1
+
+        child.write_text("world")
+        handler.on_any_event(FileModifiedEvent(str(child)))
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert self._events(broadcaster) == [
+            {"type": "modified", "path": "note.txt", "is_dir": False}
+        ]
+
+    def test_the_listing_of_a_directory_that_is_gone_is_dropped(self, tmp_path):
+        """One entry per directory that still exists: a tree that churns must
+        not grow the map for the life of the watcher."""
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "note.txt").write_text("hello")
+        broadcaster = MagicMock()
+        handler = self._handler(tmp_path, broadcaster)
+        handler.on_any_event(DirModifiedEvent(str(sub)))
+        assert str(sub) in handler._listings
+        broadcaster.reset_mock()
+
+        (sub / "note.txt").unlink()
+        sub.rmdir()
+        handler.on_any_event(DirModifiedEvent(str(sub)))
+
+        assert {"type": "deleted", "path": str(Path("sub") / "note.txt"), "is_dir": False} in (
+            self._events(broadcaster)
+        ), "what the directory held is still announced as deleted"
+        assert str(sub) not in handler._listings
+
+    def test_a_frame_inside_the_debounce_window_still_announces_what_it_carries(self, tmp_path):
+        """The frames arrive as fast as the writes that produce them.
+
+        A coalesced frame is the whole report of the change — no per-file event
+        stands behind it — so a directory frame dropped by a path debounce is a
+        change lost outright rather than a duplicate suppressed. The listing
+        diff is what keeps a repeat frame silent, so the frame does not need a
+        time window as well, and the children it announces still claim theirs.
+        """
+        broadcaster = MagicMock()
+        handler = _WorkspaceHandler(tmp_path, broadcaster)
+        # Both frames below land inside one window by construction, rather than
+        # by being fast enough on the day.
+        handler._debounce_seconds = 30.0
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+        broadcaster.reset_mock()
+
+        (tmp_path / "new_file.txt").write_text("world")
+        handler.on_any_event(DirModifiedEvent(str(tmp_path)))
+
+        assert {"type": "created", "path": "new_file.txt", "is_dir": False} in self._events(
+            broadcaster
+        )

--- a/tests/interfaces/web_terminal/test_pty_manager.py
+++ b/tests/interfaces/web_terminal/test_pty_manager.py
@@ -134,13 +134,19 @@ class TestPtySession:
         then the test calls session.resize() and checks for the file.
         """
         marker = tempfile.mktemp(suffix="_sigwinch")
+        ready = tempfile.mktemp(suffix="_sigwinch_ready")
 
-        # Python one-liner: install SIGWINCH handler, write marker, wait.
+        # Python one-liner: install SIGWINCH handler, say so, write marker on
+        # the signal, wait. The child announces the handler rather than the
+        # test guessing how long a fresh interpreter takes to reach it: a
+        # resize that lands first is delivered to a disposition that ignores
+        # it, and no second signal follows to make up for it.
         child_script = (
             "import signal, time, pathlib; "
             f"pathlib.Path('{marker}').unlink(missing_ok=True); "
             f"signal.signal(signal.SIGWINCH, lambda *_: pathlib.Path('{marker}').write_text('ok')); "
-            "time.sleep(10)"
+            f"pathlib.Path('{ready}').write_text('ok'); "
+            "time.sleep(60)"
         )
 
         session = PtySession(sys.executable)
@@ -179,19 +185,27 @@ class TestPtySession:
         fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
         try:
-            # Give child time to install the signal handler
-            time.sleep(0.5)
+            # Wait for the child to say its handler is installed.
+            deadline = time.monotonic() + 30
+            while not os.path.exists(ready):
+                assert time.monotonic() < deadline, "the child never installed its handler"
+                time.sleep(0.05)
 
-            # Resize the PTY — should deliver SIGWINCH to the child
-            new_winsize = struct.pack("HHHH", 40, 120, 0, 0)
-            fcntl.ioctl(master_fd, termios.TIOCSWINSZ, new_winsize)
-
-            # Wait for the marker file to appear
-            deadline = time.monotonic() + 3
-            while time.monotonic() < deadline:
-                if os.path.exists(marker):
-                    break
-                time.sleep(0.1)
+            # Resize the PTY until the child reports the signal. The two sizes
+            # alternate because TIOCSWINSZ raises SIGWINCH only on a size that
+            # actually changed, so a repeat of the same one would be silent.
+            sizes = (
+                struct.pack("HHHH", 40, 120, 0, 0),
+                struct.pack("HHHH", 24, 80, 0, 0),
+            )
+            attempt = 0
+            deadline = time.monotonic() + 15
+            while not os.path.exists(marker) and time.monotonic() < deadline:
+                fcntl.ioctl(master_fd, termios.TIOCSWINSZ, sizes[attempt % 2])
+                attempt += 1
+                round_ends = time.monotonic() + 1
+                while not os.path.exists(marker) and time.monotonic() < round_ends:
+                    time.sleep(0.05)
 
             assert os.path.exists(marker), "SIGWINCH was not delivered to the child process"
         finally:
@@ -205,10 +219,11 @@ class TestPtySession:
                 os.close(master_fd)
             except OSError:
                 pass
-            try:
-                os.unlink(marker)
-            except OSError:
-                pass
+            for path in (marker, ready):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="PTY not available on Windows")

--- a/tests/manual/test_sdk_image_block.py
+++ b/tests/manual/test_sdk_image_block.py
@@ -75,18 +75,27 @@ import pytest
 # is LBLnet-gated and would 403 off-VPN. Values mirror osprey's own resolver
 # (CLAUDE_CODE_PROVIDERS in osprey.cli.claude_code_resolver).
 # --------------------------------------------------------------------------
+# Each entry is (key variable, endpoint variable or literal URL, model). An
+# entry whose endpoint names a variable is skipped when that variable is unset:
+# als-apg fronts a site's own gateway and has no endpoint to default to.
 _PROVIDERS = [
-    ("ALS_APG_API_KEY", "https://llm.gianlucamartino.com", "claude-haiku-4-5-20251001"),
-    ("CBORG_API_KEY", "https://api.cborg.lbl.gov", "claude-haiku-4-5"),
+    ("ALS_APG_API_KEY", ("env", "ALS_APG_BASE_URL"), "claude-haiku-4-5-20251001"),
+    ("CBORG_API_KEY", ("url", "https://api.cborg.lbl.gov"), "claude-haiku-4-5"),
     ("ANTHROPIC_API_KEY", None, "claude-haiku-4-5-20251001"),
 ]
 
 
 def _select_provider() -> tuple[str, str | None, str] | None:
-    """Return (secret, base_url, model) for the first provider with a key."""
-    for env_var, base_url, model in _PROVIDERS:
+    """Return (secret, base_url, model) for the first usable provider."""
+    for env_var, endpoint, model in _PROVIDERS:
         secret = os.environ.get(env_var)
-        if secret and "${" not in secret:
+        if not secret or "${" in secret:
+            continue
+        if endpoint is None:
+            return secret, None, model
+        kind, value = endpoint
+        base_url = os.environ.get(value) if kind == "env" else value
+        if base_url:
             return secret, base_url, model
     return None
 

--- a/tests/models/test_completion.py
+++ b/tests/models/test_completion.py
@@ -136,7 +136,6 @@ class TestConvertTypedDictToPydantic:
 # Kept explicit so a new provider forces a deliberate entry here rather than
 # silently inheriting whichever behavior its class attributes happen to give it.
 PROVIDERS_DECLARING_A_DEFAULT_ENDPOINT = [
-    ("als-apg", "https://llm.gianlucamartino.com"),
     ("argo", "https://apps.inside.anl.gov/argoapi/v1"),
     ("ds4", "http://127.0.0.1:8000/v1"),
     ("ollama", "http://localhost:11434"),
@@ -147,7 +146,7 @@ PROVIDERS_DECLARING_A_DEFAULT_ENDPOINT = [
 # Providers that require a base_url and declare no default: nothing but config
 # (or an env override) can supply their endpoint, so the gate must keep
 # rejecting them.
-PROVIDERS_WITH_NO_ENDPOINT_SOURCE = ["amsc-i2", "asksage", "cborg"]
+PROVIDERS_WITH_NO_ENDPOINT_SOURCE = ["als-apg", "amsc-i2", "asksage", "cborg"]
 
 
 def _clear_base_url_overrides(monkeypatch):
@@ -174,10 +173,8 @@ class TestBaseUrlRequirementHonorsProviderDefaults:
     provider carrying a perfectly good default was refused for "missing" base_url
     and its default was unreachable.
 
-    That disagreement was invisible for as long as an env override happened to
-    supply the value — it surfaced the moment ``ALS_APG_BASE_URL`` was removed
-    once the default gateway came back. These tests pin the agreement rather than
-    either half, since either half alone passes while the pair is broken.
+    These tests pin the agreement rather than either half, since either half
+    alone passes while the pair is broken.
     """
 
     @pytest.fixture(autouse=True)
@@ -193,7 +190,7 @@ class TestBaseUrlRequirementHonorsProviderDefaults:
         # None in, the declared default out — the value the gate must accept.
         assert provider_class.effective_base_url(None) == expected
 
-    def test_an_env_override_still_beats_the_default(self, monkeypatch):
+    def test_an_env_override_supplies_and_beats_a_configured_value(self, monkeypatch):
         from osprey.models.provider_registry import get_provider_registry
 
         monkeypatch.setenv("ALS_APG_BASE_URL", "https://fallback.example")
@@ -203,10 +200,24 @@ class TestBaseUrlRequirementHonorsProviderDefaults:
         # a break-glass redirect for an already-deployed system.
         assert provider_class.effective_base_url("https://baked-in") == "https://fallback.example"
 
+    @pytest.mark.parametrize("provider", ["als-apg", "cborg", "vllm"])
+    def test_an_unresolved_placeholder_counts_as_no_value(self, provider):
+        """``base_url: ${VAR}`` with nothing exported is "unset", not a hostname.
+
+        The config resolver keeps the reference verbatim when the variable is
+        unset, so every provider has to read that shape as an absent value or
+        the literal reaches the HTTP client.
+        """
+        from osprey.models.provider_registry import get_provider_registry
+
+        provider_class = get_provider_registry().get_provider(provider)
+        resolved = provider_class.effective_base_url("${SOME_GATEWAY_URL}")
+        assert resolved == provider_class.default_base_url
+
     def test_a_configured_value_still_wins_over_the_default(self):
         from osprey.models.provider_registry import get_provider_registry
 
-        provider_class = get_provider_registry().get_provider("als-apg")
+        provider_class = get_provider_registry().get_provider("stanford")
         assert provider_class.effective_base_url("https://configured") == "https://configured"
 
     @pytest.mark.parametrize("provider", PROVIDERS_WITH_NO_ENDPOINT_SOURCE)
@@ -294,14 +305,33 @@ class TestGetChatCompletionAcceptsAProviderDefault:
         # The gate must not become a rubber stamp: a requires_base_url provider
         # with nothing to fall back on still fails, and still names itself.
         from osprey.models import completion as completion_module
-        from osprey.models.provider_registry import get_provider_registry
 
-        provider_class = get_provider_registry().get_provider("als-apg")
-        monkeypatch.setattr(provider_class, "apply_default_base_url_fallback", False)
         monkeypatch.setattr(
             completion_module,
             "get_provider_config",
             lambda provider: {"api_key": "k", "default_model_id": "claude-haiku-4-5-20251001"},
+        )
+
+        with pytest.raises(ValueError, match="Base URL required for als-apg"):
+            completion_module.get_chat_completion(message="ping", provider="als-apg", max_tokens=4)
+
+    def test_an_unresolved_placeholder_is_rejected_like_a_missing_url(self, monkeypatch):
+        """A deployment that never exported its gateway variable is refused.
+
+        The shipped catalog spells the endpoint ``${ALS_APG_BASE_URL}``; unset,
+        the literal survives config resolution, and the gate has to read it as
+        "no URL" rather than let it through to the HTTP client.
+        """
+        from osprey.models import completion as completion_module
+
+        monkeypatch.setattr(
+            completion_module,
+            "get_provider_config",
+            lambda provider: {
+                "api_key": "k",
+                "base_url": "${ALS_APG_BASE_URL}",
+                "default_model_id": "claude-haiku-4-5-20251001",
+            },
         )
 
         with pytest.raises(ValueError, match="Base URL required for als-apg"):

--- a/tests/models/test_litellm_adapter.py
+++ b/tests/models/test_litellm_adapter.py
@@ -738,6 +738,32 @@ class TestCheckLitellmHealth:
         assert "placeholder" in msg
 
     @pytest.mark.unit
+    def test_missing_base_url_on_a_provider_that_has_no_default(self):
+        """A gateway provider with no endpoint is refused, not routed to OpenAI.
+
+        ``als-apg`` is openai-compatible, so litellm routes it as
+        ``openai/<model>`` and, with no ``api_base``, sends the call — carrying
+        the gateway's key — to api.openai.com. That comes back as an
+        authentication failure nowhere near its cause, so the endpoint is
+        checked the same way the key is.
+        """
+        assert check_litellm_health(
+            provider="als-apg",
+            api_key="sk-real",
+            base_url=None,
+            model_id="claude-haiku-4-5-20251001",
+        ) == (False, "Base URL required for als-apg")
+
+    @pytest.mark.unit
+    def test_unknown_provider_without_base_url_still_reaches_the_call(self):
+        """The guard reads the provider class, and an unknown name has none."""
+        with patch("litellm.completion") as mock_completion:
+            mock_completion.return_value = MagicMock()
+            assert check_litellm_health(
+                provider="not-a-provider", api_key="sk-real", base_url=None, model_id="m"
+            ) == (True, "API accessible and authenticated")
+
+    @pytest.mark.unit
     def test_missing_model_id(self):
         assert check_litellm_health(
             provider="openai", api_key="sk-real", base_url=None, model_id=None

--- a/tests/models/test_providers_als_apg.py
+++ b/tests/models/test_providers_als_apg.py
@@ -11,12 +11,17 @@ ALS-APG differs from the other OpenAI-compatible proxies (amsc-i2, cborg,
 stanford) in one deliberate way: it leaves ``supports_native_structured_output``
 at the None default so structured-output support is auto-detected, rather than
 asserting True. That default is pinned below.
+
+It also declares no ``default_base_url``: the gateway is a site's own host, so
+the endpoint comes from config or from ``ALS_APG_BASE_URL`` and a call with
+neither is refused rather than sent somewhere else.
 """
 
 from unittest.mock import patch
 
 import pytest
 from pydantic import BaseModel
+from tests.conftest import GATEWAY_BASE_URL
 
 from osprey.models.providers.als_apg import ALSAPGProviderAdapter
 
@@ -55,8 +60,16 @@ class TestALSAPGMetadata:
         assert ALSAPGProviderAdapter.requires_model_id is True
         assert ALSAPGProviderAdapter.supports_proxy is True
 
-    def test_default_base_url(self):
-        assert ALSAPGProviderAdapter.default_base_url == "https://llm.gianlucamartino.com"
+    def test_declares_no_default_base_url(self):
+        """The gateway is site infrastructure — there is no endpoint to default to.
+
+        A default here would be one organisation's host shipped as every
+        deployment's fallback, and it would be reached silently: the provider
+        requires a base_url, so the requirement gate would accept the default
+        instead of asking for the deployment's own.
+        """
+        assert ALSAPGProviderAdapter.default_base_url is None
+        assert ALSAPGProviderAdapter.apply_default_base_url_fallback is False
 
     def test_default_and_health_models(self):
         assert ALSAPGProviderAdapter.default_model_id == "claude-haiku-4-5-20251001"
@@ -143,22 +156,26 @@ class TestALSAPGExecuteCompletion:
         assert kwargs["enable_thinking"] is True
         assert kwargs["budget_tokens"] == 256
 
-    def test_missing_base_url_falls_back_to_default(self):
-        """als-apg routes openai-compatible, so a missing base_url must resolve
-        to its default endpoint rather than falling through to api.openai.com."""
+    def test_missing_base_url_resolves_to_nothing(self):
+        """No endpoint is invented; the requirement gate refuses the call instead.
+
+        ``osprey.models.completion`` rejects a ``requires_base_url`` provider
+        that resolves to None, which is what makes "you have to name your
+        gateway" the error a deployer sees.
+        """
         with patch(COMPLETION, return_value="ok") as mock_exec:
             ALSAPGProviderAdapter().execute_completion(
                 message="hi", model_id="m", api_key="key", base_url=None
             )
-        assert mock_exec.call_args.kwargs["base_url"] == "https://llm.gianlucamartino.com"
+        assert mock_exec.call_args.kwargs["base_url"] is None
 
 
 class TestALSAPGBaseURLEnvOverride:
     """ALS_APG_BASE_URL redirects the adapter regardless of config.
 
-    The env var is the break-glass lever for pointing an already-deployed
-    system at a fallback gateway without rebuilding images: it must beat
-    both an explicit base_url argument and the built-in default.
+    The env var is both how a deployment names its gateway and the break-glass
+    lever for pointing an already-deployed system at a fallback without
+    rebuilding images: it must beat an explicit base_url argument.
     """
 
     def test_declares_the_env_var_name(self):
@@ -181,13 +198,27 @@ class TestALSAPGBaseURLEnvOverride:
         assert mock_exec.call_args.kwargs["base_url"] == "https://fallback.example.org/v1"
 
     def test_empty_env_var_is_ignored(self, monkeypatch):
-        """An empty export must not blank the URL — fall through to the default."""
+        """An empty export must not blank a configured URL."""
         monkeypatch.setenv("ALS_APG_BASE_URL", "")
         with patch(COMPLETION, return_value="ok") as mock_exec:
             ALSAPGProviderAdapter().execute_completion(
-                message="hi", model_id="m", api_key="key", base_url=None
+                message="hi", model_id="m", api_key="key", base_url=GATEWAY_BASE_URL
             )
-        assert mock_exec.call_args.kwargs["base_url"] == "https://llm.gianlucamartino.com"
+        assert mock_exec.call_args.kwargs["base_url"] == GATEWAY_BASE_URL
+
+    def test_an_unresolved_placeholder_is_not_a_url(self, monkeypatch):
+        """``base_url: ${ALS_APG_BASE_URL}`` with nothing exported means "unset".
+
+        The config resolver keeps a reference verbatim when the variable is
+        unset, so without this the literal string would be handed to litellm as
+        a hostname.
+        """
+        monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
+        with patch(COMPLETION, return_value="ok") as mock_exec:
+            ALSAPGProviderAdapter().execute_completion(
+                message="hi", model_id="m", api_key="key", base_url="${ALS_APG_BASE_URL}"
+            )
+        assert mock_exec.call_args.kwargs["base_url"] is None
 
     def test_env_var_redirects_check_health_too(self, monkeypatch):
         """osprey health must probe the endpoint completions actually use."""
@@ -242,10 +273,10 @@ class TestALSAPGCheckHealth:
             )
         assert mock_health.call_args.kwargs["timeout"] == 12.0
 
-    def test_missing_base_url_falls_back_to_default(self):
+    def test_missing_base_url_resolves_to_nothing(self):
         with patch(HEALTH, return_value=(True, "ok")) as mock_health:
             ALSAPGProviderAdapter().check_health(api_key="key", base_url=None)
-        assert mock_health.call_args.kwargs["base_url"] == "https://llm.gianlucamartino.com"
+        assert mock_health.call_args.kwargs["base_url"] is None
 
     def test_propagates_failure(self):
         with patch(HEALTH, return_value=(False, "down")):

--- a/tests/services/channel_finder/benchmarks/test_backend_helpers.py
+++ b/tests/services/channel_finder/benchmarks/test_backend_helpers.py
@@ -55,6 +55,58 @@ class TestResolveLitellmEndpoint:
         # No config.yml in the project dir -> resolver bails out early.
         assert _resolve_litellm_endpoint(tmp_path, "als-apg") is None
 
+    @staticmethod
+    def _gateway_project(tmp_path: Path) -> Path:
+        """A project whose provider names its endpoint through a variable.
+
+        The shape the shipped provider catalog writes: the gateway host is the
+        deployment's own, so ``base_url`` is a reference, not a literal.
+        """
+        (tmp_path / "config.yml").write_text(
+            "api:\n"
+            "  providers:\n"
+            "    als-apg:\n"
+            "      base_url: ${BENCH_GATEWAY_URL}\n"
+            "      api_key: ${ALS_APG_API_KEY}\n"
+        )
+        return tmp_path
+
+    def test_unset_endpoint_variable_is_refused_by_name(self, tmp_path: Path, monkeypatch):
+        """An unexported ${VAR} is not a hostname to hand to litellm.
+
+        The config resolver keeps the reference verbatim when the variable is
+        unset, so without this the benchmark dials a host called
+        ``${BENCH_GATEWAY_URL}`` and reports the failure as the model's.
+        """
+        monkeypatch.delenv("BENCH_GATEWAY_URL", raising=False)
+        monkeypatch.setenv("ALS_APG_API_KEY", "test-key")
+
+        with pytest.raises(ValueError, match="BENCH_GATEWAY_URL"):
+            _resolve_litellm_endpoint(self._gateway_project(tmp_path), "als-apg")
+
+    def test_endpoint_variable_is_expanded(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("BENCH_GATEWAY_URL", "https://gateway.example.com/v1")
+        monkeypatch.setenv("ALS_APG_API_KEY", "test-key")
+
+        resolved = _resolve_litellm_endpoint(self._gateway_project(tmp_path), "als-apg")
+
+        assert resolved == {"api_base": "https://gateway.example.com", "api_key": "test-key"}
+
+    def test_endpoint_variable_may_come_from_the_project_env_file(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """A benchmark run reads the deployment's ``.env``, as it does for the key."""
+        monkeypatch.delenv("BENCH_GATEWAY_URL", raising=False)
+        monkeypatch.delenv("ALS_APG_API_KEY", raising=False)
+        project = self._gateway_project(tmp_path)
+        (project / ".env").write_text(
+            "BENCH_GATEWAY_URL=https://from-dotenv.example.com\nALS_APG_API_KEY=dotenv-key\n"
+        )
+
+        resolved = _resolve_litellm_endpoint(project, "als-apg")
+
+        assert resolved == {"api_base": "https://from-dotenv.example.com", "api_key": "dotenv-key"}
+
 
 def _graph_project(tmp_path: Path) -> Path:
     """A project directory configured for the graph paradigm."""

--- a/tests/services/channel_finder/benchmarks/test_evaluation.py
+++ b/tests/services/channel_finder/benchmarks/test_evaluation.py
@@ -186,6 +186,57 @@ class TestLlmJudgeCoverage:
         assert covered == []
         assert extras == []
 
+    @staticmethod
+    def _judge_env(monkeypatch, **present: str) -> None:
+        """Leave exactly *present* set among the vars the judge consults."""
+        for name in (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_BASE_URL",
+            "ALS_APG_API_KEY",
+            "ALS_APG_BASE_URL",
+            "CBORG_API_KEY",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        for name, value in present.items():
+            monkeypatch.setenv(name, value)
+
+    @patch("osprey.models.providers.litellm_adapter.execute_litellm_completion")
+    def test_als_apg_needs_its_gateway_url_to_be_a_candidate(self, mock_completion, monkeypatch):
+        """The gateway has no built-in endpoint, so a key on its own names no
+        reachable server — the judge falls through to the next provider rather
+        than calling one it cannot address."""
+        self._judge_env(monkeypatch, ALS_APG_API_KEY="key", CBORG_API_KEY="cborg-key")
+        mock_completion.return_value = ChannelExtractionResult(
+            covered_expected_indices=[], extra_recommended=[], reasoning=""
+        )
+
+        llm_judge_coverage("response", ["CH:A"])
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["provider"] == "cborg"
+        assert kwargs["api_key"] == "cborg-key"
+
+    @patch("osprey.models.providers.litellm_adapter.execute_litellm_completion")
+    def test_als_apg_is_used_when_its_gateway_url_is_exported(self, mock_completion, monkeypatch):
+        """With both halves exported the gateway is addressable, and its URL is
+        what the call is aimed at."""
+        self._judge_env(
+            monkeypatch,
+            ALS_APG_API_KEY="key",
+            ALS_APG_BASE_URL="https://gateway.example.org",
+            CBORG_API_KEY="cborg-key",
+        )
+        mock_completion.return_value = ChannelExtractionResult(
+            covered_expected_indices=[], extra_recommended=[], reasoning=""
+        )
+
+        llm_judge_coverage("response", ["CH:A"])
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["provider"] == "als-apg"
+        assert kwargs["base_url"] == "https://gateway.example.org"
+
 
 # ---------------------------------------------------------------------------
 # evaluate_response

--- a/tests/services/facility_knowledge/test_okf_ranked_search.py
+++ b/tests/services/facility_knowledge/test_okf_ranked_search.py
@@ -248,6 +248,18 @@ class TestResultMapping:
 # ---------------------------------------------------------------------------
 
 
+def _bundle_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """The records the bundle logged, and no one else's.
+
+    ``caplog`` captures everything that reaches the root logger in this
+    process, so a server thread or config loader belonging to another test can
+    land records inside this window. What is under test is what the bundle
+    says, so the other producers are filtered out by logger name rather than
+    counted.
+    """
+    return [r for r in caplog.records if r.name == OKFBundle.__module__]
+
+
 class TestFallback:
     """When the ranked backend cannot answer."""
 
@@ -262,7 +274,7 @@ class TestFallback:
 
         assert [r.concept_id for r in results] == ["magnets/corrector_magnets"]
         assert results[0].score is None
-        assert caplog.records == []
+        assert _bundle_records(caplog) == []
 
     def test_configured_but_down_warns_and_falls_back(
         self, bundle_root: Path, caplog: pytest.LogCaptureFixture
@@ -274,7 +286,7 @@ class TestFallback:
 
         assert [r.concept_id for r in results] == ["magnets/corrector_magnets"]
         assert results[0].score is None
-        assert [r.levelname for r in caplog.records] == ["WARNING"]
+        assert [r.levelname for r in _bundle_records(caplog)] == ["WARNING"]
         assert "falling back to substring search" in caplog.text
 
     def test_outage_warns_once_not_once_per_query(
@@ -287,7 +299,7 @@ class TestFallback:
             for _ in range(5):
                 bundle.search("steer")
 
-        assert len(caplog.records) == 1
+        assert len(_bundle_records(caplog)) == 1
 
     def test_recovery_re_arms_the_warning(
         self, bundle_root: Path, caplog: pytest.LogCaptureFixture
@@ -303,7 +315,7 @@ class TestFallback:
             client.available = False
             bundle.search("steer")
 
-        assert len(caplog.records) == 2
+        assert len(_bundle_records(caplog)) == 2
 
     @pytest.mark.parametrize(
         "error",
@@ -321,7 +333,7 @@ class TestFallback:
 
         assert [r.concept_id for r in results] == ["magnets/corrector_magnets"]
         assert results[0].score is None
-        assert len(caplog.records) == 1
+        assert len(_bundle_records(caplog)) == 1
 
     def test_an_empty_ranked_result_is_not_a_fallback(self, bundle_root: Path) -> None:
         """A qmd result set of zero is an answer, and substring must not override it."""

--- a/tests/test_env_isolation.py
+++ b/tests/test_env_isolation.py
@@ -12,6 +12,14 @@ import time
 
 import pytest
 
+from tests import _env_scope_guard as guard
+from tests._env_scope_guard import (
+    LONG_LIVED_ENV_WRITES,
+    SCOPES_OUTLIVING_A_MODULE,
+    record_env_delta,
+    restore_module_environment,
+)
+
 #: Keys ``restore_environ`` clears on the way in to every test.
 PRISTINE_KEYS = ("OSPREY_CONFIG", "CONFIG_FILE", "TZ")
 
@@ -39,3 +47,132 @@ def test_process_timezone_agrees_with_environ():
         f"process timezone {before} does not match a tzset() of the current "
         f"environment ({time.tzname}); TZ was cleared without a tzset()."
     )
+
+
+class TestModuleScopedRestore:
+    """``restore_module_environment`` drops a module's writes, keeps the rest.
+
+    The two halves pull in opposite directions: a module-scoped fixture that
+    loads a seeded repo's ``.env`` must not outlive its module, while a
+    session-scoped fixture created part-way through that same module must — it
+    is still alive when the next module runs, and pytest will not set it up
+    again.
+    """
+
+    def test_a_module_scoped_write_does_not_outlive_the_module(self):
+        with restore_module_environment():
+            os.environ["OSPREY_TEST_MODULE_WRITE"] = "from-the-module-fixture"
+        assert "OSPREY_TEST_MODULE_WRITE" not in os.environ
+
+    def test_a_longer_lived_fixtures_write_survives_the_module(self):
+        """The regression: rolling this back strands a live fixture."""
+        with restore_module_environment():
+            # What the hook records around a session-scoped fixture's setup.
+            before = dict(os.environ)
+            os.environ["OSPREY_TEST_SESSION_WRITE"] = "from-the-session-fixture"
+            record_env_delta(before)
+
+            os.environ["OSPREY_TEST_MODULE_WRITE"] = "from-the-module-fixture"
+
+        try:
+            assert os.environ.get("OSPREY_TEST_SESSION_WRITE") == "from-the-session-fixture"
+            assert "OSPREY_TEST_MODULE_WRITE" not in os.environ
+        finally:
+            os.environ.pop("OSPREY_TEST_SESSION_WRITE", None)
+
+    def test_a_longer_lived_fixtures_deletion_survives_the_module(self):
+        os.environ["OSPREY_TEST_PRE_EXISTING"] = "set-before-the-module"
+        try:
+            with restore_module_environment():
+                before = dict(os.environ)
+                del os.environ["OSPREY_TEST_PRE_EXISTING"]
+                record_env_delta(before)
+            assert "OSPREY_TEST_PRE_EXISTING" not in os.environ
+        finally:
+            os.environ.pop("OSPREY_TEST_PRE_EXISTING", None)
+
+    def test_a_nested_guard_leaves_the_enclosing_record_alone(self):
+        """Every test in this module already runs inside the autouse guard.
+
+        A guard that reset the record globally would, entered a second time,
+        throw away what the enclosing one had recorded -- and its module would
+        then roll a live session fixture's writes back at teardown, which is
+        the failure the record exists to prevent.
+        """
+        before = dict(os.environ)
+        os.environ["OSPREY_TEST_ENCLOSING_WRITE"] = "from-the-session-fixture"
+        record_env_delta(before)
+        try:
+            with restore_module_environment():
+                os.environ["OSPREY_TEST_MODULE_WRITE"] = "from-the-module-fixture"
+
+            assert LONG_LIVED_ENV_WRITES.get("OSPREY_TEST_ENCLOSING_WRITE") == (
+                "from-the-session-fixture"
+            )
+            assert "OSPREY_TEST_MODULE_WRITE" not in os.environ
+        finally:
+            os.environ.pop("OSPREY_TEST_ENCLOSING_WRITE", None)
+            LONG_LIVED_ENV_WRITES.pop("OSPREY_TEST_ENCLOSING_WRITE", None)
+
+    def test_a_nested_guards_long_lived_write_is_handed_outwards(self):
+        """A session fixture set up inside the inner region outlives both.
+
+        The inner guard replays the write over its own snapshot; the enclosing
+        one has to hear about it too, or it rolls the same write back later.
+        """
+        with restore_module_environment():
+            before = dict(os.environ)
+            os.environ["OSPREY_TEST_SESSION_WRITE"] = "x"
+            record_env_delta(before)
+        try:
+            assert os.environ.get("OSPREY_TEST_SESSION_WRITE") == "x"
+            assert LONG_LIVED_ENV_WRITES.get("OSPREY_TEST_SESSION_WRITE") == "x"
+        finally:
+            os.environ.pop("OSPREY_TEST_SESSION_WRITE", None)
+            LONG_LIVED_ENV_WRITES.pop("OSPREY_TEST_SESSION_WRITE", None)
+
+    def test_a_region_that_encloses_nothing_hands_its_record_to_nobody(self, monkeypatch):
+        """One module's long-lived writes are not the next module's to replay.
+
+        Handing them outwards is right only while something is out there. The
+        outermost region has no one to tell, and a record that kept growing
+        would have every later module replaying writes it never saw.
+        """
+        monkeypatch.setattr(guard, "_OPEN_REGIONS", [])
+        monkeypatch.setattr(guard, "LONG_LIVED_ENV_WRITES", {})
+
+        with restore_module_environment():
+            before = dict(os.environ)
+            os.environ["OSPREY_TEST_SESSION_WRITE"] = "x"
+            guard.record_env_delta(before)
+        try:
+            assert os.environ.get("OSPREY_TEST_SESSION_WRITE") == "x"
+            assert guard.LONG_LIVED_ENV_WRITES == {}
+        finally:
+            os.environ.pop("OSPREY_TEST_SESSION_WRITE", None)
+
+    def test_only_scopes_that_outlive_a_module_are_measured(self):
+        """The hook skips function and module scope; measuring them would make
+        every module-scoped write look long-lived and defeat the guard."""
+        assert SCOPES_OUTLIVING_A_MODULE == {"session", "package"}
+        assert "module" not in SCOPES_OUTLIVING_A_MODULE
+        assert "function" not in SCOPES_OUTLIVING_A_MODULE
+
+
+@pytest.fixture(scope="session")
+def _session_env_probe():
+    """A session-scoped fixture that publishes an environment variable."""
+    os.environ["OSPREY_TEST_HOOK_PROBE"] = "1"
+    yield
+    os.environ.pop("OSPREY_TEST_HOOK_PROBE", None)
+
+
+def test_the_conftest_hook_attributes_a_session_fixtures_write(_session_env_probe):
+    """End to end: the hook is installed and measures the setup that matters.
+
+    The unit tests above drive ``record_env_delta`` by hand; this is what proves
+    ``pytest_fixture_setup`` in ``tests/conftest.py`` actually calls it, so a
+    pytest release that changes the hook's shape fails here rather than silently
+    reverting the guard to the behaviour it was written to replace.
+    """
+    assert LONG_LIVED_ENV_WRITES.get("OSPREY_TEST_HOOK_PROBE") == "1"

--- a/tests/utils/test_resolve_env_vars.py
+++ b/tests/utils/test_resolve_env_vars.py
@@ -1,6 +1,8 @@
 """Tests for the public resolve_env_vars() function."""
 
-from osprey.utils.config import resolve_env_vars
+import pytest
+
+from osprey.utils.config import is_unresolved_placeholder, resolve_env_vars
 
 
 class TestResolveEnvVars:
@@ -135,3 +137,37 @@ class TestResolveEnvVarsWithEnviron:
         result = resolve_env_vars(data, environ={"SHOULD_NOT_EXPAND": "leaked", "P": "argo"})
         assert result["claude_code"]["servers"]["controls"]["env"]["KEY"] == "${SHOULD_NOT_EXPAND}"
         assert result["claude_code"]["provider"] == "argo"
+
+
+class TestIsUnresolvedPlaceholder:
+    """The recogniser and the resolver must agree on what a placeholder is.
+
+    ``is_unresolved_placeholder`` exists to answer one question — "is this what
+    :func:`resolve_env_vars` leaves behind when the variable is unset?" — so its
+    accepted syntax is the resolver's, not a narrower re-statement of it.
+    """
+
+    @pytest.mark.parametrize(
+        "reference",
+        ["${MISSING}", "$MISSING", "${SOME-VAR}", "${lowercase}", "${VAR.WITH.DOTS}"],
+    )
+    def test_what_the_resolver_leaves_verbatim_is_recognised(self, reference, monkeypatch):
+        monkeypatch.setenv("OSPREY_QUIET", "1")
+        # The premise: with nothing to substitute, the resolver hands the
+        # reference back unchanged.
+        assert resolve_env_vars(reference, environ={}) == reference
+        assert is_unresolved_placeholder(reference) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://gateway.example.org/v1",
+            "${VAR:-https://default.example.org}",  # a default always substitutes
+            "prefix-${VAR}",  # the rest of the string is a value
+            "",
+            None,
+            42,
+        ],
+    )
+    def test_anything_that_is_not_a_lone_reference_is_not_a_placeholder(self, value):
+        assert is_unresolved_placeholder(value) is False


### PR DESCRIPTION
The ALS-APG gateway endpoint becomes a required deployment setting: no built-in host literal remains anywhere in the tree, and a deployment that leaves `ALS_APG_BASE_URL` unset is refused by name at the point of use instead of silently reaching a stranger's domain.

## Commits

- `fix(providers): require an explicit ALS-APG gateway URL`
- `test(conftest): restore the environment after every module's fixtures too`
- `fix(web-terminal): rescan a directory on a coalesced FSEvents frame`
- `test(okf): scope the fallback log assertions to the bundle logger`
- `test(docs): guard the gateway host out of shipped prose`
- `test(web-terminal): wait for the child before resizing the pty`
- `refactor(interfaces): take the watchdog observer backend as an argument`

## Why

A provider shipped in the framework carried a default endpoint pointing at one
person's domain, and that default was the effective endpoint the moment
`provider: als-apg` was selected — in the first five minutes of the hello-world
app, in the rendered `config.yml` of every deployment, and in the CI workflow and
benchmark scripts as a fallback. A deployer who never read the block would route
inference to a host they had not chosen.

The endpoint is now declared once in the provider catalog as `${ALS_APG_BASE_URL}`
and enforced by a refusal that names the variable, so an unset gateway fails
loudly at the point of use rather than resolving to something. Deployment-owned
endpoints and framework-owned defaults are no longer the same thing, and
`osprey init --force` / `profile expand --providers` reset to the required form
rather than back to a host.

The gateway is described as "the ALS-APG gateway" wherever prose named a specific
cloud product it is not, a docs test keeps the host out of shipped prose, and the
test suite reads the endpoint from one fixture value instead of asserting the
literal in fourteen places.

The remaining commits are repairs the above surfaced: a directory-modified
FSEvents frame that coalesced away a file creation is now a bounded one-level
rescan in both watchers, both watchers take their observer backend as an argument
so the routing tests are deterministic, module fixtures restore the environment
they mutate, the OKF fallback assertions are scoped to their own logger, and the
pty resize test waits for its child.

## Not in this PR

- The keep/collapse/relocate decision on the provider catalog itself — settled
  separately; the catalog structure is unchanged here.
- The capability flags for prompt caching and extended thinking (`design-decision`).
- The shared Ollama endpoint-resolution helper.
- The credential prose carried by the individual adapter classes.
