### PR TITLE
fix(knowledge): stop the graph, preview and CSV tools from keying on the demo machine's tokens and grammar

### DIFF
--- a/changelog.d/channel-finder-detect-and-csv.fixed.md
+++ b/changelog.d/channel-finder-detect-and-csv.fixed.md
@@ -1,0 +1,5 @@
+`osprey channel-finder preview --db-path` now recognises a middle-layer
+database by its shape — nested groups ending in a `ChannelNames` list — instead
+of by a fixed list of the demo machine's system codes. A middle-layer database
+whose top-level groups are named for your own machine previews as one rather
+than being rendered as an in-context file.

--- a/changelog.d/channel-finder-detect-and-csv.fixed.md
+++ b/changelog.d/channel-finder-detect-and-csv.fixed.md
@@ -3,3 +3,12 @@ database by its shape — nested groups ending in a `ChannelNames` list — inst
 of by a fixed list of the demo machine's system codes. A middle-layer database
 whose top-level groups are named for your own machine previews as one rather
 than being rendered as an in-context file.
+
+`osprey channel-finder build-database` now honours the CSV's `address` column
+as the family's address pattern whenever it holds a placeholder, so a machine
+whose addresses are not `<family><NN><suffix>` keeps its own shape instead of
+having one synthesised from the family name. Rows of one family that give
+different addresses, and patterns naming a placeholder the expander cannot fill
+in, stop the build and name the family, rather than being written into the
+database as the literal pattern text. The `instances` column now also accepts an explicit
+range (`4-11`) for device numbering that does not start at one.

--- a/changelog.d/knowledge-corpus-identity.changed.md
+++ b/changelog.d/knowledge-corpus-identity.changed.md
@@ -3,3 +3,12 @@ channel database's own tree lists, instead of by a built-in `SR, BR, BTS` ring
 order that only the demo machine has. `--section-order` names the order
 explicitly for a database whose key order carries no meaning; a section neither
 source names sorts after the ones they do, alphabetically.
+
+The facility token every IRI and identifier embeds now defaults to the
+project's own `facility.prefix` rather than to `demo`, so a project that
+already names its facility does not name it twice. Each run reports the token
+it minted with and the ontology table it emitted against, and warns when a
+corpus built from a database that is not the packaged demo one still carries
+`demo`. **Behaviour change:** a project with `facility.prefix` set that
+regenerated its corpus on the old default mints different IRIs on the next
+`build-ttl` — pass `--facility demo` to keep the old ones.

--- a/changelog.d/knowledge-corpus-identity.changed.md
+++ b/changelog.d/knowledge-corpus-identity.changed.md
@@ -1,0 +1,5 @@
+`osprey knowledge build-ttl` now orders the corpus by the section order the
+channel database's own tree lists, instead of by a built-in `SR, BR, BTS` ring
+order that only the demo machine has. `--section-order` names the order
+explicitly for a database whose key order carries no meaning; a section neither
+source names sorts after the ones they do, alphabetically.

--- a/changelog.d/knowledge-grammar-messages.fixed.md
+++ b/changelog.d/knowledge-grammar-messages.fixed.md
@@ -1,0 +1,5 @@
+The address grammar `osprey knowledge build-ttl` reads is now written in one
+place and quoted from there by every message that names it, so a refusal cannot
+describe a shape the parser does not actually read. A hierarchical database
+built on another level list is refused once, naming the grammar, instead of
+once per address.

--- a/changelog.d/knowledge-grammar-messages.fixed.md
+++ b/changelog.d/knowledge-grammar-messages.fixed.md
@@ -3,3 +3,9 @@ place and quoted from there by every message that names it, so a refusal cannot
 describe a shape the parser does not actually read. A hierarchical database
 built on another level list is refused once, naming the grammar, instead of
 once per address.
+
+When no channel limits file is available and the address grammar decides
+directions instead, a run that finds nothing writable now says so — a corpus
+asserting that no channel on the machine can be written is usually the wrong
+setpoint token, not the machine. The agent-facing note about that fallback
+quotes the same token the generator applied.

--- a/docs/source/how-to/facility-knowledge/use-facility-graph.rst
+++ b/docs/source/how-to/facility-knowledge/use-facility-graph.rst
@@ -174,6 +174,7 @@ channel finder does. Inside a rendered project:
    Wrote data/demo_machine.ttl.
      512 devices, 2908 channel bindings, 113 signals.
      direction from channel limits: data/channel_limits.json
+     Facility token: ca (from facility.prefix); ontology: the packaged demo table
      Load it with: osprey knowledge seed-graph data/demo_machine.ttl
 
 The shipped demo corpus is regenerated from
@@ -187,9 +188,14 @@ the first example names both:
    $ osprey knowledge build-ttl data/demo_machine.ttl \
        --channel-db data/channel_databases/tiers/tier3/hierarchical.json
 
-A corpus that is not the demo machine's wants its own facility token as well:
-``--facility <token>`` decides the token every IRI, every identifier and every
-``narad_p:facility`` value in the file carries, and it defaults to ``demo``.
+A corpus that is not the demo machine's wants its own facility token as well.
+The token every IRI, every identifier and every ``narad_p:facility`` value in
+the file carries is the project's own ``facility.prefix``, so a project that
+already names its facility does not name it twice; ``--facility <token>``
+overrides that for one run, and with neither in scope the token is ``demo``.
+The closing report names the token it minted with, and a run that falls back to
+``demo`` against a database that is not the packaged demo one says so, because
+a corpus labelled for the wrong machine is not visible from the file itself.
 
 A facility whose device database carries attributes the convention has no slot
 for — engineering units on a channel, a crate or serial identity on a device —

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -901,6 +901,13 @@ from ``services.graphdb.ttl_path``. See :doc:`/how-to/facility-knowledge/okf-bun
       ``channel_finder.pipelines.hierarchical.database.path``, resolved against
       the ``config.yml`` directory.
 
+      That grammar is the whole of what this verb reads: six levels, in that
+      order, with the device level generated. A hierarchical database built on
+      any other level list --- the shipped
+      ``data/channel_databases/examples/hierarchical_jlab_style.json``, whose
+      levels are ``system, family, sector, device, pv``, is one --- is refused
+      in one line naming the grammar, before a single address is parsed.
+
    ``--descriptions``
       The in-context database for the same machine: a flat list of addresses,
       each with a sentence about that one channel. Those sentences become

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -811,6 +811,18 @@ Options: ``--project PATH``, ``-v, --verbose``
 ``osprey channel-finder build-database``
    Build a channel database from a CSV file.
 
+   The CSV's ``address`` column *is* each family's address pattern: write the
+   address the way your machine spells it, with ``{instance:02d}`` where the
+   device number goes and ``{sub_channel}`` where the row's sub-channel goes,
+   and it is used as written --- separators, prefixes and level order are
+   yours. All rows of one family must give the same address, and it may name
+   only ``{instance}``, ``{sub_channel}``, ``{base}`` and ``{axis}``; a family
+   that breaks either rule stops the build by name. A family whose rows carry a
+   literal address instead gets ``<family>{instance:02d}{suffix}`` synthesised
+   from its name, as before. The ``instances`` column is a count
+   (``10`` means 1--10) or an explicit range (``4-11``) for a machine whose
+   device numbering does not start at one.
+
 ``osprey channel-finder validate [--database PATH] [--pipeline hierarchical|in_context|middle_layer] [-v]``
    Validate a channel database JSON file. The paradigm is auto-detected from the
    project's config; ``--pipeline`` overrides that.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -880,7 +880,7 @@ from ``services.graphdb.ttl_path``. See :doc:`/how-to/facility-knowledge/okf-bun
    synonyms and families that differ --- which is what a CI job or a pre-commit
    hook runs to prove a committed table still matches its schema.
 
-``osprey knowledge build-ttl OUTPUT [--channel-db PATH] [--descriptions PATH] [--limits PATH] [--ontology PATH] [--facility TOKEN]``
+``osprey knowledge build-ttl OUTPUT [--channel-db PATH] [--descriptions PATH] [--limits PATH] [--ontology PATH] [--section-order A,B,...] [--facility TOKEN]``
    Derive a NARAD-convention TTL corpus — the file ``seed-graph`` loads — from
    the project's own channel databases, so the graph store and the channel
    finder describe the same machine. The corpus carries one device node per
@@ -909,7 +909,7 @@ from ``services.graphdb.ttl_path``. See :doc:`/how-to/facility-knowledge/okf-bun
       the OSPREY source tree keeps the two, side by side under ``tiers/tier3/``.
       With no such neighbour the command asks for the flag.
 
-   Three more inputs decide details:
+   Four more inputs decide details:
 
    ``--limits``
       ``control_system.limits_checking.database_path``. This file is what tells
@@ -925,6 +925,16 @@ from ``services.graphdb.ttl_path``. See :doc:`/how-to/facility-knowledge/okf-bun
       (``compile-ontology`` above) rather than written by hand, though a
       hand-written JSON table is still accepted, so an existing one keeps
       working untouched.
