### PR TITLE
ci: model-spending lanes run nightly on main and on PRs only under `full-ci`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
     # the full lane set must run there, not only on the final epic-to-main
     # PR.
     branches: [ main, 'epic/**' ]
+    # `labeled` on top of the three defaults: the model-spending lanes run on
+    # a pull request only under the `full-ci` label (see "Model-spending
+    # lanes" below), and applying a label does not start a run unless the
+    # workflow subscribes to it. Any label re-runs the PR's workflow -- the
+    # per-PR concurrency group cancels the superseded run, so the cost is
+    # one restart of the always-on lanes, not a duplicate.
+    types: [ opened, synchronize, reopened, labeled ]
   workflow_dispatch:
     inputs:
       e2e_filter:
@@ -42,10 +49,53 @@ on:
         type: boolean
         default: false
   schedule:
-    # Nightly at 07:00 UTC (midnight Pacific) for the always-on jobs
-    # (test, lint, docs, ...; no `if:`). Every e2e/benchmark lane is
-    # PR-gated or dispatch-gated and does NOT run on this schedule.
+    # Nightly at 07:00 UTC (midnight Pacific): the always-on jobs (test,
+    # lint, docs, ...; no `if:`) PLUS the model-spending lanes, which take
+    # `github.event_name == 'schedule'` as one of their three arms. This is
+    # where main gets its full agentic coverage now -- once a day against
+    # the merged tree, not on every push of every PR. The secret-free e2e
+    # lanes stay PR-gated (they cost runner minutes, not model tokens) and
+    # the benchmark lane stays dispatch-only.
     - cron: '0 7 * * *'
+
+# Model-spending lanes: nightly on main, `full-ci` on a pull request.
+#
+# Eight jobs drive real Claude sessions through the ALS-APG gateway
+# (agentic-per-preset x2, e2e-tests, dispatch-deploy-e2e, dispatch-overlay-e2e,
+# scan-agentic-e2e, nextcloud-talk-bridge-e2e, gchat-bridge-e2e,
+# target-switch-agentic-e2e). Measured on the gateway ledger for the week of
+# 2026-09-01: the full set costs about $15 per run and ran on every push of
+# every same-repo PR -- ~150 runs a week, ~$2,300, on pace for $10k a month,
+# 95% of everything the group spends on models. Two things drive that and
+# neither is a test that should go away: cost scales as turns x context
+# (an Opus diagnostic session re-reads ~100k cached tokens per turn, 50
+# turns), and volume -- ~10 PRs a day at ~2.2 pushes each.
+#
+# So the lever is WHEN, not WHAT. Each of these lanes now runs on exactly
+# three events, spelled out in its `if:` in this order:
+#
+#   1. a same-repo, non-Dependabot pull request carrying the `full-ci`
+#      label -- opt-in per PR, for the change that touches what these lanes
+#      cover (`gh pr edit <n> --add-label full-ci`; the roll-up gate prints
+#      that command in the run summary of every unlabeled PR);
+#   2. the nightly `schedule` on main -- the standing coverage: a regression
+#      that slipped through an unlabeled PR shows up the next morning, and
+#      bisects over one day's merges;
+#   3. a maintainer's `revalidate_secret_lanes` dispatch against any ref
+#      (the Dependabot path, unchanged).
+#
+# Path filtering was measured and rejected: over the 161 PRs merged in the
+# two weeks before this landed, 86-91% touched something under src/ that
+# the broad lanes cover (templates alone in two of three), so a filter map
+# would have saved about a fifth and needed maintaining. The label is the
+# whole mechanism.
+#
+# What this trades: an unlabeled PR merges on the always-on lanes plus the
+# secret-free e2e lanes, and its agentic proof arrives with the nightly. A
+# nightly red is a main red -- treat it as one. Consumers that pin osprey
+# main (the ALS deployment) pin the last nightly-green sha, not raw head.
+# The stop-loss behind all of this is on the gateway key itself
+# (`osprey-github-ci`: a daily budget; the CI goes red, not the invoice).
 
 # One live CI run per ref. Without this, every push left its predecessor's
 # full job matrix queued rather than cancelled, and on an account whose
