### PR TITLE
feat(release): first-class pre-release tags + housekeeping preset-parity lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,14 @@ jobs:
         VERSION="${GITHUB_REF#refs/tags/v}"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Version: $VERSION"
+        # Anything that is not exactly X.Y.Z is a pre-release (b1/rc1 suffixes).
+        # Same rule as docs_publish.py's RELEASE_TAG_RE: the stable grammar is
+        # the whitelist, everything else must not be advertised as latest.
+        if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        else
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        fi
 
     - name: Extract release notes from CHANGELOG
       id: changelog
@@ -180,7 +188,7 @@ jobs:
         name: Release v${{ steps.get_version.outputs.version }}
         body_path: release_notes.md
         draft: false
-        prerelease: false
+        prerelease: ${{ steps.get_version.outputs.prerelease == 'true' }}
 
 # The former publish-connectors-to-pypi job (its own osprey-connectors-v* tag,
 # its own static-version check) is retired: the connectors package now versions

--- a/changelog.d/beta-release-support.added.md
+++ b/changelog.d/beta-release-support.added.md
@@ -1,0 +1,6 @@
+Pre-release tags are now first-class: tagging `vYYYY.M.PbN` (or `rcN`) builds
+and publishes a correctly named beta, marks the GitHub Release as a
+pre-release, keeps the docs site on the last stable release, and deployment
+pins keep the pre-release segment instead of naming a version that does not
+exist. The release skill documents the beta channel and the staged-release
+workflow.

--- a/changelog.d/housekeeping-preset-lane.added.md
+++ b/changelog.d/housekeeping-preset-lane.added.md
@@ -1,0 +1,4 @@
+The `housekeeping` skill gained a fifth lane: the shipped preset family. It
+checks that `hello-world` and `control-assistant` still agree with each other
+and with the app templates they select, which nothing in the build compares
+today.