+
+   ``--section-order``
+      The order the corpus lists the machine's top-level sections in, which
+      decides every device's ordinal and the order the file reads in. Unnamed,
+      it is the order the ``--channel-db`` file's own ``tree`` block lists its
+      top-level tokens in --- a hierarchical database is written in the
+      machine's layout order, and JSON keeps that order. Name your own
+      (``--section-order LINAC,TL,RING``) for a database whose key order
+      carries no meaning; a section neither source names sorts after the ones
+      they do, alphabetically.
 
    ``--facility``
       The facility token, ``demo`` by default. Every IRI and identifier the

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -937,12 +937,15 @@ from ``services.graphdb.ttl_path``. See :doc:`/how-to/facility-knowledge/okf-bun
       they do, alphabetically.
 
    ``--facility``
-      The facility token, ``demo`` by default. Every IRI and identifier the
-      corpus mints embeds it, and each device carries it as
-      ``narad_p:facility``, so name your own facility when the corpus is not
-      the demo machine's. The token is written once, from this flag: there is
-      no second place for it to come from and therefore no way for the
-      identifiers and the property to disagree.
+      The facility token. Every IRI and identifier the corpus mints embeds it,
+      and each device carries it as ``narad_p:facility``. Unnamed, it is the
+      project's own ``facility.prefix`` --- the key the rest of the deployment
+      already reads --- and ``demo`` only when no config names one, which is
+      what the shipped demo corpus carries. The token has to be usable inside
+      an identifier: a letter or underscore, then letters, digits and
+      underscores. Every run reports the token it minted with and the ontology
+      table it emitted against, and a run that falls back to ``demo`` against a
+      database that is not the packaged demo one says so.
 
    The neighbour rule for ``--descriptions`` is a convenience of the OSPREY
    source tree. A rendered project keeps only the paradigm it runs, as a flat

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -847,6 +847,39 @@ def _resolve_hierarchy_descriptions(raw: Mapping[str, Any], db_path: Path) -> An
         ) from exc
 
 
+def _resolve_section_order(explicit: str | None, raw: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return the order the corpus sorts its top-level section tokens in.
+
+    Unnamed, the order is the one the database's own ``tree`` block lists them
+    in: JSON preserves key order, and a hierarchical database is written in the
+    machine's own layout order rather than alphabetically. ``--section-order``
+    overrides that for a database whose key order carries no meaning.
+
+    Args:
+        explicit: The ``--section-order`` value, or ``None``.
+        raw: The database payload, as returned by :func:`_load_channel_map`.
+
+    Returns:
+        The section tokens, in order. Empty when neither source names any, in
+        which case every section sorts alphabetically.
+
+    Raises:
+        click.UsageError: When ``--section-order`` holds an empty token.
+    """
+    if explicit is not None:
+        tokens = tuple(token.strip() for token in explicit.split(","))
+        if not all(tokens):
+            raise click.UsageError(
+                "--section-order is a comma-separated list of section tokens; "
+                f"{explicit!r} holds an empty one."
+            )
+        return tokens
+
+    raw_tree = raw.get("tree")
+    tree: Mapping[str, Any] = raw_tree if isinstance(raw_tree, Mapping) else {}
+    return tuple(token for token in tree if not token.startswith("_"))
+
+
 def _load_ontology_table(ontology: Path | None) -> Any:
     """Return the FAMILY-to-class table to emit against.
 
@@ -957,6 +990,12 @@ def _assign_directions(graph_model: Any, limits: Path | None) -> tuple[Any, Any]
     "table shipped with OSPREY, which is compiled from a LinkML schema.",
 )
 @click.option(
+    "--section-order",
+    default=None,
+    help="Comma-separated order for the top-level section tokens, e.g. 'SR,BR,BTS'. "
+    "Defaults to the order the channel database's own tree lists them in.",
+)
+@click.option(
     "--facility",
     default=DEFAULT_FACILITY,
     show_default=True,
@@ -970,6 +1009,7 @@ def build_ttl(
     descriptions: Path | None,
     limits: Path | None,
     ontology: Path | None,
+    section_order: str | None,
     facility: str,
 ) -> None:
     """Derive a NARAD-convention TTL corpus from the channel database.
@@ -1006,6 +1046,11 @@ def build_ttl(
                     PV grammar decides instead: a :SP subfield writes and
                     everything else reads. Every run reports which of the two
                     it used.
+      --section-order
+                    The order the channel database's own tree lists its
+                    top-level sections in. Name your own when that order
+                    carries no meaning; a section neither source names sorts
+                    after the ones they do, alphabetically.
       --ontology    The demo-machine table shipped with OSPREY. Give your own
                     when your device families are not the demo machine's --
                     authored as a LinkML schema and turned into the table this
@@ -1034,11 +1079,13 @@ def build_ttl(
     channel_map, raw_database = _load_channel_map(db_path)
     binding_descriptions = _load_binding_descriptions(descriptions_path)
     hierarchy_descriptions = _resolve_hierarchy_descriptions(raw_database, db_path)
+    sections = _resolve_section_order(section_order, raw_database)
 
     try:
         graph_model = build_model(
             channel_map,
             facility=facility,
+            section_order=sections,
             hierarchy_descriptions=hierarchy_descriptions,
             binding_descriptions=binding_descriptions,
         )

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -55,6 +55,19 @@ DEMO_CHANNEL_DB = (
 )
 
 
+def _address_grammar() -> str:
+    """The address grammar, read from the module that defines it.
+
+    Lazily, so ``osprey knowledge`` still does not pull the TTL generator into
+    its import graph for verbs that never touch an address. One producer:
+    a message here and the parser's own refusal cannot spell the grammar
+    differently.
+    """
+    from osprey.services.facility_knowledge.ttl_generator.model import ADDRESS_GRAMMAR
+
+    return ADDRESS_GRAMMAR
+
+
 @click.group()
 def knowledge() -> None:
     """Manage OKF facility knowledge bundles."""
@@ -715,7 +728,7 @@ def _resolve_channel_db(channel_db: Path | None) -> Path:
             f"That is {CHANNEL_DB_CONFIG_KEY} ('{raw}') resolved against the config file's "
             f"directory. {_paradigm_databases(path.parent)}\n"
             "build-ttl reads the hierarchical-paradigm database, the one whose addresses "
-            "are RING:SYSTEM:FAMILY:DEVICE:FIELD:SUBFIELD; a project built for another "
+            f"are {_address_grammar()}; a project built for another "
             "paradigm does not ship it. Name a hierarchical database with --channel-db PATH."
         )
     return path
@@ -856,8 +869,7 @@ def _resolve_hierarchy_descriptions(raw: Mapping[str, Any], db_path: Path) -> An
     except (ValueError, AttributeError, TypeError) as exc:
         raise click.ClickException(
             f"Cannot read the level prose in {db_path}: {exc}\n"
-            "build-ttl reads the six-token grammar: RING, SYSTEM, FAMILY, DEVICE, "
-            "FIELD, SUBFIELD."
+            f"build-ttl reads the six-token grammar: {_address_grammar().replace(':', ', ')}."
         ) from exc
 
 
@@ -1160,8 +1172,7 @@ def build_ttl(
     except ValueError as exc:
         raise click.ClickException(
             f"The channel database at {db_path} holds an address build-ttl cannot read: {exc}\n"
-            "Every address must be six colon-separated tokens: "
-            "RING:SYSTEM:FAMILY:DEVICE:FIELD:SUBFIELD."
+            f"Every address must be six colon-separated tokens: {_address_grammar()}."
         ) from exc
 
     ontology_table = _load_ontology_table(ontology)

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -37,8 +37,22 @@ from .output import fail, note, report, warn
 #: Default token for ``build-ttl --facility``.  Spelled out rather than imported
 #: so that ``osprey knowledge`` does not pull the TTL generator into its import
 #: graph for every verb; ``tests/cli/test_knowledge_build_ttl.py`` pins it to
-#: ``ttl_generator.model.FACILITY`` so the two cannot drift apart.
+#: ``ttl_generator.model.FACILITY`` so the two cannot drift apart.  It is the
+#: last resort: a project that names its own facility is read first.
 DEFAULT_FACILITY = "demo"
+
+#: Config key holding the deployment's own facility token.  The corpus reads it
+#: rather than minting its own, so the identifiers a project's graph carries and
+#: the ones the rest of the deployment uses cannot say two different things.
+FACILITY_PREFIX_CONFIG_KEY = "facility.prefix"
+
+#: The demo machine's own hierarchical database, as it ships inside the package.
+#: A run against any other database that still mints ``demo`` identifiers is
+#: labelling one machine's corpus with another's name, which is worth saying.
+DEMO_CHANNEL_DB = (
+    Path(__file__).resolve().parents[1]
+    / "templates/apps/control_assistant/data/channel_databases/tiers/tier3/hierarchical.json"
+)
 
 
 @click.group()
@@ -880,6 +894,59 @@ def _resolve_section_order(explicit: str | None, raw: Mapping[str, Any]) -> tupl
     return tuple(token for token in tree if not token.startswith("_"))
 
 
+def _resolve_facility(explicit: str | None) -> tuple[str, str]:
+    """Return the facility token to mint with, and where it came from.
+
+    The token is the deployment's, not this verb's: a project that sets
+    ``facility.prefix`` already names its facility once, and reading it here is
+    what keeps the corpus's identifiers and the rest of the deployment from
+    saying two different things. An explicit flag still wins, and the built-in
+    ``demo`` is only reached when neither names anything.
+
+    ``facility.name`` is deliberately not consulted: it is a display string,
+    and a facility whose name has a space in it would mint identifiers no
+    Turtle prefixed name can hold.
+
+    Run outside any project the key cannot be read at all; that is the same
+    answer as a config that leaves it unset, so it falls through to the
+    default rather than failing.
+
+    Args:
+        explicit: The ``--facility`` value, or ``None``.
+
+    Returns:
+        Tuple of (token, the source to name in the run's report).
+
+    Raises:
+        click.ClickException: When the token cannot be part of an identifier.
+    """
+    from osprey.services.facility_knowledge.ttl_generator.model import PN_LOCAL
+    from osprey.utils.config import get_config_value
+
+    if explicit is not None:
+        token, source = explicit, "--facility"
+    else:
+        try:
+            configured = get_config_value(FACILITY_PREFIX_CONFIG_KEY, None)
+        except OSError:
+            # No config in scope at all, which names a facility exactly as
+            # loudly as a config that leaves the key unset.
+            configured = None
+        if isinstance(configured, str) and configured.strip():
+            token, source = configured.strip(), FACILITY_PREFIX_CONFIG_KEY
+        else:
+            token, source = DEFAULT_FACILITY, "the built-in default"
+
+    if PN_LOCAL.fullmatch(token) is None:
+        raise click.ClickException(
+            f"The facility token {token!r}, from {source}, cannot go into an identifier: "
+            "every IRI and id literal the corpus mints embeds it, so it must start with "
+            "a letter or an underscore and hold only letters, digits and underscores.\n"
+            f"Set {FACILITY_PREFIX_CONFIG_KEY} to such a token, or name one with --facility."
+        )
+    return token, source
+
+
 def _load_ontology_table(ontology: Path | None) -> Any:
     """Return the FAMILY-to-class table to emit against.
 
@@ -997,11 +1064,10 @@ def _assign_directions(graph_model: Any, limits: Path | None) -> tuple[Any, Any]
 )
 @click.option(
     "--facility",
-    default=DEFAULT_FACILITY,
-    show_default=True,
+    default=None,
     help="Facility token embedded in every IRI and identifier the corpus mints, "
-    "and written onto each device as narad_p:facility. Name your own facility "
-    "when the corpus is not the demo machine's.",
+    "and written onto each device as narad_p:facility. Defaults to the project's "
+    f"{FACILITY_PREFIX_CONFIG_KEY}, and to '{DEFAULT_FACILITY}' when no config names one.",
 )
 def build_ttl(
     output: Path,
@@ -1010,7 +1076,7 @@ def build_ttl(
     limits: Path | None,
     ontology: Path | None,
     section_order: str | None,
-    facility: str,
+    facility: str | None,
 ) -> None:
     """Derive a NARAD-convention TTL corpus from the channel database.
 
@@ -1055,10 +1121,11 @@ def build_ttl(
                     when your device families are not the demo machine's --
                     authored as a LinkML schema and turned into the table this
                     flag reads by 'osprey knowledge compile-ontology'.
-      --facility    The token 'demo', which is what the shipped demo corpus
-                    carries. Every IRI and identifier in the file embeds it,
-                    so name your own facility when the corpus is not the demo
-                    machine's.
+      --facility    The project's own facility.prefix, and the token 'demo'
+                    when no config names one -- which is what the shipped demo
+                    corpus carries. Every IRI and identifier in the file embeds
+                    it, so name your own facility when the corpus is not the
+                    demo machine's. Every run reports the token it used.
 
     Then load the file into the store:
 
@@ -1080,11 +1147,12 @@ def build_ttl(
     binding_descriptions = _load_binding_descriptions(descriptions_path)
     hierarchy_descriptions = _resolve_hierarchy_descriptions(raw_database, db_path)
     sections = _resolve_section_order(section_order, raw_database)
+    facility_token, facility_source = _resolve_facility(facility)
 
     try:
         graph_model = build_model(
             channel_map,
-            facility=facility,
+            facility=facility_token,
             section_order=sections,
             hierarchy_descriptions=hierarchy_descriptions,
             binding_descriptions=binding_descriptions,
@@ -1097,6 +1165,7 @@ def build_ttl(
         ) from exc
 
     ontology_table = _load_ontology_table(ontology)
+    ontology_source = "the packaged demo table" if ontology is None else str(ontology)
 
     # Directions first: the emitter refuses a model whose signals have none,
     # rather than writing a corpus that reads every setpoint as a readback.
@@ -1126,6 +1195,14 @@ def build_ttl(
         f"{len(graph_model.signal_groups)} signals."
     )
     note(direction_report.message)
+    note(f"Facility token: {facility_token} (from {facility_source}); ontology: {ontology_source}")
+    if facility_token == DEFAULT_FACILITY and db_path.resolve() != DEMO_CHANNEL_DB.resolve():
+        warn(
+            f"Every IRI and identifier in this corpus carries the token "
+            f"'{DEFAULT_FACILITY}', but the channel database is not the packaged demo one. "
+            f"Set {FACILITY_PREFIX_CONFIG_KEY} in the project's config, or pass --facility, "
+            "so the corpus is named for the machine it describes."
+        )
     note(f"Load it with: osprey knowledge seed-graph {written}")
 
 

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -1205,7 +1205,10 @@ def build_ttl(
         f"{len(graph_model.devices)} devices, {len(graph_model.bindings)} channel bindings, "
         f"{len(graph_model.signal_groups)} signals."
     )
-    note(direction_report.message)
+    if direction_report.write_groups == 0:
+        warn(direction_report.message)
+    else:
+        note(direction_report.message)
     note(f"Facility token: {facility_token} (from {facility_source}); ontology: {ontology_source}")
     if facility_token == DEFAULT_FACILITY and db_path.resolve() != DEMO_CHANNEL_DB.resolve():
         warn(

--- a/src/osprey/services/channel_finder/core/exceptions.py
+++ b/src/osprey/services/channel_finder/core/exceptions.py
@@ -47,3 +47,13 @@ class GraphIndexBuildError(ChannelFinderError):
     """Raised when the graph search index cannot be built from the corpus."""
 
     pass
+
+
+class AddressPatternError(ChannelFinderError):
+    """Raised when a device family's address pattern cannot be expanded.
+
+    The pattern is the family's own address column, so a family that gives two
+    of them, or one naming a placeholder the expander has no value for, would
+    otherwise reach the database as channels whose address is the literal
+    pattern text.  It is a defect in the input, not a family to skip.
+    """

--- a/src/osprey/services/channel_finder/tools/build_database.py
+++ b/src/osprey/services/channel_finder/tools/build_database.py
@@ -8,6 +8,13 @@ address,description,family_name,instances,sub_channel
 
 - Rows with family_name: grouped into templates
 - Rows without family_name: standalone channels
+
+The ``address`` column of a family row **is** that family's address pattern
+whenever it holds a placeholder: ``{instance}`` (or ``{instance:02d}``) for the
+device number and ``{sub_channel}`` for the row's sub-channel. A family whose
+rows carry a literal address instead gets a pattern synthesised from its name,
+``<family>{instance:02d}{suffix}``. ``instances`` is a count (``8`` means 1-8)
+or an explicit range (``4-11``).
 """
 
 import csv
@@ -15,6 +22,8 @@ import json
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
+
+from osprey.services.channel_finder.core.exceptions import AddressPatternError
 
 
 def load_csv(csv_path: Path, delimiter: str = ",") -> list[dict]:
@@ -93,12 +102,118 @@ def find_common_description(descriptions: list[str]) -> str:
     return common
 
 
+#: Placeholders the template expander fills in when it formats an address
+#: pattern (see ``databases/template.py``). A pattern naming anything else
+#: would fail at expansion time, one address at a time, so it is refused here.
+ADDRESS_PATTERN_FIELDS = ("base", "instance", "suffix", "axis")
+
+
+def parse_instance_range(raw: object) -> list[int]:
+    """Return the ``[start, end]`` instance range a family's ``instances`` cell names.
+
+    ``8`` is the common case and means 1 through 8. ``4-11`` is the other one:
+    a machine whose device numbering does not start at 1, which a bare count
+    cannot express.
+
+    Args:
+        raw: The cell's value.
+
+    Returns:
+        ``[start, end]``, inclusive.
+
+    Raises:
+        ValueError: When the cell is not a count or a range, or the range runs
+            backwards.
+    """
+    text = str(raw if raw is not None else 1).strip()
+    start_text, dash, end_text = text.partition("-")
+    if dash:
+        start, end = int(start_text), int(end_text)
+    else:
+        start, end = 1, int(text)
+    if start > end:
+        raise ValueError(f"instance range {text!r} ends before it starts")
+    return [start, end]
+
+
+def family_address_pattern(family_name: str, channels: list[dict]) -> str | None:
+    """The address pattern the family's own rows carry, or ``None``.
+
+    An address column holding a placeholder already says how the family's
+    addresses are built --- which levels there are, where the instance sits,
+    what separates them --- and synthesising a second pattern from the family
+    name silently throws that away. ``{sub_channel}`` is the CSV's name for the
+    expander's ``{suffix}``, so it is translated rather than refused.
+
+    Args:
+        family_name: The family the rows belong to, for the error message.
+        channels: The family's rows.
+
+    Returns:
+        The pattern, or ``None`` when no row carries a placeholder --- in which
+        case the caller synthesises one from the family name as before.
+
+    Raises:
+        AddressPatternError: When the family's rows do not agree on one address.
+    """
+    addresses = {
+        (channel.get("address") or "").replace("{sub_channel}", "{suffix}") for channel in channels
+    }
+    if not any("{" in address for address in addresses):
+        return None
+    if len(addresses) > 1:
+        raise AddressPatternError(
+            f"the rows of family {family_name!r} give different addresses "
+            f"({', '.join(sorted(addresses))}); one family expands from one pattern, "
+            "so put the varying part in {sub_channel}"
+        )
+    return addresses.pop()
+
+
+def check_address_pattern(family_name: str, pattern: str, channels: list[dict]) -> None:
+    """Refuse an address pattern the expander could not fill in.
+
+    Formats *pattern* for the first instance with each row's own sub-channel,
+    which is the same call the expander makes; a placeholder the expander does
+    not know about fails here, once, instead of at expansion time.
+
+    Args:
+        family_name: The family the pattern belongs to.
+        pattern: The pattern to check.
+        channels: The family's rows.
+
+    Raises:
+        AddressPatternError: When the pattern names a placeholder the expander
+            has no value for, or is not a valid format string.
+    """
+    for channel in channels:
+        try:
+            pattern.format(
+                base=family_name,
+                instance=1,
+                suffix=channel.get("sub_channel") or "",
+                axis="",
+            )
+        except (KeyError, IndexError, ValueError) as exc:
+            raise AddressPatternError(
+                f"family {family_name!r} has address pattern {pattern!r}, which "
+                f"cannot be filled in ({exc}); a pattern may use only "
+                + ", ".join(f"{{{field}}}" for field in ADDRESS_PATTERN_FIELDS)
+            ) from exc
+
+
 def create_template(family_name: str, channels: list[dict]) -> dict:
-    """Create a template from a family group."""
+    """Create a template from a family group.
+
+    Raises:
+        AddressPatternError: When the family's rows disagree about their
+            address, or name a placeholder the expander cannot fill in.
+        ValueError: When the ``instances`` cell is neither a count nor a range.
+    """
     first = channels[0]
 
-    # Get instance count
-    instances = int(first.get("instances", 1))
+    # Instance range: a bare count, or an explicit start-end.
+    instances = parse_instance_range(first.get("instances", 1))
 
     # Get sub-channels from all rows in this family
     sub_channels = []
@@ -132,14 +247,18 @@ def create_template(family_name: str, channels: list[dict]) -> dict:
                 cleaned_channel_descriptions[sub_ch] = desc
         channel_descriptions = cleaned_channel_descriptions
 
-    # Simple address pattern
-    pattern = f"{family_name}" + "{instance:02d}{suffix}"
+    # The CSV's own address column is the pattern when it holds a placeholder;
+    # only a family that gives none gets one synthesised from its name.
+    pattern = family_address_pattern(family_name, channels)
+    if pattern is None:
+        pattern = f"{family_name}" + "{instance:02d}{suffix}"
+    check_address_pattern(family_name, pattern, channels)
 
     # Build template
     template = {
         "template": True,
         "base_name": family_name,
-        "instances": [1, instances],
+        "instances": instances,
         "sub_channels": sub_channels,
         "description": base_description,
         "address_pattern": pattern,
@@ -167,6 +286,12 @@ def build_database(
 
     Returns:
         The built database dict.
+
+    Raises:
+        AddressPatternError: When a family's address pattern cannot be
+            expanded. Every other per-family failure demotes that family to
+            standalone rows; this one would write addresses that are the
+            literal pattern, so the build stops instead.
     """
     print("=" * 80)
     print("Channel Database Builder")
@@ -188,11 +313,17 @@ def build_database(
     for family_name, family_channels in families.items():
         try:
             template = create_template(family_name, family_channels)
-            templates.append(template)
-            print(f"  \u2713 {family_name}: {len(family_channels)} channels \u2192 template")
+        except AddressPatternError:
+            # Not a family to skip: every address it would contribute is the
+            # literal pattern text, so degrading it to standalone rows writes a
+            # database nothing can resolve. The input is wrong; say so and stop.
+            raise
         except Exception as e:
             print(f"  \u2717 {family_name}: ERROR - {e}")
             standalone.extend(family_channels)
+        else:
+            templates.append(template)
+            print(f"  \u2713 {family_name}: {len(family_channels)} channels \u2192 template")
 
     # Build database with metadata
     db = {

--- a/src/osprey/services/channel_finder/tools/preview_database.py
+++ b/src/osprey/services/channel_finder/tools/preview_database.py
@@ -30,6 +30,44 @@ from osprey.services.channel_finder.utils.detection import detect_pipeline_confi
 _default_console = Console()
 
 
+def _reaches_channel_names(node: object) -> bool:
+    """True when *node* is a mapping that holds, or nests, a ``ChannelNames`` list.
+
+    ``ChannelNames`` is what the middle-layer paradigm bottoms out in; every
+    level above it is named by the facility, so the walk descends through
+    whatever names it finds. Keys starting with ``_`` are metadata and are
+    skipped, as they are everywhere else in these files.
+    """
+    if not isinstance(node, dict):
+        return False
+    if isinstance(node.get("ChannelNames"), list):
+        return True
+    return any(
+        _reaches_channel_names(value)
+        for key, value in node.items()
+        if isinstance(key, str) and not key.startswith("_")
+    )
+
+
+def _looks_like_middle_layer(data: object) -> bool:
+    """True when *data* has the shape of a middle-layer database.
+
+    The paradigm is a nesting of the facility's own group names that ends in a
+    ``ChannelNames`` list --- the structure
+    :mod:`osprey.services.channel_finder.databases.middle_layer` documents.
+    Recognising it by shape is what lets any facility's file be previewed: a
+    list of group tokens would only ever recognise the machine it was written
+    from.
+    """
+    if not isinstance(data, dict):
+        return False
+    return any(
+        _reaches_channel_names(value)
+        for key, value in data.items()
+        if isinstance(key, str) and not key.startswith("_")
+    )
+
+
 def _resolve_path(path_str: str) -> Path:
     """Resolve a database path."""
     path = Path(path_str)
@@ -829,9 +867,7 @@ def preview_database(
             if "hierarchy" in data or "tree" in data:
                 pipeline_type = "hierarchical"
                 db_config = {}
-            elif isinstance(data, dict) and any(
-                key in data for key in ["SR", "BR", "BTS", "VAC", "Scraper"]
-            ):
+            elif _looks_like_middle_layer(data):
                 pipeline_type = "middle_layer"
                 db_config = {}
             else:

--- a/src/osprey/services/facility_knowledge/seeder/prompt_snapshot.py
+++ b/src/osprey/services/facility_knowledge/seeder/prompt_snapshot.py
@@ -50,6 +50,7 @@ from typing import Any
 
 from osprey.services.facility_knowledge.seeder.graph_seeder import NARAD_PREFIXES
 from osprey.services.facility_knowledge.seeder.ttl_seeder import local_name
+from osprey.services.facility_knowledge.ttl_generator.direction import WRITE_SUBFIELD
 from osprey.utils.workspace import BUILD_DIR_NAME, IMAGE_DIR_NAME
 
 logger = logging.getLogger(__name__)
@@ -382,15 +383,17 @@ DEFAULT_PARAMETERS_NOTE = "framework defaults; substitute values from this corpu
 #: the way it does. ``build-ttl`` knows; the seeder carries it in the marker;
 #: the agent needs it because the two derivations differ in what they can get
 #: wrong — a grammar-derived corpus mislabels any writable channel whose address
-#: does not end in ``:SP``. Deliberately worded without the build host's path:
-#: the whole rendered prompt is guarded against leaking one.
+#: does not end in the setpoint subfield. The token is quoted from the generator
+#: that applies it rather than spelled here, so the note cannot describe a rule
+#: the corpus was not built with. Deliberately worded without the build host's
+#: path: the whole rendered prompt is guarded against leaking one.
 DIRECTION_PROVENANCE_LINES = {
     "limits": (
         "Direction provenance: read/write edges derived from this facility's channel limits."
     ),
     "grammar": (
         "Direction provenance: read/write edges derived from the address grammar "
-        "(`:SP` writes), because no channel limits were available."
+        f"(`:{WRITE_SUBFIELD}` writes), because no channel limits were available."
     ),
 }
 

--- a/src/osprey/services/facility_knowledge/ttl_generator/direction.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/direction.py
@@ -81,11 +81,15 @@ class DirectionReport:
         limits_path: The limits file that was read, or ``None`` for the
             grammar fallback.
         message: The single operator-facing line the CLI prints.
+        write_groups: How many signal groups came out writable.  Zero means the
+            corpus asserts that nothing on this machine can be written, which
+            is a finding rather than a fact about the machine.
     """
 
     source: DirectionSource
     limits_path: Path | None
     message: str
+    write_groups: int
 
 
 class DirectionConflictError(ValueError):
@@ -236,11 +240,26 @@ def assign_directions(
             group.key: (DIRECTION_WRITE if group.subfield == WRITE_SUBFIELD else DIRECTION_READ)
             for group in model.signal_groups
         }
+        write_groups = sum(1 for value in directions.values() if value == DIRECTION_WRITE)
         grammar = f"direction from PV grammar (subfield == {WRITE_SUBFIELD} → write)"
+        if write_groups == 0:
+            # The subfield token is the facility's, not this module's: a machine
+            # that spells its setpoints anything else lands here with a corpus
+            # that says every channel is read-only, which is worth saying out
+            # loud rather than leaving to be discovered from the graph.
+            grammar += (
+                f"; 0 of {len(model.signal_groups)} signal groups matched, so the corpus "
+                "asserts nothing is writable — pass --limits or check the setpoint token"
+            )
         message = f"{grammar}; {lookup_message}" if lookup_message else grammar
         return (
             model.with_directions(directions),
-            DirectionReport(source=DirectionSource.GRAMMAR, limits_path=None, message=message),
+            DirectionReport(
+                source=DirectionSource.GRAMMAR,
+                limits_path=None,
+                message=message,
+                write_groups=write_groups,
+            ),
         )
 
     path = Path(limits_path)
@@ -262,6 +281,7 @@ def assign_directions(
             source=DirectionSource.LIMITS,
             limits_path=path,
             message=f"direction from channel limits: {path}",
+            write_groups=sum(1 for value in directions.values() if value == DIRECTION_WRITE),
         ),
     )
 

--- a/src/osprey/services/facility_knowledge/ttl_generator/model.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/model.py
@@ -65,9 +65,6 @@ PROTOCOL = "ca"
 #: Bindings are derived mechanically from the address grammar, not guessed.
 CONFIDENCE = "high"
 
-#: Rings in facility order; anything else sorts after these, alphabetically.
-RING_ORDER: tuple[str, ...] = ("SR", "BR", "BTS")
-
 #: Turtle's prefixed-name local part.  A property key outside this shape would
 #: render as a full ``<iri>`` rather than as ``narad_p:key``, so extra-property
 #: keys are held to it; the emitter reuses the same pattern when it decides
@@ -312,11 +309,16 @@ def _natural_key(token: str) -> tuple[tuple[int, int | str], ...]:
     )
 
 
-def _ring_rank(ring: str) -> tuple[int, str]:
-    """Facility order for a ring token: SR, BR, BTS, then the rest by name."""
-    if ring in RING_ORDER:
-        return (RING_ORDER.index(ring), "")
-    return (len(RING_ORDER), ring)
+def _ring_rank(ring: str, section_order: Sequence[str]) -> tuple[int, str]:
+    """Facility order for a ring token: *section_order* first, then the rest by name.
+
+    The order is the caller's, not this module's: it is the order the facility's
+    own channel database lists its top-level sections in.  A token the order
+    does not name sorts after every token it does, alphabetically.
+    """
+    if ring in section_order:
+        return (section_order.index(ring), "")
+    return (len(section_order), ring)
 
 
 def _device_sort_key(key: tuple[str, str, str, str]) -> tuple:
@@ -325,9 +327,9 @@ def _device_sort_key(key: tuple[str, str, str, str]) -> tuple:
     return (system, family, _natural_key(device))
 
 
-def _facility_sort_key(key: tuple[str, str, str, str]) -> tuple:
+def _facility_sort_key(key: tuple[str, str, str, str], section_order: Sequence[str]) -> tuple:
     """Order devices across the whole facility (ring first, then in-ring order)."""
-    return (_ring_rank(key[0]), _device_sort_key(key))
+    return (_ring_rank(key[0], section_order), _device_sort_key(key))
 
 
 # ---------------------------------------------------------------------------
@@ -719,6 +721,7 @@ def build_model(
     channel_map: Mapping[str, Mapping],
     *,
     facility: str = FACILITY,
+    section_order: Sequence[str] = (),
     hierarchy_descriptions: HierarchyDescriptions | None = None,
     binding_descriptions: Mapping[str, str] | None = None,
     device_properties: Mapping[str, Mapping[str, str | int | float]] | None = None,
@@ -741,6 +744,12 @@ def build_model(
             token the returned model carries.  Defaults to :data:`FACILITY`, so
             the shipped demo corpus is unchanged.  Two models with different
             tokens can be built in one process: nothing is stored globally.
+        section_order: The facility's own order for the top-level section
+            (``RING``) tokens — the order its channel database lists them in.
+            Devices and bindings are sorted by it, so the ordinals and the
+            emitted corpus follow the machine's layout rather than the
+            alphabet.  A token the order does not name sorts after every token
+            it does, alphabetically; the default orders every section that way.
         hierarchy_descriptions: Prose from the hierarchical tree, as returned by
             :func:`resolve_hierarchy_descriptions`.  Its ring, system and family
             maps land on :class:`Device`; its field and subfield maps land on
@@ -766,10 +775,14 @@ def build_model(
             — see :func:`_check_extra_properties`.
     """
     addresses = [parse_address(addr) for addr in channel_map]
+    order = tuple(section_order)
 
     # Devices first: ordinals depend on the sorted device population, and every
     # binding needs its device's source name to build its own IRI.
-    device_keys = sorted({address.device_key for address in addresses}, key=_facility_sort_key)
+    device_keys = sorted(
+        {address.device_key for address in addresses},
+        key=lambda key: _facility_sort_key(key, order),
+    )
     ordinal_in_section: dict[tuple[str, str, str, str], int] = {}
     seen_per_ring: dict[str, int] = {}
     for key in device_keys:
@@ -782,7 +795,7 @@ def build_model(
     }
     groups: dict[tuple[str, str, str], list[str]] = {}
 
-    for address in sorted(addresses, key=_binding_sort_key):
+    for address in sorted(addresses, key=lambda address: _binding_sort_key(address, order)):
         ring = address.ring
         name = source_name(address.family, address.device)
         group_name = signal_name(address.family, address.field, address.subfield)
@@ -857,9 +870,9 @@ def _lookup_extra_properties(
     return normalize_extra_properties(source.get(key))
 
 
-def _binding_sort_key(address: Address) -> tuple:
+def _binding_sort_key(address: Address, section_order: Sequence[str]) -> tuple:
     """Order bindings by their device, then by FIELD and SUBFIELD."""
-    return (_facility_sort_key(address.device_key), address.field, address.subfield)
+    return (_facility_sort_key(address.device_key, section_order), address.field, address.subfield)
 
 
 def _build_device(

--- a/src/osprey/services/facility_knowledge/ttl_generator/model.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/model.py
@@ -75,6 +75,12 @@ _ADDRESS_FIELDS = ("ring", "system", "family", "device", "field", "subfield")
 _ADDRESS_TOKEN_COUNT = len(_ADDRESS_FIELDS)
 _DIGIT_RUN = re.compile(r"(\d+)")
 
+#: The address grammar, spelled the way an operator sees it. Derived from the
+#: field list so the grammar and the parser cannot say different things: every
+#: message that names the grammar --- here and in the CLI --- reads it from
+#: here rather than repeating the six tokens.
+ADDRESS_GRAMMAR = ":".join(field.upper() for field in _ADDRESS_FIELDS)
+
 
 # ---------------------------------------------------------------------------
 # Address grammar
@@ -136,14 +142,13 @@ def parse_address(addr: str) -> Address:
     if len(tokens) != _ADDRESS_TOKEN_COUNT:
         raise ValueError(
             f"Channel address {addr!r} has {len(tokens)} colon-separated token(s), "
-            f"expected {_ADDRESS_TOKEN_COUNT} "
-            "(RING:SYSTEM:FAMILY:DEVICE:FIELD:SUBFIELD)"
+            f"expected {_ADDRESS_TOKEN_COUNT} ({ADDRESS_GRAMMAR})"
         )
     empty = [name for name, tok in zip(_ADDRESS_FIELDS, tokens, strict=True) if not tok]
     if empty:
         raise ValueError(
             f"Channel address {addr!r} has an empty {', '.join(empty)} token; "
-            "every token of RING:SYSTEM:FAMILY:DEVICE:FIELD:SUBFIELD must be non-empty"
+            f"every token of {ADDRESS_GRAMMAR} must be non-empty"
         )
     return Address(*tokens)
 

--- a/src/osprey/templates/apps/control_assistant/data/raw/CSV_EXAMPLE.csv
+++ b/src/osprey/templates/apps/control_assistant/data/raw/CSV_EXAMPLE.csv
@@ -7,9 +7,14 @@ VacuumPressure,Main beamline vacuum pressure in Torr,,,
 RFFrequency,Radio frequency cavity frequency in MHz,,,
 # === DEVICE FAMILY TEMPLATES (Simple) ===
 # Use for device families with multiple instances
+# The address column IS the family's address pattern: write the address the way
+# your machine spells it, with placeholders where it varies. It is used as
+# written, so any separator, prefix or level order is yours to choose.
 # Pattern: {instance:02d} will be replaced with 01, 02, 03, etc.
 # Pattern: {sub_channel} will be replaced with the sub_channel value from this row
-# All rows with same family_name will be grouped into one template
+# All rows of one family must give the same address; the sub_channel column is
+# what varies between them.
+# instances is a count (10 means 1-10) or an explicit range (4-11).
 BPM{instance:02d}{sub_channel},Horizontal position reading from BPM {instance} in millimeters,BPM,10,XPosition
 BPM{instance:02d}{sub_channel},Vertical position reading from BPM {instance} in millimeters,BPM,10,YPosition
 # === DEVICE FAMILY TEMPLATES (With Control + Readback) ===

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -18,10 +18,13 @@ Covers:
   names nothing, and an address the six-token grammar cannot read.
 - A LinkML schema handed to ``--ontology`` is pointed at ``compile-ontology``
   rather than reported as malformed JSON.
+- Section order comes from the database's own tree, ``--section-order``
+  overrides it, and a list with an empty token is refused.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 from typing import Any
@@ -838,4 +841,174 @@ def test_build_ttl_points_a_yaml_ontology_at_the_compiler(
     flat = _flat(result)
     assert "Traceback" not in result.output
     assert "compile-ontology" in flat
+    assert not output.exists()
+
+
+# ---------------------------------------------------------------------------
+# Section order and the direction warning
+# ---------------------------------------------------------------------------
+
+#: The two-section machine's addresses: the fixture's storage ring, plus a
+#: booster carrying the same magnet family.
+TWO_SECTION_ADDRESSES = FIXTURE_ADDRESSES + (
+    "BR:MAG:DIPOLE:01:CURRENT:RB",
+    "BR:MAG:DIPOLE:01:CURRENT:SP",
+    "BR:MAG:DIPOLE:02:CURRENT:RB",
+    "BR:MAG:DIPOLE:02:CURRENT:SP",
+)
+
+
+def _in_context_for(addresses: tuple[str, ...]) -> dict[str, Any]:
+    """The in-context database of a machine holding exactly *addresses*."""
+    return {
+        "_metadata": {"version": "1.0", "tier": "test", "total_channels": len(addresses)},
+        "channels": [
+            {
+                "channel": address.replace(":", "_"),
+                "address": address,
+                "description": f"Per-channel sentence for {address}.",
+            }
+            for address in addresses
+        ],
+    }
+
+
+def _two_section_payload() -> dict[str, Any]:
+    """The miniature machine with a booster added after the storage ring.
+
+    The tree lists ``SR`` before ``BR``, which is a machine order and not an
+    alphabetical one -- so a corpus that follows the tree and a corpus that
+    sorts its sections by name come out different, which is the whole point.
+    """
+    payload = _hierarchical_payload()
+    payload["tree"]["BR"] = {
+        "_description": "Booster Ring (BR).",
+        "MAG": copy.deepcopy(payload["tree"]["SR"]["MAG"]),
+    }
+    return payload
+
+
+@pytest.fixture()
+def two_section_db(tmp_path: Path) -> Path:
+    """Write the two-section database and return its path."""
+    path = tmp_path / "two_section.json"
+    path.write_text(json.dumps(_two_section_payload()), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def two_section_descriptions(tmp_path: Path) -> Path:
+    """The in-context prose of the two-section machine."""
+    path = tmp_path / "two_section_in_context.json"
+    path.write_text(json.dumps(_in_context_for(TWO_SECTION_ADDRESSES)), encoding="utf-8")
+    return path
+
+
+def _sections_in_facility_order(ttl_path: Path) -> list[str]:
+    """The section tokens of *ttl_path*, first seen first, by facility ordinal."""
+    import rdflib
+
+    graph = _parse(ttl_path)
+    ordinals = {
+        subject: int(value)
+        for subject, _predicate, value in graph.triples(
+            (None, rdflib.URIRef(NARAD_P + "ordinalInFacility"), None)
+        )
+    }
+    sections = {
+        subject: str(value)
+        for subject, _predicate, value in graph.triples(
+            (None, rdflib.URIRef(NARAD_P + "sectionCode"), None)
+        )
+    }
+    seen: list[str] = []
+    for subject in sorted(ordinals, key=lambda device: ordinals[device]):
+        if sections[subject] not in seen:
+            seen.append(sections[subject])
+    return seen
+
+
+def test_build_ttl_orders_sections_the_way_the_database_lists_them(
+    two_section_db: Path,
+    two_section_descriptions: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tree's key order reaches the corpus, and it is not the alphabet's."""
+    _no_config(monkeypatch)
+    output = tmp_path / "tree_order.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(two_section_db),
+            "--descriptions",
+            str(two_section_descriptions),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _sections_in_facility_order(output) == ["SR", "BR"]
+
+
+def test_build_ttl_section_order_option_overrides_the_tree(
+    two_section_db: Path,
+    two_section_descriptions: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A database whose key order carries no meaning can be given the real one."""
+    _no_config(monkeypatch)
+    output = tmp_path / "named_order.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(two_section_db),
+            "--descriptions",
+            str(two_section_descriptions),
+            "--section-order",
+            "BR, SR",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _sections_in_facility_order(output) == ["BR", "SR"]
+
+
+def test_build_ttl_refuses_a_section_order_with_an_empty_token(
+    two_section_db: Path,
+    two_section_descriptions: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stray comma would silently name a section no machine has."""
+    _no_config(monkeypatch)
+    output = tmp_path / "empty_token.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(two_section_db),
+            "--descriptions",
+            str(two_section_descriptions),
+            "--section-order",
+            "SR,,BR",
+        ],
+    )
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "Traceback" not in result.output
+    assert "--section-order" in flat
+    assert "empty one" in flat
     assert not output.exists()

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -277,6 +277,17 @@ def _config_channel_db(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
     monkeypatch.setattr("osprey.utils.config.get_config_value", _lookup)
 
 
+def _config_facility_prefix(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
+    """Make ``facility.prefix`` read as *value* for the token resolution."""
+
+    def _lookup(path: str, default: object = None, config_path: object = None) -> object:
+        if path == "facility.prefix":
+            return value
+        return default
+
+    monkeypatch.setattr("osprey.utils.config.get_config_value", _lookup)
+
+
 def _config_graph_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make the project read as a graph-paradigm one.
 
@@ -433,6 +444,132 @@ def test_build_ttl_facility_option_mints_the_given_token(
     assert "narad:device:xyz:SR:DIPOLE01" in text
     # A mixed-token corpus is the failure this flag exists to make impossible.
     assert "demo" not in text
+
+
+def test_build_ttl_takes_the_facility_token_from_the_project_config(
+    channel_db: Path,
+    descriptions_db: Path,
+    readonly_limits: Path,
+    ontology_table: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A project that already names its facility does not have to name it twice."""
+    _config_facility_prefix(monkeypatch, "ex")
+    output = tmp_path / "ex.ttl"
+    result = _build_ttl(
+        output,
+        channel_db=channel_db,
+        descriptions_db=descriptions_db,
+        readonly_limits=readonly_limits,
+        ontology_table=ontology_table,
+    )
+
+    assert result.exit_code == 0, result.output
+    text = output.read_text(encoding="utf-8")
+    assert 'narad_p:facility "ex"' in text
+    assert "ex_SR_DIPOLE01" in text
+    assert "demo" not in text
+
+
+def test_build_ttl_flag_wins_over_the_configured_facility_token(
+    channel_db: Path,
+    descriptions_db: Path,
+    readonly_limits: Path,
+    ontology_table: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flag is the operator's override, so it outranks the config key."""
+    _config_facility_prefix(monkeypatch, "ex")
+    output = tmp_path / "xyz.ttl"
+    result = _build_ttl(
+        output,
+        "--facility",
+        "xyz",
+        channel_db=channel_db,
+        descriptions_db=descriptions_db,
+        readonly_limits=readonly_limits,
+        ontology_table=ontology_table,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert 'narad_p:facility "xyz"' in output.read_text(encoding="utf-8")
+
+
+def test_build_ttl_refuses_a_facility_token_no_identifier_can_hold(
+    channel_db: Path,
+    descriptions_db: Path,
+    readonly_limits: Path,
+    ontology_table: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing enforces the key's shape upstream, so this verb checks it itself."""
+    _config_facility_prefix(monkeypatch, "example facility")
+    output = tmp_path / "bad.ttl"
+    result = _build_ttl(
+        output,
+        channel_db=channel_db,
+        descriptions_db=descriptions_db,
+        readonly_limits=readonly_limits,
+        ontology_table=ontology_table,
+    )
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "facility.prefix" in flat
+    assert "example facility" in flat
+    assert not output.exists()
+
+
+def test_build_ttl_reports_the_facility_token_and_the_ontology(
+    channel_db: Path,
+    descriptions_db: Path,
+    readonly_limits: Path,
+    ontology_table: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corpus is identified by both, so both are on the run's closing report."""
+    _config_facility_prefix(monkeypatch, "ex")
+    output = tmp_path / "ex.ttl"
+    result = _build_ttl(
+        output,
+        channel_db=channel_db,
+        descriptions_db=descriptions_db,
+        readonly_limits=readonly_limits,
+        ontology_table=ontology_table,
+    )
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "Facility token: ex" in flat
+    assert "facility.prefix" in flat
+    assert str(ontology_table) in flat
+
+
+def test_build_ttl_says_when_a_foreign_machine_gets_the_demo_token(
+    channel_db: Path,
+    descriptions_db: Path,
+    readonly_limits: Path,
+    ontology_table: Path,
+    tmp_path: Path,
+) -> None:
+    """The mislabelled corpus is written, but the run does not stay quiet about it."""
+    output = tmp_path / "demo.ttl"
+    result = _build_ttl(
+        output,
+        channel_db=channel_db,
+        descriptions_db=descriptions_db,
+        readonly_limits=readonly_limits,
+        ontology_table=ontology_table,
+    )
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "Facility token: demo" in flat
+    assert "not the packaged demo one" in flat
 
 
 def test_build_ttl_reports_the_limits_direction_source(

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -939,6 +939,48 @@ def test_build_ttl_rejects_a_malformed_address(descriptions_db: Path, tmp_path: 
     assert not output.exists()
 
 
+def test_build_ttl_refuses_a_foreign_level_list_before_it_parses_addresses(
+    descriptions_db: Path, tmp_path: Path
+) -> None:
+    """A machine on another level grammar gets one refusal, not one per address.
+
+    The level list is read while the prose is resolved, which happens before
+    any address is parsed; that order is what turns a whole foreign database
+    into a single line naming the grammar this verb reads.
+    """
+    payload = _hierarchical_payload()
+    # A machine whose top level is a section rather than a ring, and whose last
+    # two levels join with '_' -- so every expanded address is five colon
+    # tokens, which is what a per-address refusal would fire on.
+    payload["hierarchy"]["levels"][0] = {"name": "section", "type": "tree"}
+    payload["hierarchy"]["naming_pattern"] = (
+        "{section}:{system}:{family}:{device}:{field}_{subfield}"
+    )
+    db_path = tmp_path / "foreign_levels.json"
+    db_path.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "out.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(db_path),
+            "--descriptions",
+            str(descriptions_db),
+        ],
+    )
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "Traceback" not in result.output
+    assert "six-token grammar: RING, SYSTEM, FAMILY, DEVICE, FIELD, SUBFIELD" in flat
+    # Not the per-address refusal: nothing was parsed before the list was checked.
+    assert "holds an address build-ttl cannot read" not in flat
+    assert not output.exists()
+
+
 def test_build_ttl_points_a_yaml_ontology_at_the_compiler(
     channel_db: Path, descriptions_db: Path, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -20,6 +20,8 @@ Covers:
   rather than reported as malformed JSON.
 - Section order comes from the database's own tree, ``--section-order``
   overrides it, and a list with an empty token is refused.
+- A machine that spells its setpoints its own way gets the zero-writable
+  direction line as a warning rather than as a note.
 """
 
 from __future__ import annotations
@@ -1036,6 +1038,12 @@ TWO_SECTION_ADDRESSES = FIXTURE_ADDRESSES + (
     "BR:MAG:DIPOLE:02:CURRENT:SP",
 )
 
+#: The same machine spelling its setpoint and readback subfields its own way,
+#: which is the shape the PV-grammar fallback cannot read a write out of.
+NO_SETPOINT_ADDRESSES = tuple(
+    address.replace(":SP", ":SET").replace(":RB", ":MON") for address in FIXTURE_ADDRESSES
+)
+
 
 def _in_context_for(addresses: tuple[str, ...]) -> dict[str, Any]:
     """The in-context database of a machine holding exactly *addresses*."""
@@ -1067,6 +1075,15 @@ def _two_section_payload() -> dict[str, Any]:
     return payload
 
 
+def _no_setpoint_payload() -> dict[str, Any]:
+    """The miniature machine with ``SET``/``MON`` subfields instead of ``SP``/``RB``."""
+    payload = _hierarchical_payload()
+    current = payload["tree"]["SR"]["MAG"]["DIPOLE"]["DEVICE"]["CURRENT"]
+    current["SET"] = current.pop("SP")
+    current["MON"] = current.pop("RB")
+    return payload
+
+
 @pytest.fixture()
 def two_section_db(tmp_path: Path) -> Path:
     """Write the two-section database and return its path."""
@@ -1080,6 +1097,22 @@ def two_section_descriptions(tmp_path: Path) -> Path:
     """The in-context prose of the two-section machine."""
     path = tmp_path / "two_section_in_context.json"
     path.write_text(json.dumps(_in_context_for(TWO_SECTION_ADDRESSES)), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def no_setpoint_db(tmp_path: Path) -> Path:
+    """Write the database whose subfields the PV grammar knows nothing about."""
+    path = tmp_path / "no_setpoint.json"
+    path.write_text(json.dumps(_no_setpoint_payload()), encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def no_setpoint_descriptions(tmp_path: Path) -> Path:
+    """The in-context prose of the machine with no ``:SP`` subfield."""
+    path = tmp_path / "no_setpoint_in_context.json"
+    path.write_text(json.dumps(_in_context_for(NO_SETPOINT_ADDRESSES)), encoding="utf-8")
     return path
 
 
@@ -1191,3 +1224,67 @@ def test_build_ttl_refuses_a_section_order_with_an_empty_token(
     assert "--section-order" in flat
     assert "empty one" in flat
     assert not output.exists()
+
+
+def test_build_ttl_warns_when_the_grammar_finds_nothing_writable(
+    no_setpoint_db: Path,
+    no_setpoint_descriptions: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corpus asserting nothing can be written is a warning, not a note.
+
+    The subfield token is the machine's, so a facility that spells setpoints
+    ``SET`` lands here with every signal read-only -- which is a finding about
+    the inputs rather than a fact about the machine, and reads as one.
+    """
+    _no_config(monkeypatch)
+    output = tmp_path / "read_only.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(no_setpoint_db),
+            "--descriptions",
+            str(no_setpoint_descriptions),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "\u26a0 direction from PV grammar" in flat
+    assert "0 of 4 signal groups matched" in flat
+    assert "nothing is writable" in flat
+    assert _predicate_count(output, "writesSignal") == 0
+
+
+def test_build_ttl_keeps_the_direction_line_a_note_when_something_writes(
+    channel_db: Path,
+    descriptions_db: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The promotion is the zero case only; an ordinary run reads as before."""
+    _no_config(monkeypatch)
+    output = tmp_path / "grammar.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(channel_db),
+            "--descriptions",
+            str(descriptions_db),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    flat = _flat(result)
+    assert "direction from PV grammar" in flat
+    assert "\u26a0 direction from PV grammar" not in flat
+    assert "signal groups matched" not in flat

--- a/tests/services/channel_finder/tools/test_build_database_helpers.py
+++ b/tests/services/channel_finder/tools/test_build_database_helpers.py
@@ -12,11 +12,14 @@ from pathlib import Path
 
 import pytest
 
+from osprey.services.channel_finder.core.exceptions import AddressPatternError
 from osprey.services.channel_finder.tools.build_database import (
+    build_database,
     create_template,
     find_common_description,
     group_by_family,
     load_csv,
+    parse_instance_range,
 )
 
 # ---------------------------------------------------------------------------
@@ -264,3 +267,108 @@ def test_create_template_rejects_non_numeric_instance_count() -> None:
 
     with pytest.raises(ValueError):
         create_template("SCH", channels)
+
+
+# ---------------------------------------------------------------------------
+# The address column is the family's pattern
+# ---------------------------------------------------------------------------
+
+
+def _patterned_row(sub_channel: str, address: str, instances: str = "10") -> dict:
+    return {
+        "address": address,
+        "description": f"BPM {sub_channel}",
+        "family_name": "BPM",
+        "instances": instances,
+        "sub_channel": sub_channel,
+    }
+
+
+def test_create_template_uses_the_address_column_as_the_pattern() -> None:
+    """A machine's own address shape survives instead of being re-synthesised."""
+    address = "SR:BPM:{instance:03d}:{sub_channel}"
+    channels = [
+        _patterned_row("XPOS", address),
+        _patterned_row("YPOS", address),
+    ]
+
+    template = create_template("BPM", channels)
+
+    # {sub_channel} is the CSV's spelling of the expander's {suffix}.
+    assert template["address_pattern"] == "SR:BPM:{instance:03d}:{suffix}"
+    assert template["sub_channels"] == ["XPOS", "YPOS"]
+
+
+def test_create_template_synthesises_a_pattern_only_without_placeholders() -> None:
+    """A literal address column still gets today's <family>{instance}{suffix}."""
+    channels = [
+        _patterned_row("XPOS", "SR:BPM01:XPOS"),
+        _patterned_row("XPOS", "SR:BPM01:XPOS"),
+    ]
+
+    template = create_template("BPM", channels)
+
+    assert template["address_pattern"] == "BPM{instance:02d}{suffix}"
+
+
+def test_create_template_refuses_two_patterns_in_one_family() -> None:
+    """One family expands from one pattern, so disagreement is not guessed at."""
+    channels = [
+        _patterned_row("XPOS", "SR:BPM:{instance:03d}:{sub_channel}"),
+        _patterned_row("YPOS", "BR:BPM:{instance:02d}:{sub_channel}"),
+    ]
+
+    with pytest.raises(AddressPatternError, match="different addresses"):
+        create_template("BPM", channels)
+
+
+def test_create_template_refuses_a_placeholder_the_expander_cannot_fill() -> None:
+    """The pattern is checked against the expander's own vocabulary, once."""
+    channels = [_patterned_row("XPOS", "SR:BPM:{sector}:{instance:02d}:{sub_channel}")]
+
+    with pytest.raises(AddressPatternError, match="cannot be filled in"):
+        create_template("BPM", channels)
+
+
+def test_create_template_takes_an_explicit_instance_range() -> None:
+    """A machine whose device numbering does not start at 1 can say so."""
+    address = "SR:BPM:{instance:02d}:{sub_channel}"
+    channels = [_patterned_row("XPOS", address, instances="4-11")]
+
+    assert create_template("BPM", channels)["instances"] == [4, 11]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("8", [1, 8]), (8, [1, 8]), ("4-11", [4, 11]), (" 3 ", [1, 3]), (None, [1, 1])],
+)
+def test_parse_instance_range_reads_counts_and_ranges(raw, expected) -> None:
+    """A bare count means 1..N; a dashed pair means exactly what it says."""
+    assert parse_instance_range(raw) == expected
+
+
+def test_parse_instance_range_refuses_a_backwards_range() -> None:
+    """A range that ends before it starts expands to nothing, so it is refused."""
+    with pytest.raises(ValueError, match="ends before it starts"):
+        parse_instance_range("11-4")
+
+
+def test_build_database_stops_on_an_unfillable_address_pattern(tmp_path: Path) -> None:
+    """The build fails rather than writing addresses that are the pattern text.
+
+    Every other per-family failure demotes the family to standalone rows, which
+    is why this one has to be a distinct exception: a family whose pattern
+    cannot be expanded would otherwise land in the database verbatim, braces
+    and all, and the run would still report success.
+    """
+    csv_path = _write_csv(
+        tmp_path,
+        "address,description,family_name,instances,sub_channel\n"
+        "SR:BPM:{sector}:{instance:02d}:{sub_channel},X position,BPM,2,XPOS\n",
+    )
+    output = tmp_path / "database.json"
+
+    with pytest.raises(AddressPatternError, match="cannot be filled in"):
+        build_database(csv_path=csv_path, output_path=output)
+
+    assert not output.exists()

--- a/tests/services/channel_finder/tools/test_preview_database.py
+++ b/tests/services/channel_finder/tools/test_preview_database.py
@@ -26,6 +26,7 @@ from osprey.services.channel_finder.tools.preview_database import (
     _count_channels_at_path,
     _count_channels_matching_focus,
     _get_children_at_level,
+    _looks_like_middle_layer,
     _navigate_middle_layer_focus,
     _navigate_to_focus,
     _resolve_path,
@@ -412,6 +413,49 @@ class TestPreviewInContext:
 # ---------------------------------------------------------------------------
 
 
+#: The demo machine's own middle-layer database, as it ships in the source tree.
+SHIPPED_MIDDLE_LAYER = (
+    Path(__file__).resolve().parents[4]
+    / "src/osprey/templates/apps/control_assistant/data"
+    / "channel_databases/tiers/tier3/middle_layer.json"
+)
+
+#: Its in-context sibling, which must not be mistaken for one.
+SHIPPED_IN_CONTEXT = SHIPPED_MIDDLE_LAYER.with_name("in_context.json")
+
+
+class TestLooksLikeMiddleLayer:
+    """The paradigm is recognised by its shape, not by one machine's group names."""
+
+    def test_the_shipped_database_is_recognised(self):
+        """The file the demo machine actually ships still classifies."""
+        assert SHIPPED_MIDDLE_LAYER.is_file(), SHIPPED_MIDDLE_LAYER
+        data = json.loads(SHIPPED_MIDDLE_LAYER.read_text(encoding="utf-8"))
+        assert _looks_like_middle_layer(data) is True
+
+    def test_another_facilitys_group_names_are_recognised(self):
+        """The same file re-keyed LINAC/TL is the same paradigm."""
+        assert SHIPPED_MIDDLE_LAYER.is_file(), SHIPPED_MIDDLE_LAYER
+        data = json.loads(SHIPPED_MIDDLE_LAYER.read_text(encoding="utf-8"))
+        groups = [key for key in data if not key.startswith("_")]
+        renamed = dict(zip(("LINAC", "TL", "RING"), (data[key] for key in groups), strict=False))
+        assert _looks_like_middle_layer(renamed) is True
+
+    def test_an_in_context_database_is_not_one(self):
+        """The negative the token list used to get right by accident."""
+        assert SHIPPED_IN_CONTEXT.is_file(), SHIPPED_IN_CONTEXT
+        data = json.loads(SHIPPED_IN_CONTEXT.read_text(encoding="utf-8"))
+        assert _looks_like_middle_layer(data) is False
+
+    def test_a_bare_mapping_is_not_one(self):
+        """Nesting alone is not the paradigm; the ChannelNames leaf is."""
+        assert _looks_like_middle_layer({"SR": {"BPM": {"Monitor": {}}}}) is False
+
+    def test_metadata_keys_do_not_carry_the_shape(self):
+        """A ``_``-prefixed block is metadata, so it cannot classify the file."""
+        assert _looks_like_middle_layer({"_notes": {"ChannelNames": ["X"]}}) is False
+
+
 class TestPreviewDatabaseDispatch:
     def test_dispatch_hierarchical_by_path(self, hier_file: Path):
         console = _capture_console()
@@ -421,6 +465,19 @@ class TestPreviewDatabaseDispatch:
     def test_dispatch_middle_layer_by_path(self, ml_file: Path):
         console = _capture_console()
         preview_database(db_path=str(ml_file), console=console)
+        assert "Middle Layer Database Preview" in _text(console)
+
+    def test_dispatch_middle_layer_with_another_facilitys_groups(self, tmp_path: Path):
+        """A machine whose top-level groups are its own still previews."""
+        data = {
+            "LINAC": {
+                "BPM": {"Monitor": {"ChannelNames": ["LIN:BPM1:X"]}},
+            },
+        }
+        path = tmp_path / "linac_ml.json"
+        path.write_text(json.dumps(data), encoding="utf-8")
+        console = _capture_console()
+        preview_database(db_path=str(path), console=console)
         assert "Middle Layer Database Preview" in _text(console)
 
     def test_dispatch_in_context_by_path(self, in_context_file: Path):

--- a/tests/services/facility_knowledge/test_demo_ttl_consistency.py
+++ b/tests/services/facility_knowledge/test_demo_ttl_consistency.py
@@ -245,8 +245,10 @@ def directed_model_and_report(
     """
     from osprey.services.facility_knowledge.ttl_generator import direction, model
 
+    raw = json.loads(CHANNEL_DB_PATH.read_text(encoding="utf-8"))
     built = model.build_model(
         channel_map,
+        section_order=[token for token in raw["tree"] if not token.startswith("_")],
         hierarchy_descriptions=hierarchy_descriptions,
         binding_descriptions=binding_descriptions,
     )

--- a/tests/services/facility_knowledge/test_ttl_generator_direction.py
+++ b/tests/services/facility_knowledge/test_ttl_generator_direction.py
@@ -269,6 +269,50 @@ class TestAssignDirections:
         assert "PV grammar" in report.message
         assert "/tmp/absent.json" in report.message
 
+    def test_grammar_fallback_says_when_it_found_nothing_writable(self):
+        """A machine that spells setpoints its own way gets told, not left quiet.
+
+        Every group reading as read-only is the shape of a corpus built on the
+        wrong subfield token, not the shape of a machine nobody can write to.
+        """
+        addresses = [
+            "SR:MAG:DIPOLE:01:CURRENT:SET",
+            "SR:MAG:DIPOLE:01:CURRENT:MON",
+            "SR:VAC:VALVE:01:CONTROL:MON",
+        ]
+
+        annotated, report = assign_directions(_model(addresses), None)
+
+        assert set(_directions(annotated).values()) == {DIRECTION_READ}
+        assert report.write_groups == 0
+        assert "0 of 3 signal groups matched" in report.message
+        assert "nothing is writable" in report.message
+        assert "--limits" in report.message
+
+    def test_grammar_fallback_stays_quiet_when_something_writes(self):
+        """The count is only worth saying when it is the one that means trouble."""
+        addresses = ["SR:MAG:DIPOLE:01:CURRENT:SP", "SR:MAG:DIPOLE:01:CURRENT:RB"]
+
+        _annotated, report = assign_directions(_model(addresses), None)
+
+        assert report.write_groups == 1
+        assert "signal groups matched" not in report.message
+
+    def test_limits_source_counts_its_write_groups_too(self, tmp_path):
+        """The count is on every report, so one reader covers both derivations."""
+        addresses = ["SR:MAG:DIPOLE:01:CURRENT:SP", "SR:MAG:DIPOLE:01:CURRENT:RB"]
+        limits = _write_limits(
+            tmp_path / "limits.json",
+            {
+                "SR:MAG:DIPOLE:01:CURRENT:SP": {},
+                "SR:MAG:DIPOLE:01:CURRENT:RB": {"writable": False},
+            },
+        )
+
+        _annotated, report = assign_directions(_model(addresses), limits)
+
+        assert report.write_groups == 1
+
     def test_mixed_group_raises_naming_the_group_and_dissenters(self, tmp_path):
         """Two devices, one group, disagreeing limits: refuse and say who dissents."""
         addresses = ["SR:MAG:DIPOLE:01:CURRENT:SP", "SR:MAG:DIPOLE:02:CURRENT:SP"]

--- a/tests/services/facility_knowledge/test_ttl_generator_model.py
+++ b/tests/services/facility_knowledge/test_ttl_generator_model.py
@@ -58,6 +58,10 @@ _SYNTHETIC_ADDRESSES = (
     "BR:MAG:DIPOLE:01:CURRENT:RB",
 )
 
+#: The order the synthetic machine lists its sections in — the same shape a real
+#: database's tree carries, and not the alphabetical one.
+_SYNTHETIC_SECTION_ORDER = ("SR", "BR")
+
 
 @pytest.fixture
 def synthetic_map() -> dict[str, dict]:
@@ -93,6 +97,12 @@ def tier3_raw() -> dict:
     """The raw tier-3 database JSON — the unexpanded tree and its level list."""
     assert TIER3_DB_PATH.is_file(), f"tier-3 channel database missing at {TIER3_DB_PATH}"
     return json.loads(TIER3_DB_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def tier3_section_order(tier3_raw: dict) -> tuple[str, ...]:
+    """The order the tier-3 database's own tree lists its top-level sections in."""
+    return tuple(token for token in tier3_raw["tree"] if not token.startswith("_"))
 
 
 @pytest.fixture
@@ -214,7 +224,7 @@ class TestBuildModelDevices:
 
     def test_one_device_per_identity_tuple(self, synthetic_map):
         """Devices are the distinct (RING, SYSTEM, FAMILY, DEVICE) tuples."""
-        model = build_model(synthetic_map)
+        model = build_model(synthetic_map, section_order=_SYNTHETIC_SECTION_ORDER)
         assert model.device_addresses() == (
             "SR:MAG:DIPOLE:01",
             "SR:MAG:DIPOLE:02",
@@ -231,13 +241,15 @@ class TestBuildModelDevices:
 
     def test_section_code_and_raw_type(self, synthetic_map):
         """sectionCode is the ring token, rawType is the family token."""
-        device = build_model(synthetic_map).devices[0]
+        model = build_model(synthetic_map, section_order=_SYNTHETIC_SECTION_ORDER)
+        device = model.devices[0]
         assert device.section_code == "SR"
         assert device.raw_type == "DIPOLE"
 
     def test_ordinals_are_ring_scoped_and_facility_wide(self, synthetic_map):
         """ordinalInSection restarts per ring; ordinalInFacility does not."""
-        by_address = {d.address: d for d in build_model(synthetic_map).devices}
+        model = build_model(synthetic_map, section_order=_SYNTHETIC_SECTION_ORDER)
+        by_address = {d.address: d for d in model.devices}
         section = {a: d.ordinal_in_section for a, d in by_address.items()}
         facility = {a: d.ordinal_in_facility for a, d in by_address.items()}
         assert section == {
@@ -324,7 +336,8 @@ class TestBuildModelSignalGroups:
 
     def test_groups_and_members(self, synthetic_map):
         """One group per combination, carrying its member addresses."""
-        groups = {g.name: g for g in build_model(synthetic_map).signal_groups}
+        model = build_model(synthetic_map, section_order=_SYNTHETIC_SECTION_ORDER)
+        groups = {g.name: g for g in model.signal_groups}
         assert set(groups) == {"dipole_current_sp", "dipole_current_rb", "gauge_pressure_rb"}
         assert groups["dipole_current_sp"].members == (
             "SR:MAG:DIPOLE:01:CURRENT:SP",
@@ -376,6 +389,52 @@ class TestBuildModelSignalGroups:
             assert binding.signal_name == group.name
             assert binding.signal_iri == group.iri
             assert binding.full_pv in group.members
+
+
+class TestSectionOrder:
+    """The caller's section order decides the layout; nothing is built in."""
+
+    #: One device in each of three sections whose names are nothing like the
+    #: demo machine's, and whose facility order is not their alphabetical one.
+    _ADDRESSES = (
+        "L1:MAG:DIPOLE:01:CURRENT:RB",
+        "TL:MAG:DIPOLE:01:CURRENT:RB",
+        "RING:MAG:DIPOLE:01:CURRENT:RB",
+    )
+
+    def _sections(self, model) -> list[str]:
+        """The section token of each device, in the order the model holds them."""
+        return [device.ring for device in model.devices]
+
+    def test_given_order_wins_over_the_alphabet(self):
+        """``L1, TL, RING`` is the machine's order and not the sorted one."""
+        model = build_model(
+            {address: {} for address in self._ADDRESSES},
+            section_order=("L1", "TL", "RING"),
+        )
+        assert self._sections(model) == ["L1", "TL", "RING"]
+        assert [device.ordinal_in_facility for device in model.devices] == [1, 2, 3]
+
+    def test_bindings_follow_their_devices(self):
+        """Binding order is the device order, so the corpus reads top to bottom."""
+        model = build_model(
+            {address: {} for address in self._ADDRESSES},
+            section_order=("L1", "TL", "RING"),
+        )
+        assert [binding.address.ring for binding in model.bindings] == ["L1", "TL", "RING"]
+
+    def test_unnamed_sections_sort_after_named_ones(self):
+        """A section the order does not name lands last, alphabetically."""
+        model = build_model(
+            {address: {} for address in self._ADDRESSES},
+            section_order=("RING",),
+        )
+        assert self._sections(model) == ["RING", "L1", "TL"]
+
+    def test_no_order_sorts_every_section_alphabetically(self):
+        """With no order given nothing is privileged, so the alphabet decides."""
+        model = build_model({address: {} for address in self._ADDRESSES})
+        assert self._sections(model) == ["L1", "RING", "TL"]
 
 
 class TestBuildModelDeterminism:
@@ -432,9 +491,11 @@ class TestRealTier3Database:
         for ring, ordinals in per_ring.items():
             assert sorted(ordinals) == list(range(1, len(ordinals) + 1)), ring
 
-    def test_facility_ordinals_are_dense_and_ring_ordered(self, tier3_channel_map):
-        """Facility ordinals run 1..N in SR, BR, BTS order."""
-        model = build_model(tier3_channel_map)
+    def test_facility_ordinals_are_dense_and_ring_ordered(
+        self, tier3_channel_map, tier3_section_order
+    ):
+        """Facility ordinals run 1..N in the order the database's tree lists."""
+        model = build_model(tier3_channel_map, section_order=tier3_section_order)
         assert [d.ordinal_in_facility for d in model.devices] == list(
             range(1, len(model.devices) + 1)
         )
@@ -442,7 +503,7 @@ class TestRealTier3Database:
         for device in model.devices:
             if device.ring not in ring_first_seen:
                 ring_first_seen.append(device.ring)
-        assert ring_first_seen == ["SR", "BR", "BTS"]
+        assert ring_first_seen == list(tier3_section_order)
 
     def test_identifiers_are_unique(self, tier3_channel_map):
         """No two devices or bindings collide on an IRI or an id literal."""

--- a/tests/services/facility_knowledge/test_ttl_generator_model.py
+++ b/tests/services/facility_knowledge/test_ttl_generator_model.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from osprey.services.facility_knowledge.ttl_generator.model import (
+    ADDRESS_GRAMMAR,
     BINDING_IRI_PREFIX,
     CONFIDENCE,
     DEVICE_IRI_PREFIX,
@@ -165,6 +166,24 @@ def synthetic_tree() -> dict:
 # ---------------------------------------------------------------------------
 # Address grammar
 # ---------------------------------------------------------------------------
+
+
+class TestAddressGrammar:
+    """The grammar string and the parser come from one place."""
+
+    def test_grammar_is_the_field_list_upper_cased(self):
+        """Nothing spells the six tokens by hand, here or in the CLI."""
+        assert ADDRESS_GRAMMAR == "RING:SYSTEM:FAMILY:DEVICE:FIELD:SUBFIELD"
+
+    def test_wrong_token_count_is_refused_with_the_grammar(self):
+        """The refusal names the shape it wanted, not just the count it got."""
+        with pytest.raises(ValueError, match=ADDRESS_GRAMMAR):
+            parse_address("SR:MAG:DIPOLE:01:CURRENT")
+
+    def test_empty_token_is_refused_with_the_grammar(self):
+        """An address of the right length but a blank token says the same thing."""
+        with pytest.raises(ValueError, match=ADDRESS_GRAMMAR):
+            parse_address("SR:MAG:DIPOLE::CURRENT:SP")
 
 
 class TestParseAddress:

--- a/tests/templates/test_control_assistant_demo_ttl.py
+++ b/tests/templates/test_control_assistant_demo_ttl.py
@@ -383,6 +383,7 @@ def regenerated_ttl_text() -> str:
     raw = json.loads(CHANNEL_DB_PATH.read_text(encoding="utf-8"))
     built = model.build_model(
         HierarchicalChannelDatabase(str(CHANNEL_DB_PATH)).channel_map,
+        section_order=[token for token in raw["tree"] if not token.startswith("_")],
         hierarchy_descriptions=_resolve_hierarchy_descriptions(raw, CHANNEL_DB_PATH),
         binding_descriptions=dict(_load_binding_descriptions(DESCRIPTIONS_PATH)),
     )


### PR DESCRIPTION
Generic knowledge-graph and channel-finder code stops reading facts off the bundled demo machine — its ring tokens, its facility token, its `SP` subfield spelling, its system codes and its address shape — and reads them off the manifest, config and CSV that already carry them.

## Commits

- `fix(knowledge): take section order from the channel database's own tree`
- `fix(knowledge): default the facility token to facility.prefix and say which token and ontology a corpus was built with`
- `fix(knowledge): one producer for the six-token grammar string; check the level list before parsing addresses`
- `fix(knowledge): be loud when the grammar fallback yields no writable signal`
- `fix(channel-finder): detect the middle-layer paradigm by shape, not by demo system codes`
- `fix(channel-finder): honour the CSV address column as the family's address pattern`