@@ -1234,7 +1284,9 @@ jobs:
     name: Tier 3 — Agentic flow (${{ matrix.preset }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Only run on PRs from same repo (ALS_APG_API_KEY unavailable on forks).
+    # Model-spending lane (see the workflow-level note): runs on a same-repo
+    # PR only under the `full-ci` label, nightly on main, and on the
+    # revalidation dispatch. Fork PRs never see ALS_APG_API_KEY.
     # Gating (no continue-on-error): a red Tier 3 flow blocks the merge like
     # every other e2e lane — the house rule is full green, no advisory tiers.
     # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
@@ -1242,7 +1294,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     strategy:
       fail-fast: false
@@ -1344,15 +1398,19 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
-    # Only run on PRs (not pushes) to control API costs, and only for non-fork PRs (secrets unavailable on forks).
-    # Also runs on manual workflow_dispatch to enable scoped reruns via the e2e_filter input —
-    # unless that dispatch asked for the benchmark lanes instead (run_benchmarks).
+    # Model-spending lane (see the workflow-level note): a same-repo PR runs
+    # it only under the `full-ci` label; main gets it nightly. Fork PRs never
+    # see the secret. Also runs on manual workflow_dispatch to enable scoped
+    # reruns via the e2e_filter input — unless that dispatch asked for the
+    # benchmark lanes instead (run_benchmarks).
     # Secret-dependent lane: skips on Dependabot PRs, which get no Actions
     # secrets. Revalidate with the `revalidate_secret_lanes` dispatch input.
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && !inputs.run_benchmarks)
     # The lane's healthy runtime is ~20-25min (real-LLM SDK/CLI pipelines —
     # every full-stack docker deploy now lives in its own dedicated job, and
@@ -1754,7 +1812,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
 
     steps:
@@ -1840,7 +1900,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # Build + deploy + one real agent turn healthily fits well under 20min
     # (~11min when it ran in-lane, including the web-terminal image builds
@@ -2260,7 +2322,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # One pytest invocation covers the whole module: the offline floor/judge
     # checks plus the two live agent runs, which share a single module-scoped
@@ -2665,7 +2729,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # A job-level `permissions:` block REPLACES the default token scopes rather
     # than extending them, so `contents: read` is restated alongside the
@@ -2782,7 +2848,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # A job-level `permissions:` block REPLACES the default token scopes rather
     # than extending them, so the one scope this lane needs is stated in full.
@@ -4768,7 +4836,9 @@ jobs:
     if: >-
       (github.event_name == 'pull_request'
         && github.event.pull_request.head.repo.full_name == github.repository
-        && github.actor != 'dependabot[bot]')
+        && github.actor != 'dependabot[bot]'
+        && contains(github.event.pull_request.labels.*.name, 'full-ci'))
+      || github.event_name == 'schedule'
       || (github.event_name == 'workflow_dispatch' && inputs.revalidate_secret_lanes)
     # Composed from measured pieces, not guessed, and not re-measured by
     # re-running the LLM gate. All three figures come off the same Apple
