### PR TITLE
fix(control-target): name a connector type the switch cannot dial

### DIFF
--- a/changelog.d/control-target-connector-type-reasons.changed.md
+++ b/changelog.d/control-target-connector-type-reasons.changed.md
@@ -1,0 +1,6 @@
+A deployment whose control system is not reached over Channel Access is now
+told so by name. The control-target roster says switching is not supported by
+that connector type instead of reporting the machine as "not set up", and the
+plan lane says the connector type does not execute plans. Such a target is
+still treated as the deployment's real machine, with the posture that goes
+with one.

--- a/changelog.d/plan-dry-run-pvaccess-inert.fixed.md
+++ b/changelog.d/plan-dry-run-pvaccess-inert.fixed.md
@@ -1,0 +1,4 @@
+The bluesky plan dry-run now neutralises pvAccess addressing as well as
+Channel Access, and drops every inherited `EPICS_CA_*`/`EPICS_PVA_*` variable
+before setting its own inert values. A validation run can no longer broadcast
+on the local network looking for pvAccess servers.

--- a/docs/source/how-to/control-systems/switch-control-target.rst
+++ b/docs/source/how-to/control-systems/switch-control-target.rst
@@ -156,6 +156,15 @@ Moving toward the live machine is the direction with the extra gates. The switch
 checks them in this order and reports the first one that fails, so the answer
 names the nearest thing to fix rather than the whole list.
 
+**A control system the switch can dial** (``connector_not_switchable``).
+The switch moves a session by pointing a connector host at a Channel Access
+gateway, so a deployment whose live block is on another protocol has nothing for
+it to dial. The refusal names the connector type rather than sending you to
+author a gateways table your control system has no use for. It is not a fault in
+the config and it does not touch the machine: the deployment still runs on that
+control system, and its own baseline is still where a session comes home to.
+What it cannot do is move a session onto it.
+
 **The gateways** (``gateways_missing``).
 ``control_system.connector.epics.gateways`` names where the live machine is
 reached. A facility's gateways cannot be guessed, so nothing usable ships
@@ -472,6 +481,11 @@ not usable right now".
    * - **Already there**
      - The deployment is on that target already. The active target always
        answers this, whatever else would also be true of it.
+   * - **Switching not supported**
+     - The target's connector type is not reached over Channel Access, and the
+       switch has no way to dial it. Nothing is missing from the config and the
+       deployment still runs on that control system — a session simply cannot be
+       moved onto it.
    * - **The target is not configured**
      - No connector block for that target, no gateways table, or no entry for
        the gateway role this deployment would select. This is a build or config

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -733,21 +733,24 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
 
 
 #: The control-system targets a bluesky plan lane can serve, keyed by the
-#: ``control_system.type`` each is spelled with in a rendered config.yml — taken
-#: from the connector package's constants rather than respelled here, so a
-#: renamed type cannot leave this mapping silently matching nothing.
-#: ``MOCK`` and ``DOOCS`` are deliberately absent: they are not switch targets,
-#: so a deployment on one of them has no second lane to render.
+#: ``control_system.type`` each is spelled with in a rendered config.yml.
 #:
-#: ``LIVE_STANDIN`` is here because the stand-in is a control target in its own
+#: Derived rather than written out: the keys are the types the queue worker can
+#: build devices over (:data:`~osprey_connectors.types.CHANNEL_ACCESS_TYPES`)
+#: and each value is the target that type is the baseline of
+#: (:func:`~osprey_connectors.types.baseline_target`), so a type added to either
+#: upstream reaches the lane renderer without a second edit here. ``MOCK`` and
+#: ``DOOCS`` fall out for the reason they were left out by hand: a lane the
+#: worker cannot execute over is not a lane to render.
+#:
+#: ``LIVE_STANDIN`` is in because the stand-in is a control target in its own
 #: right — a soft IOC this deployment runs for itself, with its own connector
 #: block — and not a way of spelling ``live``. A deployment baselined on it
 #: gets a lane that says ``standin``, which is what keeps ``live`` meaning the
 #: facility's own machine on the very deployments that run both.
 _LANE_TARGET_BY_CONTROL_SYSTEM_TYPE = {
-    connector_types.EPICS: connector_types.TARGET_LIVE,
-    connector_types.VIRTUAL_ACCELERATOR: connector_types.TARGET_VA,
-    connector_types.LIVE_STANDIN: connector_types.TARGET_STANDIN,
+    cs_type: connector_types.baseline_target({"type": cs_type})
+    for cs_type in connector_types.CHANNEL_ACCESS_TYPES
 }
 
 #: Lane 1 always keeps the historical service key. Lane 2 is named for the