## Why

Six couplings to one machine's data, each removed by reading a fact that already has a producer — no new config key anywhere in this branch.

`build-ttl` sorted every corpus by a built-in `SR, BR, BTS` ring order, so a machine whose sections are named anything else was laid out alphabetically; the order now comes from the channel database's own tree, with `--section-order` for a file whose key order carries no meaning. Its facility token defaulted to `demo`, so a corpus built for another machine was silently labelled as the demo one; the token now falls back to the project's own `facility.prefix`, is checked against the identifier shape the corpus needs, and every run reports the token and the ontology table it used — warning when a foreign database still gets `demo`. The six-token grammar was spelled out by hand in five messages and is now derived once from the field list the parser splits on, and a database on another level grammar is refused once, naming the grammar, rather than once per address. When no limits file is available the subfield token decides direction, and a run that finds nothing writable now says so instead of shipping a corpus that asserts the machine is read-only.

On the channel-finder side, `preview --db-path` classified a file as middle-layer only if one of five demo system codes was a top-level key; it now tests the shape the paradigm's own module documents, so any facility's middle-layer file previews as one. `build-database` synthesised `<family>{instance:02d}{suffix}` for every family and threw away the address column the shipped example CSV documents as a pattern; the column is now the pattern whenever it holds a placeholder, disagreeing rows are refused by name, an unfillable placeholder is caught once up front, and `instances` accepts an explicit `start-end` range.

A deployer can now build a corpus and a channel database for a machine that shares nothing with the demo one — its own section names and order, its own facility token, its own level names, its own setpoint token, its own address shape — and be told, rather than left to discover, when one of those has not been supplied.

## Not in this PR

- The N-level address grammar. This branch keeps the six-token form and only stops five messages from spelling it independently.
- The `ringDescription` / `sectionCode` vocabulary in the facility-graph contract doc, `graph_queries.py`, `capabilities.py` and `graph.md.j2` — renaming or deriving those properties is a contract change, not a mechanical one.
- A `--write-subfield` flag. A declared setpoint token belongs with a declared grammar, not on its own.
- Extra CSV columns and an `--address-pattern` flag for `build-database`.
- The packaged demo ontology stays the default for `build-ttl`: it fails closed on an unknown family, and forcing `--ontology` would break the shipped demo flow.