--- a/plugins/osprey/.claude-plugin/plugin.json
+++ b/plugins/osprey/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.4",
+  "version": "2026.9.5",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "author": {
     "name": "ALS Accelerator Physics Group",

--- a/plugins/osprey/.codex-plugin/plugin.json
+++ b/plugins/osprey/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.4",
+  "version": "2026.9.5",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/osprey/skills/housekeeping/SKILL.md
+++ b/plugins/osprey/skills/housekeeping/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Use when a maintainer wants to know where OSPREY tells its users something that is no
   longer true — before cutting a release, after a long stretch of merges without one, or when
   the generated project, a shipped skill, a runtime message, or a pinned version is suspected
-  of having fallen behind the code. Triggers: "run housekeeping", "check for drift", "what has
-  rotted", "is anything stale", "housekeeping report", "sweep the repo", "what maintainer
+  of having fallen behind the code — or when two shipped presets that are supposed to agree
+  (hello-world and control-assistant) may have drifted apart. Triggers: "run housekeeping",
+  "check for drift", "what has rotted", "is anything stale", "housekeeping report", "sweep the
+  repo", "preset parity", "do the presets still agree", "what maintainer
   chores are outstanding", "pre-release drift check". Prefer it over ad-hoc grepping whenever
   the question is "has anything drifted" rather than "fix this one thing". Doc-page prose is
   not this skill's job; that is osprey:doc-sync.
@@ -39,8 +41,8 @@ a sibling skill's entire output was lost once.
 ## What counts as drift
 
 A promise is any text a person outside this repository reads and believes. OSPREY makes them in
-four places that are not doc pages, and each is one lane. Drift is any gap between a promise
-and reality.
+five places that are not doc pages, and each is one lane. Drift is any gap between a promise
+and reality — or, in lane E, between two promises that ship as a set.
 
 ```
    lane   the promise                                  reality
@@ -56,7 +58,31 @@ and reality.
             (CLI output, errors, banners,
              stamped headers in written files)
     D     pinned versions in source          ←→        what is current out in the world
+    E     the shipped preset family          ←→        each other, and the app
+            (profiles/presets/*.yml and                templates they select
+             the templates/apps/ trees)
 ```
+
+Lane E is the odd one: both sides are text that ships, and neither of them is the code. The
+presets are a family rather than a list — `hello-world` is the deliberate teaching subset of
+`control-assistant`, and says so in its own comments — and each preset also owes agreement to
+the app template it selects.
+
+It rots unseen for a precise reason, and knowing it tells you where to look. Each preset's
+*resolved* content is hash-pinned, so changing a value is a deliberate, deploy-visible event
+that a test makes someone acknowledge. Comments are not resolved content, so they do not move
+that hash: every claim a preset makes in prose is invisible to the entire suite. The failure
+this produces is a commit that correctly updates a list, correctly updates the pinned digest,
+and leaves the sentence four lines above it describing the old list. Provider parity and the
+config-drift hook are pinned separately; do not re-check those. What is unguarded is the prose:
+a header comment that counts its own hooks, a cross-reference to a sibling that no longer holds,
+and a change that lands in a preset and its app bundle but not in that bundle's own README or
+`config.yml.j2`. Check the subset relation in the direction that matters — a hook or rule
+`hello-world` carries that `control-assistant` lacks inverts the teaching relationship, and is a
+finding rather than a curiosity. An omission the preset explains in a comment is not drift; an
+omission nothing accounts for is. The same self-counting claims are repeated on the tutorial
+page that teaches the preset; those belong to doc-sync, so hand them over rather than verify
+them here.
 
 Doc pages under `docs/source/` are **osprey:doc-sync**'s territory, including a doc page that
 documents a dead CLI flag. If a lane trips over one, note it under "handed to doc-sync" and
@@ -81,6 +107,7 @@ unresolved`. An unresolved anchor is not an obstacle, it is the first finding, f
 | console-script entry in `pyproject.toml` | the CLI root |
 | `src/osprey/templates/` | what becomes a user's generated project |
 | `plugins/osprey/skills/` | the skills that ship to facilities |
+| `src/osprey/profiles/presets/` | the preset family lane E compares |
 | `tests/docs/` | where accepted findings become guards |
 | `git describe --tags --abbrev=0 --match 'v*'` | the baseline release tag |
 | `.claude/housekeeping/decisions.md` | past rulings |
@@ -103,7 +130,7 @@ because a tag is the moment that text goes public.
 
 ### 2. Hunt in parallel, file-mediated
 
-Fan out with the Agent tool, one agent per lane, four in all. Prefer a read-only agent type; an instruction can be disregarded, a missing tool cannot.
+Fan out with the Agent tool, one agent per lane, five in all. Prefer a read-only agent type; an instruction can be disregarded, a missing tool cannot.
 Give each the same brief: find where this surface disagrees with the code, prove it, return few
 findings.
 
@@ -131,6 +158,9 @@ tally. The scratch directory survives the runner; a mental note does not.
   another; token-level grep gives noise at about forty percent.
 - **Follow a verb-string grep with a grep on the underlying function name**, or a literal search
   manufactures a false positive.
+- **Count what a comment counts.** A preset that describes its own contents ("a mock control
+  system, eleven hooks, and no containers") is making a claim that is checked by parsing the
+  file and counting, never by reading the sentence and believing it.
 - **If you cannot write the fix, it is not a finding.** It is a complaint. Drop it.
 
 ### 4. Filter against past decisions
@@ -171,7 +201,7 @@ skill.
 
 ## Budget
 
-Four lanes, more only when the maintainer asks for a deeper look at one surface. Several narrow
+Five lanes, more only when the maintainer asks for a deeper look at one surface. Several narrow
 agents beat one that tries to hold the whole repo. Stop when findings stop being
 interesting rather than at a count: past roughly the eighth finding a report is skimmed, and a
 skimmed report is no report. Under-reporting is the safer error.

--- a/plugins/osprey/skills/release/SKILL.md
+++ b/plugins/osprey/skills/release/SKILL.md
@@ -8,8 +8,9 @@ description: >
   a release", "bump the version", "cut v2026.X.Y", "publish to PyPI", "tag a
   release", or asks about the release process. Composes with `/osprey:contribute`
   for the notes PR and with `/osprey:housekeeping` and `/osprey:doc-sync` for the
-  sweeps. Versions follow CalVer (vYYYY.M.P) and the source of truth is the git
-  tag — Hatch derives the version from it, so there is no version literal to bump.
+  sweeps. Versions follow CalVer (vYYYY.M.P), with PEP 440 pre-release tags
+  (vYYYY.M.PbN / rcN) for public betas, and the source of truth is the git tag —
+  Hatch derives the version from it, so there is no version literal to bump.
 allowed-tools: Read, Glob, Grep, Bash, Edit
 ---
 
@@ -44,6 +45,45 @@ OSPREY uses **CalVer**: `YYYY.M.P` where:
 
 Examples: `2026.5.0`, `2026.5.1` (patch within May 2026), `2026.6.0` (next
 month). When the year or month rolls over, `P` resets to `0`.
+
+### Pre-releases: beta and RC tags
+
+A public beta is an ordinary release whose tag carries a PEP 440 pre-release
+segment on the patch component: `v2026.9.0b1`, then `b2` if needed, then
+`rc1` for a feature freeze, then the plain `v2026.9.0` (or the next month's
+`.0` if the final slips a month — CalVer tells the truth either way). The
+segment is appended directly — never `-beta`, `-rc1`, or a dot — because the
+segment must survive two independent normalizers unchanged: `hatch-vcs`
+naming the wheel, and the release workflow comparing that wheel to the tag.
+PEP 440 orders the chain correctly: `b1 < b2 < rc1 < final`.
+
+Every step in this skill applies to a pre-release tag unchanged. The
+differences, each load-bearing:
+
+- **pip hides it by default.** Plain `pip install osprey-framework` keeps
+  resolving to the last stable release; the beta is reached only by
+  `--pre` or an exact `==` pin. That opt-in IS the beta channel — nothing
+  else has to be built for it.
+- **The connectors floor must name the pre-release.** Range specifiers
+  exclude pre-releases, so with a stable floor a beta framework wheel
+  resolves `osprey-connectors` to the OLD stable and ships skewed. In the
+  release-notes PR, set `osprey-connectors>=YYYY.M.PbN` in `pyproject.toml`
+  and regenerate the lockfile (`uv lock` — CI runs `uv lock --check`). The
+  final release afterwards moves the floor to its own stable version.
+- **The GitHub Release is marked pre-release automatically.** `release.yml`
+  classifies the tag (exactly `X.Y.Z` = stable, anything else = pre-release)
+  and sets the flag, so the beta never shows as "Latest".
+- **Docs do not publish.** `docs.yml` builds a pre-release tag but refuses to
+  deploy it: the site root and the version switcher stay on the last stable
+  release, and beta users read `/latest/`. Deliberate — do not "fix" it.
+- **The version module keeps the segment.** A clean checkout of the tag
+  reports `is_release()` true and pins `osprey-framework==YYYY.M.PbN`;
+  `tests/test_version.py::TestPreReleaseChannel` pins this. `base_version`
+  anywhere in new code is a bug factory here: it silently drops the segment
+  and manufactures pins to versions that do not exist.
+
+Say "public beta" in the `RELEASE_NOTES.md` tagline and the GitHub Release
+body; the tooling marks the channel, the prose sets the expectation.
 
 ## The Source of Truth
 
@@ -246,6 +286,29 @@ The PR title should be `release: vYYYY.M.P — <theme>`. The PR body should
 include the CHANGELOG entries verbatim so reviewers see exactly what's being
 released.
 
+### Holding the release open (the staged release)
+
+Prep and the go decision can be decoupled: everything up to here can be done
+early, and the open, green release-notes PR then sits one switch away —
+merge, tag, done, about an hour end to end (one CI cycle plus minutes of
+`release.yml`).
+
+While it holds, every batch that lands on `main` costs a refold, and skipping
+it is the one way this pattern ships a broken CHANGELOG: required checks do
+not go stale when `main` moves, so the merge button stays green while the
+newly landed fragments sit outside the rotated section — the "released
+section is missing entries" failure mode below. The refold is mechanical:
+
+1. Rebase the release branch on `main`.
+2. Run `apply` again — the new fragments fold into the fresh `## [Unreleased]`.
+3. Move those bullets down into the rotated `## [YYYY.M.P]` section, under
+   their type headings; `[Unreleased]` ends empty again.
+4. Push. This is one full CI cycle, and the push cancels the in-flight run,
+   so batch the refold rather than chasing every merge.
+
+Mind the repo's CI budget (three concurrent PR runs) when the held release
+PR re-runs beside other work.
+
 ## Step 5: Merge the PR
 
 Two status checks are required on `main`: `pre-commit.ci - pr` and
@@ -355,6 +418,7 @@ This is a fallback. The default path is the automated workflow.
 | `gh pr merge` fails with "not mergeable" | Stale checks because `main` moved | Merge or rebase `origin/main` into the release branch, push, wait for CI to re-run |
 | CI "plugin tree changed without a version bump" | A PR touched `plugins/osprey/` without `plugin_version.py bump` | Run the bump on that branch and push |
 | GitHub Release body is empty or wrong | CHANGELOG section heading didn't match the regex `release.yml` uses | Make sure the CHANGELOG heading is exactly `## [YYYY.M.P] - YYYY-MM-DD` |
+| `uv lock --check` fails on the release PR | The connectors floor (or any `pyproject.toml` edit) changed without regenerating the lockfile | Run `uv lock`, commit `uv.lock` in the same commit |
 | `changelog_fragments.py apply` exits 1 | A fragment filename is malformed or carries an unrecognized type | Rename it `<name>.<type>.md` using one of added/changed/deprecated/removed/fixed/security/internal |
 | Released section is missing entries, or fragments are still on `main` after the release | `apply` was not run before the rotation, or its deletions were not staged | Fold the leftover fragments into the released section by hand, delete them, and open a PR carrying just `CHANGELOG.md` and the fragment deletions (`git add -A changelog.d/ CHANGELOG.md`) |
 
@@ -363,9 +427,10 @@ This is a fallback. The default path is the automated workflow.
 - **Hotfix branches** — OSPREY uses GitHub Flow, no special hotfix branches.
   A hotfix is just a `fix/<short-kebab>` branch off `main`, PR'd back; then
   this skill cuts a follow-up release.
-- **Release candidates / beta tags** — not currently supported by
-  `release.yml`, which triggers on `v*.*.*` only. If you need an RC channel,
-  the workflow needs changes first.
+- Release candidates and beta tags are **in** scope — see "Pre-releases:
+  beta and RC tags" above. (An older revision of this skill claimed the
+  workflow ignores them; wrong twice — the `v*.*.*` glob matches `v2026.9.0b1`,
+  and the pipeline now handles the pre-release correctly.)
 - **Documentation builds** — `docs.yml` publishes the docs from the tag on
   its own: the site root shows the newest release and `main` publishes at
   `/latest/`. Nothing to run by hand unless the root did not pick up the new

