### PR TITLE
Ship no maintainer identity in operator-facing prose

### DIFF
--- a/changelog.d/bridge-failure-notice.fixed.md
+++ b/changelog.d/bridge-failure-notice.fixed.md
@@ -1,0 +1,4 @@
+The Nextcloud Talk bridge no longer tells a room that "nothing was changed"
+when a run fails. A run that was approved a write and then timed out reaches
+the same notice, so the claim was a safety assurance the bridge could not
+check.

--- a/changelog.d/feedback-recipient.changed.md
+++ b/changelog.d/feedback-recipient.changed.md
@@ -1,0 +1,6 @@
+The web terminal ships no default recipient for feedback mail. A prefilled
+draft can carry a session's scrollback, so the mailbox that receives it is now
+named by the deployment (`web.feedback.email`, or `web.feedback.owner.email`)
+rather than inherited. Until one is set the dialog offers its issue tracker
+only, and `osprey feedback list` / `export` still records every submission
+locally.

--- a/changelog.d/lattice-agent-description.changed.md
+++ b/changelog.d/lattice-agent-description.changed.md
@@ -1,0 +1,3 @@
+The pyAT lattice agent now describes itself as computing against the
+deployment's configured lattice model, in both its subagent file and the
+roster the framework renders, instead of naming one particular storage ring.

--- a/changelog.d/shipped-identity-placeholders.internal.md
+++ b/changelog.d/shipped-identity-placeholders.internal.md
@@ -1,0 +1,3 @@
+Shipped comments and documentation use placeholder identities
+(`alice@example.org`) in their login and roster examples instead of a
+maintainer's own address.

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -119,7 +119,7 @@ A login matches when the asserted claim equals the card's ``oidc_subject``.
 The comparison is exact for every claim except ``email``, which is compared
 case-insensitively: an address is the same mailbox in any case, and an
 identity provider is free to release the directory's spelling
-(``THellert@lbl.gov``) where the roster says ``thellert@lbl.gov``. ``sub`` is
+(``Alice@example.org``) where the roster says ``alice@example.org``. ``sub`` is
 an opaque, case-sensitive identifier by specification and stays exact.
 
 Under ``password`` or ``oidc`` a small authentication service joins the stack

--- a/docs/source/reference/configuration/config.rst
+++ b/docs/source/reference/configuration/config.rst
@@ -463,8 +463,10 @@ Documentation and feedback keys
      - ``owner/repo`` of one more GitHub tracker, captioned **GitHub** —
        shorthand for a ``github`` entry in ``trackers``.
    * - ``web.feedback.email``
-     - ``thellert@lbl.gov``
+     - unset (no Email channel)
      - Recipient of the prefilled mail draft the dialog's Email channel opens.
+       Nothing ships here: the draft can carry a session's scrollback, so name
+       the mailbox your operators should reach before offering the channel.
    * - ``web.feedback.max_store_bytes``
      - ``268435456`` (256 MB)
      - Ceiling on the on-disk feedback store. Over it, the oldest saved session

--- a/src/osprey/bridges/nextcloud_talk/ops.py
+++ b/src/osprey/bridges/nextcloud_talk/ops.py
@@ -126,11 +126,16 @@ EMPTY_ANSWER_TEXT = "The run finished without producing any text."
 successful-but-silent run is indistinguishable from a broken bridge."""
 
 ERROR_TEXT = (
-    "I couldn't complete that request. Nothing was changed. Please try again, or ask an "
-    "operator to check the bridge log."
+    "I couldn't complete that request. Please try again, or ask an operator to check the "
+    "bridge log."
 )
 """Posted for any terminal status that is not ``completed``. The machine-readable failure