@@ -5106,6 +5176,9 @@ jobs:
       env:
         ACTOR: ${{ github.actor }}
         HEAD_BRANCH: ${{ github.head_ref }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HAS_FULL_CI: ${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}
       run: |
         if [[ "${{ needs.test.result }}" != "success" ]]; then
           echo "❌ Tests failed"
@@ -5226,4 +5299,33 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           echo "⚠️  Secret-dependent lanes skipped (Dependabot run) — see run summary."
+        fi
+
+        # The same shape for the everyday case: a same-repo PR without the
+        # `full-ci` label. Its model-spending lanes skipped by design (the
+        # workflow-level note), and the nightly on main is where they run —
+        # say so, and print the one command that runs them here instead.
+        # Advisory like the block above; it can never turn a passing gate red.
+        if [ "$EVENT_NAME" = "pull_request" ] && [ "$ACTOR" != "dependabot[bot]" ] \
+           && [ "$HAS_FULL_CI" != "true" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          {
+            echo "### ℹ️ Model-spending lanes did not run (no \`full-ci\` label)"
+            echo
+            echo "These lanes drive real agent sessions and run nightly on \`main\`, not on"
+            echo "every pull request push. They skipped here:"
+            echo
+            echo "- Tier 3 — Agentic flow (both presets)"
+            echo "- E2E Tests"
+            echo "- Dispatch Deploy E2E / Dispatch Overlay E2E"
+            echo "- Nextcloud Talk Bridge E2E / Google Chat Bridge E2E"
+            echo "- Scan Stack Agentic E2E"
+            echo "- Control-Target Switch Agentic E2E"
+            echo
+            echo "If this change touches what they cover, run them on this PR:"
+            echo
+            echo '```'
+            echo "gh pr edit $PR_NUMBER --add-label full-ci"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "ℹ️  Model-spending lanes skipped (no full-ci label; nightly covers main) — see run summary."
         fi

--- a/changelog.d/ci-spend-gating.changed.md
+++ b/changelog.d/ci-spend-gating.changed.md
@@ -1,0 +1,1 @@
+CI's eight model-spending lanes (agentic per-preset, E2E, dispatch stacks, scan and target-switch agentic, chat bridges) run nightly on `main` and on pull requests only under the `full-ci` label, instead of on every push; the roll-up gate's run summary names what skipped and prints the label command.

--- a/docs/source/contributing/workflow.rst
+++ b/docs/source/contributing/workflow.rst
@@ -107,6 +107,47 @@ and both appear in ``main``'s history.
 If a required check turns out to be wrong, fix it forward — there is no
 escape hatch.
 
+Model-Spending Lanes: Nightly on ``main``, ``full-ci`` on a PR
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Eight CI lanes drive real agent sessions against a live model endpoint: the
+agentic per-preset flows, the E2E suite, the two dispatch stacks, the scan-stack
+and control-target-switch agentic lanes, and the two chat bridges. Together they
+cost about $15 per run — and they used to run on every push of every pull
+request, which at this repository's pace was the group's whole model bill.
+
+They now run on exactly three events:
+
+- **A pull request carrying the ``full-ci`` label.** Opt in per PR, for a change
+  that touches what these lanes cover:
+
+  .. code-block:: bash
+
+     gh pr edit <number> --add-label full-ci
+
+  Applying the label starts a fresh run of the PR's workflow (the workflow
+  subscribes to the ``labeled`` activity); the superseded run is cancelled.
+  The ``All CI Checks Passed`` run summary of every unlabeled PR names the
+  lanes that skipped and prints this command.
+- **The nightly schedule on ``main``** (07:00 UTC). This is the standing
+  coverage: a regression that slipped through an unlabeled PR shows up the next
+  morning and bisects over one day's merges. **A red nightly is a red
+  ``main``** — fix it forward like any other, and pin the last nightly-green
+  sha rather than raw head if you consume ``main`` directly.
+- **The ``revalidate_secret_lanes`` dispatch** against any ref, the maintainer
+  path described under Dependency Update Pull Requests below.
+
+Everything else on a PR is unchanged: the unit, lint, docs and package lanes and
+every secret-free e2e lane (build-and-boot, deploy, bluesky, auth, podman) still
+run on every push. Those cost runner minutes, not tokens, and the deploy lanes
+are the per-PR proof that a render builds and starts.
+
+Path filtering was measured and rejected as the mechanism: over the 161 PRs
+merged in the two weeks before this landed, 86–91 % touched something under
+``src/`` that the broad lanes cover, so a filter map would have saved about a
+fifth and needed maintaining. The label is the whole mechanism; the stop-loss
+behind it is a daily budget on the CI gateway key.
+
 Dependency Update Pull Requests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -5135,3 +5135,195 @@ def test_full_chain_auth_lane_outbudgets_the_single_build_lanes__mutation_back_t
     _sole_heavy_step(job)["timeout-minutes"] = _sole_heavy_step(sibling)["timeout-minutes"]
     with pytest.raises(AssertionError, match="job budget"):
         test_full_chain_auth_lane_outbudgets_the_single_build_lanes(mutated)
+
+
+# ---------------------------------------------------------------------------
+# Model-spending lanes: nightly on main, `full-ci` on a pull request
+# ---------------------------------------------------------------------------
+#
+# Eight jobs drive real Claude sessions through the gateway. Measured on its
+# ledger for the week of 2026-09-01, the set cost about $15 per run and ran on
+# every push of every same-repo PR (~150 a week, on pace for $10k a month).
+# The fix is WHEN, not WHAT: each of these lanes runs on a labeled PR, on the
+# nightly schedule against main, or on the revalidation dispatch — and on
+# nothing else. Every arm is pinned below, because the one that goes missing
+# quietly is the one that either restores the bill (label clause dropped: the
+# lane is back on every push) or removes the standing coverage (schedule arm
+# dropped: main never gets its agentic proof at all).
+
+SPENDING_LANES = frozenset(
+    {
+        "agentic-per-preset",
+        "e2e-tests",
+        "dispatch-deploy-e2e",
+        "dispatch-overlay-e2e",
+        "scan-agentic-e2e",
+        "nextcloud-talk-bridge-e2e",
+        "gchat-bridge-e2e",
+        "target-switch-agentic-e2e",
+    }
+)
+# Lanes that carry the secret but spend nothing worth gating: deploy-e2e needs
+# the key only for `osprey up`'s .env preflight and never calls a model;
+# dockerfile-e2e drives a single haiku turn. Gating them by label would drop
+# per-PR deploy coverage for no saving, so they keep the per-PR shape — and a
+# NEW secret-bearing lane must be listed in one set or the other, on purpose.
+SECRET_FREE_LANES = frozenset({"deploy-e2e", "dockerfile-e2e", BENCHMARKS_JOB})
+FULL_CI_LABEL_CLAUSE = "contains(github.event.pull_request.labels.*.name, 'full-ci')"
+SCHEDULE_ARM = "github.event_name == 'schedule'"
+# The pre-gating shape: the PR conjunction closed right after the actor guard.
+# Its absence is what proves the label clause sits INSIDE that conjunction,
+# not OR-ed beside it (where it would admit every PR again).
+_UNLABELED_PR_ARM_CLOSE = "&& github.actor != 'dependabot[bot]')"
+
+
+def _secret_bearing_jobs(wf: dict[str, Any]) -> set[str]:
+    return {name for name in _jobs(wf) if _job_declares_secret(wf, name, SECRET_TOKEN)}
+
+
+def test_every_secret_bearing_lane_declares_its_spend_posture(workflow: dict[str, Any]) -> None:
+    """A lane that holds the gateway key is either a spending lane (label /
+    nightly / revalidation) or listed as secret-free. No third category: a new
+    agentic lane that nobody classifies would run on every push by default,
+    which is exactly how the bill got where it was."""
+    unclassified = _secret_bearing_jobs(workflow) - SPENDING_LANES - SECRET_FREE_LANES
+    assert unclassified == set(), (
+        f"secret-bearing lanes with no declared posture: {sorted(unclassified)}"
+    )
+    # and the classification is not stale the other way either
+    assert SPENDING_LANES <= _secret_bearing_jobs(workflow)
+
+
+def test_every_secret_bearing_lane_declares_its_spend_posture__mutation_adds_unclassified_lane() -> (
+    None
+):
+    mutated = copy.deepcopy(_load_workflow())
+    mutated["jobs"]["new-agentic-lane"] = copy.deepcopy(mutated["jobs"]["scan-agentic-e2e"])
+    with pytest.raises(AssertionError, match="no declared posture"):
+        test_every_secret_bearing_lane_declares_its_spend_posture(mutated)
+
+
+@pytest.mark.parametrize("lane", sorted(SPENDING_LANES))
+def test_spending_lane_runs_only_under_label_nightly_or_revalidation(
+    workflow: dict[str, Any], lane: str
+) -> None:
+    """All three arms, and the label INSIDE the pull-request arm."""
+    condition = _jobs(workflow)[lane]["if"]
+    assert FULL_CI_LABEL_CLAUSE in condition, f"{lane}: no full-ci label clause"
+    assert SCHEDULE_ARM in condition, f"{lane}: no nightly schedule arm"
+    assert _DEPENDABOT_GUARD in condition, f"{lane}: Dependabot guard dropped"
+    assert "workflow_dispatch" in condition, f"{lane}: dispatch arm dropped"
+    assert _UNLABELED_PR_ARM_CLOSE not in condition, (
+        f"{lane}: the pull-request arm closes before the label clause — "
+        "an unlabeled PR would run this lane again"
+    )
+
+
+def test_spending_lane_gating__mutation_drops_the_label_clause() -> None:
+    """The regression that restores the bill: the PR arm admits every push."""
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)["scan-agentic-e2e"]
+    job["if"] = job["if"].replace(f"\n  && {FULL_CI_LABEL_CLAUSE}", "")
+    assert FULL_CI_LABEL_CLAUSE not in job["if"], "mutation is stale"
+    with pytest.raises(AssertionError, match="label clause|closes before"):
+        test_spending_lane_runs_only_under_label_nightly_or_revalidation(
+            mutated, "scan-agentic-e2e"
+        )
+
+
+def test_spending_lane_gating__mutation_ors_the_label_beside_the_pr_arm() -> None:
+    """The subtler regression: the clause is present but OR-ed outside the
+    pull-request conjunction, which admits every same-repo PR exactly as
+    before and reads as gated."""
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)["scan-agentic-e2e"]
+    job["if"] = job["if"].replace(
+        f"\n  && {FULL_CI_LABEL_CLAUSE})", f")\n|| {FULL_CI_LABEL_CLAUSE}"
+    )
+    assert _UNLABELED_PR_ARM_CLOSE in job["if"], "mutation is stale"
+    with pytest.raises(AssertionError, match="closes before the label clause"):
+        test_spending_lane_runs_only_under_label_nightly_or_revalidation(
+            mutated, "scan-agentic-e2e"
+        )
+
+
+def test_spending_lane_gating__mutation_drops_the_schedule_arm() -> None:
+    """The other failure: gated on the label alone, main never gets the lanes."""
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)["agentic-per-preset"]
+    # `>-` folds the two base-indented `||` lines onto one line with a space.
+    job["if"] = job["if"].replace(f"|| {SCHEDULE_ARM} ", "")
+    assert SCHEDULE_ARM not in job["if"], "mutation is stale"
+    with pytest.raises(AssertionError, match="schedule arm"):
+        test_spending_lane_runs_only_under_label_nightly_or_revalidation(
+            mutated, "agentic-per-preset"
+        )
+
+
+def test_secret_free_lanes_keep_the_per_pr_shape(workflow: dict[str, Any]) -> None:
+    """deploy-e2e and dockerfile-e2e are the per-PR proof that a render builds
+    and boots; they cost runner minutes, not tokens, and must not hide behind
+    the label."""
+    for lane in ("deploy-e2e", "dockerfile-e2e"):
+        condition = _jobs(workflow)[lane]["if"]
+        assert FULL_CI_LABEL_CLAUSE not in condition, f"{lane}: label-gated but spends nothing"
+        assert "pull_request" in condition
+
+
+def test_secret_free_lanes_keep_the_per_pr_shape__mutation_gates_deploy_by_label() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    _jobs(mutated)["deploy-e2e"]["if"] = _jobs(mutated)["scan-agentic-e2e"]["if"]
+    with pytest.raises(AssertionError, match="spends nothing"):
+        test_secret_free_lanes_keep_the_per_pr_shape(mutated)
+
+
+def test_workflow_fires_when_the_full_ci_label_is_applied(workflow: dict[str, Any]) -> None:
+    """A label clause in a job's ``if:`` is inert unless the workflow subscribes
+    to the ``labeled`` activity: with the three default types only, adding
+    ``full-ci`` starts nothing and the lanes wait for the next push."""
+    types = workflow[True]["pull_request"]["types"]
+    assert "labeled" in types, f"pull_request.types must include 'labeled'; got {types}"
+    # the defaults survive — the workflow still runs on open / push / reopen
+    assert {"opened", "synchronize", "reopened"} <= set(types)
+
+
+def test_workflow_fires_when_the_full_ci_label_is_applied__mutation_drops_types() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    del mutated[True]["pull_request"]["types"]
+    with pytest.raises(KeyError):
+        test_workflow_fires_when_the_full_ci_label_is_applied(mutated)
+
+
+def test_workflow_fires_when_the_full_ci_label_is_applied__mutation_drops_labeled() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    mutated[True]["pull_request"]["types"] = ["opened", "synchronize", "reopened"]
+    with pytest.raises(AssertionError, match="must include 'labeled'"):
+        test_workflow_fires_when_the_full_ci_label_is_applied(mutated)
+
+
+def test_gate_summary_tells_an_unlabeled_pr_what_did_not_run(workflow: dict[str, Any]) -> None:
+    """Same rule as the Dependabot block: a green gate with skipped lanes says
+    so where a reviewer sees it, and prints the one command that runs them."""
+    step = _find_named_step(workflow, GATE_JOB, "Check all jobs status")
+    assert step["env"]["HAS_FULL_CI"] == "${{ " + FULL_CI_LABEL_CLAUSE + " }}"
+    assert "--add-label full-ci" in step["run"]
+    for lane_name in (
+        "Tier 3 — Agentic flow (both presets)",
+        "E2E Tests",
+        "Dispatch Deploy E2E / Dispatch Overlay E2E",
+        "Nextcloud Talk Bridge E2E / Google Chat Bridge E2E",
+        "Scan Stack Agentic E2E",
+        "Control-Target Switch Agentic E2E",
+    ):
+        # named twice: once in the Dependabot block, once in the unlabeled one
+        assert step["run"].count(lane_name) == 2, (
+            f"{lane_name!r} must be named in both summary blocks"
+        )
+
+
+def test_gate_summary_tells_an_unlabeled_pr_what_did_not_run__mutation_drops_the_command() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, GATE_JOB, "Check all jobs status")
+    step["run"] = step["run"].replace("--add-label full-ci", "")
+    with pytest.raises(AssertionError):
+        test_gate_summary_tells_an_unlabeled_pr_what_did_not_run(mutated)