--- a/src/osprey/version.py
+++ b/src/osprey/version.py
@@ -207,16 +207,25 @@ def get_release_version() -> str:
     pinning, since from a development checkout it names a release whose code is
     *not* what is running.
 
+    A pre-release segment is part of the release's name, not development noise:
+    ``2026.9.0b1.post5+g...`` descends from the published ``2026.9.0b1``, never from
+    a ``2026.9.0`` that does not exist yet. ``base_version`` alone would drop the
+    segment and every pin produced from a beta would name a phantom release.
+
     Returns:
-        A release version string, e.g. ``"2026.6.2"``. Never raises.
+        A release version string, e.g. ``"2026.6.2"`` or ``"2026.9.0b1"``. Never raises.
     """
     from packaging.version import InvalidVersion, Version
 
     running = get_running_version()
     try:
-        return Version(running).base_version
+        parsed = Version(running)
     except InvalidVersion:
         return running
+    release = parsed.base_version
+    if parsed.pre is not None:
+        release += f"{parsed.pre[0]}{parsed.pre[1]}"
+    return release
 
 
 def get_image_pin_version(dev_mode: bool) -> str:
@@ -290,9 +299,11 @@ def unreleased_pin_reason() -> str:
 def is_release() -> bool:
     """Report whether this build is exactly a tagged, clean release.
 
