### PR TITLE
fix(providers): resolve provider facts from the registry and the project's own profile

### DIFF
--- a/changelog.d/provider-resolution.fixed.md
+++ b/changelog.d/provider-resolution.fixed.md
@@ -1,0 +1,16 @@
+Provider facts now come from one producer each, so a deployment that configures
+its own endpoints is reported and run as it is configured.
+
+- `osprey health` reports a provider it has no adapter class to probe as
+  skipped, including the agent's own, instead of failing the deployment.
+- `osprey audit` runs its reviewer on the audited deployment's provider and
+  default model, and refuses a bare profile with no build to resolve one from.
+- A provider registered in an application registry under a built-in name
+  replaces that built-in instead of being dropped without a word.
+- A keyless adapter passes the health check on its own `requires_api_key`
+  declaration rather than by being named in a list.
+- A `gateway:` key in a provider entry overrides the built-in default for
+  spend-attribution headers.
+- A misspelled `api_protocol` in `providers.yml` is refused at load.
+- The `osprey status` remedy and the no-provider error name the keys that
+  actually set a provider, and `registry_path` is documented.

--- a/docs/source/contributing/extending-osprey.rst
+++ b/docs/source/contributing/extending-osprey.rst
@@ -19,6 +19,15 @@ code is to hand both to a coding agent and let it draft against them.
 Everything on this page assumes a development checkout --- see
 :doc:`development-setup`.
 
+Each seam's registration lives in your deployment's own registry module, and
+the framework finds that file through the ``registry_path`` key in its
+``config.yml`` --- set it in your profile's ``config:`` block, as
+``registry_path: project/registry.py``. ``application.registry_path`` is
+accepted as an alias, and the ``REGISTRY_PATH`` environment variable outranks
+both, as :doc:`/reference/configuration/environment-variables` records. Without
+one of them the framework loads only its own components, and nothing you
+register is reachable.
+
 .. _extending-connector:
 
 Connector

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -372,8 +372,10 @@ Adding a New Provider
 To add a new OpenAI-compatible provider, append an entry to ``providers.yml``
 beside ``profile.yml`` (see
 :ref:`Provider Configuration <provider-configuration>` above) and run
-``osprey build`` — no code changes required. The rendered result in
-``build/config.yml``:
+``osprey build`` — no code changes required. ``osprey health`` reports such a
+config-only provider as *skipped*, not failed: there is no adapter class to
+probe it with, so the run says it went unverified rather than grading the
+deployment unhealthy. The rendered result in ``build/config.yml``:
 
 .. code-block:: yaml
 

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -340,8 +340,10 @@ LiteLLM SDK path used by MCP servers sets the same identity as the OpenAI
 ``user`` field. Nothing is sent to a direct vendor.
 
 The built-in ``als-apg`` and ``cborg`` providers are LiteLLM proxies and get
-this automatically. A custom gateway declares it in its ``providers.yml``
-entry:
+this automatically; a ``gateway:`` key on one of those names overrides that
+default, and ``gateway: none`` turns attribution off for an entry that points
+the name at a direct endpoint. A custom gateway declares it in its
+``providers.yml`` entry:
 
 .. code-block:: yaml
 

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -407,4 +407,7 @@ The framework automatically:
    config-only entry means nothing to them and a tool call that asks for it
    fails with ``Unknown provider``. Giving an MCP tool server a new provider
    takes code: a provider class registered under that name through a
-   ``ProviderRegistration`` in your application's registry.
+   ``ProviderRegistration`` in your application's registry. That registry file
+   is the one named by ``registry_path`` in the project's ``config.yml`` (set
+   it in your profile's ``config:`` block) or by the ``REGISTRY_PATH``
+   environment variable; see :doc:`/contributing/extending-osprey`.

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -1186,9 +1186,14 @@ directories, and lifecycle scripts.
 
    osprey audit TARGET [OPTIONS]
 
+The reviewer runs on the deployment's configured provider
+(``claude_code.provider``), so an audit needs a built project: point it at one,
+or pass ``--build`` to build the profile first.
+
 ``--build`` — Build a profile in a temp directory, then audit the result.
 
-``--model TEXT`` — Model for the reviewer agent.
+``--model TEXT`` — Model for the reviewer agent. Defaults to the project's
+sonnet tier.
 
 ``--budget FLOAT`` — Maximum budget in USD.
 

--- a/docs/source/reference/configuration/environment-variables.rst
+++ b/docs/source/reference/configuration/environment-variables.rst
@@ -74,6 +74,11 @@ deployment, which is why none of them is a config key.
      - Path to a facility's own component registry module, outranking the
        ``registry_path`` config key. Meant for pointing a container at a
        registry mounted somewhere the config could not have named.
+       ``registry_path`` at the top level of ``config.yml`` is the canonical
+       spelling of that key --- set it in your profile's ``config:`` block ---
+       and ``application.registry_path`` is accepted as an alias. All three
+       resolve through one function, so the registry that loads is the one
+       ``osprey health`` reports on.
    * - ``OSPREY_TERMINAL_BIND_HOST``
      - The address ``osprey web`` binds to, and **authoritative over both
        ``--host`` and the config**. The multi-user compose sets it on every

--- a/src/osprey/agent_runner/clean_env.py
+++ b/src/osprey/agent_runner/clean_env.py
@@ -139,7 +139,7 @@ def build_base_child_env() -> dict[str, str]:
        the SDK overlay path an absent key is inherited from ``os.environ``
        anyway, which makes it defence-in-depth there rather than a boundary.
     3. Resolve the auth-token conflict: when token-based auth is configured
-       (e.g. the CBORG proxy at LBNL), drop a stale ``ANTHROPIC_API_KEY`` that
+       (a token-auth proxy provider), drop a stale ``ANTHROPIC_API_KEY`` that
        Claude Code would otherwise auto-load from the project ``.env`` and warn
        about.
     4. Augment ``PATH`` with user-local bin dirs (e.g. ``~/.local/bin``) so child

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         ClaudeSDKClient,
         PermissionMode,
         ResultMessage,
+        SettingSource,
         SystemMessage,
         ToolResultBlock,
     )
@@ -407,24 +408,38 @@ class SDKWorkflowResult:
 # ---------------------------------------------------------------------------
 
 
-def resolve_default_model(project_dir: Path) -> str:
-    """Resolve the haiku-tier model name for the given project.
+#: Upstream Anthropic model per tier, used only when a project resolves no
+#: provider spec at all — a deployment on a gateway names its own ids.
+_TIER_FALLBACK_MODELS = {
+    "haiku": "claude-haiku-4-5-20251001",
+    "sonnet": "claude-sonnet-5",
+    "opus": "claude-opus-5",
+}
 
-    Reads ``config.yml`` and returns the provider's haiku-tier model id,
+
+def resolve_default_model(project_dir: Path, tier: str = "haiku") -> str:
+    """Resolve a tier's model name for the given project.
+
+    Reads ``config.yml`` and returns the provider's model id for *tier*,
     falling back to the upstream Anthropic default when no spec is
     configured.
 
     Args:
         project_dir: Path to an initialized OSPREY project.
+        tier: Which tier to resolve — ``"haiku"`` (the default, for the cheap
+            headless paths), ``"sonnet"`` or ``"opus"``. Resolving through the
+            project's own tier map is what keeps a caller from naming a bare
+            vendor id that a gateway-fronted deployment does not serve.
 
     Returns:
         Model identifier string suitable for passing to the Claude Agent SDK
         ``model=`` argument.
     """
+    fallback = _TIER_FALLBACK_MODELS.get(tier, _TIER_FALLBACK_MODELS["haiku"])
     spec = _resolve_project_spec(project_dir)
     if spec is not None:
-        return str(spec.tier_to_model.get("haiku", "claude-haiku-4-5-20251001"))
-    return "claude-haiku-4-5-20251001"
+        return str(spec.tier_to_model.get(tier, fallback))
+    return fallback
 
 
 def sdk_env(project_dir: Path | None = None, *, provider: str | None = None) -> dict[str, str]:
@@ -531,6 +546,7 @@ def build_agent_options(
     max_budget_usd: float = 2.0,
     model: str | None = None,
     permission_mode: PermissionMode = "bypassPermissions",
+    setting_sources: list[SettingSource] | None = None,
 ) -> ClaudeAgentOptions:
     """Build ``ClaudeAgentOptions`` routed to a project's configured provider.
 
