### PR TITLE
staging: pre-release fixes for v2026.9.0b1 (rolling umbrella)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE.txt)
 [![DOI](https://img.shields.io/badge/DOI-10.1063%2F5.0306302-blue)](https://doi.org/10.1063/5.0306302)
+[![Documentation](https://img.shields.io/badge/docs-als--apg.github.io%2Fosprey-blue)](https://als-apg.github.io/osprey)
 
 **An agentic interface to scientific control systems.**
 

--- a/changelog.d/882.security.md
+++ b/changelog.d/882.security.md
@@ -1,0 +1,1 @@
+`phoebus_drive` now honors the control-system writes kill switch (`control_system.writes_enabled` / per-connector `writes_enabled`) ahead of the approval gate, like every other write path. Previously a panel drive was gated on operator approval only (#882).

--- a/changelog.d/release-skill-condense.changed.md
+++ b/changelog.d/release-skill-condense.changed.md
@@ -1,0 +1,5 @@
+The release skill's notes-PR step now includes the maintainer's changelog
+condensation pass (collapse supersession chains, merge per-surface snippets,
+drop what a later reader cannot act on), sequenced after the final fold; the
+phantom-section and connectors-floor instructions are corrected to the shapes
+the changelog gate and the resolvers actually accept.

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -3,6 +3,14 @@ Getting Started
 
 Welcome to Osprey Framework! This comprehensive guide will take you from zero to building production-ready control system agents, with working results at every step.
 
+.. tip::
+
+   The fastest path to a deployment for your own facility is the **guided
+   installer** — a conversation with your coding agent that inventories what
+   you have and builds the project with you: :doc:`osprey-install`. The
+   tutorials below cover the same ground step by step and remain the best way
+   to learn the concepts.
+
 **What You'll Accomplish**
 --------------------------
 
@@ -65,7 +73,7 @@ By following this comprehensive learning path, you'll have:
       **Outcome:**
       Your first working agent
 
-   .. grid-item-card:: 🎯 3. Install and Set Up
+   .. grid-item-card:: 🎯 3. Install and Set Up — ⭐ recommended
       :link: osprey-install
       :link-type: doc
       :class-header: bg-success text-white

--- a/docs/source/getting-started/index.rst
+++ b/docs/source/getting-started/index.rst
@@ -8,8 +8,8 @@ Welcome to Osprey Framework! This comprehensive guide will take you from zero to
    The fastest path to a deployment for your own facility is the **guided
    installer** — a conversation with your coding agent that inventories what
    you have and builds the project with you: :doc:`osprey-install`. The
-   tutorials below cover the same ground step by step and remain the best way
-   to learn the concepts.
+   step-by-step tutorials cover the same ground and remain the best way to
+   learn the concepts.
 
 **What You'll Accomplish**
 --------------------------

--- a/docs/source/getting-started/osprey-install.rst
+++ b/docs/source/getting-started/osprey-install.rst
@@ -2,8 +2,10 @@
 Install and Set Up
 ====================
 
-The ``/osprey:install`` skill is OSPREY's installer, run as a conversation with the
-Osprey agent. It installs OSPREY if it is missing, starts from what you already
+The ``/osprey:install`` skill is OSPREY's installer, run as a conversation with a
+coding agent you bring — Claude Code in the commands below. That agent is not the
+Osprey agent: the installer builds the deployment the Osprey agent later runs
+from. It installs OSPREY if it is missing, starts from what you already
 have, agrees each step with you, and ends on a deployment repository for your
 accelerator, beamline, or detector that validates and builds. You can stop and
 resume at any point.
@@ -12,8 +14,9 @@ resume at any point.
    :color: info
    :icon: list-unordered
 
-   * **The Osprey agent CLI** — the installer runs inside an Osprey agent session.
-     Install it from `claude.ai/code <https://claude.ai/code>`_ and make sure
+   * **A coding-agent CLI** — the installer runs inside a coding-agent session;
+     the commands here use Claude Code. Install it from
+     `claude.ai/code <https://claude.ai/code>`_ and make sure
      ``claude --version`` works in your terminal.
    * **uv** — the installer puts OSPREY on your ``PATH`` with ``uv tool install``.
      :doc:`installation` covers installing ``uv``; OSPREY itself can wait for the
@@ -47,7 +50,7 @@ Run it
    cd ~/my-osprey-project
    claude
 
-In the Osprey agent session, type:
+In the agent session, type:
 
 .. code-block:: text
 

--- a/plugins/osprey/.claude-plugin/plugin.json
+++ b/plugins/osprey/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.5",
+  "version": "2026.9.6",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "author": {
     "name": "ALS Accelerator Physics Group",

--- a/plugins/osprey/.codex-plugin/plugin.json
+++ b/plugins/osprey/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.5",
+  "version": "2026.9.6",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/osprey/skills/release/SKILL.md
+++ b/plugins/osprey/skills/release/SKILL.md
@@ -64,12 +64,20 @@ differences, each load-bearing:
   resolving to the last stable release; the beta is reached only by
   `--pre` or an exact `==` pin. That opt-in IS the beta channel — nothing
   else has to be built for it.
-- **The connectors floor must name the pre-release.** Range specifiers
-  exclude pre-releases, so with a stable floor a beta framework wheel
-  resolves `osprey-connectors` to the OLD stable and ships skewed. In the
-  release-notes PR, set `osprey-connectors>=YYYY.M.PbN` in `pyproject.toml`
-  and regenerate the lockfile (`uv lock` — CI runs `uv lock --check`). The
-  final release afterwards moves the floor to its own stable version.
+- **The connectors floor needs a pre-release-admitting specifier — not a
+  pre-release floor.** Range specifiers exclude pre-releases, so with the
+  plain stable floor a beta framework wheel pairs with the OLD stable
+  connectors. But a plain `>=YYYY.M.PbN` floor is worse: every same-checkout
+  dev wheel (`<last-stable>.postN`) sorts *below* the beta, so `osprey up
+  --dev` and every image-building CI lane breaks until the tag exists (found
+  live on the v2026.9.0b1 release PR). The shape that satisfies both is
+  `osprey-connectors>=<last-stable>,!=<last-stable>a0`: the `!=` clause names
+  a pre-release, which under PEP 440 admits pre-release candidates to the
+  whole set, so pip pairs beta with beta while dev wheels still satisfy the
+  floor. uv resolves transitive pre-releases only with `--prerelease=allow`
+  and fails loudly with that hint — put the flag in the release notes. Run
+  `uv lock --check` after the edit. The final release afterwards restores
+  the plain floor at its own stable version.
 - **The GitHub Release is marked pre-release automatically.** `release.yml`
   classifies the tag (exactly `X.Y.Z` = stable, anything else = pre-release)
   and sets the flag, so the beta never shows as "Latest".
@@ -241,10 +249,34 @@ Then repair the section by hand, because `apply` only appends:
 - **Merge duplicate `### <Type>` headings.** Fragments folded at different
   times leave several `### Changed` (or `### Fixed`, `### Added`) headings
   under `[Unreleased]`; one heading per type, entries concatenated.
-- **Fold phantom sections** found in Step 0 into this release: move their
-  entries under the matching `### <Type>` heading and delete the untagged
-  `## [YYYY.M.P]` heading. Nothing is lost, and the CHANGELOG stops
-  advertising a version that was never published.
+- **Leave phantom sections where they are.** The changelog gate recognizes
+  the release rotation by the `## [` heading count *growing*; folding a
+  phantom heading away shrinks it, and the gate then reads the whole PR as
+  illegal hand-editing (found live on the v2026.9.0b1 release PR). Fold the
+  phantoms found in Step 0 into the released section in a **follow-up
+  CHANGELOG-only PR** after this one merges and before the tag: that shape
+  passes as a correction because it never touches `[Unreleased]`.
+
+Then **condense the folded section — the maintainer's editorial pass.** The
+fragments were each written for their own PR's reviewer; the released section
+is read months later by someone deciding what changed and whether to upgrade.
+The raw fold is the wrong document for that reader:
+
+- **Collapse supersession chains.** A surface added, then reworked, then
+  renamed in the same span is one entry describing where it landed, not three
+  describing states that never shipped.
+- **Merge per-PR snippets about one surface** into a single entry.
+- **Drop what the later reader cannot act on** — churn on internals that were
+  also removed in the span, fixes to bugs introduced in the same span.
+- **Never drop or soften** breaking changes, migration notes, or `Security`
+  entries.
+
+This is judgment, not mechanics: propose the condensed diff and have the
+maintainer review it before the PR merges. Sequence it as the **second-to-last
+step before the release** — after the last content PR has landed and the final
+fold has run — or the next batch's refold redoes it. On a held release PR
+(see "Holding the release open") that means: final refold first, then
+condense, then merge.
 
 There is **no version literal to edit**; the tag in Step 6 sets the version.
 This PR carries only the human-facing notes. Show the maintainer each diff
@@ -303,7 +335,9 @@ section is missing entries" failure mode below. The refold is mechanical:
 2. Run `apply` again — the new fragments fold into the fresh `## [Unreleased]`.
 3. Move those bullets down into the rotated `## [YYYY.M.P]` section, under
    their type headings; `[Unreleased]` ends empty again.
-4. Push. This is one full CI cycle, and the push cancels the in-flight run,
+4. On the *final* refold — no more batches coming — run the condensation
+   pass from Step 4 and get the maintainer's review of it.
+5. Push. This is one full CI cycle, and the push cancels the in-flight run,
    so batch the refold rather than chasing every merge.
 
 Mind the repo's CI budget (three concurrent PR runs) when the held release

--- a/src/osprey/agent_runner/write_tools.py
+++ b/src/osprey/agent_runner/write_tools.py
@@ -28,6 +28,7 @@ _FALLBACK_WRITE_TOOLS = [
     "mcp__bluesky__queue_add",
     "mcp__bluesky__queue_start",
     "mcp__controls__channel_write",
+    "mcp__phoebus__phoebus_drive",
     "mcp__python__execute",
     "mcp__python__execute_file",
 ]

--- a/src/osprey/mcp_server/audit_middleware.py
+++ b/src/osprey/mcp_server/audit_middleware.py
@@ -181,6 +181,7 @@ _FALLBACK_WRITE_TOOLS: list[str] = [
     "mcp__bluesky__queue_add",
     "mcp__bluesky__queue_start",
     "mcp__controls__channel_write",
+    "mcp__phoebus__phoebus_drive",
     "mcp__python__execute",
     "mcp__python__execute_file",
 ]

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -202,12 +202,16 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "phoebus_open_panel",
             "phoebus_open_databrowser",
         ],
-        # Driving a live panel actuates hardware-facing controls — gate on approval.
+        # Driving a live panel actuates hardware-facing controls — a widget
+        # write is a control-system write, so it carries the writes kill
+        # switch ahead of the approval gate, like every other write path.
+        # The panel itself carries no target binding, so the check is keyed
+        # the same way channel_write's is: the control-context record.
         permissions_ask=["phoebus_drive"],
         hooks_pre=[
             HookRule(
                 matcher="mcp__phoebus__phoebus_drive",
-                hooks=[_APPROVAL],
+                hooks=[_WRITES_CHECK, _APPROVAL],
             ),
         ],
         hooks_post=[_post_error("mcp__phoebus__.*")],

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_hook_log.py
@@ -76,6 +76,7 @@ FALLBACK_WRITE_TOOLS = [
     "mcp__bluesky__queue_add",
     "mcp__bluesky__queue_start",
     "mcp__controls__channel_write",
+    "mcp__phoebus__phoebus_drive",
     "mcp__python__execute",
     "mcp__python__execute_file",
 ]

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -541,6 +541,20 @@ def _resolve_one(cfg, name, ctx=None):
     return matches[0]
 
 
+def test_phoebus_drive_carries_writes_check():
+    """A panel drive is a control-system write, so the writes kill switch
+    gates it ahead of the approval prompt — the same chain channel_write
+    carries. Dropping the binding would leave panel actuation open under
+    ``control_system.writes_enabled: false``."""
+    from osprey.registry.mcp import _APPROVAL, framework_write_tools
+
+    phoebus = FRAMEWORK_SERVERS["phoebus"]
+    rules = [r for r in phoebus.hooks_pre if r.matcher == "mcp__phoebus__phoebus_drive"]
+    assert len(rules) == 1
+    assert rules[0].hooks == [_WRITES_CHECK, _APPROVAL]
+    assert "mcp__phoebus__phoebus_drive" in framework_write_tools()
+
+
 class TestExtendsServers:
     """Tests for extends clones (claude_code.servers.<name>.extends)."""
 
@@ -571,11 +585,14 @@ class TestExtendsServers:
         # Permissions inherited as bare names (unrewritten).
         assert p2["permissions_allow"] == _PHOEBUS_ALLOW
         assert p2["permissions_ask"] == _PHOEBUS_ASK
-        # Hook matchers rewritten with the anchored prefix.
+        # Hook matchers rewritten with the anchored prefix. A panel drive is
+        # a control-system write: the writes kill switch gates it ahead of
+        # the approval prompt, as on every other write path.
         assert len(p2["hooks_pre"]) == 1
         assert p2["hooks_pre"][0]["matcher"] == "mcp__phoebus2__phoebus_drive"
-        assert len(p2["hooks_pre"][0]["hooks"]) == 1
-        assert "osprey_approval.py" in p2["hooks_pre"][0]["hooks"][0]["command"]
+        assert len(p2["hooks_pre"][0]["hooks"]) == 2
+        assert "osprey_writes_check.py" in p2["hooks_pre"][0]["hooks"][0]["command"]
+        assert "osprey_approval.py" in p2["hooks_pre"][0]["hooks"][1]["command"]
         assert [r["matcher"] for r in p2["hooks_post"]] == ["mcp__phoebus2__.*"]
         assert p2["is_custom"] is False
         assert p2["url"] is None


### PR DESCRIPTION
Rolling umbrella for the small pre-release fixes that come up while the
v2026.9.0b1 release is being staged — committed directly to this branch, no
sub-PRs. Merges into `main` before the release PR (#908) runs its final
refold, so everything here rides the release.

In so far:
- Release skill: the maintainer's changelog **condensation pass** (collapse
  supersession chains, merge per-surface snippets, drop what a later reader
  cannot act on), sequenced second-to-last after the final fold; phantom
  sections corrected to a follow-up CHANGELOG-only PR (the gate detects a
  rotation by the heading count growing); connectors-floor guidance corrected
  to the pre-release-admitting specifier shape. Plugin → 2026.9.6.