-    False for anything carrying distance, a pre/post/dev segment, a local segment,
+    False for anything carrying distance, a post/dev segment, a local segment,
     or uncommitted changes — and for an environment where the version could not be
-    resolved at all.
+    resolved at all. A clean tagged pre-release (``2026.9.0b1``) IS a release: it
+    is published on PyPI and installable by exact pin, which is all any caller of
+    this function goes on to do with it.
 
     Returns:
         True only when the running version is a published release.
@@ -303,6 +314,4 @@ def is_release() -> bool:
         parsed = Version(get_running_version())
     except InvalidVersion:
         return False
-    return not (
-        parsed.is_devrelease or parsed.is_postrelease or parsed.is_prerelease or parsed.local
-    )
+    return not (parsed.is_devrelease or parsed.is_postrelease or parsed.local)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -65,6 +65,15 @@ class TestDescribeParsing:
             == "2026.6.2.post783+g012345678"
         )
 
+    def test_a_pre_release_tag_parses_like_any_other(self):
+        # The beta channel's whole tag grammar: the PEP 440 segment rides the
+        # patch component, so describe output differs only in the tag text.
+        assert version_module._pep440_from_describe("v2026.9.0b1-0-g1234567") == "2026.9.0b1"
+        assert (
+            version_module._pep440_from_describe("v2026.9.0b1-5-g83fda5e60")
+            == "2026.9.0b1.post5+g83fda5e60"
+        )
+
     def test_unparseable_output_returns_none(self):
         assert version_module._pep440_from_describe("not-a-describe") is None
         assert version_module._pep440_from_describe("") is None