### PR DESCRIPTION
## Why

The eight CI lanes that drive real agent sessions through the gateway ran on every push of every same-repo PR. Measured on the gateway ledger for the week of 2026-09-01:

| | |
|---|---|
| cost of one full run of the eight lanes | ~$15 |
| runs per week (PR pushes) | ~150 |
| weekly spend | ~$2,300, on pace for ~$10k/month |
| share of the group's total model spend | ~95% |

Cost scales as turns × context (an Opus diagnostic session re-reads ~100k cached tokens per turn over ~50 turns) and volume (~10 PRs a day at ~2.2 pushes each). Nothing here is a test that should go away. The lever is **when** they run.

## What changes

Each of the eight lanes (`agentic-per-preset` ×2, `e2e-tests`, `dispatch-deploy-e2e`, `dispatch-overlay-e2e`, `scan-agentic-e2e`, `nextcloud-talk-bridge-e2e`, `gchat-bridge-e2e`, `target-switch-agentic-e2e`) now runs on exactly three events:

1. **A same-repo PR carrying the `full-ci` label** — `gh pr edit <n> --add-label full-ci`. The workflow subscribes to `labeled`, so applying it starts the run (the per-PR concurrency group cancels the superseded one).
2. **The nightly schedule on `main`** (07:00 UTC, already existed; now carries these lanes). A regression that slipped through an unlabeled PR shows up the next morning and bisects over one day's merges. A red nightly is a red `main`.
3. **The `revalidate_secret_lanes` dispatch** — unchanged, the Dependabot path.