@@ -552,6 +568,12 @@ def build_agent_options(
         permission_mode: SDK permission mode. ``"bypassPermissions"`` for the
             read-only headless path; ``"default"`` when an approval callback
             should mediate tool use.
+        setting_sources: Which settings layers the SDK loads. ``None`` (the
+            default) means the project's own ``.claude`` settings — its hooks,
+            agents and permissions — which is right for every path that runs
+            *as* the deployment. Pass ``[]`` for a run that must not adopt the
+            target project's settings, such as a reviewer pointed at a project
+            it is only reading.
 
     Returns:
         Configured ``ClaudeAgentOptions`` ready to open a ``ClaudeSDKClient``.
@@ -590,7 +612,7 @@ def build_agent_options(
         max_turns=max_turns,
         max_budget_usd=max_budget_usd,
         env=env,
-        setting_sources=["project"],
+        setting_sources=["project"] if setting_sources is None else setting_sources,
         disallowed_tools=disallowed_tools,
     )
 

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -230,9 +230,9 @@ def provider_env_for_project(project_dir: Path, *, provider: str | None = None) 
     spec = _resolve_project_spec(project_dir, provider=provider)
     if spec is None:
         raise RuntimeError(
-            f"Project at {project_dir} has no resolvable provider in "
-            "config.yml — pass provider=<als-apg|cborg|anthropic|amsc-i2|argo> "
-            "to init_project()."
+            f"Project at {project_dir} has no resolvable provider: its config.yml "
+            "sets no claude_code.provider. Set `provider:` in profile.yml and run "
+            "`osprey build`."
         )
     env: dict[str, str] = dict(spec.env_block)
 

--- a/src/osprey/cli/audit_cmd.py
+++ b/src/osprey/cli/audit_cmd.py
@@ -33,7 +33,6 @@ _SDK_AVAILABLE = False
 try:
     from claude_agent_sdk import (
         AssistantMessage,
-        ClaudeAgentOptions,
         ResultMessage,
         TextBlock,
         query,
@@ -76,6 +75,25 @@ def _extract_json(text: str) -> str | None:
     return None
 
 
+def _reviewer_options(project_dir: Path, model: str, budget: float):
+    """Build the reviewer's SDK options from the audited project's own provider.
+
+    Separate from :func:`_run_audit` so the wiring can be read — and pinned —
+    without opening an event loop.
+    """
+    from osprey.agent_runner.primitives import build_agent_options
+
+    return build_agent_options(
+        project_dir,
+        disallowed_tools=[],
+        model=model,
+        permission_mode="bypassPermissions",
+        max_turns=30,
+        max_budget_usd=budget,
+        setting_sources=[],
+    )
+
+
 async def _run_audit(
     prompt: str,
     model: str,
@@ -85,16 +103,22 @@ async def _run_audit(
 ) -> tuple[str, float | None, int | None]:
     """Run the audit agent and collect its output.
 
+    The reviewer runs on the audited deployment's own provider: the options come
+    from the shared builder, which resolves that provider's endpoint, auth and
+    model ids from the project's ``config.yml`` (and starts the translation
+    proxy when the provider needs one). Hand-building the options here left the
+    SDK to fall through to ambient ``ANTHROPIC_*`` variables, so an audit of a
+    gateway-fronted deployment ran against whatever endpoint the operator's
+    shell happened to hold — or nothing at all.
+
+    ``setting_sources=[]`` is deliberate: the reviewer reads the target, it does
+    not run as it, so the audited project's own hooks and settings stay out of
+    the reviewing agent.
+
     Returns:
         Tuple of (collected_text, total_cost, num_turns).
     """
-    options = ClaudeAgentOptions(
-        model=model,
-        cwd=str(cwd),
-        permission_mode="bypassPermissions",
-        max_turns=30,
-        max_budget_usd=budget,
-    )
+    options = _reviewer_options(cwd, model, budget)
 
     collected_text: list[str] = []
     total_cost: float | None = None
@@ -188,14 +212,18 @@ def _display_report(report, json_output: bool, verbose: bool, cost=None, turns=N
 @click.command()
 @click.argument("target", type=click.Path(exists=True))
 @click.option("--build", "build_first", is_flag=True, help="Build profile in temp dir, then audit")
-@click.option("--model", default="claude-sonnet-5", help="Model for reviewer agent")
+@click.option(
+    "--model",
+    default=None,
+    help="Model for the reviewer (default: the project's sonnet tier)",
+)
 @click.option("--budget", default=5.0, type=float, help="Max budget in USD")
 @click.option("--verbose", "-v", is_flag=True, help="Show verbose output")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 def audit(
     target: str,
     build_first: bool,
-    model: str,
+    model: str | None,
     budget: float,
     verbose: bool,
     json_output: bool,
@@ -235,6 +263,11 @@ def audit(
 
         target_type = _detect_target_type(target)
         target_dir = Path(target)
+        # Where the reviewer runs, and the project its provider is resolved
+        # from. For a project target that is the target itself; for a profile it
+        # is whatever holds a resolvable provider — the temporary build below,
+        # or the deployment repo the profile lives in.
+        audit_root = target_dir
 
         # Optionally build the profile first
         tmpdir = None
@@ -265,25 +298,67 @@ def audit(
                 stream=False,
             )
             target_dir = Path(tmpdir) / project_name
+            audit_root = target_dir
             target_type = "project"
 
+        if target_type == "profile":
+            # A profile is a document, not a project: it has no config.yml, so
+            # no provider can be resolved from it. Its deployment repo can
+            # answer for it -- through the render under `build/`, which is where
+            # the repo keeps its config.yml and what every other runtime caller
+            # resolves a provider from. Without one there is nothing to run on,
+            # and falling through to ambient ANTHROPIC_* variables is how an
+            # audit ends up reviewing a deployment's safety config through an
+            # endpoint that has nothing to do with it.
+            from osprey.deployment.staleness import BUILD_DIRNAME
+
+            from .repo_resolver import RepoNotFoundError, find_repo_root
+
+            try:
+                repo_root = find_repo_root(target_dir.resolve().parent)
+            except RepoNotFoundError:
+                output.fail(
+                    "The reviewer has no provider to run on",
+                    f"{target} is a profile, and it is not inside a deployment repo "
+                    "whose build could say which provider to use.",
+                    "pass --build so the provider can be resolved",
+                )
+                raise SystemExit(1) from None
+
+            audit_root = repo_root / BUILD_DIRNAME
+            if not (audit_root / "config.yml").exists():
+                output.fail(
+                    "The reviewer has no provider to run on",
+                    f"{target} is a profile, and {audit_root} holds no config.yml: "
+                    "its repo has not been built, so nothing there says which "
+                    "provider to use.",
+                    "pass --build so the provider can be resolved",
+                )
+                raise SystemExit(1)
+
         try:
+            from osprey.agent_runner.primitives import resolve_default_model
+
+            # The deployment's own sonnet tier, not a bare vendor id: a
+            # gateway-fronted deployment serves its own model names.
+            resolved_model = model or resolve_default_model(audit_root, tier="sonnet")
+
             if not json_output:
                 output.section(
                     "",
                     [
                         ("Auditing", f"{target_type}: {target_dir}"),
-                        ("Model", model),
+                        ("Model", resolved_model),
                         ("Budget", f"${budget:.2f}"),
                     ],
                 )
 
-            file_listing = _list_files(target_dir)
+            file_listing = _list_files(audit_root)
             prompt = build_audit_prompt(target_type, target_dir, file_listing)
 
             # Run the agent
             raw_text, cost, turns = asyncio.run(
-                _run_audit(prompt, model, target_dir, budget, verbose)
+                _run_audit(prompt, resolved_model, audit_root, budget, verbose)
             )
 
             # Parse the result

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -860,27 +860,38 @@ def _print_endpoints_section(config, compose_files, repo_root=None):
 def _auth_availability(secret_env, repo_root):
     """Where this deployment's provider credential can be found, if anywhere.
 
-    Both places count, and which one it came from matters. The exported shell
-    environment is what ``osprey chat`` authenticates from; the repo's ``.env``
-    is the deployment's own secret store and what every container reads. A
-    check against ``os.environ`` alone would report "NOT FOUND" for a
-    perfectly-configured deployment whose key lives only in ``.env``.
+    Every place that carries it counts, and which one it came from matters. The
+    exported shell environment is what ``osprey chat`` authenticates from; the
+    env chain — ``.env.shared`` then ``.env``, later file wins — is the
+    deployment's own store and what every container reads. A check against
+    ``os.environ`` alone would report "NOT FOUND" for a perfectly-configured
+    deployment whose key lives only in a file, and a check against ``.env``
+    alone would do the same for one whose value the provider spec beside this
+    row resolves out of ``.env.shared``.
+
+    ``.env.shared`` is committed, so a secret found there is reported as found
+    *and* flagged: the row upholds that file's own header rather than
+    contradicting it.
 
     :return: ``(available, where)`` — *where* is a phrase, empty when not found
     """
     import os
 
-    from osprey.utils.dotenv import parse_dotenv_file
+    from osprey.utils.dotenv import ENV_LOCAL_FILENAME, chain_files, parse_dotenv_file
 
     if os.environ.get(secret_env):
         return True, "exported in this shell"
-    env_path = Path(repo_root) / ".env"
-    if env_path.is_file():
+    # Descending precedence: the file whose value actually wins is the one to
+    # name, so the operator edits the file the deployment is reading.
+    for env_path in reversed(chain_files(Path(repo_root))):
         try:
-            if parse_dotenv_file(env_path).get(secret_env):
-                return True, f"set in {env_path.name}"
+            if not parse_dotenv_file(env_path).get(secret_env):
+                continue
         except OSError:
-            pass
+            continue
+        if env_path.name == ENV_LOCAL_FILENAME:
+            return True, f"set in {env_path.name}"
+        return True, f"set in {env_path.name} — a committed file; move the secret to .env"
     return False, ""
 
 
@@ -1011,6 +1022,7 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
 
     from osprey.build.claude_code_resolver import AGENT_DEFAULT_TIERS, load_provider_spec
     from osprey.build.claude_code_telemetry import ObservabilityCredentialError
+    from osprey.utils.dotenv import ENV_CHAIN_FILENAMES
 
     rows: list[tuple[str, object]] = []
     notes: list[str] = []
@@ -1021,7 +1033,7 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
     if not provider_name:
         rows.append(("provider", "not configured"))
         notes.append(
-            "Set claude_code.provider in profile.yml and rebuild to resolve models "
+            "Set `provider:` in profile.yml and rebuild to resolve models "
             "and provider environment automatically."
         )
     else:
@@ -1031,8 +1043,8 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
             # durable state and never live in the disposable build zone, so a
             # custom provider's ``base_url: ${ARGO_PROD_URL}`` would otherwise
             # be reported as the literal placeholder. Same pairing as
-            # ``_auth_availability`` below, which already looks for the
-            # credential in ``repo_root/.env``.
+            # ``_auth_availability`` below, which looks for the credential in
+            # the same env chain this expansion reads.
             spec = load_provider_spec(build_dir, env_dir=repo_root)
         except ObservabilityCredentialError:
             # Ahead of the broad handler on purpose, and load-bearing: resolving
@@ -1085,7 +1097,7 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
                     (
                         "auth",
                         f"✗ ${spec.auth_secret_env} not found in this shell or in "
-                        f"{repo_root / '.env'}",
+                        f"{', '.join(ENV_CHAIN_FILENAMES)} under {repo_root}",
                     )
                 )
 

--- a/src/osprey/health/core/file_system.py
+++ b/src/osprey/health/core/file_system.py
@@ -21,8 +21,11 @@ Rows emitted:
   is not writable or cannot be created.
 * ``env_file`` — ok when a ``.env`` file is present at the repo root (the
   deployment's single secret store), warning otherwise.
-* ``registry_file`` — emitted only when ``config.yml`` declares
-  ``registry_path``: ok when the file exists, error when configured but missing.
+* ``registry_file`` — emitted only when the config declares an application
+  registry (``registry_path``, its ``application.registry_path`` alias, or the
+  ``REGISTRY_PATH`` environment override, resolved by the loader's own
+  :func:`osprey.registry.manager.resolve_registry_path`): ok when the file
+  exists, error when configured but missing.
 * ``disk_space`` — warning when free space is below 1 GB or the filesystem is at
   least 90% full, ok otherwise; warning when disk usage cannot be read.
 
@@ -166,13 +169,15 @@ def _check_file_system(config: dict[str, Any], cwd: Path) -> list[CheckResult]:
     # CONFIG_DEPENDENT, so the category still reports healthy with a row missing.
     try:
         if config:
-            file_config = config
+            # The same resolver the loader uses, so the row can never disagree
+            # with what actually loaded: it knows all three spellings
+            # (REGISTRY_PATH, `registry_path`, `application.registry_path`),
+            # expands `${VAR}`, and resolves a relative path against `cwd`.
+            from osprey.registry.manager import resolve_registry_path
 
-            registry_path_str = file_config.get("registry_path")
+            registry_path_str = resolve_registry_path(config, base_path=cwd)
             if registry_path_str:
-                # Resolve environment variables in path.
-                registry_path_str = os.path.expandvars(registry_path_str)
-                registry_path = cwd / registry_path_str
+                registry_path = Path(registry_path_str)
 
                 if registry_path.exists():
                     results.append(

--- a/src/osprey/health/core/providers.py
+++ b/src/osprey/health/core/providers.py
@@ -12,10 +12,13 @@ Results are advisory for every provider but one: a reachable provider is
 ``ok``, and every failure mode (bad key, unknown provider, unreachable
 endpoint, timeout) is ``warning``. The exception is the deployment's own agent
 provider — ``claude_code.provider``, the one every web terminal and the
-dispatch worker authenticate with. When that one fails, the deployment is down,
-so its row is an ``error`` (and ``osprey health`` exits 2); it is also an error
-when it is named but has no ``api.providers`` block to probe. Zero configured
-providers yields no rows.
+dispatch worker authenticate with. When that one *fails a probe*, the
+deployment is down, so its row is an ``error`` (and ``osprey health`` exits 2);
+it is also an error when it is named but has no ``api.providers`` block to
+probe at all. A row that never contacted anything is not escalated: a
+config-only provider (a block with no adapter class) is a ``skip``, marked as
+this deployment's agent provider so the operator sees that health did not
+verify it. Zero configured providers yields no rows.
 """
 
 from __future__ import annotations
@@ -65,7 +68,11 @@ def providers(
     cfg: Mapping[str, Any] = config or {}
     # The canary ignores the runtime; supply a never-constructed one when the
     # factory is called without a context so the ProbeContext stays type-correct.
-    ctx = ProbeContext(runtime=context if context is not None else HealthRuntime({}))
+    # The config travels with the context, not just inside each spec: the canary
+    # consults ``api.providers.<name>`` itself to tell a config-only provider
+    # from an unknown one, and must read the same config this category was
+    # handed rather than the process-default singleton.
+    ctx = ProbeContext(runtime=context if context is not None else HealthRuntime({}), config=cfg)
 
     async def _run() -> list[CheckResult]:
         api = cfg.get("api", {}) or {}
@@ -106,17 +113,31 @@ def providers(
                     details=str(outcome),
                 )
             if name == own and row.status is not Status.OK:
-                # Not advisory: this is the provider the agent runs on, so a
-                # failure here is every terminal and the dispatch worker down.
-                row = replace(
-                    row,
-                    status=Status.ERROR,
-                    message=(
-                        f"{row.message} — {own} is this deployment's agent provider "
-                        "(claude_code.provider); every web terminal and the dispatch "
-                        "worker authenticate with it"
-                    ),
-                )
+                if row.status in (Status.WARNING, Status.ERROR) and row.probed:
+                    # Not advisory: this is the provider the agent runs on, so a
+                    # failed probe here is every terminal and the dispatch
+                    # worker down.
+                    row = replace(
+                        row,
+                        status=Status.ERROR,
+                        message=(
+                            f"{row.message} — {own} is this deployment's agent provider "
+                            "(claude_code.provider); every web terminal and the dispatch "
+                            "worker authenticate with it"
+                        ),
+                    )
+                else:
+                    # Nothing was contacted, so there is no reachability fact to
+                    # escalate — grading the absence of an adapter class as a
+                    # failure exits 2 on a deployment whose agent is running.
+                    # The row keeps its status and says it went unverified.
+                    row = replace(
+                        row,
+                        message=(
+                            f"{row.message} — {own} is this deployment's agent provider "
+                            "(claude_code.provider), left unverified by this run"
+                        ),
+                    )
             rows.append(row)
         return rows
 

--- a/src/osprey/health/models.py
+++ b/src/osprey/health/models.py
@@ -42,6 +42,12 @@ class CheckResult:
         value: Measured value, e.g. ``"401.2 mA"`` (optional).
         latency_ms: Elapsed time for the check in milliseconds (optional).
         details: Extended diagnostic or error information (optional).
+        probed: Whether the check actually contacted what it grades. ``False``
+            means the row states a fact about the *configuration* (nothing was
+            reachable to try, or there was nothing to try it with), so a caller
+            deciding how loudly to report a non-``ok`` row knows there is no
+            reachability fact behind it. In-process only: it is not part of
+            :meth:`to_dict`'s locked wire shape.
     """
 
     name: str
@@ -51,6 +57,7 @@ class CheckResult:
     value: str = ""
     latency_ms: float = 0.0
     details: str = ""
+    probed: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the wire shape, omitting empty optional fields.

--- a/src/osprey/health/probes/provider_canary.py
+++ b/src/osprey/health/probes/provider_canary.py
@@ -13,7 +13,10 @@ produces an ``error`` row:
 
 * ``check_health`` returns ``(True, msg)`` → ``ok``;
 * ``check_health`` returns ``(False, msg)`` → ``warning``;
-* an unknown provider name → ``warning`` ``"Unknown provider"`` (never a crash);
+* a name with an ``api.providers`` block but no adapter class → ``skip``
+  (a config-only provider: there is nothing to probe it *with*);
+* a name with neither a class nor a config block → ``warning``
+  ``"Unknown provider"`` (never a crash);
 * a raised exception, or a timeout while the daemon thread is abandoned →
   ``warning`` (an unreachable provider must not fail the suite).
 
@@ -153,6 +156,18 @@ async def run(
     reg = registry if registry is not None else get_provider_registry()
     provider_class = reg.get_provider(provider_name)
     if provider_class is None:
+        # No adapter class is not the same fact as no provider. The documented
+        # no-code route to a new endpoint is an ``api.providers`` block and
+        # nothing else, and there is no class to instantiate for one — so a
+        # configured name is skipped (nothing to probe with), and only a name
+        # that is configured nowhere either is unknown.
+        if _provider_block(provider_name, ctx.config):
+            return CheckResult(
+                result_name,
+                category,
+                Status.SKIP,
+                "config-only provider — no code adapter to probe",
+            )
         return CheckResult(result_name, category, Status.WARNING, "Unknown provider")
 
     # Consult the config block only for fields the spec does not already supply,
@@ -164,8 +179,12 @@ async def run(
     base_url = _resolve_secret(spec["base_url"] if "base_url" in spec else block.get("base_url"))
 
     t0 = perf_counter()
+    probed = False
     try:
         provider = provider_class()
+        # Past this point the endpoint was contacted (or the attempt to contact
+        # it is what failed), so every row below states a reachability fact.
+        probed = True
         success, message = await run_sync(
             provider.check_health,
             api_key,
@@ -182,6 +201,7 @@ async def run(
             Status.WARNING,
             f"health check timed out after {timeout_s:g}s",
             latency_ms=latency_ms,
+            probed=probed,
         )
     except Exception as exc:  # noqa: BLE001 - an unreachable provider is a warning, never error
         latency_ms = (perf_counter() - t0) * 1000.0
@@ -192,6 +212,7 @@ async def run(
             "health check failed",
             latency_ms=latency_ms,
             details=str(exc),
+            probed=probed,
         )
 
     latency_ms = (perf_counter() - t0) * 1000.0
@@ -201,4 +222,5 @@ async def run(
         Status.OK if success else Status.WARNING,
         message,
         latency_ms=latency_ms,
+        probed=probed,
     )

--- a/src/osprey/infrastructure/proxy/lifecycle.py
+++ b/src/osprey/infrastructure/proxy/lifecycle.py
@@ -8,17 +8,15 @@ import threading
 import time
 from typing import Any
 
+#: The two wire protocols a provider entry may declare, imported from the
+#: catalog contract that owns them rather than kept as a second copy.
+from osprey.profiles.providers import VALID_API_PROTOCOLS
+
 logger = logging.getLogger("osprey.infrastructure.proxy")
 
 # Providers known to speak Anthropic Messages API natively.
 # Everything else is assumed to be OpenAI-compatible and needs the proxy.
 _ANTHROPIC_NATIVE_PROVIDERS = frozenset({"anthropic", "cborg", "als-apg"})
-
-#: The two wire protocols a provider entry may declare. The comparison against
-#: ``"anthropic"`` is exact, so a misspelling — ``Anthropic``, ``antropic`` —
-#: used to read as "not Anthropic" and silently insert the translation hop the
-#: config template warns about. Two values, checked as an enum.
-VALID_API_PROTOCOLS = frozenset({"anthropic", "openai"})
 
 _state: dict[str, Any] = {
     "server": None,
@@ -43,10 +41,13 @@ def is_proxy_needed(
 
     An absent ``api_protocol`` means OpenAI, which is right for nine of the
     twelve proxied built-ins. A PRESENT one is checked against
-    :data:`VALID_API_PROTOCOLS`: the old exact comparison meant a typo took the
-    step-3 branch, so a provider written ``api_protocol: Anthropic`` was routed
-    through the translation proxy the config template explicitly warns against
-    — with nothing said about it.
+    :data:`~osprey.profiles.providers.VALID_API_PROTOCOLS`: the old exact
+    comparison meant a typo took the step-3 branch, so a provider written
+    ``api_protocol: Anthropic`` was routed through the translation proxy the
+    config template explicitly warns against — with nothing said about it.
+    The catalog loader refuses such a value at load; this check stays because
+    an ``api.providers`` block can reach a build without passing through the
+    catalog — a hand-edited ``build/config.yml``, for one.
 
     Args:
         provider_name: The provider being resolved.

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -576,6 +576,27 @@ Respond ONLY with the JSON object, no additional text."""
         ) from e
 
 
+def _requires_api_key(provider: str) -> bool:
+    """Whether *provider*'s adapter declares that it needs an API key.
+
+    Reads the provider class's own ``requires_api_key`` attribute through the
+    registry — the same declaration `models/completion.py`, `cli/web_cmd.py` and
+    the production env renderer already consult. A name tuple here instead put
+    every keyless adapter but one behind a refusal it does not deserve, and a
+    facility's own keyless adapter behind it with no way out.
+
+    An unknown name is assumed to need a key, which is what a name tuple did for
+    every name it did not list.
+    """
+    # Lazy import avoids an import cycle: provider_registry imports provider
+    # modules, which import this adapter.
+    from osprey.models.provider_registry import get_provider_registry
+
+    provider_class = get_provider_registry().get_provider(provider)
+    declared = getattr(provider_class, "requires_api_key", None)
+    return True if declared is None or declared is NotImplemented else bool(declared)
+
+
 def check_litellm_health(
     provider: str,
     api_key: str | None,
@@ -594,8 +615,15 @@ def check_litellm_health(
     :param model_id: Model to test with
     :return: (success, message) tuple
     """
-    if not api_key and provider not in ("ollama",):
-        return False, "API key not set"
+    if not api_key:
+        if _requires_api_key(provider):
+            return False, "API key not set"
+        # A keyless endpoint (an on-prem vLLM, a local Ollama) still needs a
+        # non-empty key on the wire: litellm's OpenAI client refuses to send
+        # without one. "EMPTY" is the placeholder the shipped keyless adapters
+        # already substitute by hand on the completion path; this is its one
+        # home on the health path.
+        api_key = "EMPTY"
 
     # Check for placeholder values
     if api_key and (api_key.startswith("${") or "YOUR_API_KEY" in api_key.upper()):

--- a/src/osprey/models/spend_attribution.py
+++ b/src/osprey/models/spend_attribution.py
@@ -57,8 +57,10 @@ SURFACE_DISPATCH = "dispatch"
 SURFACE_SERVICE = "service"
 SURFACE_LOCAL = "local"
 
-#: Built-in providers that are LiteLLM proxies. A custom ``api.providers``
-#: entry declares the same with ``gateway: litellm``.
+#: Default gateway kind for the built-in names that are LiteLLM proxies —
+#: consulted only when a provider's own ``api.providers`` entry says nothing.
+#: It exists so the build path can answer without importing the adapters, and
+#: is parity-pinned to their ``gateway`` attribute.
 _BUILTIN_GATEWAYS: Mapping[str, str] = {
     "als-apg": LITELLM_GATEWAY,
     "cborg": LITELLM_GATEWAY,
@@ -70,16 +72,21 @@ def gateway_for(
 ) -> str | None:
     """Return the gateway kind fronting *provider_name*, or ``None`` for a direct provider.
 
-    A custom provider's ``gateway`` key wins over nothing: the built-in table
-    only names providers that have no ``api.providers`` entry of their own.
+    A declaration wins. ``api.providers.<name>.gateway`` is this deployment's
+    own statement about the endpoint it points at: a non-empty string is the
+    gateway kind, and an empty value or ``none`` says the endpoint is direct
+    and carries no attribution headers. The built-in table answers only for a
+    name whose entry says nothing about a gateway — otherwise a deployment
+    that re-points a built-in name at its own direct endpoint would go on
+    sending end-user identity to it.
     """
-    if provider_name in _BUILTIN_GATEWAYS:
-        return _BUILTIN_GATEWAYS[provider_name]
-    if api_providers:
-        declared = api_providers.get(provider_name, {}).get("gateway")
-        if isinstance(declared, str) and declared.strip():
+    block = (api_providers or {}).get(provider_name) or {}
+    if isinstance(block, Mapping) and "gateway" in block:
+        declared = block.get("gateway")
+        if isinstance(declared, str) and declared.strip() and declared.strip().lower() != "none":
             return declared.strip()
-    return None
+        return None
+    return _BUILTIN_GATEWAYS.get(provider_name)
 
 
 def acting_surface() -> str:

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -107,6 +107,21 @@ keys:
     evidence: 'config\.get\("project_root"\)'
     default: derived
     default_note: the repo root the loaded config.yml sits in
+  registry_path:
+    rendered: false
+    evidence: 'registry_path'
+    note: >-
+      The application registry module — a facility's own connectors, providers
+      and ARIEL adapters. Nothing derives it, so the build renders no line for
+      it; a deployment states it in its profile's `config:` block (commented
+      example in the control-assistant preset). Resolved by
+      `registry.manager.resolve_registry_path`, which also accepts the
+      `application.registry_path` alias and lets the `REGISTRY_PATH`
+      environment variable outrank both.
+    default: no-fallback
+    default_note: >-
+      unset names no application registry, and the framework-only registry is
+      used
   facility:
     evidence: 'config\.get\("facility"\)'
     note: >-

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -193,6 +193,13 @@ config:
   # table renders. Drop the key and the subagent is told no vocabulary was
   # declared; point it at a missing file and the build stops and says so.
   facility.ontology: data/facility_ontology.json
+  # Your facility's own registry module — the file that registers its
+  # connectors, providers and ARIEL adapters with the framework (see
+  # "Extending Osprey" in the docs). Relative to the project root; unset means
+  # no application registry, and the framework-only one is used. `REGISTRY_PATH`
+  # in the environment outranks this key, for a container pointed at a registry
+  # mounted somewhere the config could not have named.
+  # registry_path: project/registry.py
 
   # ── Control system ─────────────────────────────────────────────────────────
   # Which machine a session starts on. "live_standin" is the stand-in declared

--- a/src/osprey/profiles/providers.py
+++ b/src/osprey/profiles/providers.py
@@ -33,6 +33,14 @@ PROVIDERS_FILENAME = "providers.yml"
 #: future file-level keys without a provider named after one of them.
 _PROVIDERS_KEY = "providers"
 
+#: The two wire protocols an entry may declare. The framework compares against
+#: ``"anthropic"`` exactly, so a misspelling — ``Anthropic``, ``antropic`` —
+#: reads as "not Anthropic" and silently inserts the translation hop the config
+#: template warns about. Two values, checked as an enum where the catalog is
+#: read; :mod:`osprey.infrastructure.proxy.lifecycle` imports this set rather
+#: than keeping a second copy of it.
+VALID_API_PROTOCOLS = frozenset({"anthropic", "openai"})
+
 #: Keys the contract documents. ``base_url`` is the only required one — an entry
 #: without it names no endpoint, so nothing downstream can call it. ``api_key``,
 #: ``models`` and ``api_protocol`` are optional, and an entry may carry further
@@ -162,6 +170,12 @@ def _validate_entry(path: Path, name: str, entry: Any) -> None:
     # than refused: the entries are rendered verbatim into `api.providers`, and
     # an operator's gateway may legitimately carry a key this framework version
     # does not read yet.
+    protocol = entry.get("api_protocol")
+    if protocol is not None and protocol not in VALID_API_PROTOCOLS:
+        raise BuildProfileError(
+            f"Provider catalog {path}: `{_PROVIDERS_KEY}.{name}.api_protocol` is "
+            f"{protocol!r}; expected one of {', '.join(sorted(VALID_API_PROTOCOLS))}."
+        )
     models = entry.get("models")
     if models is not None and not isinstance(models, dict):
         raise BuildProfileError(

--- a/src/osprey/registry/base.py
+++ b/src/osprey/registry/base.py
@@ -56,11 +56,17 @@ class ProviderRegistration:
     :type module_path: str
     :param class_name: Provider class name within the module (e.g., 'AnthropicProviderAdapter')
     :type class_name: str
+    :param name: The name this provider is resolved by — the same name a config
+        names in ``claude_code.provider`` or ``models.*.provider``. REQUIRED in
+        practice: a registration without one registers nothing, and a name that
+        matches a built-in replaces it.
+    :type name: str | None
 
     Example:
         >>> ProviderRegistration(
         ...     module_path="osprey.models.providers.anthropic",
-        ...     class_name="AnthropicProviderAdapter"
+        ...     class_name="AnthropicProviderAdapter",
+        ...     name="anthropic",
         ... )
 
         The registry will load this class and introspect metadata like:

--- a/src/osprey/registry/helpers.py
+++ b/src/osprey/registry/helpers.py
@@ -198,7 +198,10 @@ def generate_explicit_registry_code(
     for prov in framework.providers:
         code_lines.append("                ProviderRegistration(")
         code_lines.append(f'                    module_path="{prov.module_path}",')
-        code_lines.append(f'                    class_name="{prov.class_name}"')
+        code_lines.append(f'                    class_name="{prov.class_name}",')
+        # The name is what the provider is resolved by; a registration without
+        # one registers nothing.
+        code_lines.append(f'                    name="{prov.name}"')
         code_lines.append("                ),")
 
     code_lines.extend(["            ],", "        )", ""])

--- a/src/osprey/registry/initializers.py
+++ b/src/osprey/registry/initializers.py
@@ -64,24 +64,51 @@ def initialize_providers(
 
     Delegates to ``ProviderRegistry.load_providers()`` for the actual import
     loop, then stores the results in *registries* for backward compatibility.
-    Custom providers from ``config.providers`` (non-built-in) are registered
-    first so they participate in the bulk load.
+    Providers from ``config.providers`` are registered first so they participate
+    in the bulk load — including one whose name shadows a built-in, which
+    replaces it (logged) rather than being dropped.
 
     Uses config-driven filtering to skip imports for unconfigured providers,
     avoiding costly module-level network calls on air-gapped machines.
     """
     # LAYERING NOTE: upward import from models (L5)
-    from osprey.models.provider_registry import get_provider_registry
+    from osprey.models.provider_registry import _BUILTIN_PROVIDERS, get_provider_registry
 
     pr = get_provider_registry()
 
+    # Register every named entry unconditionally. `register_provider` documents
+    # overwrite-by-name and `override_providers` documents "replace framework
+    # versions (by name)" — but the registry is pre-seeded with every built-in,
+    # so a name check against it dropped exactly the registrations meant to
+    # replace one, and dropped them silently.
+    registered: set[str] = set()
+    builtin_names = set(_BUILTIN_PROVIDERS)
     for registration in config.providers:
-        if registration.name and registration.name not in pr.list_providers():
-            pr.register_provider(
+        if not registration.name:
+            logger.warning(
+                "Provider registration %s.%s has no name; set name=… — this registration is inert",
+                registration.module_path,
+                registration.class_name,
+            )
+            continue
+        if registration.name in builtin_names:
+            logger.info(
+                "Application registry overrides built-in provider '%s' with %s.%s",
                 registration.name,
                 registration.module_path,
                 registration.class_name,
             )
+        pr.register_provider(
+            registration.name,
+            registration.module_path,
+            registration.class_name,
+        )
+        registered.add(registration.name)
+
+    # An override of an excluded built-in is the override, not nothing: a
+    # facility replacing `openai` excludes the framework's version and ships its
+    # own under the same name, and the exclusion must not then drop its own.
+    excluded_names = set(excluded_provider_names or ()) - registered
 
     configured_providers = _get_configured_provider_names()
 
@@ -92,7 +119,7 @@ def initialize_providers(
 
     loaded = pr.load_providers(
         configured_names=configured_providers,
-        excluded_names=excluded_provider_names or None,
+        excluded_names=excluded_names or None,
     )
 
     for name, provider_class in loaded.items():

--- a/src/osprey/registry/manager.py
+++ b/src/osprey/registry/manager.py
@@ -7,6 +7,7 @@ Provides :class:`RegistryManager` plus the global singleton helpers
 """
 
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -318,40 +319,83 @@ def get_registry(config_path: str | None = None) -> RegistryManager:
     return _registry
 
 
+#: Environment variable that names the application registry file, outranking
+#: every config spelling. Containers set it to point at a mounted registry.
+REGISTRY_PATH_ENV = "REGISTRY_PATH"
+
+
+def resolve_registry_path(
+    config: Mapping[str, Any] | None = None,
+    *,
+    base_path: Path | str | None = None,
+) -> str | None:
+    """Resolve the application registry file path — the one resolver for it.
+
+    Three spellings reach the same file, and every reader must agree on which
+    one is in effect: the registry loader, the health row that reports whether
+    that file is there, and anything else that asks whether a deployment has an
+    application registry at all. A reader that knows only one spelling reports
+    on a different deployment than the one that loaded.
+
+    Lookup order, first hit wins:
+
+    1. the ``REGISTRY_PATH`` environment variable — the container override;
+    2. top-level ``registry_path`` — the canonical spelling;
+    3. ``application.registry_path`` — an accepted alias.
+
+    ``${VAR}`` in the value is expanded against the environment, and a relative
+    path is resolved against *base_path* when one is given.
+
+    Args:
+        config: Config mapping to read. ``None`` reads through the global
+            config singleton, which is what the registry factory has when it
+            was handed only a config path.
+        base_path: Directory relative paths resolve against; ``None`` leaves a
+            relative path relative.
+
+    Returns:
+        The resolved path, or ``None`` when no spelling names one.
+    """
+    import os
+
+    raw: Any = os.environ.get(REGISTRY_PATH_ENV)
+    if not raw:
+        if config is None:
+            raw = get_config_value("registry_path", None)
+            if not raw:
+                application = get_config_value("application", None)
+                if isinstance(application, Mapping):
+                    raw = application.get("registry_path")
+        else:
+            raw = config.get("registry_path")
+            if not raw:
+                application = config.get("application")
+                if isinstance(application, Mapping):
+                    raw = application.get("registry_path")
+
+    if not raw or not isinstance(raw, str):
+        return None
+
+    expanded: str = os.path.expandvars(str(raw))
+    if base_path is not None and not Path(expanded).is_absolute():
+        return str((Path(base_path) / expanded).resolve())
+    return expanded
+
+
 def _create_registry_from_config(config_path: str | None = None) -> RegistryManager:
     """Create registry manager from global configuration.
 
-    Supports multiple configuration formats for registry path specification:
-
-    1. Environment variable (highest priority, for container overrides):
-       REGISTRY_PATH=/app/repo_src/my_app/registry.py
-
-    2. Top-level format (simple, for single-app projects):
-       registry_path: ./src/my_app/registry.py
-
-    3. Nested format (standard, recommended):
-       application:
-         registry_path: ./src/my_app/registry.py
+    The path itself comes from :func:`resolve_registry_path`, which every
+    reader of it shares (REGISTRY_PATH, then top-level ``registry_path``, then
+    ``application.registry_path``).
 
     :param config_path: Optional explicit path to configuration file
     :return: Configured registry manager with registry paths
     :rtype: RegistryManager
     :raises ConfigurationError: If configuration format is invalid
     """
-    import os
-
     logger.debug("Creating registry from config...")
     try:
-        registry_path = None
-
-        env_registry_path = os.environ.get("REGISTRY_PATH")
-        if env_registry_path:
-            registry_path = env_registry_path
-            logger.info(
-                f"Using registry path from REGISTRY_PATH environment variable: {registry_path}"
-            )
-            return RegistryManager(registry_path=registry_path)
-
         if config_path:
             from osprey.utils.config import get_config_builder
 
@@ -368,23 +412,9 @@ def _create_registry_from_config(config_path: str | None = None) -> RegistryMana
                 base_path = Path(config_path).resolve().parent
                 logger.debug(f"Using config file directory as base path: {base_path}")
 
-        def resolve_registry_path(path: str) -> str:
-            """Resolve registry path, handling relative paths correctly."""
-            if base_path and not Path(path).is_absolute():
-                resolved = (base_path / path).resolve()
-                logger.debug(f"Resolved registry path '{path}' -> '{resolved}'")
-                return str(resolved)
-            return path
-
-        registry_path = get_config_value("registry_path", None)
-
-        if not registry_path:
-            application = get_config_value("application", None)
-            if application and isinstance(application, dict):
-                registry_path = application.get("registry_path")
+        registry_path = resolve_registry_path(base_path=base_path)
 
         if registry_path:
-            registry_path = resolve_registry_path(registry_path)
             logger.info(f"Using application registry: {registry_path}")
         else:
             logger.info("No application registry configured - using framework-only registry")

--- a/tests/agent_runner/test_primitives.py
+++ b/tests/agent_runner/test_primitives.py
@@ -116,6 +116,25 @@ def test_unresolvable_provider_raises(tmp_path: Path) -> None:
         provider_env_for_project(tmp_path)
 
 
+def test_the_no_provider_error_names_the_key_the_operator_sets(tmp_path: Path) -> None:
+    """The remedy has to be one an operator can carry out.
+
+    This branch fires when the key is unset, so it names that key and the file
+    it is set in — not a five-name provider list (an *unknown* name gets the
+    registry-derived union elsewhere) and not a test-only helper.
+    """
+    (tmp_path / "config.yml").write_text("api:\n  providers: {}\n")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        provider_env_for_project(tmp_path)
+
+    message = str(excinfo.value)
+    assert "claude_code.provider" in message
+    assert "profile.yml" in message
+    assert "osprey build" in message
+    assert "init_project" not in message
+
+
 # ---------------------------------------------------------------------------
 # sdk_env composition
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_audit_cmd.py
+++ b/tests/cli/test_audit_cmd.py
@@ -298,6 +298,134 @@ class TestBuildFlag:
             assert args["project_name"].startswith("audit-")
 
 
+class TestReviewerProvider:
+    """The reviewer runs on the audited deployment's own provider."""
+
+    def _get_audit_cmd(self):
+        from osprey.cli.audit_cmd import audit
+
+        return audit
+
+    def test_options_come_from_the_projects_provider(self, tmp_project, monkeypatch):
+        """Hand-built options carried no provider env, so the SDK fell through
+        to ambient ``ANTHROPIC_*``. They now come from the shared builder, which
+        resolves the project's endpoint, auth and models."""
+        from osprey.cli import audit_cmd
+
+        captured: dict = {}
+        sentinel = object()
+
+        def fake_build(project_dir, **kwargs):
+            captured["project_dir"] = project_dir
+            captured.update(kwargs)
+            return sentinel
+
+        monkeypatch.setattr(
+            "osprey.agent_runner.primitives.build_agent_options", fake_build, raising=True
+        )
+
+        assert audit_cmd._reviewer_options(tmp_project, "some-model", 5.0) is sentinel
+        assert captured["project_dir"] == tmp_project
+        assert captured["model"] == "some-model"
+        assert captured["max_budget_usd"] == 5.0
+        assert captured["max_turns"] == 30
+        # The reviewer reads the target; it must not run as it.
+        assert captured["setting_sources"] == []
+
+    @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+    @patch("osprey.cli.audit_cmd.asyncio")
+    def test_default_model_is_the_projects_sonnet_tier(
+        self, mock_asyncio, runner, tmp_project, sample_report, monkeypatch
+    ):
+        mock_asyncio.run.return_value = (sample_report.model_dump_json(), 0.01, 5)
+        seen: dict = {}
+
+        def fake_resolve(project_dir, tier="haiku"):
+            seen["tier"] = tier
+            seen["project_dir"] = project_dir
+            return "gateway/claude-sonnet"
+
+        monkeypatch.setattr(
+            "osprey.agent_runner.primitives.resolve_default_model", fake_resolve, raising=True
+        )
+
+        result = runner.invoke(self._get_audit_cmd(), [str(tmp_project)])
+
+        assert result.exit_code == 0
+        assert seen["tier"] == "sonnet"
+        assert seen["project_dir"] == tmp_project
+        assert "gateway/claude-sonnet" in result.output
+
+    @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+    @patch("osprey.cli.audit_cmd.asyncio")
+    def test_an_explicit_model_still_wins(
+        self, mock_asyncio, runner, tmp_project, sample_report, monkeypatch
+    ):
+        mock_asyncio.run.return_value = (sample_report.model_dump_json(), 0.01, 5)
+        monkeypatch.setattr(
+            "osprey.agent_runner.primitives.resolve_default_model",
+            lambda project_dir, tier="haiku": "should-not-be-used",
+            raising=True,
+        )
+
+        result = runner.invoke(self._get_audit_cmd(), [str(tmp_project), "--model", "picked"])
+
+        assert result.exit_code == 0
+        assert "picked" in result.output
+
+    @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+    def test_a_bare_profile_outside_a_repo_is_refused(self, runner, tmp_profile):
+        """No project, no provider: better to say so than to review a
+        deployment's safety config through whatever endpoint the shell holds."""
+        result = runner.invoke(self._get_audit_cmd(), [str(tmp_profile)])
+
+        assert result.exit_code == 1
+        assert "--build" in result.output
+
+    @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+    @patch("osprey.cli.audit_cmd.asyncio")
+    def test_a_bare_profile_in_a_repo_runs_from_the_repos_build(
+        self, mock_asyncio, runner, tmp_path, sample_report, monkeypatch
+    ):
+        """The render under ``build/`` holds ``config.yml``; the repo root does
+        not, so resolving from the root is a FileNotFoundError on any real repo."""
+        from osprey.deployment.staleness import BUILD_DIRNAME
+
+        (tmp_path / "profile.yml").write_text("name: test\n")
+        (tmp_path / BUILD_DIRNAME).mkdir()
+        (tmp_path / BUILD_DIRNAME / "config.yml").write_text("claude_code:\n  provider: mock\n")
+        profile = tmp_path / "other-profile.yml"
+        profile.write_text("name: test\nprovider: mock\n")
+        mock_asyncio.run.return_value = (sample_report.model_dump_json(), 0.01, 5)
+        seen: dict = {}
+
+        def fake_resolve(project_dir, tier="haiku"):
+            seen["project_dir"] = project_dir
+            return "resolved-model"
+
+        monkeypatch.setattr(
+            "osprey.agent_runner.primitives.resolve_default_model", fake_resolve, raising=True
+        )
+
+        result = runner.invoke(self._get_audit_cmd(), [str(profile)])
+
+        assert result.exit_code == 0
+        assert seen["project_dir"] == tmp_path.resolve() / BUILD_DIRNAME
+
+    @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+    def test_a_bare_profile_in_an_unbuilt_repo_is_refused(self, runner, tmp_path):
+        """A repo that has never been built holds no config.yml to resolve a
+        provider from — say so rather than crash reading one that is not there."""
+        (tmp_path / "profile.yml").write_text("name: test\n")
+        profile = tmp_path / "other-profile.yml"
+        profile.write_text("name: test\nprovider: mock\n")
+
+        result = runner.invoke(self._get_audit_cmd(), [str(profile)])
+
+        assert result.exit_code == 1
+        assert "--build" in result.output
+
+
 # ---------------------------------------------------------------------------
 # Display tests
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_json_contracts.py
+++ b/tests/cli/test_json_contracts.py
@@ -417,7 +417,12 @@ def test_audit_verbose_keeps_the_reviewer_transcript_off_the_document(
     """
     # Imported here, not at module scope: the SDK is optional to ``audit_cmd``,
     # and a missing one should cost this test alone rather than the whole file.
-    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ResultMessage,
+        TextBlock,
+    )
 
     project = _audit_project(tmp_path)
     transcript = "reading the permission block"
@@ -440,6 +445,15 @@ def test_audit_verbose_keeps_the_reviewer_transcript_off_the_document(
     with (
         patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True),
         patch("osprey.cli.audit_cmd.query", new=_query),
+        # The real builder resolves the audited project's provider and refuses
+        # this fixture, which sets none; that wiring is TestReviewerProvider's,
+        # this test pins the streams.
+        patch(
+            "osprey.cli.audit_cmd._reviewer_options",
+            new=lambda project_dir, model, budget: ClaudeAgentOptions(
+                model=model, cwd=str(project_dir)
+            ),
+        ),
     ):
         result = runner.invoke(audit, [str(project), "--json", "-v"])
 

--- a/tests/deployment/goldens/exemplar-profile/profile.yml
+++ b/tests/deployment/goldens/exemplar-profile/profile.yml
@@ -285,6 +285,13 @@ config:
   # table renders. Drop the key and the subagent is told no vocabulary was
   # declared; point it at a missing file and the build stops and says so.
   facility.ontology: data/facility_ontology.json
+  # Your facility's own registry module — the file that registers its
+  # connectors, providers and ARIEL adapters with the framework (see
+  # "Extending Osprey" in the docs). Relative to the project root; unset means
+  # no application registry, and the framework-only one is used. `REGISTRY_PATH`
+  # in the environment outranks this key, for a container pointed at a registry
+  # mounted somewhere the config could not have named.
+  # registry_path: project/registry.py
   # Master write switch, the FIRST guard in the write-safety chain: while
   # false, every hardware write is refused before the limits check or the
   # approval prompt is consulted. On here because the baseline is the stand-in,

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -387,6 +387,50 @@ def test_a_credential_that_is_nowhere_is_reported_missing(lifecycle_repo, runtim
     text = report(lifecycle_repo)
 
     assert "not found in this shell" in text
+    # Both members of the env chain, because both are read.
+    assert ".env.shared" in text
+    assert ".env" in text
+
+
+def test_a_credential_in_the_shared_file_is_found_and_flagged(lifecycle_repo, runtime, monkeypatch):
+    """The chain is `.env.shared` then `.env`, and the spec beside this row
+    expands `${VAR}` through the whole chain. Reporting only `.env` calls a
+    resolvable credential missing. It is still the wrong file for a secret —
+    `.env.shared` is committed — so the row says so instead of blessing it."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    render_build(lifecycle_repo)
+    (lifecycle_repo / ".env.shared").write_text("ANTHROPIC_API_KEY=sk-shared\n", encoding="utf-8")
+
+    text = report(lifecycle_repo)
+
+    assert "set in .env.shared" in text
+    assert "committed file" in text
+    assert "sk-shared" not in text
+
+
+def test_the_local_env_wins_over_the_shared_one(lifecycle_repo, runtime, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    render_build(lifecycle_repo)
+    (lifecycle_repo / ".env.shared").write_text("ANTHROPIC_API_KEY=sk-shared\n", encoding="utf-8")
+    (lifecycle_repo / ".env").write_text("ANTHROPIC_API_KEY=sk-secret\n", encoding="utf-8")
+
+    text = report(lifecycle_repo)
+
+    assert "set in .env" in text
+    assert "committed file" not in text
+
+
+def test_an_unset_provider_names_the_key_the_operator_sets(lifecycle_repo, runtime, monkeypatch):
+    """`claude_code.provider` is a rendered key the build derives; writing it
+    by hand is refused. The remedy names the profile field that sets it."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    render_build(lifecycle_repo, config="project_name: als-exemplar\n")
+
+    text = report(lifecycle_repo)
+
+    assert "not configured" in text
+    assert "in profile.yml" in text
+    assert "claude_code.provider" not in text
 
 
 def _config_with_telemetry(block: str) -> str:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -332,6 +332,13 @@ config:
   # table renders. Drop the key and the subagent is told no vocabulary was
   # declared; point it at a missing file and the build stops and says so.
   facility.ontology: data/facility_ontology.json
+  # Your facility's own registry module — the file that registers its
+  # connectors, providers and ARIEL adapters with the framework (see
+  # "Extending Osprey" in the docs). Relative to the project root; unset means
+  # no application registry, and the framework-only one is used. `REGISTRY_PATH`
+  # in the environment outranks this key, for a container pointed at a registry
+  # mounted somewhere the config could not have named.
+  # registry_path: project/registry.py
 
   # ── Control system ─────────────────────────────────────────────────────────
   # Which machine a session starts on. "live_standin" is the stand-in declared

--- a/tests/health/core/test_file_system.py
+++ b/tests/health/core/test_file_system.py
@@ -216,6 +216,24 @@ class TestRegistryFile:
         by_name = _by_name(_run({"registry_path": "${REG_FILE}"}, tmp_path))
         assert by_name["registry_file"].status is Status.OK
 
+    def test_nested_spelling_is_resolved(self, tmp_path: Path) -> None:
+        """``application.registry_path`` loads a registry, so it gets a row.
+
+        The row and the loader read the same resolver, so a registry that
+        loaded can never be missing from the report.
+        """
+        (tmp_path / "registry.yml").write_text("components: []\n")
+        by_name = _by_name(_run({"application": {"registry_path": "registry.yml"}}, tmp_path))
+        assert by_name["registry_file"].status is Status.OK
+        assert str(tmp_path / "registry.yml") in by_name["registry_file"].message
+
+    def test_registry_path_env_var_outranks_the_config(self, monkeypatch, tmp_path: Path) -> None:
+        (tmp_path / "from_env.yml").write_text("components: []\n")
+        monkeypatch.setenv("REGISTRY_PATH", str(tmp_path / "from_env.yml"))
+        by_name = _by_name(_run({"registry_path": "registry.yml"}, tmp_path))
+        assert by_name["registry_file"].status is Status.OK
+        assert str(tmp_path / "from_env.yml") in by_name["registry_file"].message
+
     def test_a_config_yml_on_disk_is_not_read(self, tmp_path: Path) -> None:
         """The regression guard for the anchor bug this row used to have.
 

--- a/tests/health/core/test_providers.py
+++ b/tests/health/core/test_providers.py
@@ -85,8 +85,24 @@ async def test_mixed_results_ok_and_warning() -> None:
     assert all(r.status in (Status.OK, Status.WARNING) for r in by_name.values())
 
 
-async def test_unknown_provider_is_warning() -> None:
+async def test_a_config_only_provider_is_skipped() -> None:
+    """A configured endpoint with no adapter class cannot be probed.
+
+    The documented no-code route to a new provider is an ``api.providers``
+    block and nothing else, so "no Python class" is a normal deployment shape,
+    not a fault to report.
+    """
     config = {"api": {"providers": {"made_up": {"api_key": "k"}}}}
+    rows = await _run(config, _StubRegistry({}))
+
+    assert len(rows) == 1
+    assert rows[0].name == "made_up"
+    assert rows[0].status is Status.SKIP
+    assert "no code adapter" in rows[0].message
+
+
+async def test_unknown_provider_without_a_block_is_warning() -> None:
+    config = {"api": {"providers": {"made_up": {}}}}
     rows = await _run(config, _StubRegistry({}))
 
     assert len(rows) == 1

--- a/tests/health/core/test_providers_own.py
+++ b/tests/health/core/test_providers_own.py
@@ -77,6 +77,24 @@ async def test_without_a_claude_code_provider_every_failure_stays_advisory() -> 
     assert rows[0].status is Status.WARNING
 
 
+async def test_the_deployments_own_config_only_provider_is_skipped_not_failed() -> None:
+    """No adapter class for the agent's provider is not a broken deployment.
+
+    ``osprey health`` exits 2 on an error row, so grading "there is no Python
+    class for this name" as a failure takes down the exit status of a
+    deployment whose agent is running fine on a config-only endpoint.
+    """
+    config = {
+        "claude_code": {"provider": "house_gateway"},
+        "api": {"providers": {"house_gateway": {"base_url": "https://gw.example/v1"}}},
+    }
+    by_name = {r.name: r for r in await _run(config, _StubRegistry({}))}
+
+    assert by_name["house_gateway"].status is Status.SKIP
+    assert "no code adapter" in by_name["house_gateway"].message
+    assert "claude_code.provider" in by_name["house_gateway"].message
+
+
 async def test_an_own_provider_absent_from_api_providers_is_reported() -> None:
     """Named as the agent's provider but configured nowhere: there is no key to
     probe, and that is itself the error."""

--- a/tests/health/probes/test_provider_canary.py
+++ b/tests/health/probes/test_provider_canary.py
@@ -113,6 +113,36 @@ async def test_unknown_provider_is_warning() -> None:
     assert result.message == "Unknown provider"
 
 
+async def test_config_only_provider_is_skipped() -> None:
+    """A name with an ``api.providers`` block but no adapter class is not unknown.
+
+    The documented no-code route to a new endpoint writes a config block and
+    nothing else. There is no class to instantiate, so the canary cannot probe
+    it — that is a skip, not a complaint about the deployment.
+    """
+    result = await run(
+        {"name": "house_gateway"},
+        _ctx({"api": {"providers": {"house_gateway": {"base_url": "https://gw.example/v1"}}}}),
+        registry=_StubRegistry({}),
+    )
+
+    assert result.status is Status.SKIP
+    assert result.name == "house_gateway"
+    assert "no code adapter" in result.message
+
+
+async def test_empty_config_block_is_still_unknown() -> None:
+    """An entry with nothing in it declares no endpoint; it stays a warning."""
+    result = await run(
+        {"name": "made_up"},
+        _ctx({"api": {"providers": {"made_up": {}}}}),
+        registry=_StubRegistry({}),
+    )
+
+    assert result.status is Status.WARNING
+    assert result.message == "Unknown provider"
+
+
 async def test_env_var_resolution(monkeypatch: Any) -> None:
     monkeypatch.setenv("OSPREY_TEST_CANARY_KEY", "secret-123")
     captured: list[dict[str, Any]] = []

--- a/tests/models/test_litellm_adapter.py
+++ b/tests/models/test_litellm_adapter.py
@@ -752,14 +752,44 @@ class TestCheckLitellmHealth:
 
     @patch("litellm.completion")
     def test_ollama_healthy_without_api_key(self, mock_completion):
-        """ollama is exempt from the api-key guard, so a keyless health check
-        proceeds to the live call and the api_key is omitted from the kwargs."""
+        """A keyless adapter passes the guard and probes with the placeholder.
+
+        The exemption comes from the provider class's ``requires_api_key``,
+        not from ollama's name; the probe carries the ``EMPTY`` placeholder the
+        keyless adapters substitute by hand on the completion path.
+        """
         mock_completion.return_value = MagicMock()
         ok, msg = check_litellm_health(
             provider="ollama", api_key=None, base_url="http://localhost:11434", model_id="llama3.1"
         )
         assert (ok, msg) == (True, "API accessible and authenticated")
-        assert "api_key" not in mock_completion.call_args.kwargs
+        assert mock_completion.call_args.kwargs["api_key"] == "EMPTY"
+
+    @pytest.mark.unit
+    def test_a_registered_keyless_adapter_is_not_refused(self):
+        """Not a name list: any adapter declaring `requires_api_key = False`
+        gets the exemption, including a facility's own."""
+        from osprey.models.providers.litellm_adapter import _requires_api_key
+
+        class _Keyless:
+            requires_api_key = False
+
+        class _Registry:
+            def get_provider(self, name):
+                return _Keyless if name == "house-llm" else None
+
+        with patch(
+            "osprey.models.provider_registry.get_provider_registry", return_value=_Registry()
+        ):
+            assert _requires_api_key("house-llm") is False
+            # An unknown name keeps the old assumption: it needs a key.
+            assert _requires_api_key("who-knows") is True
+
+    @pytest.mark.unit
+    def test_a_key_requiring_adapter_still_fails_without_one(self):
+        assert check_litellm_health(
+            provider="anthropic", api_key=None, base_url=None, model_id="claude-haiku-4-5"
+        ) == (False, "API key not set")
 
     @patch("litellm.completion")
     def test_authentication_error_is_unhealthy(self, mock_completion):

--- a/tests/models/test_spend_attribution.py
+++ b/tests/models/test_spend_attribution.py
@@ -52,6 +52,25 @@ class TestGatewayFor:
     def test_unknown_provider_is_unattributed(self):
         assert gateway_for("no-such-provider") is None
 
+    def test_a_declared_gateway_wins_over_the_builtin_table(self):
+        """The table is a default for a name with nothing said about it. A
+        deployment that declares what fronts its own endpoint is not overruled
+        by a framework table that cannot know."""
+        providers = {"cborg": {"base_url": "https://gw.example/v1", "gateway": "none"}}
+        assert gateway_for("cborg", providers) is None
+
+    def test_a_builtin_can_be_pointed_at_a_different_gateway(self):
+        providers = {"als-apg": {"base_url": "https://gw.example/v1", "gateway": "house-gw"}}
+        assert gateway_for("als-apg", providers) == "house-gw"
+
+    def test_a_block_that_says_nothing_falls_back_to_the_table(self):
+        providers = {"cborg": {"base_url": "https://gw.example/v1"}}
+        assert gateway_for("cborg", providers) == LITELLM_GATEWAY
+
+    def test_an_empty_declaration_means_direct(self):
+        providers = {"cborg": {"gateway": ""}}
+        assert gateway_for("cborg", providers) is None
+
 
 class TestActingSurface:
     def test_terminal_user_wins(self, monkeypatch):

--- a/tests/profiles/test_providers_catalog.py
+++ b/tests/profiles/test_providers_catalog.py
@@ -156,6 +156,24 @@ class TestValidationRefusals:
         message = self._refuses(tmp_path, "providers:\n  gw:\n    base_url: '   '\n")
         assert "providers.gw.base_url" in message
 
+    def test_misspelled_api_protocol_refused(self, tmp_path):
+        """The value decides whether a translation hop is inserted, so a
+        misspelling is refused where the catalog is read rather than read as
+        "not Anthropic" further downstream."""
+        message = self._refuses(
+            tmp_path,
+            "providers:\n  gw:\n    base_url: https://x\n    api_protocol: Anthropic\n",
+        )
+        assert "providers.gw.api_protocol" in message
+        assert "anthropic" in message and "openai" in message
+
+    def test_both_accepted_api_protocols_load(self, tmp_path):
+        for protocol in ("anthropic", "openai"):
+            _write_catalog(
+                tmp_path, {"gw": {"base_url": "https://example.test", "api_protocol": protocol}}
+            )
+            assert load_provider_catalog(tmp_path).entries["gw"]["api_protocol"] == protocol
+
     def test_non_mapping_models_refused(self, tmp_path):
         message = self._refuses(
             tmp_path, "providers:\n  gw:\n    base_url: https://x\n    models: haiku\n"

--- a/tests/registry/test_provider_registration.py
+++ b/tests/registry/test_provider_registration.py
@@ -395,6 +395,103 @@ class AppProvider(RegistryConfigProvider):
         assert pr.get_provider("anthropic") is not None
 
 
+class TestApplicationOverridesTakeEffect:
+    """A same-name registration REPLACES the built-in it shadows.
+
+    ``register_provider`` documents overwrite-by-name and ``override_providers``
+    documents "replace framework versions (by name)", but the registry is
+    pre-seeded with every built-in, so a name check against it dropped exactly
+    the registrations that were meant to replace one — silently.
+    """
+
+    def _registry_file(self, tmp_path, body: str):
+        registry_file = tmp_path / "app" / "registry.py"
+        registry_file.parent.mkdir(parents=True, exist_ok=True)
+        registry_file.write_text(body)
+        return registry_file
+
+    def test_a_same_name_registration_replaces_the_builtin(self, tmp_path):
+        module = tmp_path / "house_openai.py"
+        module.write_text(
+            """
+from osprey.models.providers.base import BaseProvider
+
+
+class HouseOpenAIProvider(BaseProvider):
+    name = "openai"
+    requires_api_key = False
+"""
+        )
+        import sys
+
+        sys.path.insert(0, str(tmp_path))
+        try:
+            registry_file = self._registry_file(
+                tmp_path,
+                """
+from osprey.registry import (
+    RegistryConfigProvider,
+    extend_framework_registry,
+    ProviderRegistration,
+)
+
+
+class AppProvider(RegistryConfigProvider):
+    def get_registry_config(self):
+        return extend_framework_registry(
+            override_providers=[
+                ProviderRegistration(
+                    module_path="house_openai",
+                    class_name="HouseOpenAIProvider",
+                    name="openai",
+                )
+            ],
+            exclude_providers=["openai"],
+        )
+""",
+            )
+            RegistryManager(registry_path=str(registry_file)).initialize(silent=True)
+
+            pr = get_provider_registry()
+            provider_class = pr.get_provider("openai")
+            assert provider_class is not None
+            # The app's class, not the framework's.
+            assert provider_class.__name__ == "HouseOpenAIProvider"
+        finally:
+            sys.path.remove(str(tmp_path))
+
+    def test_a_nameless_registration_warns_that_it_is_inert(self, tmp_path, caplog):
+        registry_file = self._registry_file(
+            tmp_path,
+            """
+from osprey.registry import (
+    RegistryConfigProvider,
+    extend_framework_registry,
+    ProviderRegistration,
+)
+
+
+class AppProvider(RegistryConfigProvider):
+    def get_registry_config(self):
+        return extend_framework_registry(
+            providers=[
+                ProviderRegistration(
+                    module_path="my_app.providers.custom",
+                    class_name="CustomProvider",
+                )
+            ]
+        )
+""",
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            RegistryManager(registry_path=str(registry_file)).initialize(silent=True)
+
+        assert "CustomProvider" in caplog.text
+        assert "name=" in caplog.text
+
+
 class TestProviderMergingEdgeCases:
     """Test edge cases in provider merging."""
 

--- a/tests/registry/test_registry_validation.py
+++ b/tests/registry/test_registry_validation.py
@@ -10,7 +10,7 @@ This test module validates error handling and validation in the registry system:
 
 import pytest
 
-from osprey.registry.manager import RegistryError, RegistryManager
+from osprey.registry.manager import RegistryError, RegistryManager, resolve_registry_path
 
 
 class TestFileLoadingErrors:
@@ -286,6 +286,54 @@ class BadProvider(RegistryConfigProvider):
 
         with pytest.raises(RegistryError, match="No RegistryConfigProvider"):
             _ = RegistryManager(registry_path=str(registry_file))
+
+
+class TestResolveRegistryPath:
+    """The one resolver every reader of the registry path goes through.
+
+    Three spellings reach the same file, and a reader that knows only one of
+    them disagrees with the loader about whether a registry is configured at
+    all — which is how the health report came to omit a row for a registry
+    that had loaded.
+    """
+
+    def test_top_level_spelling(self, tmp_path):
+        assert resolve_registry_path({"registry_path": "app/registry.py"}) == "app/registry.py"
+
+    def test_nested_spelling_is_an_accepted_alias(self, tmp_path):
+        config = {"application": {"registry_path": "app/registry.py"}}
+        assert resolve_registry_path(config) == "app/registry.py"
+
+    def test_top_level_wins_over_nested(self, tmp_path):
+        config = {
+            "registry_path": "canonical.py",
+            "application": {"registry_path": "alias.py"},
+        }
+        assert resolve_registry_path(config) == "canonical.py"
+
+    def test_env_var_outranks_both(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("REGISTRY_PATH", "/app/from_env.py")
+        config = {
+            "registry_path": "canonical.py",
+            "application": {"registry_path": "alias.py"},
+        }
+        assert resolve_registry_path(config) == "/app/from_env.py"
+
+    def test_no_spelling_resolves_to_none(self, tmp_path):
+        assert resolve_registry_path({}) is None
+
+    def test_relative_path_resolves_against_base_path(self, tmp_path):
+        resolved = resolve_registry_path({"registry_path": "app/registry.py"}, base_path=tmp_path)
+        assert resolved == str(tmp_path / "app" / "registry.py")
+
+    def test_absolute_path_is_left_alone(self, tmp_path):
+        absolute = str(tmp_path / "registry.py")
+        assert resolve_registry_path({"registry_path": absolute}, base_path=tmp_path) == absolute
+
+    def test_env_vars_in_the_value_are_expanded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("APP_DIR", "myapp")
+        resolved = resolve_registry_path({"registry_path": "${APP_DIR}/registry.py"})
+        assert resolved == "myapp/registry.py"
 
 
 class TestConfigurationErrorMessages:


### PR DESCRIPTION
Nine places re-derived a provider fact by hand; each now asks the one producer that already owns it — the provider registry, the provider class's own attributes, the shared agent-options builder, the env-chain loader, or the deployment's own profile.

Commits, in order:

- `fix(health): never fail the agent-provider row for a provider the canary cannot probe`
- `refactor(registry): one resolver for the application registry path`
- `docs(registry): name the key that loads an application registry`
- `fix(cli): run osprey audit on the deployment's own provider`
- `fix(agent_runner): point the no-provider error at the real config key`
- `fix(deployment): status auth row reads the env chain and names the right profile key`
- `fix(models): litellm health check consults requires_api_key, not a provider-name tuple`
- `fix(registry): honour application-registry provider overrides`
- `fix(models): a declared gateway wins over the built-in gateway table`
- `fix(profiles): refuse an unknown api_protocol where the catalog is validated`

## Why

Each of these coupled a deployment's behaviour to a list, a table or a spelling written into the framework, so a deployment that configured its own endpoints was reported — or run — as something else.

With them gone, a deployer can point OSPREY at their own endpoints and have the framework agree with the configuration: a config-only provider (the documented no-code route) is *skipped* by `osprey health` rather than failing it, including when it is the agent's own provider, which used to exit 2 on a working deployment; `osprey audit` reviews a deployment's safety configuration through that deployment's own provider and default model instead of whatever ambient Anthropic credentials the shell happened to hold; an application registry that ships an adapter under a built-in name replaces that built-in instead of being dropped without a word; a keyless on-prem adapter passes the health check on its own `requires_api_key` declaration rather than on being named in a tuple; a provider entry's `gateway:` key decides whether end-user attribution headers are sent to it; a misspelled `api_protocol` is refused where the catalog is read; and the credential row, the no-provider error and the unset-provider note name keys an operator can actually set — including `registry_path`, which loaded a facility's connectors and providers while appearing in no documentation, no shipped profile and no config-key manifest.

The last commit carries the amendment folded into this item: the `api_protocol` enum check moves to the catalog validator so every entry passes through one producer, and the proxy's own check is kept — and documented — as the guard for an `api.providers` block that never passed through the catalog.

## Not in this PR

- A generic probe for a config-only provider (register `api.providers` entries behind a generic adapter, or probe the block by `api_protocol`). Until that exists, such a provider is *unverified* by health, and the skip message says so. It changes what MCP tool servers can resolve, so it is a product call.
- A first-class `registry:` field on the build profile, so `osprey build` writes the key and copies the facility's registry file. The documentation delivers most of the value; build-copying facility code is a separate decision.
- Legitimising a secret in `.env.shared`. The status row reports one found there and flags the file as committed rather than blessing it.