@@ -168,6 +177,35 @@ class TestResolutionChain:
         monkeypatch.setattr(version_module, "_version_from_stamp", lambda: "2026.6.2")
 
         assert get_running_version() == "2026.6.2"
+
+
+class TestPreReleaseChannel:
+    """A clean tagged beta is a release; everything derived keeps its segment.
+
+    ``get_release_version`` once returned ``base_version``, which drops ``b1``:
+    every pin produced from a beta install then named a version that does not
+    exist on PyPI, and ``is_release`` refused the tag outright, so the pin
+    producers would not even get that far. Both were found the day the first
+    beta (v2026.9.0b1) was prepared.
+    """
+
+    def test_clean_beta_tag_is_a_release(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.9.0b1")
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        assert get_running_version() == "2026.9.0b1"
+        assert is_release() is True
+
+    def test_release_version_keeps_the_pre_segment(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.9.0b1", extra_commits=3)
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        assert get_release_version() == "2026.9.0b1"
+        assert is_release() is False  # distance: a dev build past the beta
+
+    def test_dirty_beta_checkout_is_not_a_release(self, tmp_path, monkeypatch):
+        repo = _make_repo(tmp_path / "osprey", "v2026.9.0b1")
+        (repo / "pyproject.toml").write_text('[project]\nname = "osprey-framework"\n# dirty\n')
+        monkeypatch.setattr(version_module, "_SOURCE_ROOT", repo)
+        assert is_release() is False
 
 
 class TestUnresolvableEnvironment:


### PR DESCRIPTION
## What

Makes pre-release tags (`vYYYY.M.PbN` / `rcN`) first-class through the whole release
pipeline, ahead of cutting v2026.9.0b1, and ships the housekeeping skill's new
preset-parity lane.

### Pre-release support

- **`osprey.version`**: a clean checkout of a pre-release tag now reports
  `is_release() == True`, and `get_release_version()` keeps the PEP 440 pre-release
  segment. Previously a beta install refused to pin, and every produced pin named a
  version that does not exist on PyPI (`base_version` drops `b1`). Pinned by the new
  `tests/test_version.py::TestPreReleaseChannel`.
- **`release.yml`**: the GitHub Release is now marked `prerelease` for any tag that is
  not exactly `vX.Y.Z` (same grammar rule as `docs_publish.py`'s `RELEASE_TAG_RE`).
  Previously `prerelease: false` was hardcoded and a beta would have been advertised
  as the latest stable release.
- **Release skill**: new "Pre-releases: beta and RC tags" section (tag grammar, pip
  opt-in semantics, the connectors-floor bump the release PR must carry, docs
  posture) and a "Holding the release open" section (staged release PR + the
  per-batch refold recipe). Corrects the out-of-scope note that claimed the workflow
  ignores beta tags — the `v*.*.*` glob matches them.

Verified end to end on a locally tagged clone: both wheels build as exactly
`2026.9.0b1`, and the fixed version module reports running/release/pin correctly on
that checkout.

### Housekeeping lane E

The housekeeping skill gains a fifth lane: the shipped preset family. It compares the
presets with each other and with the app templates they select — the one drift class
where both sides are shipped text and neither is the code. Preset content hashes are
pinned over *resolved* YAML, so comments never move them; the motivating case is a
commit that updated a preset's hook list and pinned digest while the sentence four
lines above kept counting the old list.

Plugin version: 2026.9.4 → 2026.9.5 (one bump covers both skill changes).

## Test plan

- `tests/test_version.py` (22, incl. 4 new pre-release cases) green
- `tests/plugins/` (33) green
- `tests/deployment/test_container_lifecycle.py` + `tests/scripts/test_docs_publish.py` (258) green
- ruff + mypy clean; `quick_check.sh` before commit