-never appears in the room."""
+never appears in the room.
+
+It says nothing about what the run did before it stopped. ``error``, ``timeout`` and
+``cancelled`` all land here, and a run can be approved a write and then fail on its way
+to reporting it — so "nothing was changed" would be a safety assurance the bridge cannot
+check, read by a whole room. The Google adapter's notice makes no such claim either."""
 
 QUEUED_TEXT = (
     "Queued — the service I need is unavailable right now. I'll answer here once it "

--- a/src/osprey/cli/build_profile_reach.py
+++ b/src/osprey/cli/build_profile_reach.py
@@ -209,20 +209,23 @@ def feedback_owner_advisories(rendered_config: Mapping[str, Any]) -> list[str]:
 def _feedback_aim(value: Any, project_default: str) -> str:
     """Where one feedback setting points: ``moved``, ``upstream`` or ``retired``.
 
-    ``retired`` is the explicitly blank posture. It is deliberately NOT a
-    synonym for either of the others: a retired channel delivers nothing, so it
-    neither reaches the facility nor leaks upstream.
+    ``retired`` is the blank posture. It is deliberately NOT a synonym for
+    either of the others: a retired channel delivers nothing, so it neither
+    reaches the facility nor leaks upstream.
 
-    A value the runtime could not use (a mapping from a mis-indented config)
-    reads as ``upstream``, because that is where the runtime's own coercion
-    will send it.
+    Blankness is judged on the *effective* value, not the spelled one. An
+    absent key and a value the runtime could not use (a mapping from a
+    mis-indented config) both resolve to *project_default*, because that is
+    what the runtime's own coercion will do with them — so a setting whose
+    shipped default is itself blank reads as retired rather than upstream.
+    That is the mail channel today: nothing ships a recipient, so an
+    unconfigured deployment offers no Email channel and has no mail half to
+    leak.
     """
-    if not isinstance(value, str):
-        return "upstream"
-    stripped = value.strip()
-    if not stripped:
+    effective = value.strip() if isinstance(value, str) else project_default
+    if not effective:
         return "retired"
-    return "upstream" if stripped == project_default else "moved"
+    return "upstream" if effective == project_default else "moved"
 
 
 def spelled_values(config: Any, dotted_key: str) -> list[tuple[str, Any]]:

--- a/src/osprey/interfaces/web_terminal/feedback_destination.py
+++ b/src/osprey/interfaces/web_terminal/feedback_destination.py
@@ -46,8 +46,15 @@ DEFAULT_FEEDBACK_GITHUB_REPO = "als-apg/osprey"
 FEEDBACK_TRACKER_LABELS: dict[str, str] = {"github": "GitHub", "gitlab": "GitLab"}
 
 #: Recipient of the prefilled ``mailto:`` draft when ``web.feedback.email``
-#: is absent — the OSPREY maintainers.
-DEFAULT_FEEDBACK_EMAIL = "thellert@lbl.gov"
+#: is absent. Blank, and deliberately so: nothing ships a mailbox.
+#:
+#: The draft this address receives can carry a session's scrollback, so who
+#: reads it is a decision only the deployment's owner can make — a site with
+#: incident-reporting or export-control rules cannot inherit one. Unconfigured,
+#: the Email channel is simply not offered; the issue tracker
+#: (:data:`DEFAULT_FEEDBACK_GITHUB_REPO`) remains, and ``osprey feedback
+#: list``/``export`` still records every submission locally.
+DEFAULT_FEEDBACK_EMAIL = ""
 
 #: Ceiling (bytes) on the on-disk feedback store before the oldest saved
 #: contexts are pruned; 256 MB unless ``web.feedback.max_store_bytes`` says

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1783,8 +1783,10 @@ keys:
     evidence: 'get_config_value\("web\.feedback\.email", None\)'
     note: >-
       Read with a None sentinel for the same reason as
-      `web.feedback.github_repo` — see that entry.
-    default: thellert@lbl.gov
+      `web.feedback.github_repo` — see that entry. Blank ships no Email
+      channel at all: the prefilled draft can carry a session's scrollback,
+      and only the deployment's owner can say which mailbox may receive it.
+    default: ''
   web.feedback.owner:
     # Documented in every template that carries a `web:` block as a commented
     # example, never rendered as a live key: the shipped destination is the

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -429,8 +429,10 @@ config:
   #     url: https://git.example.org/controls/osprey
   #     label: Facility GitLab
   # Recipient of the prefilled mailto: draft the Email channel opens. Wins
-  # over `owner.email` above, on the same grounds as `github_repo`.
-  web.feedback.email: thellert@lbl.gov
+  # over `owner.email` above, on the same grounds as `github_repo`. Blank
+  # ships no Email channel: the draft can carry this session's scrollback,
+  # so name the mailbox this deployment's operators should reach.
+  web.feedback.email: ""
   # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
   # oldest saved session contexts are deleted; submission headers are kept.
   web.feedback.max_store_bytes: 268435456

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -234,8 +234,10 @@ config:
   #     url: https://git.example.org/controls/osprey
   #     label: Facility GitLab
   # Recipient of the prefilled mailto: draft the Email channel opens. Wins
-  # over `owner.email` above, on the same grounds as `github_repo`.
-  web.feedback.email: thellert@lbl.gov
+  # over `owner.email` above, on the same grounds as `github_repo`. Blank
+  # ships no Email channel: the draft can carry this session's scrollback,
+  # so name the mailbox this deployment's operators should reach.
+  web.feedback.email: ""
   # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
   # oldest saved session contexts are deleted; submission headers are kept.
   web.feedback.max_store_bytes: 268435456

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -822,8 +822,10 @@ config:
   #     url: https://git.example.org/controls/osprey
   #     label: Facility GitLab
   # Recipient of the prefilled mailto: draft the Email channel opens. Wins
-  # over `owner.email` above, on the same grounds as `github_repo`.
-  web.feedback.email: thellert@lbl.gov
+  # over `owner.email` above, on the same grounds as `github_repo`. Blank
+  # ships no Email channel: the draft can carry this session's scrollback,
+  # so name the mailbox this deployment's operators should reach.
+  web.feedback.email: ""
   # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
   # oldest saved session contexts are deleted; submission headers are kept.
   web.feedback.max_store_bytes: 268435456

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -807,7 +807,7 @@ FRAMEWORK_AGENTS: dict[str, AgentDefinition] = {
             "Delegate to this agent when the user needs lattice/optics quantities "
             "computed from the accelerator model (orbit, tunes, beta functions, "
             "dispersion, response matrices) — it writes and executes pyAT code "
-            "against the simulated ALS-U AR ring."
+            "against the deployment's configured lattice model."
         ),
         # Its only compute path is mcp__python__execute (read-only kernels), so
         # it must keep that tool even in a writes-disabled (read-only) persona.

--- a/src/osprey/services/auth_sidecar/identity_headers.py
+++ b/src/osprey/services/auth_sidecar/identity_headers.py
@@ -155,8 +155,8 @@ CASE_INSENSITIVE_CLAIMS: frozenset[str] = frozenset({"email"})
 ``email`` is the one claim OpenID Connect defines as an RFC 5322 address, and
 an address is the same mailbox in any case: the domain by RFC 5321, the local
 part by every mail provider in practice — the same person is
-``THellert@lbl.gov`` in a directory and ``thellert@lbl.gov`` in daily use, and
-a provider releases whichever spelling it stores. A byte-exact match would
+``Alice@example.org`` in a directory and ``alice@example.org`` in daily use,
+and a provider releases whichever spelling it stores. A byte-exact match would
 couple a roster to that cosmetic choice, refusing every login with a 403 that
 names nothing an operator can see in the config.
 

--- a/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
+++ b/src/osprey/templates/claude_code/claude/agents/pyat-specialist.md.j2
@@ -1,6 +1,6 @@
 {% if "pyat-specialist" in enabled_agents %}---
 name: pyat-specialist
-description: "Delegate to this agent when the user needs lattice/optics quantities computed from the accelerator model (orbit, tunes, beta functions, dispersion, response matrices) — it writes and executes pyAT code against the simulated ALS-U AR ring."
+description: "Delegate to this agent when the user needs lattice/optics quantities computed from the accelerator model (orbit, tunes, beta functions, dispersion, response matrices) — it writes and executes pyAT code against the deployment's configured lattice model."
 summary: Computes lattice/optics quantities by writing and executing pyAT code on the simulated ring
 model: {{ claude_code_model_spec.agent_tier("pyat-specialist") if claude_code_model_spec is defined and claude_code_model_spec else "sonnet" }}
 maxTurns: 30

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -34,7 +34,7 @@
       "display_name": str | None, "panel_env": list,
       **allocate_ports(base_ports, index)}`:
         {
-          "user": str,                  # bare username, e.g. "thellert"
+          "user": str,                  # bare username, e.g. "alice"
           "image": str,                 # resolved by resolve_personas() -> per-svc `image:`
           "project": str,               # resolved by resolve_personas() (not read by this template)
           "container_project_dir": str, # resolved by resolve_personas(); the in-container

--- a/tests/bridges/nextcloud/test_posting.py
+++ b/tests/bridges/nextcloud/test_posting.py
@@ -239,6 +239,19 @@ def test_answer_posts_the_channel_error_wording_for_a_failed_run():
     assert talk.texts == [ERROR_TEXT]
 
 
+def test_the_error_wording_claims_nothing_about_the_machine():
+    """A failed run is not evidence that the machine is untouched.
+
+    "error", "timeout" and "cancelled" all reach this notice, and a run can be
+    approved a write and then time out on its way to reporting it. Telling a
+    shared control-room conversation that nothing was changed would be a safety
+    assurance the bridge has no way to check — the Google adapter's notice
+    makes no such claim either.
+    """
+    assert "Nothing was changed" not in ERROR_TEXT
+    assert "nothing was changed" not in ERROR_TEXT.lower()
+
+
 def test_answer_never_leaks_the_machine_error_into_the_room():
     ops, talk = _ops()
     ops.post_answer(entry(), RESULT_ERROR)

--- a/tests/cli/test_explicit_config_equivalence.py
+++ b/tests/cli/test_explicit_config_equivalence.py
@@ -48,11 +48,13 @@ which land with the tasks that cause them:
 that whole mapping (it resolves to an interpreter path), so it can never surface
 as a delta and needs no entry here.
 
-One more delta is declared that Requirement 1 did not foresee:
+Two more deltas are declared that Requirement 1 did not foresee.
 ``approval.tools.entry_publish`` reaches every render made from a preset that
-spells an ARIEL approval policy. The fixtures were frozen while that tool was
+spells an ARIEL approval policy; the fixtures were frozen while that tool was
 gated nowhere, so the leaf is genuinely new rather than a render the conversion
-moved.
+moved. ``web.feedback.email`` goes the other way: the three root presets
+stopped shipping a recipient, so every document they render carries ``""``
+where the frozen one carries the address the baseline shipped.
 
 One leaf is exempt from the table rather than declared in it. ``osprey build``
 answers the presets' ``container_runtime: auto`` with the runtime that served
@@ -323,6 +325,45 @@ def _entry_publish_deltas(*documents: str) -> tuple[Delta, ...]:
     )
 
 
+#: The feedback recipient the frozen renders carry. Spelled out rather than
+#: read from a fixture: a delta that derived its expectation from the documents
+#: it compares would assert nothing. It is a historical value — what the
+#: baseline shipped — and the change below is what retires it.
+_FROZEN_FEEDBACK_EMAIL = "thellert@lbl.gov"
+
+
+def _feedback_email_deltas(*documents: str) -> tuple[Delta, ...]:
+    """The feedback recipient the root presets stopped shipping.
+
+    ``web.feedback.email`` shipped a maintainer's own mailbox, so an
+    unconfigured deployment aimed its operators' reports — and the session
+    scrollback a report can carry — outside the facility. The presets now ship
+    it blank: no Email channel is offered until the deployment names a
+    recipient. The fixtures were frozen while the address was still shipped,
+    which is why the leaf reads as a difference here rather than as a render
+    the conversion changed.
+
+    ``hello-world`` names no ``web:`` block and gains nothing, so its cell is
+    absent below.
+
+    Args:
+        documents: The rendered documents the cell emits, ``root`` plus one per
+            persona.
+
+    Returns:
+        One delta per document.
+    """
+    return tuple(
+        Delta(
+            document=document,
+            path="web.feedback.email",
+            fixture=_FROZEN_FEEDBACK_EMAIL,
+            live="",
+        )
+        for document in documents
+    )
+
+
 #: The documents a control-assistant cell renders: the root config plus one per
 #: persona in the preset's roster.
 _CONTROL_ASSISTANT_DOCUMENTS = (
@@ -343,18 +384,27 @@ CELL_DELTAS: dict[str, tuple[Delta, ...]] = {
         Delta(document="root", path="hooks.debug", fixture=ABSENT, live=False),
         *_entry_publish_deltas("root"),
     ),
-    "ariel-standalone/unset": _standalone_catalog_delta() + _entry_publish_deltas("root"),
-    "channel-finder-standalone/in_context": _standalone_catalog_delta(),
-    "channel-finder-standalone/hierarchical": _standalone_catalog_delta(),
-    "channel-finder-standalone/middle_layer": _standalone_catalog_delta(),
+    "ariel-standalone/unset": _standalone_catalog_delta()
+    + _entry_publish_deltas("root")
+    + _feedback_email_deltas("root"),
+    "channel-finder-standalone/in_context": _standalone_catalog_delta()
+    + _feedback_email_deltas("root"),
+    "channel-finder-standalone/hierarchical": _standalone_catalog_delta()
+    + _feedback_email_deltas("root"),
+    "channel-finder-standalone/middle_layer": _standalone_catalog_delta()
+    + _feedback_email_deltas("root"),
     "control-assistant/in_context": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _feedback_email_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/hierarchical": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _feedback_email_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/middle_layer": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _feedback_email_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/graph": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _feedback_email_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
 }
 
 

--- a/tests/cli/test_explicit_config_partition.py
+++ b/tests/cli/test_explicit_config_partition.py
@@ -281,6 +281,16 @@ def test_preset_values_reach_the_render_unchanged(
             assert value == "auto"
             assert render[key] in {"docker", "podman"}
             continue
+        if key == "web.feedback.email":
+            # The root presets stopped shipping a recipient after the freeze:
+            # the prefilled draft can carry a session's scrollback, so the
+            # facility names the mailbox and an unconfigured deployment offers
+            # no Email channel. Exact in both directions — the preset must be
+            # blank and the frozen render must still carry what it shipped —
+            # so neither half can drift back without being noticed.
+            assert value == "", key
+            assert render[key], key
+            continue
         if key == "deployed_services":
             # The injectors append what the profile's sections deploy; what the
             # preset lists comes first and unchanged.

--- a/tests/cli/test_feedback_owner_advisory.py
+++ b/tests/cli/test_feedback_owner_advisory.py
@@ -38,12 +38,29 @@ class TestHalfMovedDestination:
         assert "web.feedback.github_repo" in advisories[0]
         assert "web.feedback.owner" in advisories[0]
 
-    def test_a_moved_repo_with_an_upstream_email_is_named(self):
-        advisories = feedback_owner_advisories(
-            _config(email=DEFAULT_FEEDBACK_EMAIL, github_repo=FACILITY_REPO)
-        )
+    def test_a_moved_email_with_an_unspelled_repo_is_named(self):
+        """Absent is not silence: the tracker default still aims upstream."""
+        advisories = feedback_owner_advisories(_config(email=FACILITY_EMAIL))
         assert len(advisories) == 1
-        assert DEFAULT_FEEDBACK_EMAIL in advisories[0]
+        assert DEFAULT_FEEDBACK_GITHUB_REPO in advisories[0]
+
+    def test_a_moved_repo_beside_the_shipped_email_is_silent(self):
+        """The shipped mail default is blank, so it is a retired channel.
+
+        There is no "upstream email" half to leak: a deployment that names its
+        own tracker and says nothing about mail offers no mail channel, which
+        is a coherent posture rather than a half-finished edit.
+        """
+        assert (
+            feedback_owner_advisories(
+                _config(email=DEFAULT_FEEDBACK_EMAIL, github_repo=FACILITY_REPO)
+            )
+            == []
+        )
+
+    def test_a_moved_repo_beside_an_unspelled_email_is_silent(self):
+        """Absent reads as the shipped default, and the shipped default is blank."""
+        assert feedback_owner_advisories(_config(github_repo=FACILITY_REPO)) == []
 
     def test_moving_both_is_silent(self):
         assert (
@@ -81,8 +98,8 @@ class TestRetiredChannelsAreNotHalfMoves:
         """A retired channel delivers nothing, so it cannot be the leaking half."""
         assert feedback_owner_advisories(_config(email=FACILITY_EMAIL, github_repo="")) == []
 
-    def test_a_retired_repo_beside_an_upstream_email_is_silent(self):
-        """Neither channel reaches a facility; that is the shipped posture."""
+    def test_a_retired_repo_beside_the_shipped_email_is_silent(self):
+        """Neither channel reaches anyone; that is the air-gapped posture."""
         assert (
             feedback_owner_advisories(_config(email=DEFAULT_FEEDBACK_EMAIL, github_repo="")) == []
         )

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -47,30 +47,37 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # ARIEL server and has no approval table for it, so it alone stands still.
     # A rebuilt project prompts before a publish, so the staleness advisory
     # firing on already-deployed projects is the correct signal.
-    "ariel-standalone": ("sha256:2522f525c8850daf2915e59b898a13269d1c924d59d0d0f868b219a2b8e72c6d"),
+    # The fifth move, and again not every preset: the three root presets stopped
+    # shipping a feedback recipient. `web.feedback.email` carried a maintainer's
+    # own mailbox, and the prefilled draft it receives can carry a session's
+    # scrollback, so an unconfigured deployment now offers no Email channel at
+    # all and the facility names the recipient. The five control-assistant
+    # personas inherit the root preset and move with it; hello-world names no
+    # `web:` block and stands still.
+    "ariel-standalone": ("sha256:388c3db8e75bbf31519c1b9fa1a30483c6a42221a18758bc7f5ff4a6f40500f0"),
     "channel-finder-standalone": (
-        "sha256:5c5d670fb6d048e854dfa5ecff9b02d6b9bf504a4cd574d6a5f66b34e18e3fa1"
+        "sha256:e9191d66287745d731fd238b3893677d8a16426a4a17c495b9e2086f42b6e77d"
     ),
     "control-assistant": (
-        "sha256:e1cd276ba9e3062452b5afe86daed341be5c8cfa12b6a992d7b4ea0e33c2ff05"
+        "sha256:6feee637a96e871ee57f437375eead18cc5fd5652345cb918d9ede9a91e9c68c"
     ),
     "control-assistant-admin": (
-        "sha256:c29f07d93cee491afda6276603d5a86a9cf0e919960ba598f78c8906e419eb3c"
+        "sha256:85556bc278e3fc27e323a5c4699a1ccb9119d503ed535dbe7bc3a1d31db1ac02"
     ),
     "control-assistant-knowledge": (
-        "sha256:84fb320d701ef1d14d18155c0c59dfff4b2bcc2d5441175733f7fb6d2aad90f0"
+        "sha256:3a2664feecf9f4a22cd8a0e10d90d8ca39c99aa647863f2fadcd1c2c4584f7b1"
     ),
     "control-assistant-logbook": (
-        "sha256:a63cee6c479a8bee82c1f6e261b921ea96708226cb9e0d331d52d9e800b195e4"
+        "sha256:e52cb8666629459d370f47264ee6737805dc6d00b113ba3108646d09e37a05e9"
     ),
     "control-assistant-readonly": (
-        "sha256:99a75fd3714a9114fd527724b77de6b7bd36aac571b821882b8903be6c626c3c"
+        "sha256:19fc54cb889725e742a1b7d44a8a8e9ae4b74506c9e47ed22c5c991c366ac6f3"
     ),
     "control-assistant-readwrite": (
-        "sha256:3a8c88791900e5c0d7bff064db59f65a1244dd07425a90e1e17301311aa63a19"
+        "sha256:3ea78f64f7e5dbffacdca537465ebdc9530917ffb938760b83a36ad754f49691"
     ),
     "control-assistant-va-readwrite": (
-        "sha256:93c34788a885b8013162c85bb9f39fd506b6950c210fc8f07ae1579e13f42f20"
+        "sha256:71c9c770a0cfc611e06d38228b8cc797225a408f55ea02ecd31af7bcaf8bff05"
     ),
     "hello-world": ("sha256:5f23b2a31f03c885b20dae82781aa87efda81db3960d6865c3bc93e54e4ca837"),
 }

--- a/tests/deployment/goldens/exemplar-profile/profile.yml
+++ b/tests/deployment/goldens/exemplar-profile/profile.yml
@@ -801,8 +801,10 @@ config:
   #   - kind: gitlab
   #     url: https://git.example.org/controls/osprey
   #     label: Facility GitLab
-  # Recipient of the prefilled mailto: draft the Email channel opens.
-  web.feedback.email: thellert@lbl.gov
+  # Recipient of the prefilled mailto: draft the Email channel opens. Blank
+  # ships no Email channel: the draft can carry this session's scrollback,
+  # so name the mailbox this deployment's operators should reach.
+  web.feedback.email: ""
   # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
   # oldest saved session contexts are deleted; submission headers are kept.
   web.feedback.max_store_bytes: 268435456

--- a/tests/docs/test_shipped_identity_literals.py
+++ b/tests/docs/test_shipped_identity_literals.py
@@ -1,0 +1,211 @@
+"""Guard: nothing OSPREY ships names a real person, site or institution.
+
+An operator reads the framework's own prose — an agent description, a log line,
+a `--help` example, a comment in a rendered compose file — as a statement about
+*their* deployment. When that prose carries the name of whoever happened to
+write it, it is wrong everywhere else, and it is wrong in the one place a
+deployer cannot edit: files that `osprey init --force` and `profile expand`
+regenerate.
+
+The rule this pins is therefore not "fewer names" but "no identities": shipped
+text under ``src/osprey/`` and ``docs/source/`` names no real person, mailbox,
+institution or site. Magnitudes stay — "~135,000 documents", "~41 minutes" —
+because they are facts about the software's behaviour rather than about whose
+machine produced them. Examples use the placeholder cast the roster
+documentation already uses: ``alice`` and ``carol`` at ``example.org``, a
+facility called *Example Research Facility*, a ``simulation`` gateway, a
+project at ``~/my-assistant``.
+
+Removing a literal is a one-line edit; keeping it removed is what needs a
+guard, because every new pull request is an opportunity to add one back and
+nothing else would notice.
+
+**The list grows.** It starts at what has actually been swept out of the tree,
+because a pattern that fires on the current tree is not a guard, it is a
+failing test. As each remaining literal is removed, its pattern joins
+:data:`DENIED` in the same change that removes it: the maintainers' gateway
+host, ``lbl.gov``, ``\\bALS\\b`` and ``ALS-U`` outside the simulation and
+virtual-accelerator packages, ``BELLA``, ``GEECS``.
+
+Three kinds of surface legitimately name an institution and will need an
+``allow`` entry rather than an edit when their patterns land: the shipped
+provider adapters for named LLM gateways, the named ingestion adapter, and the
+packaging and escalation metadata that has to spell the upstream project's own
+``owner/repo``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Everything OSPREY ships that a deployer or operator can read. Code and
+#: comments as much as documentation: a rendered template's comment reaches a
+#: deployment, and a docstring reaches the API reference.
+ROOTS = ("src/osprey", "docs/source")
+
+SCAN_SUFFIXES = (
+    ".py",
+    ".md",
+    ".rst",
+    ".txt",
+    ".j2",
+    ".yml",
+    ".yaml",
+    ".json",
+    ".toml",
+    ".sh",
+    ".js",
+    ".html",
+    ".css",
+)
+
+
+@dataclass(frozen=True)
+class Denied:
+    """One identity the shipped tree may not name."""
+
+    name: str
+    """How the guard's failure message calls it."""
+
+    pattern: re.Pattern[str]
+    """What a reintroduction looks like."""
+
+    why: str
+    """What is wrong with shipping it, in one clause."""
+
+    sample: str
+    """A line this pattern must match, so a broken pattern cannot read as a
+    clean tree."""
+
+    allow: frozenset[str] = frozenset()
+    """Repo-relative paths that may keep it, each for a stated reason."""
+
+
+#: The identities already swept out of ``src/osprey`` and ``docs/source``.
+#: Each entry is here because the tree is clean of it *now*; see the module
+#: docstring for the ones still to come.
+DENIED: tuple[Denied, ...] = (
+    Denied(
+        name="maintainer account",
+        pattern=re.compile(r"thellert", re.IGNORECASE),
+        why="a maintainer's own login and mailbox is not an example anyone can copy",
+        sample='  # bare username, e.g. "thellert"',
+    ),
+)
+
+
+def _shipped_sources() -> list[Path]:
+    files: list[Path] = []
+    for root in ROOTS:
+        base = _REPO_ROOT / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+                continue
+            if "__pycache__" in path.parts:
+                continue
+            files.append(path)
+    return files
+
+
+def _hits(denied: Denied) -> list[tuple[str, int, str]]:
+    """Every ``(repo-relative path, line number, stripped line)`` naming it."""
+    found: list[tuple[str, int, str]] = []
+    for path in _shipped_sources():
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:  # pragma: no cover - defensive
+            continue
+        if not denied.pattern.search(content):
+            continue
+        relative = str(path.relative_to(_REPO_ROOT))
+        for number, line in enumerate(content.splitlines(), start=1):
+            if denied.pattern.search(line):
+                found.append((relative, number, line.strip()))
+    return found
+
+
+@pytest.mark.parametrize("denied", DENIED, ids=lambda d: d.name)
+def test_no_shipped_text_names_a_real_identity(denied: Denied) -> None:
+    offenders = [hit for hit in _hits(denied) if hit[0] not in denied.allow]
+    assert offenders == [], (
+        f"shipped text names {denied.name} — {denied.why}. "
+        f"Use the placeholder cast (alice/carol@example.org, Example Research "
+        f"Facility, ~/my-assistant, simulation) instead:\n"
+        + "\n".join(f"{path}:{number}: {line}" for path, number, line in offenders)
+    )
+
+
+@pytest.mark.parametrize("denied", DENIED, ids=lambda d: d.name)
+def test_every_exemption_still_has_something_to_explain(denied: Denied) -> None:
+    """An exemption whose file stopped carrying the literal should be deleted.
+
+    Otherwise the allowlist quietly becomes a list of files the guard does not
+    cover, which is the failure mode a guard is written to prevent.
+    """
+    seen = {path for path, _, _ in _hits(denied)}
+    stale = sorted(denied.allow - seen)
+    assert stale == [], f"{denied.name}: exemptions with no remaining occurrence: {stale}"
+
+
+@pytest.mark.parametrize("denied", DENIED, ids=lambda d: d.name)
+def test_the_sweep_would_catch_a_regression(
+    denied: Denied, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sweep that finds nothing reads exactly like one whose pattern is dead.
+
+    Each entry carries the line it must trip on, so a pattern that is edited
+    into uselessness fails here rather than reporting a clean tree forever.
+    """
+    fake_root = tmp_path / "repo"
+    (fake_root / "src" / "osprey").mkdir(parents=True)
+    (fake_root / "src" / "osprey" / "regress.py").write_text(
+        f"# {denied.sample}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(f"{__name__}._REPO_ROOT", fake_root, raising=True)
+
+    with pytest.raises(AssertionError, match="shipped text names"):
+        test_no_shipped_text_names_a_real_identity(denied)
+
+
+def test_the_placeholder_cast_is_not_swept() -> None:
+    """The names the rule tells an author to use must survive the rule.
+
+    A guard that condemned its own replacement text would push the next author
+    back to a real one.
+    """
+    placeholders = (
+        "alice@example.org",
+        "carol@example.org",
+        "Example Research Facility",
+        "~/my-assistant",
+        "epics_gateway=simulation",
+    )
+    for denied in DENIED:
+        for placeholder in placeholders:
+            assert not denied.pattern.search(placeholder), (
+                f"{denied.name} condemns the placeholder {placeholder!r}"
+            )
+
+
+def test_the_sweep_reaches_shipped_templates_and_docs() -> None:
+    """The guard has to cover the surfaces the literals actually lived in.
+
+    A rendered template's comment and a how-to page are exactly where an
+    identity survives review, and both would be missed by a rule written for
+    ``.py`` alone.
+    """
+    scanned = {str(path.relative_to(_REPO_ROOT)) for path in _shipped_sources()}
+    for required in (
+        "src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2",
+        "src/osprey/profiles/presets/control-assistant.yml",
+        "docs/source/how-to/web-terminal/multi-user/login.rst",
+    ):
+        assert required in scanned, f"{required} is shipped but the sweep cannot see it"

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -961,8 +961,10 @@ config:
   #     url: https://git.example.org/controls/osprey
   #     label: Facility GitLab
   # Recipient of the prefilled mailto: draft the Email channel opens. Wins
-  # over `owner.email` above, on the same grounds as `github_repo`.
-  web.feedback.email: thellert@lbl.gov
+  # over `owner.email` above, on the same grounds as `github_repo`. Blank
+  # ships no Email channel: the draft can carry this session's scrollback,
+  # so name the mailbox this deployment's operators should reach.
+  web.feedback.email: ""
   # Ceiling in bytes on the on-disk feedback store (256 MB). Above it the
   # oldest saved session contexts are deleted; submission headers are kept.
   web.feedback.max_store_bytes: 268435456

--- a/tests/interfaces/web_terminal/test_feedback_config.py
+++ b/tests/interfaces/web_terminal/test_feedback_config.py
@@ -119,6 +119,16 @@ class TestFeedbackConfigDefaults:
                 {"kind": "github", "label": "GitHub", "repo": DEFAULT_FEEDBACK_GITHUB_REPO}
             ]
 
+    def test_no_mailbox_ships_as_the_default_recipient(self):
+        """The unconfigured deployment offers no Email channel at all.
+
+        A prefilled feedback draft can carry a session's scrollback, so who
+        receives it is the deployment owner's decision and never the
+        framework's. Unconfigured, the Email channel is retired and the issue
+        tracker is the only channel the dialog offers.
+        """
+        assert DEFAULT_FEEDBACK_EMAIL == ""
+
     def test_default_ceiling_is_256_mb(self):
         """The documented default, spelled out so a silent change is caught."""
         assert DEFAULT_FEEDBACK_MAX_STORE_BYTES == 268435456

--- a/tests/registry/test_pyat_specialist_agent.py
+++ b/tests/registry/test_pyat_specialist_agent.py
@@ -19,6 +19,7 @@ All template assertions pin what the artifacts actually contain (truthful pins).
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +29,19 @@ from osprey.registry.mcp import FRAMEWORK_AGENTS, resolve_agents, resolve_server
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+#: Where the shipped subagent files live, so the frontmatter pin reads the
+#: same file the build renders rather than a copy of its text.
+AGENT_TEMPLATE_ROOT = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "osprey"
+    / "templates"
+    / "claude_code"
+    / "claude"
+    / "agents"
+)
 
 
 def _base_ctx(**overrides):
@@ -63,6 +77,30 @@ class TestPyatSpecialistAgentCatalog:
     def test_description_is_non_empty(self):
         adef = FRAMEWORK_AGENTS["pyat-specialist"]
         assert adef.description
+
+    def test_the_description_names_no_particular_machine(self):
+        """This sentence is rendered into every persona's prompt, everywhere.
+
+        It is the framework speaking about a framework agent, so it can only
+        say what the agent computes against — the lattice model this
+        deployment configured. Naming the ring the shipped demo data happens
+        to hold tells an operator at any other facility that the answer came
+        from someone else's machine.
+        """
+        description = FRAMEWORK_AGENTS["pyat-specialist"].description
+        assert "the deployment's configured lattice model" in description
+        assert "ALS" not in description
+
+    def test_the_shipped_agent_file_repeats_the_registry_description(self):
+        """One sentence, two spellings — the frontmatter and the registry.
+
+        The agent file's `description:` is what Claude Code itself reads when
+        choosing a subagent; the registry's is what the roster in CLAUDE.md
+        renders. Drift between them is invisible until an operator compares
+        two prompts, so it is pinned instead.
+        """
+        template = (Path(AGENT_TEMPLATE_ROOT) / "pyat-specialist.md.j2").read_text(encoding="utf-8")
+        assert FRAMEWORK_AGENTS["pyat-specialist"].description in template
 
     def test_server_dependency_is_python(self):
         """pyat-specialist computes via mcp__python__execute — it needs the python server."""

--- a/tests/services/channel_finder/graph_index/test_writer.py
+++ b/tests/services/channel_finder/graph_index/test_writer.py
@@ -12,6 +12,7 @@ previous file byte-identical and no temporary file behind.
 
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -263,6 +264,22 @@ class TestReport:
         assert report.path.exists()
 
 
+#: The logger the builder warns on. The two assertions below are about what
+#: *the builder* says, so they read that logger by name rather than everything
+#: `caplog` happens to hold: the root capture picks up whatever else in the
+#: process logs during the window — an audit refusal from a server another test
+#: left running, a config reader on a worker shared under `-n auto` — and
+#: "somebody warned" would fail a test about a corpus that builds cleanly. The
+#: claims are unchanged: exactly one warning for an empty corpus, none for a
+#: populated one.
+_BUILDER_LOGGER = "osprey.services.channel_finder.graph_index.builder"
+
+
+def _builder_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """The WARNING records the graph-index builder itself emitted."""
+    return [r for r in caplog.records if r.name == _BUILDER_LOGGER and r.levelname == "WARNING"]
+
+
 class TestEmptyCorpus:
     @pytest.fixture
     def parsed(self) -> ParsedCorpus:
@@ -281,18 +298,18 @@ class TestEmptyCorpus:
 
     def test_it_warns(self, parsed: ParsedCorpus, tmp_path: Path, caplog):
         path = tmp_path / "graph.duckdb"
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("WARNING", logger=_BUILDER_LOGGER):
             _build(parsed, path)
-        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        warnings = _builder_warnings(caplog)
         assert len(warnings) == 1
         assert str(path) in warnings[0].getMessage()
 
     def test_a_corpus_with_bindings_does_not_warn(
         self, chain: ParsedCorpus, tmp_path: Path, caplog
     ):
-        with caplog.at_level("WARNING"):
+        with caplog.at_level("WARNING", logger=_BUILDER_LOGGER):
             _build(chain, tmp_path / "graph.duckdb")
-        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+        assert _builder_warnings(caplog) == []
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
Removes the three operator-facing identity and safety literals that block a
rollout at a site other than the one this was written at, and adds the guard
that stops the next one being added.

- `fix(feedback): ship no default recipient`
- `chore(registry): describe the lattice agent by the model it is given`
- `fix(bridges): drop the unverifiable "nothing was changed" claim`
- `chore: use placeholder identities in shipped examples`
- `test: pin that shipped prose names no real identity`
- `test(channel-finder): scope the graph-index warning pins to the builder`

## Why

Three things shipped that were only true for the people who wrote them, and a
deployer could not fix any of them by editing a file the build regenerates.

The feedback dialog's mail draft — which can carry a session's scrollback —
had a named mailbox as its default recipient, so an unconfigured deployment
sent its operators' reports outside the facility. `web.feedback.email` now
ships blank at every site that spells it (the constant, the three root presets,
the key manifest, the configuration reference): no Email channel is offered
until the deployment names one, the issue tracker still is, and
`osprey feedback list` / `export` still record locally. The build's
half-redirected-destination advisory follows, judging each setting on its
effective value so a blank shipped default reads as a retired channel rather
than as the half that leaks upstream.

The pyAT lattice agent described itself as computing against one particular
storage ring, in a sentence that reaches every persona's prompt and the
harness's subagent choice. It now says the deployment's configured lattice
model, in both the registry and the subagent file, pinned to each other.

The Nextcloud bridge told a room "Nothing was changed." for any status that was
not `completed` — which covers a run that was approved a write and then timed
out. That is a safety assurance the bridge cannot check, so it is gone; the
sibling Google Chat adapter never made the claim.

A deployer can now stand a deployment up without editing a regenerated file to
remove someone else's mailbox, without a lattice agent claiming to model a ring
they do not have, and without a bridge asserting their machine is untouched.
The guard is what keeps it that way: it sweeps `src/osprey/` and `docs/source/`
for a table of denied identities and reports file and line. The table starts at
what the tree is provably clean of — a pattern that fires today is a failing
test, not a guard — and each remaining literal joins it in the change that
removes it; the module names which are still to come and which surfaces will
need an exemption instead of an edit.

The last commit is unrelated to the above: two graph-index warning assertions
read every record `caplog` held rather than the builder's own logger, so any
other component logging a warning in the same worker failed a test about a
corpus that builds cleanly. It failed a full local sweep here. Fixed at the
assertion, not weakened: the claims are still "exactly one warning for an empty
corpus, none for a populated one", and injecting the observed foreign warnings
fails both tests before the change and neither after it.

## Not in this PR

- The rest of the shipped-prose sweep: the container log line, the core
  rationale comments, the named external installations, the `--help` canon and
  the gateway shorthand table, the demo skills and the first-run artifact, the
  knowledge-bundle placeholder markers. Each adds its own denylist pattern when
  it lands.
- The one-paragraph statement that framework chrome is English and
  facility-authored markdown is the localisation seam. i18n itself is ruled
  out: no locale key, no catalogues, no per-bridge wording overrides.
- `web.feedback.github_repo`, which keeps the upstream tracker as the
  documented escalation channel; only the mail default changes here.
- The demo ring inside the simulation package, and whether the lattice agent
  gains a configurable lattice path.