--- a/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
+++ b/src/osprey/interfaces/web_terminal/static/js/control-target-facts.js
@@ -194,12 +194,18 @@ export function statePhrase(word) {
  * The three `not set up` codes are one phrase on purpose: all three mean the
  * deployment has not authored this machine yet, and the distinction between
  * them belongs to the tooltip, not the row.
+ *
+ * `connector_not_switchable` is deliberately NOT one of them: that block is
+ * authored and the deployment is running on it — the switch just has no way to
+ * dial its protocol — so the row says what is unsupported instead of implying
+ * the deployer left something out.
  * @type {Record<string, string>}
  */
 export const REASON_PHRASES = {
   connector_block_missing: 'not set up',
   gateways_missing: 'not set up',
   probe_channel_missing: 'not set up',
+  connector_not_switchable: 'switching not supported',
   target_unresolvable: 'unavailable',
   limits_posture: 'needs strict limits',
   operator_ack_missing: 'needs gateway ack',

--- a/src/osprey/mcp_server/control_system/connector_host_manager.py
+++ b/src/osprey/mcp_server/control_system/connector_host_manager.py
@@ -126,13 +126,13 @@ from osprey.mcp_server.control_system.target_eligibility import (
 )
 from osprey_connectors.control_system.base import is_readonly_run
 from osprey_connectors.ipc import frames
+from osprey_connectors.ipc.host import EPICS_ENV_PREFIXES
 from osprey_connectors.ipc.proxy import ConnectorHostProxy
 from osprey_connectors.types import (
-    MOCK,
+    _SIMULATED_TYPES,
     TARGET_LIVE,
     TARGET_STANDIN,
     TARGET_VA,
-    VIRTUAL_ACCELERATOR,
 )
 from osprey_connectors.types import baseline_target as types_baseline_target
 from osprey_connectors.types import switch_capable as types_switch_capable
@@ -163,10 +163,17 @@ __all__ = [
 #: in ``ps``.
 CHILD_MODULE = "osprey_connectors.ipc.host"
 
-#: Scrubbed from the environment handed to a child. The child scrubs again on
-#: its own first line; this is the defense-in-depth half of the same rule, so
-#: that an ambient gateway cannot even reach the process that might read it.
-EPICS_ENV_PREFIXES = ("EPICS_CA_", "EPICS_PVA_")
+# -- Facts this module imports rather than restates -------------------------
+#
+# ``EPICS_ENV_PREFIXES`` names the environment families scrubbed from what a
+# child is handed. The child scrubs again on its own first line; this
+# parent-side pass is the defense-in-depth half of that one rule, and a rule
+# spelled in two places is a rule its two halves can come to disagree about.
+#
+# ``_SIMULATED_TYPES`` names the connector types that serve a machine nobody
+# has to be careful around. It labels the state file's per-target display
+# metadata, and a type added to the connector package but forgotten in a local
+# copy would put "Real machine" on a simulator's row.
 
 #: ``control_system.target_switch.drain_timeout_s`` and its default.
 DRAIN_TIMEOUT_KEY = "drain_timeout_s"
@@ -203,10 +210,6 @@ REASON_VERIFICATION_FAILED = "verification_failed"
 REASON_PROBE_FAILED = "probe_failed"
 #: Not a switch stage: the state a session is in when its child has died.
 REASON_NO_CHILD = "no_connector_host"
-
-#: Connector types that serve a machine nobody has to be careful around. Used
-#: only to label the state file's per-target display metadata.
-_SIMULATED_TYPES = (MOCK, VIRTUAL_ACCELERATOR)
 
 #: The operator-facing name each display branch defaults to — one word per way
 #: a target can be derived, not per target name, because that is what the name

--- a/src/osprey/mcp_server/control_system/target_eligibility.py
+++ b/src/osprey/mcp_server/control_system/target_eligibility.py
@@ -124,6 +124,7 @@ from osprey_connectors.standin import (
     live_standin_active,
 )
 from osprey_connectors.types import (
+    CHANNEL_ACCESS_TYPES,
     INVENTED_HISTORY_TYPES,
     TARGET_LIVE,
     TARGET_STANDIN,
@@ -178,6 +179,15 @@ DIRECTION_BACK = "back"
 REASON_ALREADY_ACTIVE = "already_active"
 REASON_TARGET_UNRESOLVABLE = "target_unresolvable"
 REASON_CONNECTOR_BLOCK_MISSING = "connector_block_missing"
+#: The switch has no way to dial this connector type. It points a connector host
+#: at a Channel Access gateway, so a type reached over another protocol is
+#: undialable whether or not its block authored a gateways table — this is asked
+#: ahead of :data:`REASON_GATEWAYS_MISSING` rather than being that table's empty
+#: case, so a deployer is never told to author, or repair, something their
+#: control system has no use for. It says nothing about the machine: such a type
+#: is still this deployment's real one, with the posture that goes with a real
+#: machine.
+REASON_CONNECTOR_NOT_SWITCHABLE = "connector_not_switchable"
 REASON_GATEWAYS_MISSING = "gateways_missing"
 REASON_SELECTED_ROLE_MISSING = "selected_role_missing"
 REASON_PROBE_CHANNEL_MISSING = "probe_channel_missing"
@@ -674,7 +684,11 @@ def evaluate_eligibility(
        would select *for this target* (a target armed for writes with only a read
        gateway selects ``read_only`` and is eligible; a target with only a write
        gateway whose own posture leaves writes unarmed selects ``read_only`` and
-       is not);
+       is not). Before that table is read at all, the connector type has to be
+       one the switch can dial: a type that is not reached over Channel Access
+       has no gateway to point a connector host at, whatever its block says, and
+       is refused as the protocol it is (:data:`REASON_CONNECTOR_NOT_SWITCHABLE`)
+       rather than judged on a table that cannot apply to it;
     4. that block names a ``probe_channel`` — a target that cannot prove itself
        reachable is never switched to;
     5. for ``standin`` only: the endpoint that block selects really is the
@@ -762,6 +776,25 @@ def evaluate_eligibility(
     selected_role = derivation.selected_role
 
     if switching_away:
+        # Asked before the gateways table, not as its empty case: the switch
+        # points a connector host at a Channel Access gateway, so a type that is
+        # not reached that way is undialable whether or not its block authored a
+        # table. Judging such a block on its gateways would report the protocol
+        # as a key nobody filled in, or worse, walk a deployment on another
+        # control system through checks that read a Channel Access address.
+        if connector_type not in CHANNEL_ACCESS_TYPES:
+            speaks = ", ".join(repr(t) for t in CHANNEL_ACCESS_TYPES)
+            return Eligibility(
+                False,
+                REASON_CONNECTOR_NOT_SWITCHABLE,
+                f"Target {target!r} resolves to connector type "
+                f"{connector_type!r}, which the switch has no way to dial: it "
+                f"points a connector host at a gateway named in "
+                f"'{block_key}.gateways', and only {speaks} are reached that "
+                f"way. The deployment still runs on {connector_type!r} — what "
+                "it cannot do is move a session onto it.",
+            )
+
         if not _sub(raw_block, "gateways"):
             return Eligibility(
                 False,

--- a/src/osprey/runtime/__init__.py
+++ b/src/osprey/runtime/__init__.py
@@ -33,11 +33,11 @@ Write Outcomes:
     object to find out whether the hardware took the value.
 
 Control Target:
-    The execution sandbox is launched with a *target stamp* — ``live`` or ``va``
-    — in its environment, written by
-    :mod:`osprey.mcp_server.python_executor.executor`. That stamp, not the
-    config's own ``control_system.type``, decides which connector this runtime
-    builds: the type is resolved through
+    The execution sandbox is launched with a *target stamp* — one of
+    :data:`osprey_connectors.types.CONTROL_TARGETS` — in its environment,
+    written by :mod:`osprey.mcp_server.python_executor.executor`. That stamp,
+    not the config's own ``control_system.type``, decides which connector this
+    runtime builds: the type is resolved through
     :func:`osprey_connectors.types.resolve_target`, so the factory reads
     ``control_system.connector.<that type>`` and ``connect()`` derives that
     target's gateways here rather than anywhere upstream. An unstamped process

--- a/src/osprey/services/bluesky_bridge/plan_validation.py
+++ b/src/osprey/services/bluesky_bridge/plan_validation.py
@@ -25,9 +25,10 @@ which can reject outright before the next ever runs:
    is not falsely rejected by the framework's default (bare ``.put(``/
    ``.get(``) patterns.
 3. **Mock-RunEngine dry-run** (:func:`_dry_run`) — actually builds and drives
-   the plan's generator, in a subprocess whose ``EPICS_CA_*`` variables are
-   neutralized to explicit inert values (no address, no auto-discovery — see
-   :data:`_EPICS_CA_INERT_ENV`), against in-process mock devices
+   the plan's generator, in a subprocess whose ``EPICS_CA_*``/``EPICS_PVA_*``
+   variables are neutralized to explicit inert values (no address, no
+   auto-discovery — see :data:`_EPICS_INERT_ENV`), against in-process mock
+   devices
    (:mod:`osprey.services.bluesky_bridge.devices.mock`) built for exactly the
    channels the plan's ``PARAMS`` declared movable or readable. This is an
    **authoring-quality gate** ("does the body actually run"), not a
@@ -68,6 +69,7 @@ from osprey.mcp_server.workspace.execution.sandbox_executor import validate_sand
 from osprey.services.python_executor.analysis.pattern_detection import (
     detect_control_system_operations,
 )
+from osprey_connectors.ipc.host import scrub_epics_env
 
 logger = logging.getLogger("osprey.services.bluesky_bridge.plan_validation")
 
@@ -370,28 +372,33 @@ class ValidationResult:
 
 
 # ---------------------------------------------------------------------------
-# Stage 3: mock-RunEngine dry-run, in a subprocess with EPICS_CA_* neutralized
+# Stage 3: mock-RunEngine dry-run, in a subprocess with EPICS addressing inert
 # ---------------------------------------------------------------------------
 # Set (not merely deleted) in the dry-run subprocess's environment, on top of
-# the shared `scrub_sensitive_env` deny-list. Deleting these keys outright
-# would be actively WORSE than leaving them alone: a CA client that sees
-# neither `EPICS_CA_ADDR_LIST` nor an explicit `EPICS_CA_AUTO_ADDR_LIST`
-# defaults auto-discovery to YES, which makes it BROADCAST on the local
-# subnet looking for IOCs — exactly the unsolicited network traffic this
-# scrub exists to prevent, not "no CA address to reach." Setting explicit
-# inert values (an empty address list, auto-discovery off, no name server)
-# closes that gap: even if some future bluesky/ophyd-async escape hatch let a
-# plan body reach real CA machinery despite stages 1-2 rejecting the
-# constructs to do so, there is nowhere for it to send a request.
-_EPICS_CA_INERT_ENV: dict[str, str] = {
+# the shared `scrub_sensitive_env` deny-list and the connector package's own
+# `scrub_epics_env` (which removes every inherited variable in the two EPICS
+# addressing families). Deleting these keys outright would be actively WORSE
+# than leaving them alone: a client that sees neither an address list nor an
+# explicit auto-address setting defaults auto-discovery to YES, which makes it
+# BROADCAST on the local subnet looking for servers — exactly the unsolicited
+# network traffic this scrub exists to prevent, not "no address to reach."
+# Setting explicit inert values (an empty address list, auto-discovery off, no
+# name server) closes that gap: even if some future bluesky/ophyd-async escape
+# hatch let a plan body reach real EPICS machinery despite stages 1-2 rejecting
+# the constructs to do so, there is nowhere for it to send a request.
+#
+# Both protocols, not just Channel Access: an ophyd-async device speaks
+# pvAccess, whose defaults broadcast the same way, and a dry-run that neutered
+# one family while leaving the other at its defaults would be inert only
+# against the protocol nobody was going to use.
+_EPICS_INERT_ENV: dict[str, str] = {
     "EPICS_CA_ADDR_LIST": "",
     "EPICS_CA_AUTO_ADDR_LIST": "NO",
     "EPICS_CA_NAME_SERVERS": "",
+    "EPICS_PVA_ADDR_LIST": "",
+    "EPICS_PVA_AUTO_ADDR_LIST": "NO",
+    "EPICS_PVA_NAME_SERVERS": "",
 }
-# Dropped outright rather than set to a value: with no address to reach and
-# auto-discovery disabled (see above), nothing ever consults a configured
-# server port.
-_EPICS_CA_ENV_NAMES_TO_DROP: tuple[str, ...] = ("EPICS_CA_SERVER_PORT",)
 
 # Extra wall-clock time (on top of the caller's `dry_run_timeout`) the parent
 # waits for the subprocess to exit after that timeout — long enough for the
@@ -680,10 +687,10 @@ async def _dry_run(
     why it happens there rather than here.
 
     Runs in a subprocess (its own interpreter, own event loop) with the
-    shared `scrub_sensitive_env` deny-list applied AND every
-    `_EPICS_CA_INERT_ENV` variable set to an inert value (never merely
-    deleted — see that constant's docstring for why deleting would be worse)
-    on top of it. Authoring-QUALITY gate only — "does it actually run" — not
+    shared `scrub_sensitive_env` deny-list applied, the connector package's
+    `scrub_epics_env` run over what is left, AND every `_EPICS_INERT_ENV`
+    variable set to an inert value (never merely deleted — see that constant's
+    docstring for why deleting would be worse) on top of that. Authoring-QUALITY gate only — "does it actually run" — not
     a containment boundary (see module docstring).
 
     A body that runs clean is then held to what its own ``PLAN_METADATA``
@@ -712,9 +719,11 @@ async def _dry_run(
         )
 
         env = scrub_sensitive_env(os.environ.copy())
-        env.update(_EPICS_CA_INERT_ENV)
-        for name in _EPICS_CA_ENV_NAMES_TO_DROP:
-            env.pop(name, None)
+        # Every inherited EPICS addressing variable goes first — a configured
+        # server port, a repeater port, anything this dict does not name — and
+        # the inert values go back on top of the emptied families.
+        scrub_epics_env(env)
+        env.update(_EPICS_INERT_ENV)
 
         proc = await asyncio.create_subprocess_exec(
             sys.executable,

--- a/src/osprey/services/bluesky_bridge/qserver_startup.py
+++ b/src/osprey/services/bluesky_bridge/qserver_startup.py
@@ -180,6 +180,13 @@ def build_connector_config(control_system_type: str) -> dict[str, Any]:
     else is forwarded through with no type-specific config, so an unrecognized
     value surfaces as ``ConnectorFactory``'s own "Unknown control system type"
     error rather than being silently mis-wired to a connector nobody asked for.
+
+    Forwarding is not an offer to run plans on it: this connector type does not
+    execute plans. What keeps such a type away from a worker is the lane
+    renderer, which never renders one for it, and the sentence an operator reads
+    about it is the lane's capability report
+    (``REASON_UNSUPPORTED_CONNECTOR`` in
+    :mod:`osprey.services.bluesky_bridge.queue_backend`).
     """
     from osprey_connectors.types import CHANNEL_ACCESS_TYPES
 

--- a/src/osprey/services/bluesky_bridge/queue_backend.py
+++ b/src/osprey/services/bluesky_bridge/queue_backend.py
@@ -1350,10 +1350,12 @@ class QueueBackend:
                 lane_target=lane_target,
                 lane_degraded=lane_degraded,
                 detail=(
-                    f"The {connector_type!r} connector is not one the plan stack can execute "
-                    "plans against: the queue worker builds its devices over Channel "
-                    "Access, so a deployment executes plans only on a connector that "
-                    "speaks it. Plans can be composed and validated here."
+                    f"This connector type does not execute plans: the queue worker "
+                    f"builds its devices over Channel Access and {connector_type!r} "
+                    "does not speak it, so plans can be composed and validated here "
+                    "but not run. That is a property of the worker's device layer "
+                    "rather than of the plan stack — what executing them needs is a "
+                    "device layer for this protocol."
                 ),
             )
 

--- a/tests/interfaces/web_terminal/control-target-facts.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-facts.test.mjs
@@ -22,6 +22,7 @@ import {
   contextRefusalCode,
   contextRefusalPhrase,
   contextWritable,
+  descriptor,
   lockReason,
   resolvePendingSwitch,
   switchFailureNote,
@@ -347,5 +348,16 @@ describe('switchFailureNote', () => {
 
   test('the operator reads a phrase for it, not the code', () => {
     expect(REASON_PHRASES[REASON_SWITCH_FAILED]).toBe('not applied');
+  });
+});
+
+describe('a connector the switch cannot dial', () => {
+  test('reads as unsupported, not as unauthored', () => {
+    // Its own phrase, and deliberately not one of the three "not set up" codes:
+    // the block IS authored, and the deployment is running on it.
+    expect(REASON_PHRASES.connector_not_switchable).toBe('switching not supported');
+    expect(descriptor({ reason: 'connector_not_switchable' }, 'live')).toBe(
+      'Writes move hardware'
+    );
   });
 });

--- a/tests/interfaces/web_terminal/control-target-popover.test.mjs
+++ b/tests/interfaces/web_terminal/control-target-popover.test.mjs
@@ -471,6 +471,31 @@ describe('names', () => {
     expect(desc.textContent).toBe('Not set up yet');
     expect(desc.dataset.tone).toBeUndefined();
   });
+
+  test('a machine the switch cannot dial is still a machine, and reads as one', async () => {
+    // Refused for its protocol, not for a key nobody filled in: the deployment
+    // runs on that connector and the descriptor keeps saying what writing there
+    // would do. "Not set up" would be the wrong sentence twice over.
+    await bootOpen(
+      viewOf({
+        targets: [
+          rowOf(KINDS.live, {
+            ...STATES['read-only'],
+            available_now: false,
+            reason: 'connector_not_switchable',
+            reason_detail: "Target 'live' resolves to connector type 'doocs'.",
+          }),
+          rowOf(KINDS.va, { active: true, available_now: false, reason: 'already_active' }),
+        ],
+      })
+    );
+    const desc = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-tip-what'));
+    expect(desc.textContent).toBe('Writes move hardware');
+    expect(desc.dataset.tone).toBe('hazard');
+    const reason = /** @type {HTMLElement} */ (rowEl('live')?.querySelector('.ctc-reason'));
+    expect(reason.textContent).toBe('switching not supported');
+    expect(reason.title).toBe("Target 'live' resolves to connector type 'doocs'.");
+  });
 });
 
 /* ---- reachability -------------------------------------------------------- */

--- a/tests/mcp_server/test_control_target_set.py
+++ b/tests/mcp_server/test_control_target_set.py
@@ -246,6 +246,13 @@ STANDIN_PORT = 5074
 STANDIN_PROBE = "STANDIN:BEAM:CURRENT"
 ACK_HOST = "gw.example.org"
 
+#: The connector type a facility's live machine is reached over. The lifecycle
+#: harness's own live type is a dotted-path mock connector — servable inside a
+#: test, but not a control system the switch can dial, so a target on it is
+#: refused ``connector_not_switchable`` before any FR-8 gate is reached. Tests
+#: about those gates name this instead, which is what a facility deployment has.
+EPICS_TYPE = "epics"
+
 
 def config_with_a_standin(
     *,
@@ -253,6 +260,7 @@ def config_with_a_standin(
     strict_limits=True,
     acknowledged=False,
     recorder=False,
+    live_type=None,
 ):
     """The gateway harness config, plus the stand-in this deployment co-deploys.
 
@@ -268,8 +276,11 @@ def config_with_a_standin(
     gated. The remaining three arguments set the FR-8 facts the live family is
     judged on: the limits posture, the operator acknowledgment, and whether an
     ``archiver_recorder`` makes the archive the stand-in's history.
+
+    *live_type* names the connector type ``live`` resolves to, for the tests
+    that ask what happens on the way to it: see :data:`EPICS_TYPE`.
     """
-    raw = config_with_gateways()
+    raw = config_with_gateways(**({"live_type": live_type} if live_type else {}))
     control_system = raw["control_system"]
     control_system["connector"][LIVE_STANDIN] = {
         "probe_channel": STANDIN_PROBE,
@@ -664,7 +675,12 @@ class TestTheStandinIsGatedAsAThirdTarget:
         unacknowledged deployment would hand a session the facility's real
         machine.
         """
-        raw = config_with_a_standin(baseline_standin=True, strict_limits=True, acknowledged=False)
+        raw = config_with_a_standin(
+            baseline_standin=True,
+            strict_limits=True,
+            acknowledged=False,
+            live_type=EPICS_TYPE,
+        )
         manager = make_manager(raw=raw)
         install_context(manager, monkeypatch)
         assert manager.baseline == "standin"
@@ -681,7 +697,12 @@ class TestTheStandinIsGatedAsAThirdTarget:
         self, make_manager, monkeypatch, emitted, record_root
     ):
         """Same direction, the earlier of the two away-gates, and target-worded."""
-        raw = config_with_a_standin(baseline_standin=True, strict_limits=False, acknowledged=True)
+        raw = config_with_a_standin(
+            baseline_standin=True,
+            strict_limits=False,
+            acknowledged=True,
+            live_type=EPICS_TYPE,
+        )
         manager = make_manager(raw=raw)
         install_context(manager, monkeypatch)
         owned_here(record_root, target="standin")
@@ -706,7 +727,11 @@ class TestTheStandinIsGatedAsAThirdTarget:
         a real machine's readings must not be spliced onto it.
         """
         raw = config_with_a_standin(
-            baseline_standin=True, strict_limits=True, acknowledged=True, recorder=True
+            baseline_standin=True,
+            strict_limits=True,
+            acknowledged=True,
+            recorder=True,
+            live_type=EPICS_TYPE,
         )
         manager = make_manager(raw=raw)
         install_context(manager, monkeypatch)

--- a/tests/mcp_server/test_target_eligibility.py
+++ b/tests/mcp_server/test_target_eligibility.py
@@ -39,6 +39,11 @@ EPICS_TYPE = "epics"
 VA_TYPE = "virtual_accelerator"
 STANDIN_TYPE = "live_standin"
 
+#: A control system the switch has no way to dial. Any type outside
+#: ``CHANNEL_ACCESS_TYPES`` would do; this one is a real connector a facility
+#: can be deployed on, which is the case the refusal exists for.
+UNSWITCHABLE_TYPE = "doocs"
+
 #: The port this deployment's stand-in soft IOC serves, as
 #: ``services.live_standin.port`` projects it and as the stand-in's own gateways
 #: dial it. Deliberately not 5064: a stand-in on the Channel Access default
@@ -245,6 +250,53 @@ def test_an_empty_gateways_table_is_ineligible() -> None:
     assert verdict.eligible is False
     assert verdict.reason == te.REASON_GATEWAYS_MISSING
     assert "control_system.connector.epics.gateways" in verdict.detail
+
+
+def test_a_connector_the_switch_cannot_dial_is_refused_by_name() -> None:
+    """A deployment on another control system is told that, not that its
+    Channel Access table is empty. The switch points a connector host at a CA
+    gateway, so a block that was never going to carry one is a refusal about the
+    protocol rather than about a key nobody filled in."""
+    config = _config(
+        control_system_type=UNSWITCHABLE_TYPE,
+        connector={UNSWITCHABLE_TYPE: {"timeout": 5.0}, VA_TYPE: _va_block()},
+    )
+
+    verdict = _eligibility(config, LIVE)
+
+    assert verdict.eligible is False
+    assert verdict.reason == te.REASON_CONNECTOR_NOT_SWITCHABLE
+    assert UNSWITCHABLE_TYPE in verdict.detail
+
+
+def test_a_connector_the_switch_cannot_dial_is_refused_even_with_gateways() -> None:
+    """Authoring a gateways table does not make another control system dialable.
+    The switch points a connector host at a Channel Access address; a block that
+    writes one under a type nothing reaches that way is still refused for the
+    protocol, not walked through the Channel Access checks behind it."""
+    config = _config(
+        control_system_type=UNSWITCHABLE_TYPE,
+        connector={
+            UNSWITCHABLE_TYPE: _epics_block(probe_channel=""),
+            VA_TYPE: _va_block(),
+        },
+    )
+
+    verdict = _eligibility(config, LIVE)
+
+    assert verdict.eligible is False
+    assert verdict.reason == te.REASON_CONNECTOR_NOT_SWITCHABLE
+
+
+def test_coming_home_to_a_connector_the_switch_cannot_dial_is_not_refused() -> None:
+    """The same block is still where the deployment lives: refusing the return
+    leg over the protocol would strand the session on the simulator."""
+    config = _config(
+        control_system_type=UNSWITCHABLE_TYPE,
+        connector={UNSWITCHABLE_TYPE: {"timeout": 5.0}, VA_TYPE: _va_block()},
+    )
+
+    assert _eligibility(config, LIVE, direction=te.DIRECTION_BACK).eligible is True
 
 
 def test_a_gateways_table_without_the_selectable_role_is_ineligible() -> None:

--- a/tests/registry/test_target_switch_pins.py
+++ b/tests/registry/test_target_switch_pins.py
@@ -324,10 +324,7 @@ def test_the_approval_hooks_target_literals_match_the_frameworks() -> None:
     assert hook._TARGET_STANDIN == TARGET_STANDIN
     assert hook._VIRTUAL_ACCELERATOR_TYPE == connector_types.VIRTUAL_ACCELERATOR
     assert hook._LIVE_STANDIN_TYPE == connector_types.LIVE_STANDIN
-    assert hook._BASELINE_TARGETS == {
-        connector_types.VIRTUAL_ACCELERATOR: TARGET_VA,
-        connector_types.LIVE_STANDIN: TARGET_STANDIN,
-    }
+    assert hook._BASELINE_TARGETS == connector_types._BASELINE_TARGETS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/bluesky_bridge/test_plan_validation.py
+++ b/tests/services/bluesky_bridge/test_plan_validation.py
@@ -39,13 +39,13 @@ from osprey.services.bluesky_bridge.plan_fields import (  # noqa: E402
 )
 from osprey.services.bluesky_bridge.plan_validation import (  # noqa: E402
     _CA_ONLY_PATTERNS,
-    _EPICS_CA_ENV_NAMES_TO_DROP,
-    _EPICS_CA_INERT_ENV,
+    _EPICS_INERT_ENV,
     _ca_pattern_scan,
     _static_allowlist_check,
     hash_plan_body,
     validate_plan,
 )
+from osprey_connectors.ipc.host import EPICS_ENV_PREFIXES  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # A tiny, fully-contract-compliant benign plan body: one movable channel, one
@@ -995,20 +995,12 @@ class TestDeclaredPointCountGate:
 
 
 class TestDryRunEnvScrub:
-    async def test_epics_ca_vars_are_neutralized_in_the_subprocess_env(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        """Asserts `_dry_run` passes a neutralized env to
-        `create_subprocess_exec` — the real subprocess spawn is mocked out so
-        this test stays fast and doesn't need a real bluesky dry-run to prove
-        the env wiring specifically.
+    @staticmethod
+    def _capture_dry_run_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+        """Point `_dry_run` at a fake subprocess and hand back the env it passed.
 
-        Deliberately asserts the SET values, not merely "key absent": a CA
-        client that sees neither `EPICS_CA_ADDR_LIST` nor an explicit
-        `EPICS_CA_AUTO_ADDR_LIST` defaults auto-discovery to YES and
-        broadcasts on the local subnet looking for IOCs — so simply deleting
-        these keys would have been worse than leaving them alone. The
-        assertions below are what actually proves that gap is closed.
+        The real spawn is mocked out so these tests stay fast and do not need a
+        real bluesky dry-run to prove the env wiring specifically.
         """
         captured_env: dict[str, str] = {}
 
@@ -1030,18 +1022,31 @@ class TestDryRunEnvScrub:
             result_path = script_path.parent / "result.json"
             # Stands in for what the real script writes, declared point count
             # included: `BENIGN_PLAN_BODY` says it moves channels, so a payload
-            # without one would be rejected by the point-count gate and this
-            # test would be asserting the wrong thing about the env wiring.
+            # without one would be rejected by the point-count gate and these
+            # tests would be asserting the wrong thing about the env wiring.
             result_path.write_text(json.dumps({"success": True, "declared_points": [3]}))
             return _FakeProc()
 
+        monkeypatch.setattr(
+            plan_validation.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
+        )
+        return captured_env
+
+    async def test_epics_ca_vars_are_neutralized_in_the_subprocess_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Deliberately asserts the SET values, not merely "key absent": a CA
+        client that sees neither `EPICS_CA_ADDR_LIST` nor an explicit
+        `EPICS_CA_AUTO_ADDR_LIST` defaults auto-discovery to YES and
+        broadcasts on the local subnet looking for IOCs — so simply deleting
+        these keys would have been worse than leaving them alone. The
+        assertions below are what actually proves that gap is closed.
+        """
         monkeypatch.setenv("EPICS_CA_ADDR_LIST", "10.0.0.1")
         monkeypatch.setenv("EPICS_CA_NAME_SERVERS", "10.0.0.1:5064")
         monkeypatch.setenv("EPICS_CA_AUTO_ADDR_LIST", "YES")
         monkeypatch.setenv("EPICS_CA_SERVER_PORT", "5064")
-        monkeypatch.setattr(
-            plan_validation.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec
-        )
+        captured_env = self._capture_dry_run_env(monkeypatch)
 
         reasons = await plan_validation._dry_run(
             BENIGN_PLAN_BODY, plan_name="tiny_sweep", sample_args=BENIGN_SAMPLE_ARGS, timeout=5.0
@@ -1051,19 +1056,56 @@ class TestDryRunEnvScrub:
         assert captured_env["EPICS_CA_AUTO_ADDR_LIST"] == "NO"
         assert captured_env["EPICS_CA_ADDR_LIST"] == ""
         assert captured_env["EPICS_CA_NAME_SERVERS"] == ""
-        for name in _EPICS_CA_ENV_NAMES_TO_DROP:
-            assert name not in captured_env
+        # Named by no inert value: it is carried off by the prefix scrub, which
+        # is what makes the neutralisation about the family rather than about
+        # the handful of names anyone thought to list.
+        assert "EPICS_CA_SERVER_PORT" not in captured_env
+
+    async def test_pvaccess_vars_are_neutralized_in_the_subprocess_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """An ophyd-async device speaks pvAccess, whose auto-discovery
+        broadcasts exactly as Channel Access's does. A dry-run inert against one
+        family and left at its defaults on the other is inert only against the
+        protocol nobody was going to use.
+        """
+        monkeypatch.setenv("EPICS_PVA_ADDR_LIST", "10.0.0.1")
+        monkeypatch.setenv("EPICS_PVA_NAME_SERVERS", "10.0.0.1:5075")
+        monkeypatch.setenv("EPICS_PVA_AUTO_ADDR_LIST", "YES")
+        monkeypatch.setenv("EPICS_PVA_SERVER_PORT", "5075")
+        captured_env = self._capture_dry_run_env(monkeypatch)
+
+        reasons = await plan_validation._dry_run(
+            BENIGN_PLAN_BODY, plan_name="tiny_sweep", sample_args=BENIGN_SAMPLE_ARGS, timeout=5.0
+        )
+
+        assert reasons == []
+        assert captured_env["EPICS_PVA_AUTO_ADDR_LIST"] == "NO"
+        assert captured_env["EPICS_PVA_ADDR_LIST"] == ""
+        assert captured_env["EPICS_PVA_NAME_SERVERS"] == ""
+        assert "EPICS_PVA_SERVER_PORT" not in captured_env
 
     def test_inert_env_constants_are_actually_inert(self):
-        """`_EPICS_CA_INERT_ENV` is the source of truth the assertions above
+        """`_EPICS_INERT_ENV` is the source of truth the assertions above
         rely on — pin its exact values so a future edit can't quietly
         reintroduce the broadcast-discovery gap this fix closed.
+
+        Both addressing families are pinned, and the pin is checked against the
+        connector host's own prefixes rather than a second list of them, so a
+        family added upstream shows up here as a failing test rather than as a
+        dry-run that quietly leaves it at its defaults.
         """
-        assert _EPICS_CA_INERT_ENV == {
+        assert _EPICS_INERT_ENV == {
             "EPICS_CA_ADDR_LIST": "",
             "EPICS_CA_AUTO_ADDR_LIST": "NO",
             "EPICS_CA_NAME_SERVERS": "",
+            "EPICS_PVA_ADDR_LIST": "",
+            "EPICS_PVA_AUTO_ADDR_LIST": "NO",
+            "EPICS_PVA_NAME_SERVERS": "",
         }
+        assert all(name.startswith(EPICS_ENV_PREFIXES) for name in _EPICS_INERT_ENV)
+        for prefix in EPICS_ENV_PREFIXES:
+            assert any(name.startswith(prefix) for name in _EPICS_INERT_ENV), prefix
 
 
 # =========================================================================


### PR DESCRIPTION
Makes the control-target and plan-lane refusals say what is actually unsupported when a deployment's control system is not reached over Channel Access, and reads the connector-type tuples those answers are built on from the connector package instead of restating them.

Commits:

- `fix(control-target): name a connector type the switch cannot dial`
- `fix(bluesky): neutralise pvAccess addressing in the plan dry-run`
- `docs(runtime): point the target stamp at the control-target list`

## Why

A deployment whose control system is something other than Channel Access was told its own machine was "not set up". The roster reported `gateways_missing` — a key the deployer is expected to fill in — on a block that will never carry one, and the web terminal folded it into the three unauthored-machine codes. The refusal is now its own reason, `connector_not_switchable`, asked ahead of the gateways table rather than as its empty case: the switch points a connector host at a Channel Access gateway, so a type reached over another protocol is undialable whether or not its block authored a table, and judging it on that table would walk a deployment on another control system through checks that read a Channel Access address. It is raised only on the way out, so a session on such a baseline can still come home to it; the web terminal reads "switching not supported" and keeps the real machine's descriptor, because that block is authored and the deployment is running on it. The switch how-to lists the new code beside the reasons it sits between. The plan lane's refusal leads with the same honesty: this connector type does not execute plans.

Where core restated one of the connector package's own facts — the simulated types, the EPICS environment prefixes, the type-to-lane-target map — it now reads them, so a type added upstream reaches every consumer instead of one.

The dry-run rider is the other half of the same assumption. The bluesky plan validator neutralised `EPICS_CA_*` and left `EPICS_PVA_*` at its defaults, which broadcast on the local subnet exactly as Channel Access's do; both families are now inert, and every inherited variable in either is removed first through `scrub_epics_env` rather than through a local list of the names anyone thought of.

A deployer on a non-Channel-Access control system now gets a reason that names the protocol rather than a key to author, and plan validation on a machine whose devices speak pvAccess no longer broadcasts looking for servers.

## Not in this PR

- Connector-declared capabilities as class attributes (`is_simulated`, `supports_plan_execution`, …) — the tuples stay, they only become honest and single-sourced here.
- The stdlib target-state hook's own copies of the type tuples: it answers a type question with no server running, so the state file cannot answer it for the hook; its parity pins already hold it to the package's values.
- `build_connector_config` still forwards an unrecognised type untouched — only its docstring now says what keeps such a type away from a worker and where the refusal an operator reads comes from.
- PVA writes at the EPICS connector, the plan-body pattern families, image layout, and a batched `read_channels` — tracked separately.