`deploy-e2e` and `dockerfile-e2e` keep the per-PR shape: they hold the key only for the `.env` preflight and one haiku turn, and they are the per-PR proof that a render builds and boots. Every secret-free e2e lane is untouched.

The roll-up gate already passed a skipped lane (fork/Dependabot PRs). It now also writes a run summary on every unlabeled PR naming what did not run and printing the label command, the same shape as the existing Dependabot block — a green check never implies coverage it lacks.

## Path filtering: measured, rejected

Over the 161 PRs merged in the two weeks before this branch: 86–91% touched something under `src/` that the broad lanes cover (templates alone in two of three), and only 12 touched nothing but docs/interfaces/scripts. A per-lane filter map would have saved about a fifth and needed maintaining. The label is the whole mechanism.

## Tests

20 new wiring tests in `tests/deployment/test_ci_workflow_wiring.py`, assert + mutation pairs in the file's style:
- every spending lane carries the label clause **inside** the PR conjunction (a mutation that ORs it beside the arm fails), the schedule arm, the Dependabot guard, the dispatch arm;
- `labeled` is in `pull_request.types` (without it the label is inert);
- `deploy-e2e` / `dockerfile-e2e` are **not** label-gated;
- every secret-bearing job must be classified as spending or secret-free, so a new agentic lane cannot default back onto every push;
- the gate summary names the lanes and the command.

Full suite: 380 passed. Docs build clean. `full-ci` label created on the repo.

## Follow-ups (not here)

- Consumers that pin osprey `main` (the ALS deployment) should pin the last nightly-green sha rather than raw head.
- A nightly failure currently notifies only via the workflow-run email; an auto-filed issue on schedule-red is a separate change.
- The stop-loss that backs this is on the gateway key itself (`osprey-github-ci`: $250/day, team $6,000/30d).
