### PR TITLE
fix: refuse client writes at the defining object, close the SQL FROM-list bypass, limits-check aioca/pvaPy/p4p raw

### DIFF
--- a/changelog.d/limits-aioca-pvaccess.security.md
+++ b/changelog.d/limits-aioca-pvaccess.security.md
@@ -1,0 +1,11 @@
+A `readwrite` run now checks writes against the channel limits database on
+routes that previously went straight to the machine: `aioca`, pvaPy's
+`Channel` setters, p4p's raw client under the flavour clients, and p4p values
+written as a structure or as JSON, which are checked on the number they carry
+rather than skipped for not looking like one.
+
+Writes that carry nothing to bound are refused instead of passed: p4p `rpc`
+and builder callbacks, pvaPy `parsePut`/`parsePutGet`, Tango commands, and
+Tango group writes, which fan one value out to every device in the group. The
+routes still unchecked in a `readwrite` run are listed in the architecture
+docs.

--- a/changelog.d/sql-from-list.security.md
+++ b/changelog.d/sql-from-list.security.md
@@ -1,0 +1,14 @@
+ARIEL's `sql_query` tool now refuses a `FROM`/`JOIN` shape its table allowlist
+cannot resolve: a comma-separated FROM list (`FROM enhanced_entries, pg_shadow`),
+a parenthesised join in place of a subquery, and any quoted identifier, comment,
+dollar quoting or backslash anywhere in the query — each of which reached a
+table the allowlist never checked. A `TABLE name` command inside a `WITH`
+body, a set operation or a subquery is checked against the allowlist like a
+`FROM` target. A multi-CTE `WITH a AS (...), b AS (...)` query, which was
+refused by mistake, is now accepted.
+
+A name counts as a CTE only where the query really declares one, and only where
+Postgres would see it: inside a `WITH` list, outside any string literal, after
+its body closes, and for references in the query that declared it. A literal
+spelling a CTE declaration, an alias in a `WINDOW` list, or a `WITH` inside a
+subquery no longer hides a joined table from the allowlist.

--- a/changelog.d/write-surface.security.md
+++ b/changelog.d/write-surface.security.md
@@ -1,8 +1,10 @@
-A `readonly` Python run now refuses two more Channel Access routes to the
-machine: `doocs4py`, the client the DOOCS connector itself writes through, and
-`aioca`, which every OSPREY environment carries as ophyd-async's Channel Access
-backend. Both are refused at import and at the call. Driving hardware through
+A `readonly` Python run now refuses two more client routes to the machine:
+`doocs4py`, the client the DOOCS connector itself writes through, and `aioca`,
+which every OSPREY environment carries as ophyd-async's Channel Access backend.
+Both are refused at import and at the call. Driving hardware through
 ophyd-async signals or a Bluesky `RunEngine` is refused too, while importing
-those libraries for analysis stays allowed. The runtime guard and the import
-denylist are now generated from one table, so they cannot describe different
+those libraries for analysis stays allowed. A write is refused at the module
+that *defines* it as well as at the name a script reaches for, so the private
+definition behind a client's public name refuses too. The runtime guard and the
+import denylist are generated from one table, so they cannot describe different
 libraries.

--- a/docs/screenshots/contact_sheet.py
+++ b/docs/screenshots/contact_sheet.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import html
 import json
+import os
 import re
 import shlex
 import shutil
@@ -409,6 +410,20 @@ def hermetic_hub() -> Iterator[HermeticHub]:
         shell_command = _replay_shell_command(DEMO_TRANSCRIPT_PATH)
 
         with ExitStack() as stack:
+            # Both apps below claim a control-context record at lifespan, and the
+            # artifacts backend resolves an agent-data root of its own. Neither
+            # reads ``project_dir`` for that: unstamped, both resolve to whatever
+            # checkout this process runs from and write into it. Stamped here,
+            # inside the throwaway tree that is already torn down below, so the
+            # word "hermetic" holds for the capture harness as well as for the
+            # test that drives it.
+            stack.enter_context(
+                mock.patch.dict(
+                    os.environ,
+                    {"OSPREY_AGENT_DATA_ROOT": str(project_dir / "var" / "agent_data")},
+                )
+            )
+
             from osprey.interfaces.artifacts.app import create_app as create_artifacts_app
 
             artifacts_app = create_artifacts_app(workspace_root=project_dir)

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -132,9 +132,33 @@ Nine safety layers are applied in sequence:
    in **every** execution mode.
 
 7. **Limits monkeypatch** (``ExecutionWrapper`` /
-   ``LimitsValidator``)---at runtime, direct client writes this build knows
-   how to intercept (pyepics, p4p, Tango, caproto and DOOCS) are validated
-   against the channel limits database. Out-of-range values are blocked.
+   ``LimitsValidator``)---at runtime, a write this build knows how to
+   intercept is checked against the channel limits database before it
+   leaves, and an out-of-range value never reaches the machine. That covers
+   pyepics, aioca, pvaPy, all four p4p clients including the raw one
+   underneath them, caproto's ``sync.client.write`` and threading
+   ``PV.write``, Tango attribute writes and DOOCS. A structured payload is
+   checked on the number it carries; a p4p payload written as JSON is
+   decoded first, ``bytes`` included --- which p4p itself would not decode,
+   so such a write is checked on the number it *would* become rather than
+   waved through for not looking like one.
+
+   Writes that cannot be checked are refused outright instead, in range or
+   not: p4p's ``rpc``, a p4p value passed as a builder callback, pvaPy's
+   ``parsePut``/``parsePutGet``, Tango commands---on ``DeviceProxy`` and on
+   the ``Connection`` class that defines them---and every Tango ``Group``
+   write, which fans one value out to many devices with no single channel
+   to bound it under.
+
+   A few routes are neither checked nor refused: Tango's asynchronous and
+   read-write attribute spellings, ``AttributeProxy`` writes, caproto's
+   ``Batch``, asyncio and ``read_write_read`` writes, and the ctypes
+   binding underneath aioca, ``epicscorelibs.ca.cadef.ca_array_put``. The
+   code names the first group ``_LIMITS_NOT_YET_WRAPPED`` and the ctypes
+   binding ``_LIMITS_UNWRAPPABLE``, rather than leaving the gap
+   implicit---a ``readwrite`` run reaches hardware through any of them
+   without passing the limits database, while a ``readonly`` run refuses
+   them like everything else.
 
 8. **Process isolation**---code always runs in a separate subprocess, never
    inside the MCP server process.

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -108,10 +108,11 @@ Nine safety layers are applied in sequence:
 
 3. **Readonly import denylist** (``check_readonly_imports``)---a
    ``readonly`` run may not import control-system client libraries
-   (``epics``, ``aioca``, ``p4p``, ``caproto``, ``pvaccess``, ``tango``,
-   ``doocs4py``) at all. Reads go through ``read_channel()``. The list is
-   derived from the client half of the write surface below, so a client
-   added there is denied at import in the same change.
+   (``epics``, ``epicscorelibs``, ``aioca``, ``p4p``, ``caproto``,
+   ``pvaccess``, ``tango``, ``doocs4py``) at all. Reads go through
+   ``read_channel()``. The list is derived from the client half of the write
+   surface below, so a client added there is denied at import in the same
+   change.
 
 4. **Control-system pattern detection**
    (``detect_control_system_operations``)---identifies read and write
@@ -166,18 +167,23 @@ the import denylist and this page all read that one table.
 resolved dynamically:
 
 - **pyepics** --- ``caput``, ``caput_many``, ``PV.put``, ``ca.put``
-- **aioca** --- ``caput``, ``caput_many``. Every OSPREY environment carries
-  it: it is the Channel Access backend of ``ophyd-async[ca]``
-- **p4p** --- ``Context.put``/``rpc`` for the thread, asyncio and cothread
-  clients; ``SharedPV.post``/``open`` on the server side
-- **caproto** --- ``sync.client.write``, ``threading.client.PV.write``,
-  ``Batch.write``, ``asyncio.client.PV.write``
+- **aioca** --- ``caput``. Every OSPREY environment carries it: it is the
+  Channel Access backend of ``ophyd-async[ca]``
+- **epicscorelibs** --- ``ca.cadef.ca_array_put`` and
+  ``ca_array_put_callback``, the ctypes binding aioca loads ``libca``
+  through
+- **p4p** --- ``Context.put``/``rpc`` for the raw, thread, asyncio and
+  cothread clients; ``SharedPV.post``/``open`` on the server side
+- **caproto** --- ``sync.client.write`` and ``sync.client.read_write_read``,
+  ``threading.client.PV.write``, ``Batch.write``, ``asyncio.client.PV.write``
 - **pvaPy** --- every ``Channel.put*`` method, including the typed setters
-  such as ``putDouble`` and ``putScalarArray``
+  such as ``putDouble`` and ``putScalarArray``, and ``asyncPut``,
+  ``parsePut`` and ``parsePutGet`` alongside them
 - **doocs4py** --- ``set``, the call the DOOCS connector writes through
 - **Tango** --- ``DeviceProxy.write_attribute`` and its variants,
-  ``AttributeProxy.write``, and ``command_inout`` (a Tango command acts on
-  the device rather than reading it)
+  ``AttributeProxy.write``, ``Group`` attribute writes, and ``command_inout``
+  (a Tango command acts on the device rather than reading it), refused on the
+  ``Connection`` base that defines it as well as on ``DeviceProxy``
 
 **Acquisition frameworks.** These drive hardware through a client below them,
 so their write entry points refuse --- but they are also ordinary document and

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -87,7 +87,15 @@ echo ""
 echo "→ Running pytest with coverage..."
 # -n auto sizes the worker pool to this machine; CI pins -n 4 to keep its matrix cells
 # comparable. Override with PYTEST_XDIST_AUTO_NUM_WORKERS=<n>.
-if ! uv run pytest tests/ --ignore=tests/e2e -m "not pty" -n auto --dist loadgroup -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term; then
+#
+# tests/services/channel_finder/graph_index/test_scale.py is ignored for the same
+# reason ci.yml's lane ignores it: it is a wall-clock latency guard whose budgets
+# are held to an unloaded workstation, and its own module docstring says it does
+# not run in the parallel lane. Under -n it measures worker contention rather
+# than the index, so leaving it in made this script red on every branch. It runs
+# on demand — `uv run pytest tests/services/channel_finder/graph_index/test_scale.py`
+# — and in the benchmark job.
+if ! uv run pytest tests/ --ignore=tests/e2e --ignore=tests/services/channel_finder/graph_index/test_scale.py -m "not pty" -n auto --dist loadgroup -v --tb=short --cov=src/osprey --cov-report=xml --cov-report=term; then
     FAILED_CHECKS+=("pytest")
     echo "❌ Tests failed"
 else
@@ -160,7 +168,15 @@ echo ""
 
 echo "→ Building documentation..."
 cd docs
-if ! make clean > /dev/null 2>&1 && make html SPHINXOPTS="-W --keep-going"; then
+# The clean is its own statement, and the build runs under `uv run`, for two
+# reasons this step used to get wrong at once. `! make clean && make html` binds
+# the negation to the clean alone, so a clean that SUCCEEDED short-circuited the
+# `&&` and the build never ran -- and the else branch then printed a green
+# "Documentation build passed" for a build nobody had performed. And `make`
+# outside `uv run` gets no venv on PATH, so once the build did run it died on
+# `sphinx-build: command not found`. ci.yml spells both lines `uv run make`.
+make clean > /dev/null 2>&1 || true
+if ! uv run make html SPHINXOPTS="-W --keep-going"; then
     FAILED_CHECKS+=("docs-build")
     echo "❌ Documentation build failed"
 else
@@ -169,7 +185,7 @@ fi
 
 echo ""
 echo "→ Checking for broken links..."
-if ! make linkcheck 2>&1 | grep -q "build succeeded"; then
+if ! uv run make linkcheck 2>&1 | grep -q "build succeeded"; then
     echo "⚠️  Link check found issues (not blocking)"
 else
     echo "✅ Link check passed"

--- a/src/osprey/services/ariel_search/search/sql_query.py
+++ b/src/osprey/services/ariel_search/search/sql_query.py
@@ -11,6 +11,7 @@ SearchToolDescriptor pattern (that's for the LangChain agent executor).
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -42,6 +43,154 @@ FORBIDDEN_KEYWORDS = {
 # Maximum rows per query
 MAX_ROWS = 200
 
+# Lexical shapes the FROM-list scan cannot read, refused outright rather than
+# resolved: a quoted identifier hides a table name from an unquoted-identifier
+# scan, a comment can carry a parenthesis or a comma that desynchronises it,
+# dollar quoting opens a string the scan does not terminate, and a backslash in
+# an ``E'...'`` string escapes the quote (``E'\''``), which desynchronises the
+# scan from the server's lexer. No agent query needs any of them.
+REFUSED_LEXEMES = (
+    ('"', "Quoted identifiers"),
+    ("--", "Line comments"),
+    ("/*", "Block comments"),
+    ("$", "Dollar quoting and dollar parameters"),
+    ("\\", "Backslash escapes"),
+)
+
+# Identifiers, single-quoted strings (skipped whole, so a comma or parenthesis
+# inside one is not read as syntax), parentheses and commas.
+_TOKEN_RE = re.compile(r"'(?:[^']|'')*'|[a-zA-Z_][a-zA-Z0-9_]*|[(),]")
+
+# Keywords that end a FROM clause at their own paren depth. Anything else --
+# an alias, ``AS``, ``ON`` and its condition -- leaves the clause open. A
+# modifier between the keyword and the name (``FROM ONLY t``, ``JOIN LATERAL
+# (``, ``WITH RECURSIVE t AS``, ``WITH t(a) AS``, ``AS MATERIALIZED``) is read
+# as the name itself, so those forms are refused as an unknown table rather
+# than resolved; the rule is not grown to read them. The same goes for the
+# ``FROM`` inside ``EXTRACT(... FROM col)``, ``TRIM(... FROM col)`` and
+# ``POSITION(... IN col)``-family calls: the column is read as a table name.
+_FROM_ENDING_KEYWORDS = frozenset(
+    {
+        "WHERE",
+        "GROUP",
+        "HAVING",
+        "ORDER",
+        "LIMIT",
+        "OFFSET",
+        "WINDOW",
+        "UNION",
+        "INTERSECT",
+        "EXCEPT",
+        "FETCH",
+        "FOR",
+        "SELECT",
+    }
+)
+
+
+@dataclass
+class _Scope:
+    """Scan state for one paren depth, scoped the way Postgres scopes it.
+
+    ``ctes`` holds the CTE names a reference at this depth (or deeper) may
+    resolve to; ``pending`` is a declared name whose body has not closed yet --
+    without ``RECURSIVE`` the body cannot see its own name, so it binds only
+    when the body's ``)`` returns to this scope.
+    """
+
+    in_from: bool = False
+    in_with: bool = False
+    ctes: set[str] = field(default_factory=set)
+    pending: str | None = None
+
+
+def _scan_relations(normalized: str) -> list[str]:
+    """Return the ``FROM``/``JOIN``/``TABLE`` targets that are not a CTE in scope.
+
+    One pass over one token stream is the only reader of the query text. A
+    single-quoted string is consumed whole, so nothing inside a literal is
+    read as syntax (a backslash, the one escape the scan cannot follow, is
+    refused up front). A CTE name is resolved where the reference is read,
+    against the declarations visible at that depth: a ``WITH`` inside a
+    subquery does not cover a ``JOIN`` at the top level.
+
+    The allowlist resolves one name per ``FROM``/``JOIN``/``TABLE`` (Postgres's
+    ``TABLE name`` is ``SELECT * FROM name`` without the keyword), so any shape
+    that reaches a second relation from the same clause reaches a table this
+    scan never sees. Rather than parse those shapes, the scan refuses them: a
+    comma-separated FROM list, and a parenthesised join in place of a subquery.
+
+    Args:
+        normalized: The query, stripped and without its trailing semicolon.
+
+    Returns:
+        The referenced table names in the order they appear.
+
+    Raises:
+        ValueError: If the query carries a refused lexeme or FROM shape.
+    """
+    for lexeme, label in REFUSED_LEXEMES:
+        if lexeme in normalized:
+            raise ValueError(f"{label} are not allowed in a query; remove {lexeme!r}.")
+
+    tokens = _TOKEN_RE.findall(normalized)
+    refs: list[str] = []
+    # One frame per paren depth; a closing paren discards its frame, so the
+    # clause the subquery interrupted is still open after it, and a CTE the
+    # subquery declared is gone with it.
+    scopes = [_Scope()]
+
+    def declares_cte(index: int) -> bool:
+        """Is the token at ``index`` followed by ``AS (``, binding a CTE name?
+
+        The trailing "(" is what keeps a select-list alias (", author AS name")
+        from laundering a table name into the CTE set.
+        """
+        return [t.upper() for t in tokens[index + 1 : index + 3]] == ["AS", "("]
+
+    for index, token in enumerate(tokens):
+        previous = tokens[index - 1].upper() if index else ""
+        upper = token.upper()
+        scope = scopes[-1]
+
+        if token == "(":
+            if previous in ("FROM", "JOIN"):
+                following = tokens[index + 1].upper() if index + 1 < len(tokens) else ""
+                if following not in ("SELECT", "WITH"):
+                    raise ValueError(
+                        "A parenthesised FROM/JOIN target must be a subquery starting "
+                        "with SELECT or WITH."
+                    )
+            scopes.append(_Scope())
+        elif token == ")":
+            if len(scopes) > 1:
+                scopes.pop()
+                if scopes[-1].pending:  # the CTE body just closed; its name binds now
+                    scopes[-1].ctes.add(scopes[-1].pending)
+                    scopes[-1].pending = None
+        elif token == ",":
+            if scope.in_from:
+                raise ValueError("comma-separated FROM lists are not allowed; use JOIN")
+        elif token.startswith("'"):
+            continue  # a string literal is a value, never syntax
+        elif upper in ("FROM", "JOIN", "TABLE"):
+            scope.in_from = True
+        elif upper == "WITH":
+            scope.in_with = True
+        elif upper in _FROM_ENDING_KEYWORDS:
+            # The statement's own SELECT ends the WITH list along with the clause.
+            scope.in_from = scope.in_with = False
+        elif previous in ("FROM", "JOIN", "TABLE"):
+            if not any(token.lower() in s.ctes for s in scopes):
+                refs.append(token)
+        elif scope.in_with and previous in ("WITH", ",") and declares_cte(index):
+            # ``WITH name AS (`` and every later ``, name AS (`` in that list.
+            # Requiring an open WITH list is what stops a ``, name AS (`` in a
+            # WINDOW list from binding the name of a table the query joins.
+            scope.pending = token.lower()
+
+    return refs
+
 
 class SqlQueryInput(BaseModel):
     """Input schema for SQL query tool."""
@@ -58,11 +207,13 @@ class SqlQueryInput(BaseModel):
 def validate_sql_query(query: str) -> None:
     """Validate that a SQL query is safe to execute.
 
-    Four rules, all of which must hold:
+    Five rules, all of which must hold:
 
     - starts with SELECT or WITH (for CTEs);
     - one statement — no semicolons in the body;
     - no DML/DDL/DCL keyword anywhere;
+    - every FROM/JOIN target is a shape the allowlist can resolve — no comma
+      list, no quoted identifier, no comment, no dollar quoting;
     - reads at least one allowlisted table, and no table outside the
       allowlist.
 
@@ -71,7 +222,10 @@ def validate_sql_query(query: str) -> None:
     JOIN at all — ``SELECT pg_read_file('/etc/passwd')`` — has nothing to
     check against the allowlist, and the read-only transaction the caller opens
     stops writes, not server-side file reads. So a query that resolves to no
-    allowlisted table is refused on that ground alone.
+    allowlisted table is refused on that ground alone. A query that *does* name
+    one — ``SELECT pg_read_file('/etc/passwd') FROM enhanced_entries`` — still
+    passes here: bounding what a function call may read is the read-only
+    database role's job, not the allowlist's.
 
     Args:
         query: The SQL query to validate.
@@ -112,21 +266,13 @@ def validate_sql_query(query: str) -> None:
                 "Only read-only SELECT queries are allowed."
             )
 
-    # Table allowlist check
-    # Extract CTE names (WITH x AS ...) so we can skip them in FROM/JOIN checks
-    cte_pattern = r"\bWITH\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+AS\b"
-    cte_names = {name.lower() for name in re.findall(cte_pattern, normalized, re.IGNORECASE)}
+    # Table allowlist check. One tokenised pass yields the FROM/JOIN targets
+    # with every CTE reference already resolved in its own scope (a CTE is a
+    # query of its own, checked by whatever IT reads), refusing the shapes that
+    # reach a relation this resolution would never see.
+    table_refs = _scan_relations(normalized)
 
-    # Extract table references from FROM and JOIN clauses
-    table_pattern = r"\b(?:FROM|JOIN)\s+([a-zA-Z_][a-zA-Z0-9_]*)"
-    table_refs = re.findall(table_pattern, normalized, re.IGNORECASE)
-
-    # Only the references that survive CTE resolution are real tables; a name
-    # a WITH clause defined is a query of its own, already checked by whatever
-    # IT reads.
-    resolved_refs = [ref for ref in table_refs if ref.lower() not in cte_names]
-
-    for table_ref in resolved_refs:
+    for table_ref in table_refs:
         table_lower = table_ref.lower()
         # Check exact match or prefix match (for text_embeddings_* tables)
         if not any(
@@ -141,7 +287,7 @@ def validate_sql_query(query: str) -> None:
     # Nothing to check IS the failure: the loop above passes vacuously for a
     # query that reads no table, which is exactly the shape a server-side file
     # read takes.
-    if not resolved_refs:
+    if not table_refs:
         raise ValueError(
             "Query reads no allowlisted table. Allowed tables: enhanced_entries, text_embeddings_*"
         )

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -771,7 +771,15 @@ if not _execution_dir.exists():
         The table covers three kinds of route: the control-system client
         libraries themselves, the process-spawning surface that could shell out
         to ``caput``, and ``ctypes``, which reaches Channel Access without
-        importing any client package at all. It is emitted into the script
+        importing any client package at all. Each patched attribute is also
+        followed back to the module that defined it, so a write a package
+        merely re-exports refuses under both of its spellings. That step is
+        what covers the defining modules no table can enumerate — PyTango
+        defines its writes in ``tango.device_proxy`` and ``tango.connection``
+        and binds them onto ``DeviceProxy``, and every binding has its own
+        such layout; the one row that does name a private module
+        (``aioca._catools``) is belt-and-braces for the single library whose
+        second spelling is known. It is emitted into the script
         rather than applied here because the objects to patch only exist in the
         subprocess.
 
@@ -788,6 +796,7 @@ if not _execution_dir.exists():
             # every route out of Python that could reach one. Installed before
             # user code, so an alias bound later resolves here.
             import importlib as _osprey_importlib
+            import sys as _osprey_sys
 
             # CPython resolves ``platform.uname().processor`` lazily, by
             # shelling out to ``uname -p`` on first read — and h5py reads it
@@ -840,14 +849,60 @@ if not _execution_dir.exists():
                     if _osprey_obj is None:
                         continue
                     for _osprey_attr in _osprey_attrs:
-                        if hasattr(_osprey_obj, _osprey_attr):
-                            setattr(_osprey_obj, _osprey_attr, _osprey_readonly_refuse)
+                        if not hasattr(_osprey_obj, _osprey_attr):
+                            continue
+                        _osprey_original = getattr(_osprey_obj, _osprey_attr)
+                        setattr(_osprey_obj, _osprey_attr, _osprey_readonly_refuse)
+                        # A re-export leaves a second spelling behind that no
+                        # table can name for every binding: PyTango defines
+                        # its writes in ``tango.device_proxy`` and
+                        # ``tango.connection`` and binds them onto
+                        # ``DeviceProxy``, so patching the class attribute
+                        # alone leaves the module-level function writing.
+                        # Follow the original back to the module that defined
+                        # it and refuse there too. The identity check is what
+                        # makes this safe to run generically: ``__module__``
+                        # and ``__name__`` are metadata a decorator or a rebind
+                        # can leave pointing at a module holding something else
+                        # entirely, and replacing an attribute on a name match
+                        # alone could silently refuse an unrelated read.
+                        try:
+                            _osprey_home = _osprey_sys.modules.get(
+                                getattr(_osprey_original, "__module__", None)
+                            )
+                            _osprey_name = getattr(_osprey_original, "__name__", None)
+                            if (
+                                _osprey_home is not None
+                                and isinstance(_osprey_name, str)
+                                and getattr(_osprey_home, _osprey_name, None)
+                                is _osprey_original
+                            ):
+                                setattr(
+                                    _osprey_home, _osprey_name, _osprey_readonly_refuse
+                                )
+                        except Exception as _osprey_home_error:
+                            # Secondary, best-effort step: the attribute the
+                            # table names already refuses. A failure here — an
+                            # unhashable ``__module__``, a module ``__getattr__``
+                            # that raises — must name the attribute and let the
+                            # REST of the row be patched, so it is caught here
+                            # rather than at the row level.
+                            print(
+                                "⚠️  readonly guard "
+                                f"({{_osprey_dotted}}.{{_osprey_attr}}) "
+                                f"defining-module step failed: {{_osprey_home_error}}"
+                            )
                     # pvaPy spells one typed setter per scalar and array type
                     # (putDouble, putScalarArray, ...). Enumerating them would
-                    # go stale against the binding; the prefix will not.
+                    # go stale against the binding; the prefix will not. Three
+                    # writes sit outside that prefix — asyncPut, parsePut and
+                    # parsePutGet — and they reach the machine exactly as the
+                    # rest do, so they are swept with them.
                     if _osprey_dotted == "pvaccess.Channel":
                         for _osprey_attr in dir(_osprey_obj):
-                            if _osprey_attr.startswith("put"):
+                            if _osprey_attr.startswith(
+                                ("put", "asyncPut", "parsePut")
+                            ):
                                 setattr(_osprey_obj, _osprey_attr, _osprey_readonly_refuse)
                 except Exception as _osprey_guard_error:
                     # A target that cannot be patched must not stop the ones
@@ -856,7 +911,7 @@ if not _execution_dir.exists():
                         f"⚠️  readonly guard ({{_osprey_dotted}}) failed: {{_osprey_guard_error}}"
                     )
 
-            del _osprey_importlib, _osprey_targets, _osprey_resolve
+            del _osprey_importlib, _osprey_sys, _osprey_targets, _osprey_resolve
         """
         return textwrap.dedent(guard).strip().replace("@@REFUSAL@@", READONLY_REFUSAL)
 

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -346,49 +346,123 @@ if not _execution_dir.exists():
                     print("ℹ️  osprey.runtime not available for limits injection")
 
                 import inspect as _inspect
+                import json as _json
 
+                # pyepics spells a write three ways - caput(), PV.put() and
+                # ca.put() - and the first two reach the network through the
+                # third. Guarding the choke point alone validates every
+                # spelling exactly once and pays for one max_step read, where
+                # a wrapper per spelling validated the same write at each layer
+                # it passed and still left a direct ca.put() unchecked.
                 try:
-                    import epics
+                    from epics import ca as _epics_ca
 
-                    # Store original functions
-                    _original_caput = epics.caput
-                    _original_caget = getattr(epics, 'caget', None)
-                    _original_PV_put = epics.PV.put if hasattr(epics.PV, 'put') else None
+                    _original_ca_put = _epics_ca.put
+                    _original_ca_get = _epics_ca.get
+                    _original_ca_name = _epics_ca.name
 
-                    def _ca_current_value(_address):
+                    def _ca_current_value(_chid):
                         '''Read a channel's present value for the max_step check.
 
                         The script's OWN Channel Access client, captured before
                         the guard is installed - the validator holds no client
-                        and must not reach for one. A client that cannot read
-                        answers None, which fails the step check closed.
+                        and must not reach for one. The read goes through the
+                        very channel id the put is going through, so the step
+                        is measured over the channel being written. A client
+                        that cannot read answers None, which fails the step
+                        check closed.
                         '''
-                        if _original_caget is None:
+                        try:
+                            return _original_ca_get(_chid, timeout=STEP_READ_TIMEOUT_SECONDS)
+                        except Exception:
                             return None
-                        return _original_caget(_address, timeout=STEP_READ_TIMEOUT_SECONDS)
 
-                    def _checked_caput(pvname, value, wait=False, timeout=60, **kwargs):
-                        '''Limits-checked wrapper for epics.caput()'''
+                    def _checked_ca_put(chid, value, *args, **kwargs):
+                        '''Limits-checked wrapper for epics.ca.put()
+
+                        A chid is opaque, so the channel the limits database is
+                        keyed by has to be asked for by name - validating the
+                        chid itself would look up a channel no database has
+                        heard of.
+
+                        A refusal here leaves pyepics' own pre-put state as
+                        it found it: ``PV.put`` coerces an enum string to its
+                        index and sets ``_put_complete`` before it reaches
+                        ca.put, and neither is rolled back.
+                        '''
                         _limits_validator.validate(
-                            pvname, value, read_current=_ca_current_value
+                            _original_ca_name(chid),
+                            value,
+                            read_current=lambda _address: _ca_current_value(chid),
                         )  # Raises if invalid
-                        return _original_caput(pvname, value, wait=wait, timeout=timeout, **kwargs)
+                        return _original_ca_put(chid, value, *args, **kwargs)
 
-                    if _original_PV_put is not None:
-                        def _checked_PV_put(self, value, wait=False, timeout=60, **kwargs):
-                            '''Limits-checked wrapper for PV.put()'''
-                            _limits_validator.validate(
-                                self.pvname, value, read_current=_ca_current_value
-                            )  # Raises if invalid
-                            return _original_PV_put(self, value, wait=wait, timeout=timeout, **kwargs)
-
-                        epics.PV.put = _checked_PV_put
-
-                    epics.caput = _checked_caput
-                    print("✅ Monkeypatched epics.caput() and PV.put()")
+                    _epics_ca.put = _checked_ca_put
+                    print("✅ Monkeypatched epics.ca.put()")
 
                 except ImportError:
                     print("ℹ️  pyepics not available - EPICS limits checking disabled")
+
+                # --- aioca. A second Channel Access client, and a separate
+                # library: an `await aioca.caput(...)` never passes through
+                # epics.ca.put, so the pyepics choke point above leaves it
+                # unchecked. aioca's package namespace re-exports what
+                # `aioca._catools` defines, so both spellings are rebound to
+                # the same wrapper - patching only the re-export would leave
+                # `from aioca._catools import caput` unguarded and would also
+                # break the array form, whose per-pair re-entry goes through
+                # the submodule global.
+                try:
+                    import aioca as _aioca
+                    from aioca import _catools as _aioca_catools
+
+                    _orig_aioca_caput = _aioca_catools.caput
+                    _orig_aioca_caget = _aioca_catools.caget
+
+                    async def _checked_aioca_caput(pv, value, *args, **kwargs):
+                        '''Limits-checked wrapper for aioca.caput().
+
+                        A non-str ``pv`` is aioca's array form, which aioca
+                        dispatches to ``caput_array``. That function writes
+                        each pair by calling the module-global ``caput`` -
+                        this wrapper, since it is bound there - so forwarding
+                        the sequence unchanged is what gets every pair
+                        validated, once, under its own channel's limits.
+                        Validating the sequence here instead would check a
+                        list of values against one channel's limits and refuse
+                        the write for the wrong reason.
+
+                        The guard is a coroutine, so unlike the synchronous
+                        clients it can await the max_step read itself and hand
+                        the validator a plain value. That read is bought only
+                        by a channel that configures max_step, and a read that
+                        fails answers None, which fails the step check closed.
+                        '''
+                        if not isinstance(pv, str):
+                            return await _orig_aioca_caput(pv, value, *args, **kwargs)
+
+                        _cfg = _limits_validator.get_limits_config(pv)
+                        _current = None
+                        if _cfg and _cfg['max_step'] is not None:
+                            try:
+                                _current = await _orig_aioca_caget(
+                                    pv, timeout=STEP_READ_TIMEOUT_SECONDS
+                                )
+                            except Exception:
+                                _current = None
+
+                        _limits_validator.validate(
+                            pv, value, read_current=lambda _address: _current
+                        )  # Raises if invalid
+                        return await _orig_aioca_caput(pv, value, *args, **kwargs)
+
+                    _aioca.caput = _checked_aioca_caput
+                    _aioca_catools.caput = _checked_aioca_caput
+                    print("✅ Monkeypatched aioca.caput()")
+                except ImportError:
+                    print("ℹ️  aioca not available - aioca limits checking disabled")
+                except Exception as _aioca_error:
+                    print(f"⚠️  aioca guard failed: {{_aioca_error}}")
 
                 # p4p / PVAccess clients: p4p ships parallel Context classes per
                 # concurrency flavor, so each one is imported and patched in its
@@ -419,6 +493,77 @@ if not _execution_dir.exists():
 
                     return _read
 
+                def _p4p_reduce(_value):
+                    '''Reduce a p4p put payload to the number the limits are about.
+
+                    p4p takes the value FOUR ways: a bare scalar, a ``Value``
+                    carrying it in a ``value`` field, a plain dict of fields,
+                    and a JSON STRING of those fields. The limits database
+                    holds numbers and the validator SKIPS every check it
+                    cannot read a number for, so handing it a structure
+                    unreduced would let an out-of-range value dressed as a
+                    structure through unchecked.
+
+                    The JSON string is the spelling that has to be read out of
+                    p4p's own put() rather than its docstring: the flavour
+                    client does ``json.loads`` on a payload whose first
+                    character is '{{' INSIDE put(), after this guard has
+                    already run. Left as a str it fails the validator's
+                    ``float()`` and skips every check, and p4p then decodes it
+                    into the very number that was never checked. So it is
+                    decoded HERE, on p4p's own rule, and checked as the dict it
+                    becomes. Bytes are decoded too, which is one spelling
+                    stricter than p4p (whose test never matches a bytes
+                    payload) and errs closed.
+
+                    A structure carrying no ``value`` field fails CLOSED with a
+                    ValueError - dict, decoded JSON and ``Value`` alike, the
+                    last recognised by p4p's own ``has()`` field protocol. That
+                    is the same trade the batch guard makes for a payload it
+                    cannot pair up; a payload whose ``has()`` is something else
+                    entirely raises out of here, which refuses the write.
+
+                    p4p also takes a BUILDER CALLABLE, which p4p invokes with a
+                    blank Value only once the operation is under way. There is
+                    no value here to check and no way to know the one the
+                    callable will write, so the write is refused outright, in
+                    range or not - the posture the pvaPy guard takes for
+                    ``parsePut``.
+                    '''
+                    if callable(_value):
+                        raise ValueError(
+                            "p4p put with a builder callable cannot be "
+                            "limits-checked; pass the value itself"
+                        )
+                    if isinstance(_value, (str, bytes)) and _value[:1] in ('{{', b'{{'):
+                        try:
+                            _value = _json.loads(_value)
+                        except ValueError as _json_error:
+                            raise ValueError(
+                                "p4p put requires a value to limits-check: the "
+                                "payload reads as a JSON structure but does "
+                                "not decode"
+                            ) from _json_error
+                        if not isinstance(_value, dict):
+                            raise ValueError(
+                                "p4p put requires a value to limits-check: the "
+                                "JSON payload is not a structure of fields"
+                            )
+                    if isinstance(_value, dict):
+                        if 'value' not in _value:
+                            raise ValueError(
+                                "p4p put requires a value to limits-check: "
+                                "the structure written carries no 'value' field"
+                            )
+                        return _value['value']
+                    _has_field = getattr(_value, 'has', None)
+                    if callable(_has_field) and not _has_field('value'):
+                        raise ValueError(
+                            "p4p put requires a value to limits-check: "
+                            "the structure written carries no 'value' field"
+                        )
+                    return getattr(_value, 'value', _value)
+
                 def _p4p_validate_put(_name, _values, _read_current):
                     '''Validate a p4p put payload BEFORE any network operation.
 
@@ -432,6 +577,10 @@ if not _execution_dir.exists():
                     the shorter prefix, and a shape p4p would accept but we
                     cannot pair up fails closed via ValueError.
 
+                    Every payload is reduced by ``_p4p_reduce`` before it
+                    is checked, so a structure is checked on the number it
+                    carries and a builder callable is refused.
+
                     ``_read_current`` is the putting context's own reader,
                     used only by channels that configure max_step.
 
@@ -440,7 +589,9 @@ if not _execution_dir.exists():
                     consume the caller's names.
                     '''
                     if isinstance(_name, str):
-                        _limits_validator.validate(_name, _values, read_current=_read_current)
+                        _limits_validator.validate(
+                            _name, _p4p_reduce(_values), read_current=_read_current
+                        )
                         return _name
 
                     if not isinstance(_values, (list, tuple)):
@@ -462,9 +613,22 @@ if not _execution_dir.exists():
 
                     for _pair_name, _pair_value in zip(_names_seq, _values, strict=True):
                         _limits_validator.validate(
-                            _pair_name, _pair_value, read_current=_read_current
+                            _pair_name, _p4p_reduce(_pair_value), read_current=_read_current
                         )
                     return _names_seq
+
+                def _p4p_blocked_rpc(self, *args, **kwargs):
+                    '''Unconditional refusal for p4p Context.rpc().
+
+                    Limits semantics cannot apply to an arbitrary rpc payload,
+                    so refusal is the only honest parity. It is defined once
+                    here rather than per class because the raw base refuses
+                    with the same function the flavours do.
+                    '''
+                    raise RuntimeError(
+                        "rpc is not mediated and cannot be approved — "
+                        "use the supervised write path"
+                    )
 
                 def _p4p_install_guard(_context_cls):
                     '''Limits-check put() and refuse rpc() on one p4p Context class.'''
@@ -481,17 +645,6 @@ if not _execution_dir.exists():
                         _context_cls.put = _p4p_checked_put
 
                     if hasattr(_context_cls, 'rpc'):
-                        def _p4p_blocked_rpc(self, *args, **kwargs):
-                            '''Unconditional refusal for p4p Context.rpc().
-
-                            Limits semantics cannot apply to an arbitrary rpc
-                            payload, so refusal is the only honest parity.
-                            '''
-                            raise RuntimeError(
-                                "rpc is not mediated and cannot be approved — "
-                                "use the supervised write path"
-                            )
-
                         _context_cls.rpc = _p4p_blocked_rpc
 
                 try:
@@ -534,6 +687,225 @@ if not _execution_dir.exists():
                     )
                 except Exception as _p4p_error:
                     print(f"⚠️  p4p.client.cothread guard failed: {{_p4p_error}}")
+
+                # --- p4p's raw Context: the base every flavour above
+                # subclasses, and an object a script can drive on its own. A
+                # flavour put re-enters here through ``super().put`` once it
+                # has already been validated, so the gate below checks only a
+                # put whose receiver IS the raw Context - validating the
+                # re-entry too would check each pair twice and buy a second
+                # max_step read for the same write.
+                try:
+                    from p4p.client.raw import Context as _P4PRawContext
+
+                    if hasattr(_P4PRawContext, 'put'):
+                        _original_raw_put = _P4PRawContext.put
+
+                        def _raw_gated_put(self, name, handler, builder=None, *args, **kwargs):
+                            '''Limits-checked wrapper for p4p raw Context.put().
+
+                            A raw put names ONE channel and spells its value
+                            ``builder`` - a value, a structure, or a callable
+                            p4p invokes later, which ``_p4p_reduce`` refuses
+                            because there is nothing to check yet. The batch
+                            form belongs to the flavour clients, which reach
+                            this method one pair at a time.
+
+                            A receiver of a SUBCLASS type is a flavour put
+                            re-entering through ``super().put``, already
+                            validated by the flavour wrapper, so it is
+                            forwarded untouched. A subclass a script writes
+                            itself is forwarded unchecked for the same reason,
+                            which is why the write surface records this row as
+                            guarded for the raw Context only.
+
+                            The reader is the raw context's own, and raw
+                            ``get`` answers through a handler rather than
+                            returning a value - so a max_step channel written
+                            straight through raw fails CLOSED rather than
+                            being measured.
+                            '''
+                            if type(self) is not _P4PRawContext:
+                                return _original_raw_put(
+                                    self, name, handler, builder, *args, **kwargs
+                                )
+
+                            _limits_validator.validate(
+                                name,
+                                _p4p_reduce(builder),
+                                read_current=_p4p_current_value(self),
+                            )  # Raises if invalid
+                            return _original_raw_put(
+                                self, name, handler, builder, *args, **kwargs
+                            )
+
+                        _P4PRawContext.put = _raw_gated_put
+
+                    if hasattr(_P4PRawContext, 'rpc'):
+                        _P4PRawContext.rpc = _p4p_blocked_rpc
+
+                    print("✅ Monkeypatched p4p.client.raw Context.put()/.rpc()")
+                except ImportError:
+                    print(
+                        "ℹ️  p4p.client.raw not available - "
+                        "PVA limits checking disabled"
+                    )
+                except Exception as _p4p_error:
+                    print(f"⚠️  p4p.client.raw guard failed: {{_p4p_error}}")
+
+                # --- pvaPy. A PVAccess client of its own, not a p4p spelling:
+                # a ``pvaccess.Channel`` put never passes through a p4p
+                # Context, so the flavour guards above leave it unchecked. The
+                # binding spells one typed setter per scalar and array kind
+                # (putDouble, putScalarArray, ...), so the family is swept by
+                # PREFIX, the way the readonly guard sweeps it - enumerating
+                # the names would go stale against the binding, and every name
+                # it missed would be an unchecked write.
+                try:
+                    import pvaccess as _pvaccess
+
+                    def _pva_reduce(_payload):
+                        '''Reduce a pvaPy value to the number the limits are about.
+
+                        pvaPy takes the value three ways: a ``PvObject``
+                        structure, a plain dict of fields, and a bare scalar.
+                        The limits database holds numbers, and the validator
+                        SKIPS every check it cannot read a number for - so
+                        handing it the structure unreduced would let an
+                        out-of-range value dressed as a structure through
+                        unchecked.
+
+                        ``PvObject.getPyObject()`` answers the value under the
+                        structure's ``value`` field and raises pvaPy's own
+                        InvalidRequest when there is none, so a valueless
+                        structure is refused THERE, before the dict branch is
+                        reached. That branch is for a plain dict handed in
+                        directly; one with no ``value`` key fails CLOSED with a
+                        ValueError, the same trade the p4p batch guard makes
+                        for a payload it cannot pair up.
+                        '''
+                        _get_py = getattr(_payload, 'getPyObject', None)
+                        if _get_py is not None:
+                            _payload = _get_py()
+                        if isinstance(_payload, dict):
+                            if 'value' not in _payload:
+                                raise ValueError(
+                                    "pvaccess put requires a value to limits-check: "
+                                    "the structure written carries no 'value' field"
+                                )
+                            _payload = _payload['value']
+                        if callable(_payload):
+                            raise ValueError(
+                                "pvaccess put requires a value to limits-check, "
+                                "not a callable"
+                            )
+                        return _payload
+
+                    _pva_channel_cls = getattr(_pvaccess, 'Channel', None)
+                    _pva_original_get = getattr(_pva_channel_cls, 'get', None)
+
+                    def _pva_current_value(_channel):
+                        '''A reader for the max_step check, bound to the writing Channel.
+
+                        The read goes through the ORIGINAL ``Channel.get`` and
+                        the very channel the put is going through, so the step
+                        is measured over that channel under its own addressing.
+                        pvaPy answers a get with a structure, so the answer is
+                        reduced exactly as the payload is - left unreduced it
+                        is non-numeric, and the validator would SKIP the step
+                        check rather than enforce it. A read that fails answers
+                        None, which fails the step check closed.
+                        '''
+                        if _pva_original_get is None:
+                            return None
+
+                        def _read(_address):
+                            try:
+                                return _pva_reduce(_pva_original_get(_channel))
+                            except Exception:
+                                return None
+
+                        return _read
+
+                    def _pva_refuse_unreducible(_pva_name):
+                        '''Refuse a write whose payload cannot be reduced.
+
+                        ``parsePut``/``parsePutGet`` take a LIST OF JSON
+                        strings, parsed against the channel's introspected
+                        structure - not a value object. There is nothing to
+                        reduce, and nothing that says which string carries the
+                        field the limits are about; guessing would be a check
+                        that silently means nothing. So the write is refused
+                        outright, in range or not, the same posture the p4p
+                        guard takes for a callable payload.
+                        '''
+                        def _refuse(self, *args, **kwargs):
+                            raise ValueError(
+                                "pvaccess " + _pva_name + " cannot be "
+                                "limits-checked; use put"
+                            )
+
+                        return _refuse
+
+                    def _pva_checked_put(_original_put):
+                        '''Wrap ONE member of the put family.
+
+                        The original is bound per attribute by this factory
+                        because closing over the sweep's loop variable would
+                        leave every wrapper calling whichever put was seen
+                        last - one setter's writes going out under another
+                        setter's typing.
+                        '''
+                        def _checked(self, value, *args, **kwargs):
+                            _limits_validator.validate(
+                                self.getName(),
+                                _pva_reduce(value),
+                                read_current=_pva_current_value(self),
+                            )  # Raises if invalid
+                            return _original_put(self, value, *args, **kwargs)
+
+                        return _checked
+
+                    # pvaPy spells three more writes OUTSIDE the put prefix:
+                    # asyncPut (a put with a completion callback, PvObject
+                    # first, so the ordinary wrapper covers it) and
+                    # parsePut/parsePutGet (JSON strings, refused above).
+                    # Each is the same value reaching the machine, so each is
+                    # swept with the family.
+                    _pva_swept = []
+                    if _pva_channel_cls is not None:
+                        for _pva_attr in dir(_pva_channel_cls):
+                            if not _pva_attr.startswith(
+                                ('put', 'asyncPut', 'parsePut')
+                            ):
+                                continue
+                            _pva_original_put = getattr(_pva_channel_cls, _pva_attr, None)
+                            if not callable(_pva_original_put):
+                                continue
+                            if _pva_attr.startswith('parsePut'):
+                                _pva_wrapper = _pva_refuse_unreducible(_pva_attr)
+                            else:
+                                _pva_wrapper = _pva_checked_put(_pva_original_put)
+                            setattr(_pva_channel_cls, _pva_attr, _pva_wrapper)
+                            _pva_swept.append(_pva_attr)
+
+                    # The success line is the operator's only evidence the
+                    # guard is on. A pvaccess without a Channel, or a Channel
+                    # carrying no put, wrapped nothing and must not report
+                    # itself guarded.
+                    if _pva_swept:
+                        print(
+                            "✅ Monkeypatched pvaccess Channel "
+                            "put*()/asyncPut()/parsePut*()"
+                        )
+                    elif _pva_channel_cls is None:
+                        print("⚠️  pvaccess guard failed: no Channel class")
+                    else:
+                        print("⚠️  pvaccess guard failed: Channel has no put method")
+                except ImportError:
+                    print("ℹ️  pvaccess not available - pvaPy limits checking disabled")
+                except Exception as _pva_error:
+                    print(f"⚠️  pvaccess guard failed: {{_pva_error}}")
 
                 # --- Tango. Its writes carry the attribute name only; the
                 # channel a limits database is keyed by is the full
@@ -584,6 +956,58 @@ if not _execution_dir.exists():
                             _pairs.append((_attr, _value))
                         return _pairs
 
+                    # A Tango COMMAND is not a channel write. It names an
+                    # operation on the device, and its argument is whatever
+                    # that command's own signature says - a mode string, a
+                    # struct, nothing at all. There is no channel address to
+                    # look the limits up under and no number to bound, so a
+                    # limits-checked run cannot approve one; a check that
+                    # let it through would mean nothing. Both spellings
+                    # refuse outright, argument or not, which is the posture
+                    # the p4p guard takes for rpc().
+                    def _tango_refuse_command(self, *args, **kwargs):
+                        '''Unconditional refusal for a Tango command call.'''
+                        raise RuntimeError(
+                            "Tango command refused in a limits-checked run: "
+                            "a command carries no value to bound"
+                        )
+
+                    # A group write fans one value out to every device the
+                    # group matched - there is no single channel address to
+                    # look limits up under and no one device to bound the
+                    # step against, so it refuses in range or not.
+                    def _tango_refuse_group_write(self, *args, **kwargs):
+                        '''Unconditional refusal for a Group attribute write.'''
+                        raise RuntimeError(
+                            "Tango group write refused in a limits-checked "
+                            "run: a group write fans one value out to many "
+                            "devices and is not limits-checked"
+                        )
+
+                    def _tango_refuse_on(_class_name, _spellings):
+                        '''Install a refusal per spelling the named class carries.
+
+                        Answers the names installed, so the success line can
+                        say what this binding actually had; a tango without
+                        the class answers an empty list.
+                        '''
+                        _cls = getattr(_tango, _class_name, None)
+                        _installed = []
+                        if _cls is not None:
+                            for _name, _refusal in _spellings:
+                                if hasattr(_cls, _name):
+                                    setattr(_cls, _name, _refusal)
+                                    _installed.append(_name)
+                        return _installed
+
+                    _tango_commands = (
+                        ('command_inout', _tango_refuse_command),
+                        ('command_inout_asynch', _tango_refuse_command),
+                    )
+                    _tango_wrapped = []
+                    _tango_refused = []
+                    _tango_refused_base = []
+
                     if hasattr(_tango, "DeviceProxy"):
                         if hasattr(_tango.DeviceProxy, "write_attribute"):
                             _orig_tango_write = _tango.DeviceProxy.write_attribute
@@ -598,6 +1022,7 @@ if not _execution_dir.exists():
                                 return _orig_tango_write(self, attr_name, value, *args, **kwargs)
 
                             _tango.DeviceProxy.write_attribute = _checked_tango_write
+                            _tango_wrapped.append("write_attribute")
 
                         if hasattr(_tango.DeviceProxy, "write_attributes"):
                             _orig_tango_write_many = _tango.DeviceProxy.write_attributes
@@ -618,8 +1043,63 @@ if not _execution_dir.exists():
                                 return _orig_tango_write_many(self, _pairs, *args, **kwargs)
 
                             _tango.DeviceProxy.write_attributes = _checked_tango_write_many
+                            _tango_wrapped.append("write_attributes")
 
-                    print("✅ Monkeypatched tango DeviceProxy.write_attribute(s)()")
+                        _tango_refused = _tango_refuse_on('DeviceProxy', _tango_commands)
+
+                        # PyTango DEFINES both spellings on the base class
+                        # ``Connection``; ``DeviceProxy`` only inherits them.
+                        # Patching the subclass installs a shadow in
+                        # ``DeviceProxy.__dict__`` and leaves the original
+                        # reachable on the definer, so an unbound
+                        # ``tango.Connection.command_inout(proxy, 'On')`` would
+                        # still drive the device with the refusal installed.
+                        # Refusing on the definer closes that spelling, and
+                        # every other Connection subclass with it.
+                        _tango_refused_base = _tango_refuse_on('Connection', _tango_commands)
+
+                        if not _tango_wrapped and not _tango_refused:
+                            print(
+                                "⚠️  tango guard failed: DeviceProxy has no write "
+                                "or command method"
+                            )
+                    else:
+                        # The success line is the operator's only evidence the
+                        # guard is on. A tango without a DeviceProxy wrapped
+                        # nothing on it, and must not report it guarded.
+                        print("⚠️  tango guard failed: no DeviceProxy class")
+
+                    # ``tango.Group`` is not a Connection subclass. It is a
+                    # separate pure-Python class carrying its own commands AND
+                    # its own attribute writes, so neither install above
+                    # reaches it. It is patched on its own, outside the
+                    # DeviceProxy branch: a Group is a write surface whether
+                    # or not a DeviceProxy sits beside it.
+                    _tango_refused_group = _tango_refuse_on(
+                        'Group',
+                        _tango_commands
+                        + (
+                            ('write_attribute', _tango_refuse_group_write),
+                            ('write_attribute_asynch', _tango_refuse_group_write),
+                        ),
+                    )
+
+                    # The success line is the operator's only evidence the
+                    # guard is on, so it names what this binding actually
+                    # carried, class by class, rather than what the block can
+                    # install.
+                    _tango_report = [
+                        _tango_label + ", ".join(_n + "()" for _n in _tango_names)
+                        for _tango_label, _tango_names in (
+                            ("wrapped on DeviceProxy: ", _tango_wrapped),
+                            ("refused on DeviceProxy: ", _tango_refused),
+                            ("refused on Connection: ", _tango_refused_base),
+                            ("refused on Group: ", _tango_refused_group),
+                        )
+                        if _tango_names
+                    ]
+                    if _tango_report:
+                        print("✅ Monkeypatched tango: " + "; ".join(_tango_report))
                 except ImportError:
                     print("ℹ️  tango not available - Tango limits checking disabled")
                 except Exception as _tango_error:

--- a/src/osprey/services/python_executor/write_surface.py
+++ b/src/osprey/services/python_executor/write_surface.py
@@ -27,6 +27,34 @@ is what makes the guard immune to spelling. ``importlib.import_module("epics")``
 up holding the refusing function, because they all resolve through the one
 module object the guard mutates.
 
+The floor of that technique is the Python name. A handle that has already left
+Python cannot be re-pointed: ``cadef.libca['ca_array_put']`` fetches a fresh
+function pointer out of the shared library on every call. The immutable
+C-extension type ``p4p._p4p.ClientOperation`` is the same kind of floor, and it
+deliberately has **no row** in the table below. The type refuses ``setattr``, so
+it cannot be patched; the two names that hand it out cannot be patched either
+without breaking reads, because ``p4p/client/raw.py`` subclasses the type at
+import time and resolves the subclass — the *same* object — for ``get`` as well
+as for ``put`` and ``rpc``. Refusing those names would refuse every PVAccess
+read, which is the path readonly mode exists to keep open. That route is
+covered instead by refusing the ``p4p`` import outright in a readonly run and by
+the ``p4p.client.*.Context`` ``put``/``rpc`` rows, which refuse the write calls
+in any process that already holds the library. So readonly enforcement for
+Channel Access and PVAccess rests on the Python layer named below together with
+the import denylist, the connector's own refusal of ``write_channel`` and the
+read-only network posture — not on the C objects themselves.
+
+PyTango has a floor of the same shape. Its ``Group`` is a Python class wrapping
+a C++ group it keeps at ``self._Group__group``, and that C++ class is reachable
+from the module namespace as ``tango.group._RealGroup`` — so
+``tango.group._RealGroup("all").write_attribute_asynch(...)`` writes past the
+Python-level ``Group`` refusals. It has no row for the same reason
+``p4p._p4p.ClientOperation`` has none: it is a C-extension type carrying the
+group's reads as well as its writes, so it cannot be re-pointed from Python and
+refusing it would refuse reading a group at all. A readonly run is covered
+because ``tango`` cannot be imported there; a limits-checked run's group
+refusals sit on the Python class only.
+
 The table is split three ways because the three groups are answered
 differently by the *static* import check:
 
@@ -48,14 +76,27 @@ _CLIENT_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     # --- EPICS Channel Access (pyepics) ---
     ("epics", ("caput", "caput_many")),
     ("epics.PV", ("put",)),
-    ("epics.ca", ("put", "put_complete")),
+    ("epics.ca", ("put",)),
     # --- EPICS Channel Access (aioca). Not an optional extra: ophyd-async's
     # [ca] backend pulls it into every environment OSPREY builds, so a readonly
-    # script can reach ``aioca.caput`` with nothing else installed.
-    ("aioca", ("caput", "caput_many")),
+    # script can reach ``aioca.caput`` with nothing else installed. The name on
+    # the package is a re-export of ``aioca._catools.caput``, so the defining
+    # module is listed too: patching only ``aioca`` leaves
+    # ``from aioca._catools import caput`` reaching the machine.
+    ("aioca", ("caput",)),
+    ("aioca._catools", ("caput",)),
+    # --- Channel Access (epicscorelibs). The ctypes binding that aioca loads
+    # ``libca`` through, so it is a client route in its own right. Listing it
+    # also puts ``epicscorelibs`` in :data:`READONLY_DENIED_IMPORTS`, which is
+    # the half that holds: the module attributes are only re-pointable until
+    # something re-fetches the function pointer out of ``libca`` itself.
+    # pyepics is unaffected — its ``epics.ca.libca`` is ``None`` until
+    # ``initialize_libca()`` runs.
+    ("epicscorelibs.ca.cadef", ("ca_array_put", "ca_array_put_callback")),
     # --- PVAccess (p4p): one client Context per concurrency flavour, plus the
     # server-side SharedPV, which puts values on the wire when it is opened or
     # posted to.
+    ("p4p.client.raw.Context", ("put", "rpc")),
     ("p4p.client.thread.Context", ("put", "rpc")),
     ("p4p.client.asyncio.Context", ("put", "rpc")),
     ("p4p.client.cothread.Context", ("put", "rpc")),
@@ -63,15 +104,16 @@ _CLIENT_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("p4p.server.thread.SharedPV", ("post", "open")),
     ("p4p.server.asyncio.SharedPV", ("post", "open")),
     # --- Channel Access (caproto) ---
-    ("caproto.sync.client", ("write", "write_read")),
-    ("caproto.threading.client.PV", ("write", "write_all")),
+    ("caproto.sync.client", ("write", "read_write_read")),
+    ("caproto.threading.client.PV", ("write",)),
     ("caproto.threading.client.Batch", ("write",)),
     ("caproto.asyncio.client.PV", ("write",)),
     # --- PVAccess (pvaPy). Its ``Channel`` carries one typed setter per scalar
-    # and array type, so the ``put`` prefix is swept dynamically by the guard
-    # rather than enumerated here; ``put`` itself is listed so the table still
-    # names the library.
-    ("pvaccess.Channel", ("put", "putGet")),
+    # and array type, so the guards sweep the ``put``, ``asyncPut`` and
+    # ``parsePut`` prefixes dynamically rather than enumerating the setters
+    # here. One name per family is listed so the table still names the library
+    # and so a test that puts back what a guard patched covers all three.
+    ("pvaccess.Channel", ("put", "putGet", "asyncPut", "parsePut", "parsePutGet")),
     # --- DOOCS (doocs4py). The client the shipped DOOCS connector writes
     # through (``osprey_connectors.control_system.doocs_connector``), so a
     # readonly script on a DOOCS deployment can reach the machine with the one
@@ -90,13 +132,29 @@ _CLIENT_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "write_attributes_asynch",
             "write_read_attribute",
             "write_read_attributes",
-            "write_pipe",
             "put_property",
             "command_inout",
             "command_inout_asynch",
         ),
     ),
+    # ``Connection`` is where PyTango DEFINES both command spellings;
+    # ``DeviceProxy`` only inherits them. Patching the subclass alone installs
+    # a shadow and leaves ``tango.Connection.command_inout(proxy, "On")``
+    # reaching the device, so the definer carries its own row.
+    ("tango.Connection", ("command_inout", "command_inout_asynch")),
     ("tango.AttributeProxy", ("write", "write_asynch", "write_read")),
+    # ``Group`` is not a ``Connection`` subclass. It is a separate class with
+    # its own commands and its own attribute writes, and a group write fans one
+    # value out to every device the group matched.
+    (
+        "tango.Group",
+        (
+            "command_inout",
+            "command_inout_asynch",
+            "write_attribute",
+            "write_attribute_asynch",
+        ),
+    ),
     (
         "PyTango.DeviceProxy",
         (
@@ -121,7 +179,7 @@ _FRAMEWORK_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     # keeps working.
     ("ophyd_async.core.SignalW", ("set",)),
     ("ophyd_async.core.SignalRW", ("set",)),
-    ("ophyd_async.core.SignalX", ("trigger", "execute")),
+    ("ophyd_async.core.SignalX", ("trigger",)),
     # Running a plan is how the Bluesky stack moves hardware. Patching
     # ``__call__`` on the class is enough: Python resolves a dunder on the
     # type, so ``RE(plan)`` on any instance lands here.

--- a/src/osprey/services/python_executor/write_surface.py
+++ b/src/osprey/services/python_executor/write_surface.py
@@ -67,6 +67,15 @@ differently by the *static* import check:
   out of the denylist.
 * :data:`_ESCAPE_ROUTES` — routes out of Python that reach a control system
   without importing a client at all.
+
+Refusing a write is one question; letting an *approved* write through only
+within the channel's limits is another, and the second is answered for fewer
+entry points than the first. :data:`_LIMITS_WRAPPED`, :data:`_LIMITS_REFUSED`,
+:data:`_LIMITS_UNWRAPPABLE` and :data:`_LIMITS_NOT_YET_WRAPPED` partition
+:data:`_CLIENT_WRITE_TARGETS` by what a limits-checked run does with each entry
+point, so "which client writes are bounded" has a written answer instead of
+being read out of the generated monkeypatch. ``tests/services/python_executor/
+execution/test_limits_parity.py`` holds the partition to the table.
 """
 
 #: Control-system client libraries, as ``(dotted target, attributes)``. Also
@@ -268,10 +277,137 @@ READONLY_DENIED_IMPORTS: frozenset[str] = frozenset(
     dotted.split(".")[0] for dotted, _attrs in _CLIENT_WRITE_TARGETS
 )
 
+#: What a *limits-checked* run does with each client entry point, wrapped in
+#: :data:`_LIMITS_WRAPPED`: the value is how the check is reached, either
+#: ``"direct"`` — the guard patches this very name — or the name it is checked
+#: through. The four buckets below partition :data:`_CLIENT_WRITE_TARGETS`
+#: exactly, and are keyed by the canonical ``tango`` spelling: a
+#: ``PyTango.DeviceProxy`` row resolves to the same class object, so its fate is
+#: the ``tango.DeviceProxy`` row's fate and it carries no separate entry.
+_LIMITS_WRAPPED: dict[tuple[str, str], str] = {
+    ("epics", "caput"): "via epics.ca.put — caput() puts through a PV",
+    ("epics", "caput_many"): "via epics.ca.put — one PV.put() per pair",
+    ("epics.PV", "put"): "via epics.ca.put",
+    ("epics.ca", "put"): (
+        "direct — the choke point every pyepics spelling reaches; the channel "
+        "is asked for by name because a chid is opaque"
+    ),
+    ("aioca", "caput"): "direct — the package re-export is rebound to the checked coroutine",
+    ("aioca._catools", "caput"): (
+        "direct — the defining module is rebound too, which is also what gets "
+        "the array form checked: it writes each pair through this global"
+    ),
+    ("p4p.client.raw.Context", "put"): (
+        "direct, but only for a put whose receiver IS the raw Context. A "
+        "subclass receiver is forwarded unvalidated — that is a flavour "
+        "Context re-entering through super().put after its own check, and "
+        "equally a subclass a script writes itself, which is therefore checked "
+        "nowhere"
+    ),
+    ("p4p.client.thread.Context", "put"): "direct",
+    ("p4p.client.asyncio.Context", "put"): "direct",
+    ("p4p.client.cothread.Context", "put"): "direct",
+    ("caproto.sync.client", "write"): "direct",
+    ("caproto.threading.client.PV", "write"): "direct — the PV knows its own channel",
+    ("pvaccess.Channel", "put"): "direct — swept by the put prefix",
+    ("pvaccess.Channel", "putGet"): "direct — swept by the put prefix",
+    ("pvaccess.Channel", "asyncPut"): "direct — swept by the asyncPut prefix",
+    ("doocs4py", "set"): "direct",
+    ("tango.DeviceProxy", "write_attribute"): (
+        "direct — the channel is rebuilt as dev_name()/attribute"
+    ),
+    ("tango.DeviceProxy", "write_attributes"): "direct — one check per (attribute, value) pair",
+}
+
+#: Entry points a limits-checked run refuses outright, in range or not, with
+#: the reason no bound can be put on them.
+_LIMITS_REFUSED: dict[tuple[str, str], str] = {
+    ("p4p.client.raw.Context", "rpc"): "an rpc payload is arbitrary; limits cannot apply",
+    ("p4p.client.thread.Context", "rpc"): "an rpc payload is arbitrary; limits cannot apply",
+    ("p4p.client.asyncio.Context", "rpc"): "an rpc payload is arbitrary; limits cannot apply",
+    ("p4p.client.cothread.Context", "rpc"): "an rpc payload is arbitrary; limits cannot apply",
+    ("pvaccess.Channel", "parsePut"): (
+        "a list of JSON strings parsed against the channel's own structure — "
+        "nothing says which string carries the field the limits are about"
+    ),
+    ("pvaccess.Channel", "parsePutGet"): (
+        "a list of JSON strings parsed against the channel's own structure — "
+        "nothing says which string carries the field the limits are about"
+    ),
+    ("tango.DeviceProxy", "command_inout"): (
+        "a command is an action on the device, not a channel write: no address "
+        "to look limits up under and no number to bound"
+    ),
+    ("tango.DeviceProxy", "command_inout_asynch"): (
+        "a command is an action on the device, not a channel write: no address "
+        "to look limits up under and no number to bound"
+    ),
+    ("tango.Connection", "command_inout"): (
+        "the class that DEFINES the command; refusing here closes the unbound "
+        "spelling and every other Connection subclass with it"
+    ),
+    ("tango.Connection", "command_inout_asynch"): (
+        "the class that DEFINES the command; refusing here closes the unbound "
+        "spelling and every other Connection subclass with it"
+    ),
+    ("tango.Group", "command_inout"): "a group command is an action on many devices",
+    ("tango.Group", "command_inout_asynch"): "a group command is an action on many devices",
+    ("tango.Group", "write_attribute"): (
+        "a group write fans one value out to every device the group matched: "
+        "no single channel to bound it under and no one device to step against"
+    ),
+    ("tango.Group", "write_attribute_asynch"): (
+        "a group write fans one value out to every device the group matched: "
+        "no single channel to bound it under and no one device to step against"
+    ),
+}
+
+#: Entry points a limits check cannot be attached to at all. Listed so the
+#: partition stays honest about them: a readonly run still refuses every one.
+_LIMITS_UNWRAPPABLE: dict[tuple[str, str], str] = {
+    ("epicscorelibs.ca.cadef", "ca_array_put"): (
+        "a patch would have a floor under it, because "
+        "cadef.libca['ca_array_put'] re-fetches the function pointer out of "
+        "the shared library"
+    ),
+    ("epicscorelibs.ca.cadef", "ca_array_put_callback"): (
+        "a patch would have a floor under it, because "
+        "cadef.libca['ca_array_put_callback'] re-fetches the function pointer "
+        "out of the shared library"
+    ),
+    ("p4p.server.raw.SharedPV", "post"): "server side — serves a PV, writes no device",
+    ("p4p.server.raw.SharedPV", "open"): "server side — serves a PV, writes no device",
+    ("p4p.server.thread.SharedPV", "post"): "server side — serves a PV, writes no device",
+    ("p4p.server.thread.SharedPV", "open"): "server side — serves a PV, writes no device",
+    ("p4p.server.asyncio.SharedPV", "post"): "server side — serves a PV, writes no device",
+    ("p4p.server.asyncio.SharedPV", "open"): "server side — serves a PV, writes no device",
+    ("tango.DeviceProxy", "put_property"): "writes the Tango database, not a channel",
+}
+
+#: Entry points that COULD be limits-checked and are not yet. A readwrite run
+#: reaches the machine through any of them without passing the limits database,
+#: which is why the bucket is named rather than left implicit.
+_LIMITS_NOT_YET_WRAPPED: dict[tuple[str, str], str] = {
+    ("tango.DeviceProxy", "write_attribute_asynch"): "followups-897 item 16",
+    ("tango.DeviceProxy", "write_attributes_asynch"): "followups-897 item 16",
+    ("tango.DeviceProxy", "write_read_attribute"): "followups-897 item 16",
+    ("tango.DeviceProxy", "write_read_attributes"): "followups-897 item 16",
+    ("tango.AttributeProxy", "write"): "followups-897 item 16",
+    ("tango.AttributeProxy", "write_asynch"): "followups-897 item 16",
+    ("tango.AttributeProxy", "write_read"): "followups-897 item 16",
+    ("caproto.sync.client", "read_write_read"): "followups-897 item 16",
+    ("caproto.threading.client.Batch", "write"): "followups-897 item 16",
+    ("caproto.asyncio.client.PV", "write"): "followups-897 item 16",
+}
+
 __all__ = [
     "READONLY_DENIED_IMPORTS",
     "_CLIENT_WRITE_TARGETS",
     "_ESCAPE_ROUTES",
     "_FRAMEWORK_WRITE_TARGETS",
+    "_LIMITS_NOT_YET_WRAPPED",
+    "_LIMITS_REFUSED",
+    "_LIMITS_UNWRAPPABLE",
+    "_LIMITS_WRAPPED",
     "_READONLY_WRITE_TARGETS",
 ]

--- a/src/osprey/version.py
+++ b/src/osprey/version.py
@@ -116,9 +116,13 @@ def _pep440_from_describe(described: str) -> str | None:
     # it, or the build stamp and this string disagree on hash length alone.
     local = f"g{remainder[:9]}"
     if dirty:
-        from datetime import date
+        from datetime import UTC, datetime
 
-        local = f"{local}.d{date.today():%Y%m%d}"
+        # UTC, because that is the clock setuptools-scm's node-and-date scheme
+        # reads. Local time here made the two derivations disagree by a day for
+        # every dirty checkout west of Greenwich after 17:00, which is not a
+        # midnight race but a several-hour window every single day.
+        local = f"{local}.d{datetime.now(UTC):%Y%m%d}"
     return f"{base}.post{distance}+{local}"
 
 

--- a/tests/dispatch/test_run_artifacts.py
+++ b/tests/dispatch/test_run_artifacts.py
@@ -32,6 +32,24 @@ HTML_BYTES = b"<html><body><h1>plot</h1></body></html>"
 TOKEN = "test-worker-token"
 
 
+@pytest.fixture(autouse=True)
+def _no_artifact_server_autolaunch(monkeypatch):
+    """Keep ``save_file``'s companion-server auto-launch out of this module.
+
+    Every save below goes through ``ArtifactStore.save_file``, whose last act is
+    to start the artifacts backend if it is not already up. That is a real
+    uvicorn on a daemon thread, and its lifespan resolves an agent-data root of
+    its own -- not the ``workspace_root`` these tests hand the store. Unstamped,
+    that resolves to the checkout, so the thread writes ``var/agent_data`` into
+    the repository, outliving the test that started it and failing the session
+    on ``no_agent_data_in_the_repo`` under whichever test happened to be running
+    at the time. Nothing here asserts on the server, so it is not started.
+    """
+    from osprey.infrastructure import server_launcher
+
+    monkeypatch.setattr(server_launcher, "ensure_artifact_server", lambda *a, **k: None)
+
+
 def _save(
     store: ArtifactStore,
     run_id: str,

--- a/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
+++ b/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
@@ -90,6 +90,21 @@ def notebook_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
         environment.setenv("TMPDIR", str(root))
         environment.setenv("OSPREY_AUDIT_IDENTITY", AUDIT_IDENTITY)
         environment.setenv(TERMINAL_FAMILY_PROBE, "reachable-from-the-terminal")
+        # And the agent-data root, here rather than from the autouse stamp in
+        # tests/interfaces/conftest.py. That one is function-scoped, and the
+        # fixtures below it are module-scoped: pytest builds the module scope
+        # first, so the app lifespan ``proxied`` enters — which claims the
+        # control-context record — runs before any per-test stamp exists and
+        # resolves the root to the checkout. The result is a real
+        # ``<repo>/var/agent_data`` that ``no_agent_data_in_the_repo`` fails the
+        # whole session over, from a module that never asked for one.
+        environment.setenv("OSPREY_AGENT_DATA_ROOT", str(root / "var" / "agent_data"))
+        # The audit zone too, for the same reason: the app's HTTP mutation
+        # records would otherwise land in ``<repo>/var/audit`` under the
+        # identity stamped above.
+        from osprey.audit import writer as audit_writer
+
+        environment.setattr(audit_writer, "audit_dir", lambda: root / "var" / "audit")
         yield root
 
 

--- a/tests/mcp_server/python_executor/test_executor_adapter.py
+++ b/tests/mcp_server/python_executor/test_executor_adapter.py
@@ -300,7 +300,7 @@ def test_wrapper_includes_monkeypatch_when_validator_present(tmp_path, monkeypat
 
     wrapper = ExecutionWrapper(limits_validator=validator)
     wrapped = wrapper.create_wrapper("print('hello')", tmp_path)
-    assert "_checked_caput" in wrapped
+    assert "_checked_ca_put" in wrapped
     assert "LimitsValidator" in wrapped
 
 
@@ -313,7 +313,7 @@ def test_wrapper_omits_monkeypatch_when_no_validator(tmp_path, monkeypatch):
 
     wrapper = ExecutionWrapper(limits_validator=None)
     wrapped = wrapper.create_wrapper("print('hello')", tmp_path)
-    assert "_checked_caput" not in wrapped
+    assert "_checked_ca_put" not in wrapped
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/ariel_search/test_sql_query.py
+++ b/tests/services/ariel_search/test_sql_query.py
@@ -184,6 +184,225 @@ class TestValidateSqlQueryRejects:
         assert "enhanced_entries" in str(exc_info.value)
 
 
+class TestFromListRule:
+    """The FROM/JOIN shape rule.
+
+    The allowlist resolves one identifier per ``FROM``/``JOIN``. Every shape
+    below reaches a second table that resolution never sees, so the validator
+    refuses the shape rather than trying to resolve it.
+    """
+
+    def test_comma_list_after_from(self):
+        with pytest.raises(
+            ValueError, match="comma-separated FROM lists are not allowed; use JOIN"
+        ):
+            validate_sql_query("SELECT * FROM enhanced_entries, pg_shadow")
+
+    def test_comma_list_with_aliases(self):
+        """An alias between the table and the comma does not change the shape."""
+        with pytest.raises(
+            ValueError, match="comma-separated FROM lists are not allowed; use JOIN"
+        ):
+            validate_sql_query("SELECT * FROM enhanced_entries e, pg_shadow s")
+
+    def test_comma_after_a_join_condition(self):
+        """``ON`` does not end the FROM clause, so the comma is still a FROM list."""
+        with pytest.raises(
+            ValueError, match="comma-separated FROM lists are not allowed; use JOIN"
+        ):
+            validate_sql_query(
+                "SELECT * FROM enhanced_entries e "
+                "JOIN text_embeddings_nomic t ON t.entry_id = e.entry_id, pg_shadow"
+            )
+
+    def test_comma_after_a_parenthesised_subquery(self):
+        """Closing the subquery returns to a FROM clause that is still open."""
+        with pytest.raises(
+            ValueError, match="comma-separated FROM lists are not allowed; use JOIN"
+        ):
+            validate_sql_query(
+                "SELECT * FROM (SELECT entry_id FROM enhanced_entries) AS sub, pg_shadow"
+            )
+
+    def test_comma_before_a_set_returning_function(self):
+        """The second FROM item need not be a table at all."""
+        with pytest.raises(
+            ValueError, match="comma-separated FROM lists are not allowed; use JOIN"
+        ):
+            validate_sql_query("SELECT * FROM enhanced_entries e, pg_ls_dir('/') d")
+
+    def test_quoted_identifier_is_refused(self):
+        """A quoted name is invisible to an unquoted-identifier scan."""
+        with pytest.raises(ValueError, match="Quoted identifiers are not allowed"):
+            validate_sql_query('SELECT * FROM enhanced_entries, "pg_shadow"')
+
+    def test_block_comment_is_refused(self):
+        """A comment can carry a parenthesis that would desynchronise the scan."""
+        with pytest.raises(ValueError, match="Block comments are not allowed"):
+            validate_sql_query("SELECT * FROM enhanced_entries /* ( */ , pg_shadow")
+
+    def test_line_comment_is_refused(self):
+        with pytest.raises(ValueError, match="Line comments are not allowed"):
+            validate_sql_query("SELECT * FROM enhanced_entries -- (\n, pg_shadow")
+
+    def test_backslash_is_refused(self):
+        """An ``E'...'`` string treats ``\\'`` as an escaped quote; the scan does not.
+
+        After ``E'\\''`` the scan and Postgres disagree on where the string
+        ends, so the FROM/JOIN targets Postgres reads are inside a literal to
+        the scan. The query below read ``pg_shadow`` on the pre-fix code.
+        """
+        with pytest.raises(ValueError, match="Backslash escapes are not allowed"):
+            validate_sql_query(
+                "SELECT E'\\'' FROM pg_shadow WHERE usename <> ' FROM enhanced_entries '"
+            )
+
+    def test_parenthesised_join_is_refused(self):
+        """``FROM (`` may only open a subquery, never a join expression."""
+        with pytest.raises(ValueError, match="must be a subquery starting with SELECT or WITH"):
+            validate_sql_query("SELECT * FROM (pg_shadow s JOIN enhanced_entries e ON true)")
+
+    # Postgres's ``TABLE name`` is ``SELECT * FROM name`` with neither keyword,
+    # legal as a CTE body, a set-operation branch and a subquery. The scan reads
+    # it as a third binder, so the name after it is a table the allowlist checks.
+
+    def test_table_command_as_a_cte_body_is_checked(self):
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query("WITH x AS (TABLE pg_shadow) SELECT * FROM x")
+
+    def test_table_command_as_a_cte_body_is_checked_behind_a_decoy_read(self):
+        """The decoy ``FROM enhanced_entries`` satisfied the allowlist; the body did not."""
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "WITH x AS (TABLE pg_shadow) SELECT usename FROM enhanced_entries JOIN x ON true"
+            )
+
+    def test_table_command_as_a_union_branch_is_checked(self):
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query("SELECT * FROM enhanced_entries UNION ALL TABLE pg_shadow")
+
+    def test_table_command_as_a_from_subquery_is_refused(self):
+        """``FROM (TABLE ...)`` stays on the paren rule: only SELECT/WITH open a subquery."""
+        with pytest.raises(ValueError, match="must be a subquery starting with SELECT or WITH"):
+            validate_sql_query("SELECT * FROM (TABLE pg_shadow) s")
+
+    def test_table_command_with_a_comma_list_is_refused(self):
+        with pytest.raises(ValueError, match="comma-separated FROM lists are not allowed"):
+            validate_sql_query("WITH x AS (TABLE enhanced_entries, pg_shadow) SELECT * FROM x")
+
+    def test_table_command_on_an_allowlisted_table_is_allowed(self):
+        validate_sql_query("WITH x AS (TABLE enhanced_entries) SELECT * FROM x")
+
+    def test_multi_cte_query_is_allowed(self):
+        """Every ``, name AS (`` in a WITH list binds a CTE name, not just the first."""
+        validate_sql_query(
+            "WITH a AS (SELECT entry_id FROM enhanced_entries), "
+            "b AS (SELECT entry_id FROM enhanced_entries) "
+            "SELECT * FROM a JOIN b ON a.entry_id = b.entry_id"
+        )
+
+    def test_commas_outside_a_from_clause_are_allowed(self):
+        """Select lists and ORDER BY are comma-separated by construction."""
+        validate_sql_query(
+            "SELECT entry_id, author FROM enhanced_entries ORDER BY entry_id, author"
+        )
+
+    def test_comma_inside_an_in_list_is_allowed(self):
+        validate_sql_query("SELECT * FROM enhanced_entries WHERE entry_id IN (1, 2)")
+
+    def test_function_read_on_an_allowlisted_table_still_passes(self):
+        """EXPECTED PASS, pinned deliberately.
+
+        Naming an allowlisted table satisfies the allowlist, so a server-side
+        function call in the select list goes through. Bounding what the
+        session may read is the read-only database role's job — task A2
+        ``sql-readonly-role`` — not the allowlist's, and this case is pinned
+        here so that gap is recorded rather than implied closed.
+        """
+        validate_sql_query("SELECT pg_read_file('/etc/passwd') FROM enhanced_entries LIMIT 1")
+
+
+class TestCteNameBinding:
+    """Only a real ``WITH`` list binds a name the allowlist then skips.
+
+    A bound CTE name is removed from the allowlist check, so anything that
+    binds a name a query did not declare hands a joined table a free pass. The
+    FROM/JOIN targets and the CTE names come out of one token pass, which
+    consumes a single-quoted string whole, and a name only binds inside an open
+    WITH list.
+    """
+
+    def test_literal_mimicking_a_later_cte_binds_no_name(self):
+        """A `, name AS (` inside a literal must not launder a joined table."""
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "SELECT ', pg_shadow AS (' FROM enhanced_entries JOIN pg_shadow ON true"
+            )
+
+    def test_literal_mimicking_a_with_clause_binds_no_name(self):
+        """Same bypass through the first CTE's `WITH name AS` spelling."""
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "SELECT 'WITH pg_shadow AS ' FROM enhanced_entries JOIN pg_shadow ON true"
+            )
+
+    def test_window_alias_does_not_bind_a_cte_name(self):
+        """``, name AS (`` binds a CTE only inside a WITH list, not in a WINDOW list."""
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "SELECT * FROM enhanced_entries JOIN pg_shadow ON true "
+                "WINDOW w AS (), pg_shadow AS ()"
+            )
+
+    # Postgres scopes a CTE to the query that declares it: a name bound inside a
+    # subquery is a real relation at the outer level, so the allowlist must
+    # resolve each FROM/JOIN reference against the declarations visible THERE.
+
+    def test_cte_declared_in_a_from_subquery_does_not_cover_an_outer_join(self):
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "SELECT * FROM (WITH pg_shadow AS (SELECT 1 AS n) "
+                "SELECT * FROM enhanced_entries) s JOIN pg_shadow ON true"
+            )
+
+    def test_cte_declared_in_a_scalar_subquery_does_not_cover_an_outer_join(self):
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "SELECT (WITH pg_shadow AS (SELECT 1 AS n) SELECT n FROM pg_shadow) "
+                "FROM enhanced_entries JOIN pg_shadow ON true"
+            )
+
+    def test_cte_declared_in_an_in_subquery_does_not_cover_a_union_branch(self):
+        with pytest.raises(ValueError, match="Table 'pg_authid' is not in the allowlist"):
+            validate_sql_query(
+                "SELECT * FROM enhanced_entries WHERE x IN (WITH pg_authid AS (SELECT 1) "
+                "SELECT 1) UNION SELECT * FROM pg_authid"
+            )
+
+    def test_non_recursive_cte_body_cannot_see_its_own_name(self):
+        """Without RECURSIVE a CTE's name is bound only after its body closes.
+
+        Inside the body the name is the real table, so a CTE named after a
+        catalog table reads that table from its own body.
+        """
+        with pytest.raises(ValueError, match="Table 'pg_shadow' is not in the allowlist"):
+            validate_sql_query(
+                "WITH pg_shadow AS (SELECT usename FROM pg_shadow) "
+                "SELECT * FROM enhanced_entries JOIN pg_shadow ON true"
+            )
+
+    def test_cte_declared_in_a_subquery_covers_a_reference_in_that_subquery(self):
+        validate_sql_query(
+            "SELECT * FROM (WITH x AS (SELECT * FROM enhanced_entries) SELECT * FROM x) s"
+        )
+
+    def test_outer_cte_covers_a_reference_inside_a_subquery(self):
+        validate_sql_query(
+            "WITH x AS (SELECT entry_id FROM enhanced_entries) "
+            "SELECT * FROM enhanced_entries WHERE entry_id IN (SELECT entry_id FROM x)"
+        )
+
+
 class TestValidateSqlQueryVariantSets:
     """The two constants are read at call time — swap in copies, never mutate."""
 

--- a/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
+++ b/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
@@ -9,9 +9,17 @@ That asymmetry is what these tests pin shut.
 Like the p4p monkeypatch tests, they execute the generated *source text*
 against fake client modules injected into ``sys.modules``: the block is emitted
 to run inside the executor subprocess, so there is no object to patch here.
+
+Because that source runs in the *test* process, every client it imports is
+faked before it is exec'd — aioca and p4p are really installed in this
+environment, and exec'ing the block against them would rebind the installed
+libraries for the rest of the session. The autouse fixture below is the second
+net under that: whatever a test does manage to patch is put back afterwards.
 """
 
+import asyncio
 import contextlib
+import importlib
 import io
 import sys
 from types import ModuleType
@@ -24,8 +32,65 @@ from osprey.connectors.control_system.limits_validator import (
 )
 from osprey.errors import ChannelLimitsViolationError
 from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
+from osprey.services.python_executor.write_surface import _CLIENT_WRITE_TARGETS
 
 pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Restoration
+# ---------------------------------------------------------------------------
+
+
+def _resolve_target(dotted):
+    """Resolve a write-surface row to the object that carries its attributes.
+
+    A copy of the resolver the emitted guard uses, kept for the same reason
+    ``test_readonly_guard.py`` keeps one: the guard has to be self-contained —
+    it runs before user code in a subprocess that may not be able to import
+    OSPREY at all — so there is no function to share.
+    """
+    parts = dotted.split(".")
+    for cut in range(len(parts), 0, -1):
+        try:
+            obj = importlib.import_module(".".join(parts[:cut]))
+        except ImportError:
+            continue
+        for attr in parts[cut:]:
+            try:
+                obj = getattr(obj, attr)
+            except AttributeError:
+                return None
+        return obj
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _restore_patched_targets():
+    """Undo any client patch that escaped the fakes, after every test.
+
+    The block these tests exec is written to patch installed control-system
+    clients, and it is exec'd in the test process. The fakes below are what
+    normally absorbs that, but a client the fakes miss — a row added to the
+    write surface, a spelling the harness does not yet stand in for — would
+    otherwise leave the installed library patched for the remainder of the
+    session, and unrelated tests would fail on a limits refusal far from here.
+
+    Snapshotting happens before a test injects its fakes, so it captures the
+    real objects; restoring writes back to those same objects and is therefore
+    unaffected by whatever ``sys.modules`` held in between.
+    """
+    saved = []
+    for dotted, attrs in _CLIENT_WRITE_TARGETS:
+        target = _resolve_target(dotted)
+        if target is None:
+            continue
+        for attr in attrs:
+            if hasattr(target, attr):
+                saved.append((target, attr, getattr(target, attr)))
+    yield
+    for target, attr, value in saved:
+        setattr(target, attr, value)
 
 
 # ---------------------------------------------------------------------------
@@ -33,29 +98,332 @@ pytestmark = pytest.mark.unit
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_epics():
-    """Keep the block's own epics branch off any real pyepics install."""
-    mod = ModuleType("epics")
+#: Marks a module as one of this suite's stand-ins, so ``_run_monkeypatch``
+#: can tell a fake a test already installed from a real installed client.
+_FAKE_CLIENT_MARKER = "_osprey_fake_client"
 
-    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+
+def _fake_module(name):
+    """A module object marked as one of this suite's client stand-ins."""
+    mod = ModuleType(name)
+    setattr(mod, _FAKE_CLIENT_MARKER, True)
+    return mod
+
+
+class _FakeChid:
+    """What ``epics.ca`` addresses a channel by: an opaque id, not a name."""
+
+    def __init__(self, pvname):
+        self.pvname = pvname
+
+
+def _install_fake_epics(monkeypatch, writes=None):
+    """Inject an ``epics`` whose every write funnels through ``epics.ca.put``.
+
+    Real pyepics spells a write three ways — ``caput``, ``PV.put`` and
+    ``ca.put`` — and the first two reach the network through the third. The
+    fake keeps that chain, so a wrapper installed on ``ca.put`` alone is
+    provably the choke point for all three, and it looks ``ca.put`` up on the
+    module at call time so a ``PV.put`` reaches the wrapper the block installs
+    rather than the function captured when the class was defined.
+    """
+    writes = [] if writes is None else writes
+    mod = _fake_module("epics")
+    ca = _fake_module("epics.ca")
+
+    def _ca_name(chid):
+        return chid.pvname
+
+    def _ca_create_channel(pvname, **kwargs):
+        return _FakeChid(pvname)
+
+    def _ca_put(chid, value, wait=False, timeout=60, **kwargs):
+        writes.append((ca.name(chid), value))
         return 1
+
+    def _ca_get(chid, timeout=60, **kwargs):
+        return 1.0
+
+    ca.name = _ca_name
+    ca.create_channel = _ca_create_channel
+    ca.put = _ca_put
+    ca.get = _ca_get
 
     class PV:
         def __init__(self, pvname):
             self.pvname = pvname
+            self.chid = ca.create_channel(pvname)
 
         def put(self, value, wait=False, timeout=60, **kwargs):
-            return 1
+            return ca.put(self.chid, value, wait=wait, timeout=timeout, **kwargs)
 
-    mod.caput = caput
+        def get(self, **kwargs):
+            return ca.get(self.chid)
+
+    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+        return PV(pvname).put(value, wait=wait, timeout=timeout, **kwargs)
+
+    def caget(pvname, timeout=60, **kwargs):
+        return ca.get(ca.create_channel(pvname), timeout=timeout)
+
+    mod.ca = ca
     mod.PV = PV
+    mod.caput = caput
+    mod.caget = caget
+    monkeypatch.setitem(sys.modules, "epics", mod)
+    monkeypatch.setitem(sys.modules, "epics.ca", ca)
     return mod
 
 
-def _install_fake_tango(monkeypatch, writes):
-    mod = ModuleType("tango")
+def _install_fake_aioca(monkeypatch, writes=None, reads=None, read=None):
+    """Inject an ``aioca`` that shares one ``caput``/``caget`` with ``_catools``.
 
-    class DeviceProxy:
+    On a real install ``aioca.caput is aioca._catools.caput`` — the package
+    namespace re-exports what the submodule defines. A fake giving each module
+    its own function would let a wrapper installed on one spelling look
+    effective while the other still wrote.
+
+    The array form keeps aioca's own re-entry: real ``caput`` dispatches a
+    list of channels to ``caput_array``, which writes each pair by calling the
+    module-global ``caput``. That is why the guard needs no array wrapper of
+    its own — and a fake that wrote the pairs directly would hide the fact.
+
+    ``read`` replaces what ``caget`` answers, and may raise: a client that
+    cannot read is the case a step check has to fail closed on.
+    """
+    writes = [] if writes is None else writes
+    reads = [] if reads is None else reads
+    mod = _fake_module("aioca")
+    catools = _fake_module("aioca._catools")
+
+    async def caput(pv, value, *args, **kwargs):
+        if isinstance(pv, (list, tuple)):
+            return [
+                await catools.caput(one_pv, one_value, *args, **kwargs)
+                for one_pv, one_value in zip(pv, value, strict=True)
+            ]
+        writes.append((pv, value))
+        return "put-done"
+
+    async def caget(pv, *args, **kwargs):
+        reads.append(pv)
+        if read is not None:
+            return read(pv)
+        return 1.0
+
+    for target in (mod, catools):
+        target.caput = caput
+        target.caget = caget
+    mod._catools = catools
+    monkeypatch.setitem(sys.modules, "aioca", mod)
+    monkeypatch.setitem(sys.modules, "aioca._catools", catools)
+    return mod
+
+
+class _RecordingRawContext:
+    """Stand-in for ``p4p.client.raw.Context``, the base every flavour puts through.
+
+    Its ``put`` takes the raw signature — a handler and a ``builder`` — which
+    is what distinguishes a direct raw put from a flavour's own put.
+    """
+
+    def __init__(self, provider="pva", **kwargs):
+        self.puts = []
+        self.rpcs = []
+
+    def put(self, name, handler, builder=None, request=None, **kwargs):
+        self.puts.append((name, builder))
+        return "put-done"
+
+    def rpc(self, name, handler, value=None, **kwargs):
+        self.rpcs.append((name, value))
+        return "rpc-done"
+
+    def get(self, name, handler=None, request=None, **kwargs):
+        return 1.0
+
+
+def _install_fake_p4p(monkeypatch):
+    """Inject a ``p4p`` package: one Context per flavour plus the raw base.
+
+    p4p is installed in this environment, so without this the block would
+    rebind the real ``Context.put`` of every flavour. The p4p *behaviour* is
+    tested in ``test_p4p_monkeypatch.py``; here the fake exists only so these
+    tests leave the installed library alone.
+    """
+    p4p_mod = _fake_module("p4p")
+    client_mod = _fake_module("p4p.client")
+    raw_mod = _fake_module("p4p.client.raw")
+    raw_mod.Context = type("RawContext", (_RecordingRawContext,), {})
+
+    class FlavorContext(raw_mod.Context):
+        """A flavour Context: subclasses raw as p4p's flavours do, and takes
+        the flavour ``put`` signature (a name and values, no handler)."""
+
+        def put(self, name, values, request=None, timeout=5.0, **kwargs):
+            self.puts.append((name, values))
+            return "put-done"
+
+        def rpc(self, name, value=None, request=None, timeout=5.0):
+            self.rpcs.append((name, value))
+            return "rpc-done"
+
+        def get(self, name, request=None, timeout=5.0):
+            return 1.0
+
+    p4p_mod.client = client_mod
+    client_mod.raw = raw_mod
+    modules = {"p4p": p4p_mod, "p4p.client": client_mod, "p4p.client.raw": raw_mod}
+
+    for flavor in ("thread", "asyncio", "cothread"):
+        flavor_mod = _fake_module(f"p4p.client.{flavor}")
+        flavor_mod.Context = type(f"{flavor.capitalize()}Context", (FlavorContext,), {})
+        setattr(client_mod, flavor, flavor_mod)
+        modules[f"p4p.client.{flavor}"] = flavor_mod
+
+    for name, mod in modules.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    # The C extension is not faked: it holds an immutable type the block never
+    # patches, and leaving it unimportable keeps the real one out of reach.
+    monkeypatch.setitem(sys.modules, "p4p._p4p", None)
+    return p4p_mod
+
+
+class _FakePvObject:
+    """The structure a pvaccess ``Channel`` hands back and takes in.
+
+    Shaped after the real binding, because pvaccess is not installed here and
+    this fake is therefore the only evidence the guard binds correctly on it.
+    pvaPy's no-arg ``getPyObject()`` answers the VALUE of the structure's
+    ``value`` field and raises ``pvaccess.InvalidRequest`` when there is none;
+    ``toDict()`` is the spelling that answers the whole structure as a dict.
+    (The exception type is not part of the guard's contract — it lets whatever
+    is raised propagate, and the write fails closed either way.)
+    """
+
+    def __init__(self, data):
+        self._data = dict(data)
+
+    def getPyObject(self):  # noqa: N802 - pvaccess spells it this way
+        if "value" not in self._data:
+            raise RuntimeError("PvObject has no value field")
+        return self._data["value"]
+
+    def toDict(self):  # noqa: N802 - pvaccess spells it this way
+        return dict(self._data)
+
+
+def _install_fake_pvaccess(monkeypatch, writes=None, reads=None, read=None):
+    """Inject a ``pvaccess`` with the typed put family a Channel really carries.
+
+    pvaPy spells a write as ``put`` plus a typed setter per scalar kind
+    (``putDouble``, ``putInt``, …), which is why the block sweeps every
+    ``put``-prefixed attribute rather than naming one. ``asyncPut``,
+    ``parsePut`` and ``parsePutGet`` are the three writes whose names fall
+    outside that prefix, and they are here so the sweep is tested against them.
+
+    ``get`` answers a structure, as pvaPy's does, so a guard that reduces the
+    payload but not the read is caught here. ``read`` replaces what it
+    answers, and may raise: a channel that cannot be read is the case a step
+    check has to fail closed on.
+    """
+    writes = [] if writes is None else writes
+    reads = [] if reads is None else reads
+    mod = _fake_module("pvaccess")
+
+    class Channel:
+        def __init__(self, name, provider=None):
+            self._name = name
+            self.current = 1.0
+
+        def getName(self):  # noqa: N802 - pvaccess spells it this way
+            return self._name
+
+        def get(self, request=""):
+            reads.append(self._name)
+            if read is not None:
+                return read(self._name)
+            return _FakePvObject({"value": self.current})
+
+        def put(self, value, request=""):
+            writes.append((self._name, value))
+            return "put-done"
+
+        def putDouble(self, value, request=""):  # noqa: N802
+            writes.append((self._name, value))
+            return "put-done"
+
+        def putGet(self, value, request=""):  # noqa: N802
+            writes.append((self._name, value))
+            return _FakePvObject({"value": value})
+
+        def asyncPut(self, value, callback=None, request=""):  # noqa: N802
+            # pvaPy's asynchronous write: a PvObject first, the completion
+            # callback second. A write whose name does not start with "put".
+            writes.append((self._name, value))
+            return "async-put-done"
+
+        def parsePut(self, args, request=""):  # noqa: N802
+            # Takes a LIST OF JSON STRINGS, not a value object.
+            writes.append((self._name, args))
+            return "parse-put-done"
+
+        def parsePutGet(self, args, request=""):  # noqa: N802
+            writes.append((self._name, args))
+            return _FakePvObject({"value": args})
+
+    mod.Channel = Channel
+    mod.PvObject = _FakePvObject
+    monkeypatch.setitem(sys.modules, "pvaccess", mod)
+    return mod
+
+
+def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=None):
+    """Inject a ``tango`` whose DeviceProxy and Group record what reaches them.
+
+    PyTango is not installed in this environment, so this module is the only
+    surface the tango branch of the block is ever exercised against, which
+    makes it the tree's one statement of PyTango's binding layout. Two things
+    it copies exactly:
+
+    * ``Connection`` DEFINES both command spellings and ``DeviceProxy``
+      merely inherits them (upstream ``tango/connection.py``), so a guard
+      that patches only the subclass leaves
+      ``tango.Connection.command_inout(proxy, 'On')`` live.
+    * the signatures — ``command_inout(name, cmd_param=None, *, green_mode,
+      wait, timeout)`` after ``green()`` rewrites it, and
+      ``command_inout_asynch(cmd_name, *args)``, which takes ``forget``
+      positionally and rejects it as a keyword.
+
+    ``Group`` is here for the same reason and is deliberately NOT a subclass of
+    anything: upstream it is a plain Python class (``tango/group.py``) defining
+    its own two commands and its own two attribute writes, which is why neither
+    the DeviceProxy nor the Connection install reaches it. Upstream,
+    ``write_attribute_asynch`` and ``command_inout_asynch`` are not in the
+    class body at all: ``group_init()`` binds each as a ``(*args, **kwds)``
+    proxy onto the C++ group, so the guard can only find them by attribute
+    name, never by signature.
+
+    Both classes are built fresh on every call, so a test that patches them
+    leaves nothing behind for the next one.
+    """
+    writes = [] if writes is None else writes
+    commands = [] if commands is None else commands
+    group_calls = [] if group_calls is None else group_calls
+    mod = _fake_module("tango")
+
+    class Connection:
+        """The class PyTango really defines the two command spellings on."""
+
+        def command_inout(self, name, cmd_param=None, *, green_mode=None, wait=None, timeout=None):
+            commands.append((name, cmd_param))
+            return "commanded"
+
+        def command_inout_asynch(self, cmd_name, *args):
+            commands.append((cmd_name, args[0] if args else None))
+            return 1
+
+    class DeviceProxy(Connection):
         def __init__(self, name):
             self._name = name
 
@@ -73,13 +441,45 @@ def _install_fake_tango(monkeypatch, writes):
         def read_attribute(self, attr):
             return 1.0
 
+    class Group:
+        """PyTango's group: its own class, with its own four write spellings."""
+
+        def __init__(self, name):
+            self._name = name
+
+        def get_name(self):
+            return self._name
+
+        def add(self, pattern):
+            return None
+
+        def write_attribute(self, attr_name, value, forward=True, multi=False):
+            group_calls.append(("write_attribute", attr_name, value))
+            return "written"
+
+        def write_attribute_asynch(self, attr_name, value, forward=True, multi=False):
+            group_calls.append(("write_attribute_asynch", attr_name, value))
+            return 1
+
+        def command_inout(self, cmd_name, param=None, forward=True):
+            group_calls.append(("command_inout", cmd_name, param))
+            return "commanded"
+
+        def command_inout_asynch(self, cmd_name, param=None, forget=False, forward=True):
+            group_calls.append(("command_inout_asynch", cmd_name, param))
+            return 1
+
+    mod.Connection = Connection
     mod.DeviceProxy = DeviceProxy
+    mod.Group = Group
+    mod.group_calls = group_calls
     monkeypatch.setitem(sys.modules, "tango", mod)
     return mod
 
 
-def _install_fake_doocs(monkeypatch, writes):
-    mod = ModuleType("doocs4py")
+def _install_fake_doocs(monkeypatch, writes=None):
+    writes = [] if writes is None else writes
+    mod = _fake_module("doocs4py")
 
     def _set(address, value):
         writes.append((address, value))
@@ -90,13 +490,14 @@ def _install_fake_doocs(monkeypatch, writes):
     return mod
 
 
-def _install_fake_caproto(monkeypatch, writes):
+def _install_fake_caproto(monkeypatch, writes=None):
     """Inject a fake ``caproto`` with both write entry points."""
-    caproto_mod = ModuleType("caproto")
-    sync_mod = ModuleType("caproto.sync")
-    sync_client = ModuleType("caproto.sync.client")
-    threading_mod = ModuleType("caproto.threading")
-    threading_client = ModuleType("caproto.threading.client")
+    writes = [] if writes is None else writes
+    caproto_mod = _fake_module("caproto")
+    sync_mod = _fake_module("caproto.sync")
+    sync_client = _fake_module("caproto.sync.client")
+    threading_mod = _fake_module("caproto.threading")
+    threading_client = _fake_module("caproto.threading.client")
 
     def write(pv_name, data, **kwargs):
         writes.append((pv_name, data))
@@ -152,13 +553,52 @@ def _make_validator():
         "TEST:MAG:SP": ChannelLimitsConfig(
             channel_address="TEST:MAG:SP", min_value=0.0, max_value=10.0
         ),
+        # The one channel here that configures max_step, so a test can tell a
+        # guard that reads the present value from one that never does.
+        "TEST:MAG:STEP": ChannelLimitsConfig(
+            channel_address="TEST:MAG:STEP",
+            min_value=0.0,
+            max_value=100.0,
+            max_step=2.0,
+        ),
     }
     return LimitsValidator(limits, {"allow_unlisted_channels": False})
 
 
+#: Every client the emitted block imports, with the fake that stands in for it.
+#: A client missing from this list is one the block could patch for real.
+_CLIENT_FAKES = (
+    ("epics", _install_fake_epics),
+    ("aioca", _install_fake_aioca),
+    ("p4p", _install_fake_p4p),
+    ("pvaccess", _install_fake_pvaccess),
+    ("tango", _install_fake_tango),
+    ("doocs4py", _install_fake_doocs),
+    ("caproto", _install_fake_caproto),
+)
+
+_UNSET = object()
+
+
+def _needs_fake(name):
+    """Whether ``_run_monkeypatch`` should stand in for this client itself.
+
+    A test that installed its own fake keeps it — recording writes is the
+    point of most of them — and so does a test that set the module to ``None``
+    to exercise the block's "not available" branch. Anything else, including a
+    client really installed in this environment, is replaced.
+    """
+    entry = sys.modules.get(name, _UNSET)
+    if entry is None:
+        return False
+    return entry is _UNSET or not getattr(entry, _FAKE_CLIENT_MARKER, False)
+
+
 def _run_monkeypatch(monkeypatch):
-    """Execute the generated monkeypatch block; return its stdout."""
-    monkeypatch.setitem(sys.modules, "epics", _make_fake_epics())
+    """Execute the generated monkeypatch block against fakes; return its stdout."""
+    for name, installer in _CLIENT_FAKES:
+        if _needs_fake(name):
+            installer(monkeypatch)
 
     import osprey.runtime as runtime_module
 
@@ -171,6 +611,599 @@ def _run_monkeypatch(monkeypatch):
     out = buf.getvalue()
     assert "Limits checking setup failed" not in out, out
     return out
+
+
+# ---------------------------------------------------------------------------
+# pyepics
+# ---------------------------------------------------------------------------
+
+
+def _count_validations(monkeypatch):
+    """Record every ``LimitsValidator.validate`` the emitted block performs.
+
+    Refusing an out-of-range write proves a guard is somewhere on the path;
+    it does not prove there is only one. The count is what separates a single
+    wrapper at the choke point from wrappers stacked on ``caput``, ``PV.put``
+    and ``ca.put`` alike — three validations, and up to three ``max_step``
+    reads, for one write.
+    """
+    calls: list = []
+    original = LimitsValidator.validate
+
+    def _recording(self, channel_address, value, **kwargs):
+        calls.append((channel_address, value))
+        return original(self, channel_address, value, **kwargs)
+
+    monkeypatch.setattr(LimitsValidator, "validate", _recording)
+    return calls
+
+
+def test_ca_put_within_limits_reaches_the_channel(monkeypatch):
+    writes: list = []
+    mod = _install_fake_epics(monkeypatch, writes)
+    calls = _count_validations(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    chid = mod.ca.create_channel("TEST:MAG:SP")
+    assert mod.ca.put(chid, 5.0) == 1
+    assert writes == [("TEST:MAG:SP", 5.0)]
+    assert calls == [("TEST:MAG:SP", 5.0)]
+    assert mod.ca.get(chid) == 1.0, "reads must survive the guard untouched"
+
+
+def test_ca_put_out_of_bounds_raises_before_the_channel(monkeypatch):
+    """The lowest pyepics spelling is checked, not just the convenience ones.
+
+    ``epics.ca.put`` is the function every other pyepics write ends at, and it
+    is also callable directly — a script that creates its own channel and puts
+    through it used to reach the network with no limits check at all.
+    """
+    writes: list = []
+    mod = _install_fake_epics(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    chid = mod.ca.create_channel("TEST:MAG:SP")
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.ca.put(chid, 99.0)
+    assert writes == []
+
+
+def test_ca_put_names_the_channel_from_the_chid(monkeypatch):
+    """A chid is opaque, so the guard has to ask ``ca.name`` what it addresses.
+
+    Validating the chid itself looks up a channel the database has never heard
+    of, which on a deployment that allows unlisted channels is a write that
+    passes unchecked.
+    """
+    writes: list = []
+    mod = _install_fake_epics(monkeypatch, writes)
+    calls = _count_validations(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.ca.put(mod.ca.create_channel("TEST:MAG:SP"), 99.0)
+    assert calls == [("TEST:MAG:SP", 99.0)]
+
+
+def test_pv_put_is_refused_at_the_ca_put_choke_point(monkeypatch):
+    writes: list = []
+    mod = _install_fake_epics(monkeypatch, writes)
+    calls = _count_validations(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.PV("TEST:MAG:SP").put(99.0)
+    assert writes == []
+    assert calls == [("TEST:MAG:SP", 99.0)]
+
+
+def test_caput_validates_once_on_its_way_through_ca_put(monkeypatch):
+    """``caput`` reaches the network through ``PV.put`` and then ``ca.put``.
+
+    With a wrapper on each spelling the same write was validated at every
+    layer it passed; with one at the bottom it is validated once, and pays for
+    one ``max_step`` read instead of three.
+    """
+    writes: list = []
+    mod = _install_fake_epics(monkeypatch, writes)
+    calls = _count_validations(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    assert mod.caput("TEST:MAG:SP", 5.0) == 1
+    assert writes == [("TEST:MAG:SP", 5.0)]
+    assert calls == [("TEST:MAG:SP", 5.0)]
+
+
+def test_caput_out_of_bounds_is_refused_at_the_choke_point(monkeypatch):
+    writes: list = []
+    mod = _install_fake_epics(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.caput("TEST:MAG:SP", 99.0)
+    assert writes == []
+
+
+def test_the_block_wraps_only_ca_put(monkeypatch):
+    """``caput`` and ``PV.put`` are left as pyepics defined them.
+
+    They are covered because they route through ``ca.put``, so wrapping them
+    as well buys nothing and costs a duplicate validation per write.
+    """
+    mod = _install_fake_epics(monkeypatch)
+    original_caput = mod.caput
+    original_pv_put = mod.PV.put
+    original_ca_put = mod.ca.put
+    _run_monkeypatch(monkeypatch)
+
+    assert mod.caput is original_caput
+    assert mod.PV.put is original_pv_put
+    assert mod.ca.put is not original_ca_put
+
+
+def test_absent_pyepics_does_not_stop_the_block(monkeypatch):
+    monkeypatch.setitem(sys.modules, "epics", None)
+    monkeypatch.setitem(sys.modules, "epics.ca", None)
+    writes: list = []
+    _install_fake_doocs(monkeypatch, writes)
+
+    out = _run_monkeypatch(monkeypatch)
+    assert "pyepics not available" in out
+    assert "✅ Monkeypatched doocs4py.set()" in out
+
+
+# ---------------------------------------------------------------------------
+# aioca
+# ---------------------------------------------------------------------------
+
+
+def test_aioca_caput_within_limits_reaches_the_channel(monkeypatch):
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_aioca(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    assert asyncio.run(mod.caput("TEST:MAG:SP", 5.0)) == "put-done"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+    # A channel with no max_step has no step to measure, so the guard buys no
+    # read for it — the round trip is paid for only where it is needed.
+    assert reads == []
+
+
+def test_aioca_caput_out_of_bounds_raises_before_the_channel(monkeypatch):
+    """aioca is a second Channel Access client, not a spelling of pyepics.
+
+    Its writes never pass through ``epics.ca.put``, so the pyepics choke point
+    leaves an ``await aioca.caput(...)`` unchecked; this is the guard that
+    closes it.
+    """
+    writes: list = []
+    mod = _install_fake_aioca(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        asyncio.run(mod.caput("TEST:MAG:SP", 99.0))
+    assert writes == []
+
+
+def test_aioca_array_caput_validates_every_pair(monkeypatch):
+    """The list form is checked per pair, through aioca's own ``caput_array``.
+
+    A list of channels is forwarded unchanged, because aioca dispatches it to
+    ``caput_array``, which writes each pair by calling the module-global
+    ``caput`` — this guard. Validating the list against a single channel's
+    limits here would refuse the whole write for the wrong reason and still
+    check no pair.
+    """
+    writes: list = []
+    mod = _install_fake_aioca(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        asyncio.run(mod.caput(["TEST:MAG:SP", "TEST:MAG:SP"], [5.0, 99.0]))
+
+    # The in-range pair went through on its own way past the guard; the
+    # out-of-range one was refused before it reached the channel.
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+
+def test_aioca_caput_beyond_max_step_reads_through_aiocas_own_caget(monkeypatch):
+    """The step is measured over aioca, awaiting its own ``caget``.
+
+    The validator is synchronous and owns no client; the guard is a coroutine,
+    so it can await the read itself and hand the answer over as a plain value.
+    """
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_aioca(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        asyncio.run(mod.caput("TEST:MAG:STEP", 50.0))
+
+    assert exc.value.violation_type == "MAX_STEP_EXCEEDED"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == []
+
+
+def test_aioca_caput_within_max_step_reaches_the_channel(monkeypatch):
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_aioca(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    # The fake reads back 1.0, so this is a step of 1.0 against a max of 2.0.
+    assert asyncio.run(mod.caput("TEST:MAG:STEP", 2.0)) == "put-done"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == [("TEST:MAG:STEP", 2.0)]
+
+
+def test_aioca_caput_fails_closed_when_its_caget_raises(monkeypatch):
+    """A client that cannot read refuses the write; it does not skip the check.
+
+    The guard swallows the read error so the refusal comes from the validator
+    with the channel and value attached — but swallowing it must not turn into
+    letting the write past, which is what an unmeasured step would be.
+    """
+    writes: list = []
+    reads: list = []
+
+    def _raise(_pv):
+        raise OSError("channel unreachable")
+
+    mod = _install_fake_aioca(monkeypatch, writes, reads, read=_raise)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        asyncio.run(mod.caput("TEST:MAG:STEP", 2.0))
+
+    assert exc.value.violation_type == "STEP_CHECK_FAILED"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == []
+
+
+def test_aioca_caput_fails_closed_when_its_caget_answers_none(monkeypatch):
+    """A read that succeeds with nothing in it is no measurement either."""
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_aioca(monkeypatch, writes, reads, read=lambda _pv: None)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        asyncio.run(mod.caput("TEST:MAG:STEP", 2.0))
+
+    assert exc.value.violation_type == "STEP_CHECK_FAILED"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == []
+
+
+def test_the_block_rebinds_both_aioca_caput_spellings(monkeypatch):
+    """``aioca.caput`` and ``aioca._catools.caput`` are the same function.
+
+    The package namespace re-exports what the submodule defines, so patching
+    only the re-export would leave ``from aioca._catools import caput``
+    unchecked — and would also break the array form, whose per-pair re-entry
+    goes through the submodule global.
+    """
+    mod = _install_fake_aioca(monkeypatch)
+    original_caput = mod.caput
+    _run_monkeypatch(monkeypatch)
+
+    catools = sys.modules["aioca._catools"]
+    assert mod.caput is not original_caput
+    assert catools.caput is mod.caput
+
+
+def test_absent_aioca_does_not_stop_the_block(monkeypatch):
+    monkeypatch.setitem(sys.modules, "aioca", None)
+    monkeypatch.setitem(sys.modules, "aioca._catools", None)
+    writes: list = []
+    _install_fake_doocs(monkeypatch, writes)
+
+    out = _run_monkeypatch(monkeypatch)
+    assert "aioca not available" in out
+    assert "✅ Monkeypatched doocs4py.set()" in out
+
+
+# ---------------------------------------------------------------------------
+# pvaPy (pvaccess)
+# ---------------------------------------------------------------------------
+
+
+def test_pvaccess_put_within_limits_reaches_the_channel(monkeypatch):
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    assert mod.Channel("TEST:MAG:SP").put(5.0) == "put-done"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+    # No max_step on this channel, so the guard buys no read for it.
+    assert reads == []
+
+
+def test_pvaccess_put_out_of_bounds_raises_before_the_channel(monkeypatch):
+    """pvaPy is a PVAccess client of its own, not a p4p spelling.
+
+    A ``pvaccess.Channel`` put never passes through a p4p ``Context``, so the
+    p4p guards leave it unchecked; this is the guard that closes it.
+    """
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.Channel("TEST:MAG:SP").put(99.0)
+    assert writes == []
+
+
+def test_pvaccess_typed_put_is_refused_out_of_range(monkeypatch):
+    """The typed setters are the same write under another name.
+
+    pvaPy spells one setter per scalar and array kind — ``putDouble``,
+    ``putInt``, ``putScalarArray`` — so the guard sweeps every ``put``-prefixed
+    attribute rather than naming ``put``. Naming them would go stale against
+    the binding, and every name missed would be an unchecked write.
+    """
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.Channel("TEST:MAG:SP").putDouble(99.0)
+    assert writes == []
+
+
+def test_pvaccess_structure_payload_is_reduced_before_validation(monkeypatch):
+    """A ``PvObject`` payload is unwrapped to the number it carries.
+
+    Handed the structure itself, the validator finds nothing numeric to check
+    and lets the write past — so an out-of-range value dressed as a structure
+    would reach the machine.
+    """
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.Channel("TEST:MAG:SP").put(_FakePvObject({"value": 99.0}))
+    assert writes == []
+
+
+def test_pvaccess_dict_payload_is_reduced_before_validation(monkeypatch):
+    """The plain dict a structure converts to is unwrapped the same way."""
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.Channel("TEST:MAG:SP").put({"value": 99.0})
+    assert writes == []
+
+
+def test_pvaccess_dict_without_a_value_field_fails_closed(monkeypatch):
+    """A shape with no value under it is refused, not written unchecked."""
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ValueError):
+        mod.Channel("TEST:MAG:SP").put({"unit": "A"})
+    assert writes == []
+
+
+def test_pvaccess_callable_payload_fails_closed(monkeypatch):
+    """A callable is not a value a limits database can be asked about."""
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ValueError):
+        mod.Channel("TEST:MAG:SP").put(lambda: 5.0)
+    assert writes == []
+
+
+def test_pvaccess_step_check_reads_through_the_channels_own_get(monkeypatch):
+    """The step is measured over the same Channel the put goes through.
+
+    pvaPy answers a get with a structure, so the reader reduces it exactly as
+    it reduces a payload. Left unreduced, the structure is non-numeric, the
+    validator SKIPS the step check, and a 49-unit step past a max of 2 reaches
+    the machine — which is why this asserts the refusal is ``MAX_STEP_EXCEEDED``
+    and not merely that something raised.
+    """
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        mod.Channel("TEST:MAG:STEP").put(50.0)
+
+    assert exc.value.violation_type == "MAX_STEP_EXCEEDED"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == []
+
+
+def test_pvaccess_put_within_max_step_reaches_the_channel(monkeypatch):
+    """The reader is a real read, not a blanket refusal on max_step channels."""
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    # The fake reads back 1.0, so this is a step of 1.0 against a max of 2.0.
+    assert mod.Channel("TEST:MAG:STEP").put(2.0) == "put-done"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == [("TEST:MAG:STEP", 2.0)]
+
+
+def test_pvaccess_step_check_fails_closed_when_the_read_fails(monkeypatch):
+    """A Channel that cannot be read refuses the write rather than skipping it."""
+    writes: list = []
+    reads: list = []
+
+    def _raise(_name):
+        raise OSError("channel unreachable")
+
+    mod = _install_fake_pvaccess(monkeypatch, writes, reads, read=_raise)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        mod.Channel("TEST:MAG:STEP").put(2.0)
+
+    assert exc.value.violation_type == "STEP_CHECK_FAILED"
+    assert writes == []
+
+
+def test_pvaccess_async_put_out_of_range_is_refused(monkeypatch):
+    """``asyncPut`` is a write whose name does not start with ``put``.
+
+    pvaPy spells the asynchronous write ``asyncPut(pvObject, callback)`` — the
+    same put with a completion callback bolted on, and the same value going to
+    the machine. A sweep keyed on the ``put`` prefix alone leaves it out, so an
+    approved run could send an out-of-range value with no check at all.
+    """
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError):
+        mod.Channel("TEST:MAG:SP").asyncPut(_FakePvObject({"value": 99.0}), lambda _r: None)
+    assert writes == []
+
+
+def test_pvaccess_async_put_within_limits_reaches_the_channel(monkeypatch):
+    """The first positional is a PvObject, so the ordinary reduction covers it."""
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    channel = mod.Channel("TEST:MAG:SP")
+    assert channel.asyncPut(_FakePvObject({"value": 5.0}), lambda _r: None) == "async-put-done"
+    assert len(writes) == 1
+    assert writes[0][0] == "TEST:MAG:SP"
+
+
+def test_pvaccess_parse_put_cannot_be_limits_checked(monkeypatch):
+    """``parsePut``/``parsePutGet`` carry JSON strings, so they are refused.
+
+    Their payload is a list of ``field=value`` strings parsed against the
+    channel's introspected structure — there is no value object to reduce, and
+    the wrapper cannot know which string names the field the limits are about.
+    Guessing would be a check that silently means nothing, so the write is
+    refused with the same posture the p4p guard takes for a callable payload:
+    an in-range value is refused too, and the caller is pointed at ``put``.
+    """
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ValueError, match="cannot be limits-checked"):
+        mod.Channel("TEST:MAG:SP").parsePut(["value=5.0"])
+    with pytest.raises(ValueError, match="cannot be limits-checked"):
+        mod.Channel("TEST:MAG:SP").parsePutGet(["value=5.0"])
+    assert writes == []
+
+
+def test_pvaccess_structure_payload_over_max_step_is_refused(monkeypatch):
+    """A structure payload is stepped against a structure read, both reduced.
+
+    This is the shape a real pvaPy run has on both sides — ``PvObject`` in,
+    ``PvObject`` back from ``get`` — and neither is a number until the guard
+    reduces it. Unreduced, the validator finds nothing numeric and SKIPS the
+    step check, so the assertion is on ``MAX_STEP_EXCEEDED`` specifically.
+    """
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        mod.Channel("TEST:MAG:STEP").put(_FakePvObject({"value": 50.0}))
+
+    assert exc.value.violation_type == "MAX_STEP_EXCEEDED"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == []
+
+
+def test_pvaccess_valueless_structure_payload_fails_closed(monkeypatch):
+    """A structure with no value under it is refused by pvaPy's own accessor.
+
+    ``PvObject.getPyObject()`` raises when the structure has no ``value``
+    field, which happens before the guard's own dict branch is reached. The
+    exception propagates and the write never leaves — a different exception
+    type from the plain-dict refusal, the same fail-closed outcome.
+    """
+    writes: list = []
+    mod = _install_fake_pvaccess(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        mod.Channel("TEST:MAG:SP").put(_FakePvObject({"unit": "A"}))
+    assert writes == []
+
+
+def test_fake_pv_object_answers_the_way_pvapy_does():
+    """The fake is the only surface standing in for binding on the real library.
+
+    pvaPy's no-arg ``PvObject.getPyObject()`` answers the VALUE of the
+    ``value`` field and raises ``pvaccess.InvalidRequest`` when there is none;
+    ``toDict()`` is the spelling that answers the whole structure as a dict. A
+    fake that answered a dict from ``getPyObject()`` would test the guard only
+    against a shape a real PvObject never produces. (The exception type is not
+    part of the contract — the guard lets whatever is raised propagate.)
+    """
+    payload = _FakePvObject({"value": 99.0, "unit": "A"})
+
+    assert payload.getPyObject() == 99.0
+    assert payload.toDict() == {"value": 99.0, "unit": "A"}
+    with pytest.raises(RuntimeError):
+        _FakePvObject({"unit": "A"}).getPyObject()
+
+
+def test_pvaccess_without_a_channel_class_reports_the_gap(monkeypatch):
+    """A pvaccess module with no ``Channel`` must not report itself guarded.
+
+    The success line is the operator's only evidence the guard is on. A stub or
+    broken install that carries no ``Channel`` wraps nothing, and saying so is
+    the difference between a known gap and an unchecked write believed checked.
+    """
+    monkeypatch.setitem(sys.modules, "pvaccess", _fake_module("pvaccess"))
+    writes: list = []
+    _install_fake_doocs(monkeypatch, writes)
+
+    out = _run_monkeypatch(monkeypatch)
+    assert "no Channel class" in out
+    assert "✅ Monkeypatched pvaccess" not in out
+    # The rest of the block still runs.
+    assert "✅ Monkeypatched doocs4py.set()" in out
+
+
+def test_pvaccess_channel_without_a_put_reports_the_gap(monkeypatch):
+    """A ``Channel`` the sweep found nothing on is the same gap, and says so."""
+    mod = _fake_module("pvaccess")
+
+    class Channel:
+        def get(self):
+            return 1.0
+
+    mod.Channel = Channel
+    monkeypatch.setitem(sys.modules, "pvaccess", mod)
+
+    out = _run_monkeypatch(monkeypatch)
+    assert "⚠️  pvaccess guard failed: Channel has no put method" in out
+    assert "✅ Monkeypatched pvaccess" not in out
+
+
+def test_absent_pvaccess_does_not_stop_the_block(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pvaccess", None)
+    writes: list = []
+    _install_fake_doocs(monkeypatch, writes)
+
+    out = _run_monkeypatch(monkeypatch)
+    assert "pvaccess not available" in out
+    assert "✅ Monkeypatched doocs4py.set()" in out
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +1291,211 @@ def test_tango_write_attributes_fails_closed_on_an_unpairable_shape(monkeypatch)
     with pytest.raises(ValueError, match="pairs"):
         proxy.write_attributes([object()])
     assert writes == []
+
+
+def test_tango_command_inout_is_refused(monkeypatch):
+    """A command is refused in a limits-checked run, argument or not.
+
+    A Tango command names an operation, not a channel: there is no address the
+    limits database is keyed by and no number to bound. Letting one through
+    because "no value was found to check" would be a limits-checked run
+    driving the device unchecked, so the call refuses outright — including
+    with an argument that would pass every bound if it were a write.
+    """
+    commands: list = []
+    mod = _install_fake_tango(monkeypatch, commands=commands)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        proxy.command_inout("On")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        proxy.command_inout("SetCurrent", 5.0)
+    assert commands == []
+
+
+def test_tango_command_inout_asynch_is_refused(monkeypatch):
+    """The asynchronous spelling reaches the same device and refuses too."""
+    commands: list = []
+    mod = _install_fake_tango(monkeypatch, commands=commands)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        proxy.command_inout_asynch("On")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        proxy.command_inout_asynch("SetCurrent", 5.0, True)
+    assert commands == []
+
+
+def test_tango_attribute_writes_stay_checked_alongside_the_command_refusal(monkeypatch):
+    """Refusing commands must not cost write_attribute its limits check.
+
+    Both installs run against the same DeviceProxy class, so a mistake in
+    either — an exception escaping the command loop, a name overwritten — is
+    a write that stops being validated. This pins the two together.
+    """
+    writes: list = []
+    commands: list = []
+    mod = _install_fake_tango(monkeypatch, writes, commands)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attribute("current", 5.0) == "written"
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attribute("current", 99.0)
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        proxy.command_inout("On")
+
+    assert writes == [("current", 5.0)]
+    assert commands == []
+
+
+def test_tango_command_refusal_reaches_the_class_that_defines_it(monkeypatch):
+    """The unbound call on the definer refuses too, not just the subclass.
+
+    PyTango defines both command spellings on ``Connection``; ``DeviceProxy``
+    inherits them. Patching only the subclass installs a shadow and leaves the
+    original reachable as ``tango.Connection.command_inout(proxy, 'On')`` —
+    an unbound call with the proxy as ``self``, which drives the real device
+    with the guard reporting itself installed. Both spellings are pinned on
+    the definer here, and the instance spelling with them.
+    """
+    commands: list = []
+    mod = _install_fake_tango(monkeypatch, commands=commands)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        mod.Connection.command_inout(proxy, "On")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        mod.Connection.command_inout_asynch(proxy, "On")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        proxy.command_inout("On")
+
+    assert commands == []
+
+
+def test_tango_definer_refusal_leaves_write_attribute_checked(monkeypatch):
+    """Patching the base class must not cost the subclass its write check."""
+    writes: list = []
+    commands: list = []
+    mod = _install_fake_tango(monkeypatch, writes, commands)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attribute("current", 5.0) == "written"
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attribute("current", 99.0)
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        mod.Connection.command_inout(proxy, "On")
+
+    assert writes == [("current", 5.0)]
+    assert commands == []
+
+
+def test_tango_group_writes_and_commands_are_all_refused(monkeypatch):
+    """A group write is a broadcast, so all four Group spellings refuse.
+
+    ``tango.Group`` is its own class: it inherits neither from ``DeviceProxy``
+    nor from ``Connection``, so the two installs above do not reach it, and one
+    ``g.write_attribute('current', 5.0)`` fans that value out to every device
+    the group matched. There is no single channel address to look limits up
+    under and no one device to bound the step against, so the value being in
+    range buys nothing — all four refuse, commands with the command message and
+    writes with the group-write message.
+    """
+    mod = _install_fake_tango(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    group = mod.Group("all")
+    group.add("sys/tg_test/*")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        group.command_inout("On")
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        group.command_inout_asynch("On")
+    with pytest.raises(RuntimeError, match="fans one value out to many devices"):
+        group.write_attribute("current", 5.0)
+    with pytest.raises(RuntimeError, match="fans one value out to many devices"):
+        group.write_attribute_asynch("current", 5.0)
+
+    assert mod.group_calls == []
+
+
+def test_tango_group_refusal_leaves_device_writes_checked(monkeypatch):
+    """Refusing the group must not cost a single-device write its check."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    group = mod.Group("all")
+    assert proxy.write_attribute("current", 5.0) == "written"
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attribute("current", 99.0)
+    with pytest.raises(RuntimeError, match="fans one value out to many devices"):
+        group.write_attribute("current", 5.0)
+
+    assert writes == [("current", 5.0)]
+    assert mod.group_calls == []
+
+
+def test_tango_success_line_names_the_commands_it_refused(monkeypatch):
+    """The block reports what it actually installed on this binding."""
+    _install_fake_tango(monkeypatch)
+
+    out = _run_monkeypatch(monkeypatch)
+
+    assert "✅ Monkeypatched tango: " in out
+    assert "wrapped on DeviceProxy: write_attribute(), write_attributes()" in out
+    assert "refused on DeviceProxy: command_inout(), command_inout_asynch()" in out
+    assert "refused on Connection: command_inout(), command_inout_asynch()" in out
+    assert (
+        "refused on Group: command_inout(), command_inout_asynch(), "
+        "write_attribute(), write_attribute_asynch()" in out
+    )
+
+
+def test_tango_without_a_device_proxy_does_not_report_itself_guarded(monkeypatch):
+    """A tango carrying no DeviceProxy wrapped nothing and must say so."""
+    mod = _fake_module("tango")
+    monkeypatch.setitem(sys.modules, "tango", mod)
+
+    out = _run_monkeypatch(monkeypatch)
+
+    assert "⚠️  tango guard failed: no DeviceProxy class" in out
+    assert "✅ Monkeypatched tango" not in out
+
+
+def test_tango_group_is_refused_without_a_device_proxy(monkeypatch):
+    """The Group install does not hang off the DeviceProxy branch.
+
+    A tango carrying a ``Group`` but no ``DeviceProxy`` still has four live
+    write spellings; installed under the DeviceProxy branch, the guard would
+    warn about the missing class and leave every one of them writing. The
+    success line names only the class that was actually patched.
+    """
+    real = _install_fake_tango(monkeypatch)
+    mod = _fake_module("tango")
+    mod.Group = real.Group
+    mod.group_calls = real.group_calls
+    monkeypatch.setitem(sys.modules, "tango", mod)
+
+    out = _run_monkeypatch(monkeypatch)
+
+    assert "⚠️  tango guard failed: no DeviceProxy class" in out
+    success = [line for line in out.splitlines() if line.startswith("✅ Monkeypatched tango")]
+    assert success == [
+        "✅ Monkeypatched tango: refused on Group: command_inout(), "
+        "command_inout_asynch(), write_attribute(), write_attribute_asynch()"
+    ]
+
+    group = mod.Group("all")
+    with pytest.raises(RuntimeError, match="fans one value out to many devices"):
+        group.write_attribute("current", 5.0)
+    with pytest.raises(RuntimeError, match="a command carries no value to bound"):
+        group.command_inout("On")
+    assert mod.group_calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/python_executor/execution/test_limits_parity.py
+++ b/tests/services/python_executor/execution/test_limits_parity.py
@@ -1,0 +1,138 @@
+"""The limits partition is held to the write-surface table.
+
+A readonly run refuses every entry point in ``_CLIENT_WRITE_TARGETS``. A
+readwrite run does something *different* with each one — checks the value
+against the channel limits, refuses it outright, cannot reach it at all, or
+lets it through unchecked because nobody has wrapped it yet. Those four answers
+are written down as :data:`_LIMITS_WRAPPED`, :data:`_LIMITS_REFUSED`,
+:data:`_LIMITS_UNWRAPPABLE` and :data:`_LIMITS_NOT_YET_WRAPPED`.
+
+Written down, they can go stale: a row added to the table with no bucket would
+quietly claim a limits check it never gets, and a bucket entry left behind by a
+removed row would describe a write surface that no longer exists. Both
+directions are pinned here, and every failure names the offending row.
+
+The buckets are keyed by the canonical ``tango`` spelling. ``PyTango`` is the
+legacy alias for the same package, so ``PyTango.DeviceProxy`` resolves to the
+same class object and its fate is the ``tango.DeviceProxy`` row's fate; the
+alias rows are canonicalised before the lookup rather than duplicated.
+"""
+
+import pytest
+
+from osprey.services.python_executor.write_surface import (
+    _CLIENT_WRITE_TARGETS,
+    _LIMITS_NOT_YET_WRAPPED,
+    _LIMITS_REFUSED,
+    _LIMITS_UNWRAPPABLE,
+    _LIMITS_WRAPPED,
+)
+
+pytestmark = pytest.mark.unit
+
+
+#: The buckets, by the name a failure should print.
+_BUCKETS = {
+    "_LIMITS_WRAPPED": _LIMITS_WRAPPED,
+    "_LIMITS_REFUSED": _LIMITS_REFUSED,
+    "_LIMITS_UNWRAPPABLE": _LIMITS_UNWRAPPABLE,
+    "_LIMITS_NOT_YET_WRAPPED": _LIMITS_NOT_YET_WRAPPED,
+}
+
+_ALIAS_PACKAGE = "PyTango"
+_CANONICAL_PACKAGE = "tango"
+
+
+def _canonical(dotted):
+    """The spelling the buckets are keyed by.
+
+    ``PyTango`` re-exports the ``tango`` package, so both dotted names resolve
+    to one class object and a guard patching either patches both.
+    """
+    if dotted == _ALIAS_PACKAGE or dotted.startswith(_ALIAS_PACKAGE + "."):
+        return _CANONICAL_PACKAGE + dotted[len(_ALIAS_PACKAGE) :]
+    return dotted
+
+
+def _table_rows():
+    """Every ``(dotted, attribute)`` in the client half of the write surface."""
+    return [(dotted, attr) for dotted, attrs in _CLIENT_WRITE_TARGETS for attr in attrs]
+
+
+def test_every_client_row_is_in_exactly_one_bucket():
+    """A row with no bucket, or with two, is the drift this partition exists to catch."""
+    for dotted, attr in _table_rows():
+        row = (_canonical(dotted), attr)
+        holders = [name for name, bucket in _BUCKETS.items() if row in bucket]
+        assert holders, (
+            f"{dotted}.{attr} is in the write surface but in no limits bucket — "
+            "say whether a limits-checked run wraps, refuses, cannot reach or "
+            "does not yet check it"
+        )
+        assert len(holders) == 1, (
+            f"{dotted}.{attr} is in more than one limits bucket: {', '.join(holders)}"
+        )
+
+
+def test_no_bucket_names_a_row_outside_the_table():
+    """A bucket entry that outlives its row would describe a surface that is gone."""
+    table = {(_canonical(dotted), attr) for dotted, attr in _table_rows()}
+    for name, bucket in _BUCKETS.items():
+        for dotted, attr in bucket:
+            assert (dotted, attr) in table, (
+                f"{name} names {dotted}.{attr}, which is not in _CLIENT_WRITE_TARGETS"
+            )
+
+
+def test_not_yet_wrapped_bucket_holds_ten_rows():
+    """The unchecked remainder is a fixed, countable list, not an open set.
+
+    Ten entry points reach hardware in a readwrite run without passing the
+    limits database. Wrapping one moves it out of here; a new client row
+    landing here instead of in a wrapper is a decision, and this count makes it
+    one somebody has to make on purpose.
+    """
+    assert len(_LIMITS_NOT_YET_WRAPPED) == 10, (
+        "the not-yet-wrapped bucket changed size: "
+        + ", ".join(f"{dotted}.{attr}" for dotted, attr in _LIMITS_NOT_YET_WRAPPED)
+    )
+
+
+def test_not_yet_wrapped_rows_name_the_follow_up():
+    """Every unchecked row is pinned to the one tracker item that closes them.
+
+    The literal is the point: the bucket is deliberately tracked as a single
+    piece of work, so a row that belongs to a different follow-up does not
+    belong here. Splitting the tracking is a decision somebody makes on
+    purpose --- either the row moves to a bucket that fits it, or this pin is
+    widened knowingly --- the same argument the ten-row count makes for itself.
+    """
+    for (dotted, attr), reason in _LIMITS_NOT_YET_WRAPPED.items():
+        assert reason == "followups-897 item 16", (
+            f"{dotted}.{attr} names {reason!r}, but this bucket is pinned to "
+            "the single tracker item 'followups-897 item 16'; move the row to "
+            "a bucket that fits it, or widen the pin here on purpose"
+        )
+
+
+def test_every_bucket_entry_carries_a_reason():
+    """A bucket is a reason per row; an empty one answers nothing."""
+    for name, bucket in _BUCKETS.items():
+        for (dotted, attr), reason in bucket.items():
+            assert reason.strip(), f"{name}[{dotted}.{attr}] carries no reason"
+
+
+def test_alias_rows_resolve_to_a_row_the_table_spells_canonically():
+    """The legacy ``PyTango`` rows are covered by their ``tango`` twins, not on their own.
+
+    That only holds while the canonical row exists. An alias row naming an
+    attribute ``tango`` does not list would be bucketed by accident of the
+    rewrite rather than by anyone having looked at it.
+    """
+    table = {(dotted, attr) for dotted, attr in _table_rows()}
+    alias_rows = [row for row in table if row[0].startswith(_ALIAS_PACKAGE)]
+    assert alias_rows, "the alias contract this test pins no longer has any rows"
+    for dotted, attr in alias_rows:
+        assert (_canonical(dotted), attr) in table, (
+            f"{dotted}.{attr} has no {_CANONICAL_PACKAGE} row to inherit its limits bucket from"
+        )

--- a/tests/services/python_executor/execution/test_p4p_monkeypatch.py
+++ b/tests/services/python_executor/execution/test_p4p_monkeypatch.py
@@ -2,13 +2,16 @@
 
 The wrapper emits *source text* that runs inside the executor subprocess, so
 these tests execute that generated source against fake ``p4p`` modules injected
-into ``sys.modules``. A fake ``epics`` module is injected too, so exec'ing the
-block never patches a real pyepics install in the test process.
+into ``sys.modules``. Every other client the block imports is faked or blocked
+too, so exec'ing it never patches a real install — pyepics, aioca and p4p are
+all present in this environment, and a patch that escaped here would outlive
+the test. The autouse fixture below is the second net under that.
 """
 
 import asyncio
 import contextlib
 import gc
+import importlib
 import io
 import sys
 from types import ModuleType
@@ -21,6 +24,7 @@ from osprey.connectors.control_system.limits_validator import (
 )
 from osprey.errors import ChannelLimitsViolationError
 from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
+from osprey.services.python_executor.write_surface import _CLIENT_WRITE_TARGETS
 
 pytestmark = pytest.mark.unit
 
@@ -28,23 +32,119 @@ RPC_REFUSAL = "rpc is not mediated and cannot be approved"
 
 
 # ---------------------------------------------------------------------------
+# Restoration
+# ---------------------------------------------------------------------------
+
+
+def _resolve_target(dotted):
+    """Resolve a write-surface row to the object that carries its attributes.
+
+    A copy of the resolver the emitted guard uses, kept for the same reason
+    ``test_readonly_guard.py`` keeps one: the guard has to be self-contained —
+    it runs before user code in a subprocess that may not be able to import
+    OSPREY at all — so there is no function to share.
+    """
+    parts = dotted.split(".")
+    for cut in range(len(parts), 0, -1):
+        try:
+            obj = importlib.import_module(".".join(parts[:cut]))
+        except ImportError:
+            continue
+        for attr in parts[cut:]:
+            try:
+                obj = getattr(obj, attr)
+            except AttributeError:
+                return None
+        return obj
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _restore_patched_targets():
+    """Undo any client patch that escaped the fakes, after every test.
+
+    The block these tests exec is written to patch installed control-system
+    clients, and it is exec'd in the test process. The fakes below are what
+    normally absorbs that, but a client the fakes miss — a row added to the
+    write surface, a spelling the harness does not yet stand in for — would
+    otherwise leave the installed library patched for the remainder of the
+    session, and unrelated tests would fail on a limits refusal far from here.
+
+    Snapshotting happens before a test injects its fakes, so it captures the
+    real objects; restoring writes back to those same objects and is therefore
+    unaffected by whatever ``sys.modules`` held in between.
+    """
+    saved = []
+    for dotted, attrs in _CLIENT_WRITE_TARGETS:
+        target = _resolve_target(dotted)
+        if target is None:
+            continue
+        for attr in attrs:
+            if hasattr(target, attr):
+                saved.append((target, attr, getattr(target, attr)))
+    yield
+    for target, attr, value in saved:
+        setattr(target, attr, value)
+
+
+# ---------------------------------------------------------------------------
 # Fakes
 # ---------------------------------------------------------------------------
 
 
-class RecordingContext:
-    """Stand-in for ``p4p.client.<flavor>.Context``.
+class RawRecordingContext:
+    """Stand-in for ``p4p.client.raw.Context``, the base every flavor subclasses.
 
-    ``puts``/``rpcs`` record what actually reached the (fake) network, so a test
-    can prove validation happened *before* any I/O.
+    ``raw_puts`` records what reached the (fake) network through the raw layer.
+    A flavor put lands here through ``super().put`` exactly as p4p's own do, so
+    a test can tell a forwarded write apart from a re-validated one. The
+    signature is the real one: a raw put names ONE channel and spells its value
+    ``builder``.
     """
 
     def __init__(self):
         self.puts = []
         self.rpcs = []
+        self.raw_puts = []
+
+    def put(self, name, handler, builder=None, request=None, get=True):
+        self.raw_puts.append((name, builder))
+        return "raw-put-done"
+
+    def rpc(self, name, handler, value=None, request=None):
+        self.rpcs.append((name, value))
+        return "raw-rpc-done"
+
+
+class HandlerGetRawContext(RawRecordingContext):
+    """A raw fake whose ``get`` carries the real signature: it answers a HANDLER.
+
+    ``p4p.client.raw.Context.get(self, name, handler, request=None)`` hands the
+    value to a callback instead of returning it, so the one-argument read the
+    step check makes raises ``TypeError`` against it and the write fails closed
+    on the reader-error branch. ``RawRecordingContext`` has no ``get`` at all,
+    which fails closed one branch EARLIER — on "no reader supplied" — so
+    without this fake the branch the installed library actually takes goes
+    untested.
+    """
+
+    def get(self, name, handler, request=None):
+        handler(1.0)
+        return "raw-get-started"
+
+
+class RecordingContext:
+    """Stand-in for the flavor half of ``p4p.client.<flavor>.Context``.
+
+    ``puts``/``rpcs`` record what actually reached the (fake) network, so a test
+    can prove validation happened *before* any I/O. It is mixed with a fresh
+    raw base per test rather than subclassing one here, so the guard's patch of
+    the raw class cannot outlive the test that installed it.
+    """
 
     def put(self, name, values, request=None, timeout=5.0, **kwargs):
         self.puts.append((name, values))
+        super().put(name, None, builder=values)
         return "put-done"
 
     def rpc(self, name, value=None, request=None, timeout=5.0):
@@ -57,34 +157,83 @@ class AsyncRecordingContext(RecordingContext):
 
     async def put(self, name, values, request=None, timeout=5.0, **kwargs):
         self.puts.append((name, values))
+        super(RecordingContext, self).put(name, None, builder=values)
         return "put-done"
 
 
-def _make_fake_epics():
-    mod = ModuleType("epics")
+class _FakeChid:
+    """What ``epics.ca`` addresses a channel by: an opaque id, not a name."""
 
-    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+    def __init__(self, pvname):
+        self.pvname = pvname
+
+
+def _make_fake_epics():
+    """An ``epics`` whose writes funnel through ``epics.ca.put``, as pyepics' do.
+
+    ``caput`` and ``PV.put`` reach the network through ``ca.put`` on a real
+    install, and the fake keeps that chain so the block's pyepics branch finds
+    the same shape here. ``ca`` is looked up on the module at call time, so a
+    ``PV.put`` reaches whatever wrapper the block installed.
+    """
+    mod = ModuleType("epics")
+    ca = ModuleType("epics.ca")
+
+    def _ca_name(chid):
+        return chid.pvname
+
+    def _ca_create_channel(pvname, **kwargs):
+        return _FakeChid(pvname)
+
+    def _ca_put(chid, value, wait=False, timeout=60, **kwargs):
         return 1
+
+    def _ca_get(chid, timeout=60, **kwargs):
+        return 1.0
+
+    ca.name = _ca_name
+    ca.create_channel = _ca_create_channel
+    ca.put = _ca_put
+    ca.get = _ca_get
 
     class PV:
         def __init__(self, pvname):
             self.pvname = pvname
+            self.chid = ca.create_channel(pvname)
 
         def put(self, value, wait=False, timeout=60, **kwargs):
-            return 1
+            return ca.put(self.chid, value, wait=wait, timeout=timeout, **kwargs)
 
-    mod.caput = caput
+        def get(self, **kwargs):
+            return ca.get(self.chid)
+
+    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+        return PV(pvname).put(value, wait=wait, timeout=timeout, **kwargs)
+
+    def caget(pvname, timeout=60, **kwargs):
+        return ca.get(ca.create_channel(pvname), timeout=timeout)
+
+    mod.ca = ca
     mod.PV = PV
+    mod.caput = caput
+    mod.caget = caget
     return mod
 
 
-def _install_fake_p4p(monkeypatch, flavors=("thread", "asyncio"), bases=None, broken=()):
+def _install_fake_p4p(
+    monkeypatch, flavors=("thread", "asyncio"), bases=None, broken=(), raw_base=None
+):
     """Inject a fake ``p4p`` package exposing a fresh Context per flavor.
 
-    Returns ``{flavor: context_class}``. Flavors not listed are left
-    unimportable, so the "not available" branch is exercised for them.
-    ``bases`` overrides the base class for a flavor; flavors named in
-    ``broken`` raise ``RuntimeError`` when their ``Context`` is imported.
+    Returns ``{flavor: context_class}`` plus ``"raw"`` for the base class, which
+    is created fresh per call: the guard patches it, and a class shared between
+    tests would carry that patch into the next one. Each flavor class is built
+    on that base, as p4p's own are, so a flavor put re-enters the raw guard the
+    way the real client does. Flavors not listed are left unimportable, so the
+    "not available" branch is exercised for them. ``bases`` overrides the flavor
+    half of a class; ``raw_base`` overrides the base the raw Context is built
+    on; flavors named in ``broken`` raise ``RuntimeError`` when their
+    ``Context`` is imported.
     """
     bases = bases or {}
     p4p_mod = ModuleType("p4p")
@@ -93,7 +242,13 @@ def _install_fake_p4p(monkeypatch, flavors=("thread", "asyncio"), bases=None, br
     monkeypatch.setitem(sys.modules, "p4p", p4p_mod)
     monkeypatch.setitem(sys.modules, "p4p.client", client_mod)
 
-    classes = {}
+    raw_mod = ModuleType("p4p.client.raw")
+    raw_cls = type("RawContext", (raw_base or RawRecordingContext,), {})
+    raw_mod.Context = raw_cls
+    client_mod.raw = raw_mod
+    monkeypatch.setitem(sys.modules, "p4p.client.raw", raw_mod)
+
+    classes = {"raw": raw_cls}
     for flavor in flavors:
         flavor_mod = ModuleType(f"p4p.client.{flavor}")
         if flavor in broken:
@@ -104,7 +259,9 @@ def _install_fake_p4p(monkeypatch, flavors=("thread", "asyncio"), bases=None, br
             flavor_mod.__getattr__ = _boom
         else:
             ctx_cls = type(
-                f"{flavor.capitalize()}Context", (bases.get(flavor, RecordingContext),), {}
+                f"{flavor.capitalize()}Context",
+                (bases.get(flavor, RecordingContext), raw_cls),
+                {},
             )
             flavor_mod.Context = ctx_cls
             classes[flavor] = ctx_cls
@@ -116,6 +273,9 @@ def _install_fake_p4p(monkeypatch, flavors=("thread", "asyncio"), bases=None, br
     for flavor in ("thread", "asyncio", "cothread"):
         if flavor not in flavors:
             monkeypatch.setitem(sys.modules, f"p4p.client.{flavor}", None)
+    # The C extension is installed here and nothing fakes it, so a test that
+    # reached it would patch the real library.
+    monkeypatch.setitem(sys.modules, "p4p._p4p", None)
     return classes
 
 
@@ -127,6 +287,8 @@ def _block_p4p(monkeypatch):
         "p4p.client.thread",
         "p4p.client.asyncio",
         "p4p.client.cothread",
+        "p4p.client.raw",
+        "p4p._p4p",
     ):
         monkeypatch.setitem(sys.modules, name, None)
 
@@ -143,6 +305,13 @@ def _make_validator():
         ),
         "TEST:OTHER:SP": ChannelLimitsConfig(
             channel_address="TEST:OTHER:SP", min_value=0.0, max_value=10.0, writable=True
+        ),
+        "TEST:STEP:SP": ChannelLimitsConfig(
+            channel_address="TEST:STEP:SP",
+            min_value=0.0,
+            max_value=10.0,
+            max_step=1.0,
+            writable=True,
         ),
         "TEST:RO": ChannelLimitsConfig(channel_address="TEST:RO", writable=False),
     }
@@ -161,10 +330,39 @@ def _make_permissive_validator():
     return LimitsValidator(strict.limits, {"allow_unlisted_channels": True})
 
 
+def _count_validations(namespace):
+    """Record every ``validate`` the installed guards make; return the log.
+
+    The guards close over the validator OBJECT, so shadowing the bound method
+    on that instance counts calls wherever they come from. This is what tells a
+    put forwarded through the raw base apart from one validated twice on its
+    way there.
+    """
+    validator = namespace["_limits_validator"]
+    original = validator.validate
+    calls = []
+
+    def _counting(channel_address, value, **kwargs):
+        calls.append((channel_address, value))
+        return original(channel_address, value, **kwargs)
+
+    validator.validate = _counting
+    return calls
+
+
 def _run_monkeypatch(monkeypatch, validator=None):
     """Execute the generated monkeypatch block; return ``(namespace, stdout)``."""
     validator = validator or _make_validator()
-    monkeypatch.setitem(sys.modules, "epics", _make_fake_epics())
+    fake_epics = _make_fake_epics()
+    monkeypatch.setitem(sys.modules, "epics", fake_epics)
+    monkeypatch.setitem(sys.modules, "epics.ca", fake_epics.ca)
+
+    # The other clients the block imports are made absent rather than faked:
+    # this module is about p4p, and aioca is really installed here — exec'ing
+    # the block against it would rebind the installed library for the rest of
+    # the session. Their behaviour is covered in test_client_limits_monkeypatch.
+    for name in ("aioca", "aioca._catools", "pvaccess"):
+        monkeypatch.setitem(sys.modules, name, None)
 
     # The block injects the validator into osprey.runtime as a side effect.
     import osprey.runtime as runtime_module
@@ -193,6 +391,7 @@ def test_generated_source_patches_every_p4p_flavor():
     assert "from p4p.client.thread import Context" in source
     assert "from p4p.client.asyncio import Context" in source
     assert "from p4p.client.cothread import Context" in source
+    assert "from p4p.client.raw import Context" in source
     # Fail-closed batch iteration, not a truncating plain zip.
     assert "strict=True" in source
     # Scalar-vs-batch keys on str, exactly as p4p's own put() does.
@@ -407,7 +606,7 @@ def test_absent_p4p_prints_disabled_and_does_not_crash(monkeypatch):
     _block_p4p(monkeypatch)
     namespace, out = _run_monkeypatch(monkeypatch)
 
-    for flavor in ("thread", "asyncio", "cothread"):
+    for flavor in ("thread", "asyncio", "cothread", "raw"):
         assert f"p4p.client.{flavor} not available - PVA limits checking disabled" in out
     # The rest of the block still completed.
     assert "Runtime channel limits checking ENABLED" in out
@@ -539,3 +738,314 @@ def test_async_put_out_of_bounds_raises_synchronously(monkeypatch):
         ctxt.put("TEST:MAG:SP", 99.0)  # no await
     gc.collect()  # a stray coroutine would warn "never awaited" here
     assert ctxt.puts == []
+
+
+# ---------------------------------------------------------------------------
+# Payloads that carry no number to check
+# ---------------------------------------------------------------------------
+
+
+def test_builder_callable_raises_before_any_call(monkeypatch):
+    """p4p invokes a builder later, so there is nothing to check now."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ValueError, match="builder callable"):
+        ctxt.put("TEST:MAG:SP", lambda value: value)
+    assert ctxt.puts == []
+    assert ctxt.raw_puts == []
+
+
+def test_dict_payload_out_of_range_raises(monkeypatch):
+    """A structure must be checked on the number it carries, not waved through."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", {"value": 99.0})
+    assert ctxt.puts == []
+
+
+def test_dict_payload_within_limits_forwards_unreduced(monkeypatch):
+    """The client is handed the structure it was given, not the number."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    assert ctxt.put("TEST:MAG:SP", {"value": 5.0}) == "put-done"
+    assert ctxt.puts == [("TEST:MAG:SP", {"value": 5.0})]
+
+
+def test_dict_payload_without_a_value_field_fails_closed(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ValueError, match="no 'value' field"):
+        ctxt.put("TEST:MAG:SP", {"severity": 0})
+    assert ctxt.puts == []
+
+
+def test_value_object_payload_out_of_range_raises(monkeypatch):
+    """A p4p ``Value`` carries the number in a ``value`` field."""
+
+    class FakeValue:
+        value = 99.0
+
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", FakeValue())
+    assert ctxt.puts == []
+
+
+def test_json_string_payload_out_of_range_raises(monkeypatch):
+    """p4p decodes a '{'-leading string itself, AFTER the guard has run.
+
+    ``Context.put`` does ``json.loads`` on this payload inside its own loop, so
+    a guard that stopped at scalar/dict/``Value`` would hand the validator a
+    str, fail ``float()``, skip every check, and let p4p write the number it
+    decoded.
+    """
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", '{"value": 999.0}')
+    assert ctxt.puts == []
+    assert ctxt.raw_puts == []
+
+
+def test_json_string_payload_within_limits_forwards_exactly_once(monkeypatch):
+    """In range, the client is handed the STRING it was given, checked once."""
+    classes = _install_fake_p4p(monkeypatch)
+    namespace, _ = _run_monkeypatch(monkeypatch)
+    validations = _count_validations(namespace)
+
+    ctxt = classes["thread"]()
+    assert ctxt.put("TEST:MAG:SP", '{"value": 5.0}') == "put-done"
+    assert validations == [("TEST:MAG:SP", 5.0)]
+    assert ctxt.puts == [("TEST:MAG:SP", '{"value": 5.0}')]
+    assert ctxt.raw_puts == [("TEST:MAG:SP", '{"value": 5.0}')]
+
+
+def test_json_string_payload_without_a_value_field_fails_closed(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ValueError, match="no 'value' field"):
+        ctxt.put("TEST:MAG:SP", '{"severity": 0}')
+    assert ctxt.puts == []
+
+
+def test_undecodable_json_string_payload_fails_closed(monkeypatch):
+    """p4p refuses this payload too — the guard must not wave it through."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ValueError, match="does not decode"):
+        ctxt.put("TEST:MAG:SP", "{value: 999.0")
+    assert ctxt.puts == []
+
+
+def test_json_bytes_payload_out_of_range_raises(monkeypatch):
+    """Decoded one spelling stricter than p4p, which errs closed.
+
+    p4p's own test is ``value[:1] == '{'``, which a bytes payload never
+    matches, so p4p forwards it undecoded. Refusing an out-of-range one here
+    costs a string write that begins with a brace and buys immunity to a p4p
+    that later decodes bytes too.
+    """
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", b'{"value": 999.0}')
+    assert ctxt.puts == []
+
+
+def test_plain_string_payload_is_not_treated_as_json(monkeypatch):
+    """Only a '{'-leading string is a structure; the rest is a string write."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    assert ctxt.put("TEST:MAG:SP", "Off") == "put-done"
+    assert ctxt.puts == [("TEST:MAG:SP", "Off")]
+
+
+def test_value_object_without_a_value_field_fails_closed(monkeypatch):
+    """A ``Value`` carrying other fields fails closed like a dict does.
+
+    p4p spells "is this field present" as ``Value.has(name)``, and a real
+    ``Value`` with no ``value`` field answers the ``getattr`` fallback with
+    ITSELF — which the validator then skips as non-numeric. Dicts already fail
+    closed here; this is the same trade for the other structure spelling.
+    """
+
+    class FakeValueWithoutValue:
+        def has(self, name):
+            return name == "severity"
+
+        severity = 0
+
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ValueError, match="no 'value' field"):
+        ctxt.put("TEST:MAG:SP", FakeValueWithoutValue())
+    assert ctxt.puts == []
+
+
+def test_value_object_with_a_value_field_is_checked_on_its_number(monkeypatch):
+    """The ``has()`` probe must not get in the way of a well-formed ``Value``."""
+
+    class FakeValueWithValue:
+        value = 99.0
+
+        def has(self, name):
+            return name == "value"
+
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", FakeValueWithValue())
+    assert ctxt.puts == []
+
+
+def test_batch_put_reduces_every_pair(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put(["TEST:MAG:SP", "TEST:OTHER:SP"], [{"value": 1.0}, {"value": 999.0}])
+    assert ctxt.puts == []
+
+
+# ---------------------------------------------------------------------------
+# The raw base: the direct route, and the flavours' way through it
+# ---------------------------------------------------------------------------
+
+
+def test_direct_raw_put_out_of_bounds_raises(monkeypatch):
+    """A script driving raw.Context itself is checked like any other client."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", None, builder=99.0)
+    assert ctxt.raw_puts == []
+
+
+def test_direct_raw_put_within_limits_reaches_the_client(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    assert ctxt.put("TEST:MAG:SP", None, builder=5.0) == "raw-put-done"
+    assert ctxt.raw_puts == [("TEST:MAG:SP", 5.0)]
+
+
+def test_direct_raw_put_with_a_builder_callable_raises(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    with pytest.raises(ValueError, match="builder callable"):
+        ctxt.put("TEST:MAG:SP", None, builder=lambda value: value)
+    assert ctxt.raw_puts == []
+
+
+def test_direct_raw_put_to_an_unlisted_channel_is_blocked(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:NOT:IN:DB", None, builder=1.0)
+    assert ctxt.raw_puts == []
+
+
+def test_raw_put_to_a_max_step_channel_fails_closed(monkeypatch):
+    """Raw ``get`` answers a handler, so the step read cannot be made.
+
+    The wrapper claims a max_step channel written straight through raw fails
+    CLOSED. With a real-signature ``get`` installed on the raw fake, the
+    guard's one-argument read raises ``TypeError`` and the validator turns any
+    reader error into a refusal — which is the branch the installed library
+    takes, rather than the "no reader supplied" one a ``get``-less fake hits.
+    """
+    classes = _install_fake_p4p(monkeypatch, raw_base=HandlerGetRawContext)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    with pytest.raises(ChannelLimitsViolationError) as excinfo:
+        ctxt.put("TEST:STEP:SP", None, builder=5.0)
+    assert excinfo.value.violation_type == "STEP_CHECK_FAILED"
+    assert "Channel read failed" in excinfo.value.violation_reason
+    assert ctxt.raw_puts == []
+
+
+def test_raw_put_to_a_max_step_channel_fails_closed_without_a_reader(monkeypatch):
+    """The other closed branch: a raw context exposing no ``get`` at all."""
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    with pytest.raises(ChannelLimitsViolationError) as excinfo:
+        ctxt.put("TEST:STEP:SP", None, builder=5.0)
+    assert excinfo.value.violation_type == "STEP_CHECK_FAILED"
+    assert "No way to read" in excinfo.value.violation_reason
+    assert ctxt.raw_puts == []
+
+
+def test_raw_rpc_is_refused(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["raw"]()
+    with pytest.raises(RuntimeError, match=RPC_REFUSAL):
+        ctxt.rpc("TEST:MAG:SP", None, 1.0)
+    assert ctxt.rpcs == []
+
+
+def test_flavor_put_forwards_through_raw_exactly_once(monkeypatch):
+    """The re-entry through ``super().put`` must not be validated a second time."""
+    classes = _install_fake_p4p(monkeypatch)
+    namespace, _ = _run_monkeypatch(monkeypatch)
+    validations = _count_validations(namespace)
+
+    ctxt = classes["thread"]()
+    assert ctxt.put("TEST:MAG:SP", 5.0) == "put-done"
+    assert validations == [("TEST:MAG:SP", 5.0)]
+    assert ctxt.raw_puts == [("TEST:MAG:SP", 5.0)]
+
+
+def test_flavor_put_out_of_bounds_never_reaches_raw(monkeypatch):
+    classes = _install_fake_p4p(monkeypatch)
+    _run_monkeypatch(monkeypatch)
+
+    ctxt = classes["thread"]()
+    with pytest.raises(ChannelLimitsViolationError):
+        ctxt.put("TEST:MAG:SP", 99.0)
+    assert ctxt.raw_puts == []
+
+
+def test_raw_guard_reports_itself_installed(monkeypatch):
+    _install_fake_p4p(monkeypatch)
+    _, out = _run_monkeypatch(monkeypatch)
+
+    assert "Monkeypatched p4p.client.raw" in out

--- a/tests/services/python_executor/execution/test_readonly_guard.py
+++ b/tests/services/python_executor/execution/test_readonly_guard.py
@@ -8,22 +8,29 @@ user code runs. Late binding makes this spelling-independent: an alias such as
 ``from epics import caput as _w`` resolves to the refusing function because the
 patch is already in place when the alias is bound.
 
-Like the limits monkeypatch tests, these execute the generated *source text*
-against fake ``epics``/``p4p`` modules injected into ``sys.modules``.
+Like the limits monkeypatch tests, most of these execute the generated *source
+text* against fake ``epics``/``p4p`` modules injected into ``sys.modules``. A
+fake proves the guard patches the name the table spells; it cannot prove the
+guard reached the object a real library defines that write on, so the last test
+in the file runs the guard in a subprocess against whatever is installed.
 """
 
 import asyncio
 import importlib
+import json
 import platform
 import re
+import subprocess
 import sys
 from types import ModuleType
 
 import pytest
 
+from osprey.services.python_executor.execution import wrapper as wrapper_module
 from osprey.services.python_executor.execution.wrapper import (
     _READONLY_WRITE_TARGETS,
     READONLY_REFUSAL,
+    READONLY_REFUSAL_MARKER,
     ExecutionWrapper,
 )
 
@@ -76,8 +83,20 @@ def _restore_patched_targets():
         if target is None:
             continue
         for attr in attrs:
-            if hasattr(target, attr):
-                saved.append((target, attr, getattr(target, attr)))
+            if not hasattr(target, attr):
+                continue
+            original = getattr(target, attr)
+            saved.append((target, attr, original))
+            # The guard patches the second spelling of a re-exported write as
+            # well — the module that defined it, reached by following the
+            # original back through ``__module__``/``__name__`` — so snapshot
+            # it on the same rule the guard patches it on, or it stays
+            # refusing for the rest of the session.
+            home = sys.modules.get(getattr(original, "__module__", ""))
+            name = getattr(original, "__name__", None)
+            if home is not None and isinstance(name, str):
+                if getattr(home, name, None) is original:
+                    saved.append((home, name, original))
     yield
     for target, attr, value in saved:
         setattr(target, attr, value)
@@ -363,7 +382,12 @@ def test_readonly_refuses_caproto_threading_pv_write(monkeypatch):
 
 
 def test_readonly_refuses_pvaccess_typed_setters(monkeypatch):
-    """pvaPy spells one setter per type; the ``put`` prefix is swept wholesale."""
+    """pvaPy spells one setter per type, plus three writes off the prefix.
+
+    ``put``/``putDouble``/… are swept wholesale, and ``asyncPut``,
+    ``parsePut`` and ``parsePutGet`` are swept with them: they are writes
+    whose names simply do not begin with ``put``.
+    """
     mod = ModuleType("pvaccess")
     writes: list = []
 
@@ -377,6 +401,12 @@ def test_readonly_refuses_pvaccess_typed_setters(monkeypatch):
         def putDouble(self, value):  # noqa: N802 — pvaPy's own spelling
             writes.append(("putDouble", value))
 
+        def asyncPut(self, value, callback=None):  # noqa: N802 — pvaPy's own spelling
+            writes.append(("asyncPut", value))
+
+        def parsePut(self, args):  # noqa: N802 — pvaPy's own spelling
+            writes.append(("parsePut", args))
+
         def get(self):
             return 1.0
 
@@ -389,6 +419,12 @@ def test_readonly_refuses_pvaccess_typed_setters(monkeypatch):
         channel.put(150)
     with pytest.raises(RuntimeError, match=_REFUSAL):
         channel.putDouble(150.0)
+    # The three writes pvaPy spells outside the ``put`` prefix are the same
+    # write to the machine, and are refused with it.
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        channel.asyncPut(150.0, lambda _r: None)
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        channel.parsePut(["value=150.0"])
     assert writes == []
     assert channel.get() == 1.0, "reads must survive the guard untouched"
 
@@ -605,3 +641,500 @@ def test_guard_is_silent_when_optional_libraries_are_absent(capsys, monkeypatch)
         monkeypatch.setitem(sys.modules, name, None)
     _run_guard("readonly")
     assert capsys.readouterr().out == ""
+
+
+# The defining module both tests below use. It must stay OUT of the table: a
+# row naming it would patch it directly, and the assertions would then observe
+# the row instead of the generic defining-module step they exist to pin down.
+_HOME = "aioca._impl"
+
+
+def test_readonly_refuses_the_module_that_defines_a_reexported_write(monkeypatch):
+    """A re-exported write has two spellings, and both have to refuse.
+
+    A package re-exports what a private module defines, and the two names are
+    one function object: patching only the attribute the table names leaves
+    ``from aioca._impl import caput`` writing to the machine. So the guard
+    follows each original attribute back to the module that defined it and
+    refuses there too — generically, for the defining modules no row can
+    enumerate (PyTango's ``tango.device_proxy`` among them).
+    """
+    assert not any(dotted == _HOME for dotted, _ in _READONLY_WRITE_TARGETS), (
+        f"{_HOME} must stay absent from the write table, or this test passes "
+        "on the row rather than on the defining-module step"
+    )
+    package = ModuleType("aioca")
+    impl = ModuleType(_HOME)
+    writes: list = []
+
+    async def caput(pv, value, **kwargs):
+        writes.append((pv, value))
+
+    caput.__module__ = _HOME
+    impl.caput = caput
+    package.caput = caput
+    package._impl = impl
+    monkeypatch.setitem(sys.modules, "aioca", package)
+    monkeypatch.setitem(sys.modules, _HOME, impl)
+
+    _run_guard("readonly")
+
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        package.caput("SR:MAG:QF:01:CURRENT:SP", 150)
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        impl.caput("SR:MAG:QF:01:CURRENT:SP", 150)
+    assert writes == []
+
+
+def test_defining_module_step_needs_identity_not_a_name_match(monkeypatch):
+    """The step follows the object, never the name.
+
+    ``__module__``/``__name__`` are metadata a decorator or a rebind can leave
+    pointing at a module that holds something else entirely under that name.
+    Patching on a name match alone would silently replace an unrelated
+    attribute — including a read — so the step fires only when the defining
+    module still holds this exact object.
+    """
+    assert not any(dotted == _HOME for dotted, _ in _READONLY_WRITE_TARGETS), (
+        f"{_HOME} must stay absent from the write table, or this test observes "
+        "the row rather than the defining-module step"
+    )
+    package = ModuleType("aioca")
+    impl = ModuleType(_HOME)
+    reads: list = []
+
+    async def caput(pv, value, **kwargs):
+        pass
+
+    async def unrelated(pv, **kwargs):
+        reads.append(pv)
+        return 1.0
+
+    # Same ``__name__``/``__module__`` as the patched attribute, different
+    # object: the module's ``caput`` is not the one the table reached.
+    caput.__module__ = _HOME
+    unrelated.__name__ = "caput"
+    unrelated.__module__ = _HOME
+    impl.caput = unrelated
+    package.caput = caput
+    monkeypatch.setitem(sys.modules, "aioca", package)
+    monkeypatch.setitem(sys.modules, _HOME, impl)
+
+    _run_guard("readonly")
+
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        package.caput("SR:MAG:QF:01:CURRENT:SP", 150)
+    assert impl.caput is unrelated
+    assert asyncio.run(impl.caput("SR:MAG:QF:01:CURRENT")) == 1.0
+    assert reads == ["SR:MAG:QF:01:CURRENT"]
+
+
+def test_defining_module_failure_does_not_skip_the_rest_of_the_row(capsys, monkeypatch):
+    """A failing defining-module step costs its own attribute, nothing more.
+
+    The step is secondary — the attribute the table names already refuses when
+    it runs — but it touches metadata a library controls, so it can raise:
+    an unhashable ``__module__``, or a PEP 562 module ``__getattr__`` that
+    raises something other than ``AttributeError``. If that escaped to the row
+    handler, every LATER attribute of the row would be left unpatched, which
+    for a row like ``os`` means ``execv`` still spawning after ``system`` was
+    caught.
+    """
+    module = ModuleType("osprey_fake_client")
+
+    def write_a(*args, **kwargs):
+        return "wrote a"
+
+    def write_b(*args, **kwargs):
+        return "wrote b"
+
+    # Unhashable ``__module__``: ``sys.modules.get`` raises TypeError.
+    write_a.__module__ = ["not", "a", "name"]
+    module.write_a = write_a
+    module.write_b = write_b
+    monkeypatch.setitem(sys.modules, "osprey_fake_client", module)
+    monkeypatch.setattr(
+        wrapper_module,
+        "_READONLY_WRITE_TARGETS",
+        (("osprey_fake_client", ("write_a", "write_b")),),
+    )
+
+    _run_guard("readonly")
+
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        module.write_a()
+    with pytest.raises(RuntimeError, match=_REFUSAL):
+        # The attribute AFTER the one whose step raised must still refuse.
+        module.write_b()
+    warning = capsys.readouterr().out
+    assert "osprey_fake_client.write_a" in warning, (
+        "the operator has to be told which attribute's step failed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The installed libraries
+#
+# Everything above runs the guard's source in this process against fakes, which
+# is what makes a spelling assertion readable — but a fake cannot tell us
+# whether the guard reaches the object a REAL client library defines its write
+# on. aioca re-exports ``caput`` from ``aioca._catools``; every p4p client
+# flavour inherits ``put`` from ``p4p.client.raw.Context``; ophyd-async defines
+# ``set`` on a base of ``SignalRW``. A guard that patches only the name the
+# table spells leaves each of those originals reachable, and no fake would
+# notice.
+#
+# So this runs in a real interpreter against whatever is installed: snapshot
+# every resolvable row first, exec the guard, then assert the original survives
+# nowhere — not at its defining module, and not in any base class that still
+# holds it. A subprocess rather than this process because the guard patches
+# ``os``, ``subprocess`` and ``ctypes`` for real, and because two of the checks
+# have to call a write for real.
+# ---------------------------------------------------------------------------
+
+#: Last line of the probe's stdout, so anything the guard itself printed — it
+#: warns about a row it could not patch — stays distinguishable from the report.
+_REPORT_MARKER = "@@REPORT@@"
+
+_INSTALLED_LIBRARY_PROBE = """
+# Snapshot the write surface as the installed libraries actually define it,
+# install the guard, then report what survived. A report rather than bare
+# assertions, so the parent test can also check the run had teeth: a probe that
+# silently checked nothing must not read as a pass.
+#
+# argv[1] is the guard source; argv[2] is the substring every refusal carries.
+import importlib
+import json
+import pathlib
+import sys
+
+from osprey.services.python_executor.write_surface import (
+    _CLIENT_WRITE_TARGETS,
+    _FRAMEWORK_WRITE_TARGETS,
+)
+
+TABLE = _CLIENT_WRITE_TARGETS + _FRAMEWORK_WRITE_TARGETS
+REFUSE = "_osprey_readonly_refuse"
+REPORT_MARKER = "@@REPORT@@"
+MARKER = sys.argv[2]
+
+# Py_TPFLAGS_IMMUTABLETYPE. A C-extension type carrying it refuses setattr, so
+# the guard cannot patch it and the MRO walk must not demand that it did.
+IMMUTABLE_TYPE = 1 << 8
+
+
+def resolve(dotted):
+    # The guard's own resolver, restated: the emitted guard has to be
+    # self-contained in the subprocess it runs in, so there is none to share.
+    parts = dotted.split(".")
+    for cut in range(len(parts), 0, -1):
+        try:
+            obj = importlib.import_module(".".join(parts[:cut]))
+        except ImportError:
+            continue
+        for attr in parts[cut:]:
+            try:
+                obj = getattr(obj, attr)
+            except AttributeError:
+                return None
+        return obj
+    return None
+
+
+def refusing(value):
+    return getattr(value, "__name__", None) == REFUSE
+
+
+# --- before the guard ------------------------------------------------------
+# Only attributes that exist NOW are checked afterwards. The guard skips an
+# attribute a library does not have, and a row may name a client flavour that
+# is not installed; neither is a finding.
+snapshot = []
+absent = []
+for dotted, attrs in TABLE:
+    obj = resolve(dotted)
+    if obj is None:
+        absent.append(dotted)
+        continue
+    for attr in attrs:
+        if not hasattr(obj, attr):
+            continue
+        original = getattr(obj, attr)
+        try:
+            home = sys.modules.get(getattr(original, "__module__", None))
+        except TypeError:
+            # An unhashable ``__module__``; the guard tolerates it too.
+            home = None
+        name = getattr(original, "__name__", None)
+        # Conditional: most originals are not module-level names at all
+        # (``epics.PV.put`` is a method), and a name that resolves to a
+        # DIFFERENT object is not this write's definition.
+        defines_it = (
+            home is not None
+            and isinstance(name, str)
+            and getattr(home, name, None) is original
+        )
+        bases = []
+        if isinstance(obj, type):
+            # ``__mro__[:-1]`` drops ``object``, which defines none of these.
+            bases = [base for base in obj.__mro__[:-1] if attr in vars(base)]
+        snapshot.append(
+            {
+                "dotted": dotted,
+                "attr": attr,
+                "home": home,
+                "name": name,
+                "defines_it": defines_it,
+                "bases": bases,
+            }
+        )
+
+# --- the guard -------------------------------------------------------------
+exec(compile(pathlib.Path(sys.argv[1]).read_text(), "<osprey-readonly-guard>", "exec"), globals())
+
+# --- after the guard -------------------------------------------------------
+failures = []
+checked_home = []
+checked_mro = []
+skipped_mro = []
+
+for row in snapshot:
+    label = row["dotted"] + "." + row["attr"]
+    if row["defines_it"]:
+        home_label = row["home"].__name__ + "." + row["name"]
+        checked_home.append(home_label)
+        if not refusing(getattr(row["home"], row["name"], None)):
+            failures.append(
+                "(a) " + label + ": the module that defines it, " + home_label
+                + ", still holds the original write"
+            )
+    for base in row["bases"]:
+        base_label = base.__module__ + "." + base.__qualname__ + "." + row["attr"]
+        if base.__flags__ & IMMUTABLE_TYPE:
+            # A C-extension type refuses setattr. That floor is stated in
+            # write_surface's docstring and covered by the import denylist.
+            skipped_mro.append(base_label + " (immutable C type)")
+            continue
+        if getattr(base, "_is_protocol", False):
+            # A typing.Protocol member is a stub nobody calls; patching it
+            # would say nothing about the class that implements it.
+            skipped_mro.append(base_label + " (typing.Protocol)")
+            continue
+        checked_mro.append(base_label)
+        if not refusing(vars(base).get(row["attr"])):
+            failures.append(
+                "(b) " + label + ": base class " + base_label
+                + " still holds the original write"
+            )
+
+# --- the rows this hotfix exists for ---------------------------------------
+NAMED = (
+    ("aioca._catools", "caput"),
+    ("p4p.client.raw.Context", "put"),
+    ("epicscorelibs.ca.cadef", "ca_array_put"),
+    ("bluesky.run_engine.RunEngine", "__call__"),
+    ("ophyd_async.core.SignalRW", "set"),
+)
+checked_named = []
+for dotted, attr in NAMED:
+    obj = resolve(dotted)
+    if obj is None:
+        failures.append("(c) " + dotted + " did not resolve in the probe")
+        continue
+    checked_named.append(dotted + "." + attr)
+    if not refusing(getattr(obj, attr, None)):
+        failures.append("(c) " + dotted + "." + attr + " is not the refusing function")
+
+
+def expect_refusal(label, call):
+    # A real call, not an identity check: the two frameworks reach their write
+    # through a dunder and through a base class, which is exactly where an
+    # identity check on the spelled name passes while the write still runs.
+    try:
+        call()
+    except RuntimeError as exc:
+        if MARKER not in str(exc):
+            failures.append(
+                "(d) " + label + " raised a RuntimeError that is not the refusal: " + str(exc)
+            )
+        return
+    except BaseException as exc:
+        failures.append(
+            "(d) " + label + " raised " + type(exc).__name__ + " instead of refusing: " + str(exc)
+        )
+        return
+    failures.append("(d) " + label + " returned instead of refusing")
+
+
+import bluesky.run_engine
+
+# ``__new__`` without ``__init__``: running a plan is what has to refuse, and a
+# fully built RunEngine would open an event loop to find that out.
+expect_refusal(
+    "RunEngine(plan)",
+    lambda: bluesky.run_engine.RunEngine.__new__(bluesky.run_engine.RunEngine)([]),
+)
+
+import ophyd_async.core
+
+expect_refusal(
+    "soft_signal_rw(float, 0.0).set(1.0)",
+    lambda: ophyd_async.core.soft_signal_rw(float, 0.0).set(1.0),
+)
+
+# --- the read path the guard must NOT close --------------------------------
+# ``p4p.client.raw`` subclasses the immutable C operation type at import time
+# and hands the SAME object out for get as for put, so a row naming either of
+# those two names refuses every PVAccess read — the path readonly mode exists
+# to keep open. Pinned here: a get against a PV nobody serves has to time out,
+# and only the put has to refuse.
+import p4p.client.thread
+
+context = p4p.client.thread.Context("pva")
+try:
+    try:
+        context.get("OSPREY:READONLY:PROBE:NO:SUCH:PV", timeout=0.3)
+        read_outcome = "returned a value"
+    except TimeoutError:
+        read_outcome = "TimeoutError"
+    except BaseException as exc:
+        read_outcome = type(exc).__name__ + ": " + str(exc)
+    if read_outcome != "TimeoutError":
+        failures.append(
+            "(read) p4p Context.get under the guard: " + read_outcome
+            + " -- a readonly run must still be able to read PVAccess"
+        )
+    expect_refusal(
+        "p4p thread Context.put",
+        lambda: context.put("OSPREY:READONLY:PROBE:NO:SUCH:PV", 1.0, timeout=0.3),
+    )
+finally:
+    context.close()
+
+print(
+    REPORT_MARKER
+    + json.dumps(
+        {
+            "failures": failures,
+            "absent": absent,
+            "checked_home": checked_home,
+            "checked_mro": checked_mro,
+            "skipped_mro": skipped_mro,
+            "checked_named": checked_named,
+            "attributes": [row["dotted"] + "." + row["attr"] for row in snapshot],
+        }
+    )
+)
+"""
+
+#: Appended AFTER the guard source, in a cold interpreter. Bluesky's import
+#: chain reads ``platform.uname().processor``, which CPython answers by
+#: shelling out on first read — under a guard that refuses spawning and forgot
+#: to pre-warm it, importing Bluesky at all would fail. So this checks the
+#: import the guard has to leave working, in the one ordering where it breaks.
+_COLD_IMPORT_PROBE = """
+import importlib
+
+run_engine = importlib.import_module("bluesky.run_engine")
+assert run_engine.RunEngine.__call__.__name__ == "_osprey_readonly_refuse", (
+    "a framework imported after the guard must still refuse its write"
+)
+print("@@COLD-OK@@")
+"""
+
+
+def _run_probe(tmp_path, name, source, *args):
+    """Run *source* in a real interpreter and return its stdout."""
+    script = tmp_path / name
+    script.write_text(source)
+    result = subprocess.run(
+        [sys.executable, str(script), *args], capture_output=True, text=True, timeout=300
+    )
+    assert result.returncode == 0, (
+        f"{name} exited {result.returncode}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    return result.stdout
+
+
+def test_guard_holds_against_installed_libraries(tmp_path):
+    """Every installed write the table names refuses at the object defining it.
+
+    The in-process tests above prove the guard patches the name each row
+    spells. This proves the harder half against the real libraries: that the
+    original is not still reachable one level down — at the private module a
+    package re-exports it from, or in a base class the spelled class inherits
+    it from. Both were open on the pre-fix table, and neither is visible to a
+    fake.
+
+    Rows for libraries that are not installed contribute nothing, which is the
+    ordinary case; the named rows are guarded by ``importorskip`` so a missing
+    library skips loudly instead of passing quietly.
+    """
+    for library in ("aioca", "p4p", "epicscorelibs", "bluesky", "ophyd_async"):
+        pytest.importorskip(library, reason=f"{library} is not installed in this environment")
+
+    guard_path = tmp_path / "readonly_guard.py"
+    guard_path.write_text(ExecutionWrapper(execution_mode="readonly")._get_readonly_guard())
+
+    stdout = _run_probe(
+        tmp_path,
+        "probe_installed_libraries.py",
+        _INSTALLED_LIBRARY_PROBE,
+        str(guard_path),
+        READONLY_REFUSAL_MARKER,
+    )
+
+    assert _REPORT_MARKER in stdout, f"the probe produced no report:\n{stdout}"
+    noise, _, payload = stdout.partition(_REPORT_MARKER)
+    assert noise.strip() == "", (
+        f"the guard warned about a row it could not patch against the installed libraries:\n{noise}"
+    )
+    report = json.loads(payload)
+
+    assert report["failures"] == [], "\n".join(["the guard did not hold:", *report["failures"]])
+
+    # --- the run has to have had teeth --------------------------------------
+    # Every check above is a loop over what resolved, so all of them pass
+    # vacuously if nothing did. The rows this hotfix was written for are named
+    # here: the libraries are importorskip'd above, so their absence from the
+    # report is a broken probe rather than a thin environment.
+    assert set(report["checked_named"]) == {
+        "aioca._catools.caput",
+        "p4p.client.raw.Context.put",
+        "epicscorelibs.ca.cadef.ca_array_put",
+        "bluesky.run_engine.RunEngine.__call__",
+        "ophyd_async.core.SignalRW.set",
+    }
+    assert "aioca._catools.caput" in report["checked_home"], (
+        "the defining-module check must have run for aioca, the re-export that "
+        "reached the machine before this fix"
+    )
+    assert "p4p.client.raw.Context.put" in report["checked_mro"], (
+        "the MRO check must have run for the p4p base every client flavour inherits its put from"
+    )
+    assert "ophyd_async.core._signal.SignalW.set" in report["checked_mro"], (
+        "the MRO check must have run for the ophyd-async base SignalRW inherits set from"
+    )
+
+    # --- and the skips have to be the two named reasons ---------------------
+    # A skip is how a check stops being a check, so an unexplained one is the
+    # quiet way this test would lose its teeth.
+    for skipped in report["skipped_mro"]:
+        assert skipped.endswith(("(immutable C type)", "(typing.Protocol)")), (
+            f"a base was skipped for an unnamed reason: {skipped}"
+        )
+    assert any(s.startswith("p4p._p4p.SharedPV.") for s in report["skipped_mro"]), (
+        "p4p's immutable C base is the floor write_surface documents; it has to "
+        "be reached and skipped, not silently absent"
+    )
+    assert any(s.startswith("bluesky.protocols.Movable.set") for s in report["skipped_mro"]), (
+        "the Movable protocol stub has to be reached and skipped"
+    )
+
+    # --- the guard must not break the import --------------------------------
+    cold_stdout = _run_probe(
+        tmp_path, "probe_cold_import.py", guard_path.read_text() + _COLD_IMPORT_PROBE
+    )
+    assert cold_stdout.strip() == "@@COLD-OK@@", (
+        f"importing Bluesky under the guard is not clean:\n{cold_stdout}"
+    )

--- a/tests/services/python_executor/execution/test_sandbox_step_reader.py
+++ b/tests/services/python_executor/execution/test_sandbox_step_reader.py
@@ -2,11 +2,11 @@
 
 ``max_step`` is the one limit that needs a fresh read, and the shared validator
 owns no control-system client. In the generated wrapper each guard supplies
-one: the Channel Access guard hands over the script's own ``epics.caget``, the
-p4p guard the very Context the put is going through, the Tango guard the
-DeviceProxy doing the write, the DOOCS guard ``doocs4py.get``, and the caproto
-guards that client's own read — so the step is measured over the client and the
-addressing the write itself uses.
+one: the Channel Access guard reads back through ``epics.ca.get`` on the
+channel id being written, the p4p guard the very Context the put is going
+through, the Tango guard the DeviceProxy doing the write, the DOOCS guard
+``doocs4py.get``, and the caproto guards that client's own read — so the step
+is measured over the client and the addressing the write itself uses.
 
 One client answers no reader: p4p's asyncio flavour has only a coroutine
 ``get``, and the validator is synchronous. There the step cannot be measured
@@ -46,29 +46,77 @@ def _step_validator(channel=CHANNEL):
     return LimitsValidator(limits, {"allow_unlisted_channels": False})
 
 
-def _install_fake_epics(monkeypatch, reads, writes):
-    mod = ModuleType("epics")
+def _raising_read(_channel):
+    """A Channel Access read that fails, as a disconnected channel's does."""
+    raise RuntimeError("channel is not connected")
 
-    def caget(pvname, timeout=None, **kwargs):
-        reads.append(pvname)
+
+def _absent_read(_channel):
+    """A Channel Access read that answers nothing, as a timed-out one does."""
+    return None
+
+
+def _install_fake_epics(monkeypatch, reads, writes, read=None):
+    """A pyepics whose three write spellings all funnel through ``ca.put``.
+
+    Real pyepics reaches the network from ``caput`` through ``PV.put`` and
+    from ``PV.put`` through ``ca.put``, which is why the guard sits on the
+    last of the three. Keeping that chain in the fake is what makes a test
+    written against ``caput`` an honest exercise of the wrapper.
+
+    ``read`` replaces what ``ca.get`` answers, and may raise: a client that
+    cannot read is the case a step check has to fail closed on.
+    """
+    mod = ModuleType("epics")
+    ca = ModuleType("epics.ca")
+
+    class _Chid:
+        """What ``epics.ca`` addresses a channel by: an opaque id, not a name."""
+
+        def __init__(self, pvname):
+            self.pvname = pvname
+
+    def name(chid):
+        return chid.pvname
+
+    def create_channel(pvname, **kwargs):
+        return _Chid(pvname)
+
+    def get(chid, timeout=None, **kwargs):
+        reads.append(name(chid))
+        if read is not None:
+            return read(name(chid))
         return CURRENT
 
-    def caput(pvname, value, wait=False, timeout=60, **kwargs):
-        writes.append((pvname, value))
+    def put(chid, value, wait=False, timeout=60, **kwargs):
+        writes.append((name(chid), value))
         return 1
+
+    ca.name = name
+    ca.create_channel = create_channel
+    ca.get = get
+    ca.put = put
 
     class PV:
         def __init__(self, pvname):
             self.pvname = pvname
+            self.chid = ca.create_channel(pvname)
 
         def put(self, value, wait=False, timeout=60, **kwargs):
-            writes.append((self.pvname, value))
-            return 1
+            return ca.put(self.chid, value, wait=wait, timeout=timeout, **kwargs)
 
+    def caget(pvname, timeout=None, **kwargs):
+        return ca.get(ca.create_channel(pvname), timeout=timeout)
+
+    def caput(pvname, value, wait=False, timeout=60, **kwargs):
+        return PV(pvname).put(value, wait=wait, timeout=timeout, **kwargs)
+
+    mod.ca = ca
     mod.caget = caget
     mod.caput = caput
     mod.PV = PV
     monkeypatch.setitem(sys.modules, "epics", mod)
+    monkeypatch.setitem(sys.modules, "epics.ca", ca)
     return mod
 
 
@@ -150,7 +198,7 @@ def _run_monkeypatch(monkeypatch, channel=CHANNEL):
 # ---------------------------------------------------------------------------
 
 
-def test_caput_measures_the_step_with_the_scripts_own_caget(monkeypatch):
+def test_caput_measures_the_step_with_the_scripts_own_ca_get(monkeypatch):
     reads: list = []
     writes: list = []
     epics = _install_fake_epics(monkeypatch, reads, writes)
@@ -174,7 +222,7 @@ def test_caput_beyond_max_step_never_reaches_the_control_system(monkeypatch):
     assert writes == []
 
 
-def test_pv_put_measures_the_step_with_the_scripts_own_caget(monkeypatch):
+def test_pv_put_measures_the_step_with_the_scripts_own_ca_get(monkeypatch):
     reads: list = []
     writes: list = []
     epics = _install_fake_epics(monkeypatch, reads, writes)
@@ -184,6 +232,46 @@ def test_pv_put_measures_the_step_with_the_scripts_own_caget(monkeypatch):
 
     assert reads == [CHANNEL]
     assert writes == [(CHANNEL, CURRENT + 1.0)]
+
+
+def test_ca_get_that_raises_fails_the_step_check_closed(monkeypatch):
+    """A read that blows up is not a step of zero — it is no measurement at all.
+
+    The guard swallows the error so the refusal names the missing measurement
+    rather than the client's own exception, but what it must never do is let
+    the write through: an unmeasured step is an unapproved one.
+    """
+    reads: list = []
+    writes: list = []
+    epics = _install_fake_epics(monkeypatch, reads, writes, read=_raising_read)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        epics.caput(CHANNEL, CURRENT + 0.5)
+
+    assert exc.value.violation_type == "STEP_CHECK_FAILED"
+    assert reads == [CHANNEL]
+    assert writes == []
+
+
+def test_ca_get_that_answers_none_fails_the_step_check_closed(monkeypatch):
+    """pyepics answers a timed-out read with ``None``, not an exception.
+
+    The step is as unmeasured as it is when the read raises, and the write is
+    inside ``max_step`` only if the current value is assumed — which is the
+    assumption the step check exists to refuse.
+    """
+    reads: list = []
+    writes: list = []
+    epics = _install_fake_epics(monkeypatch, reads, writes, read=_absent_read)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        epics.caput(CHANNEL, CURRENT + 0.5)
+
+    assert exc.value.violation_type == "STEP_CHECK_FAILED"
+    assert reads == [CHANNEL]
+    assert writes == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/python_executor/test_tool_gates.py
+++ b/tests/services/python_executor/test_tool_gates.py
@@ -12,6 +12,7 @@ execution.
 """
 
 import json
+import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -105,6 +106,22 @@ def _script(root, code):
     return target
 
 
+#: A whitespace-delimited token is a filesystem path when it opens -- after any
+#: quoting -- on a path separator or a drive letter. The path-policy refusal
+#: quotes the protected root it matched, and that root is an absolute path under
+#: whatever directory the checkout happens to live in. On a checkout named
+#: ``readonly-guard-hotfix`` the refusal text therefore contains "readonly"
+#: while blaming nothing at all. Prose words carry no separator, so dropping
+#: these tokens leaves every word the gate itself composed.
+_ABSOLUTE_PATH_TOKEN = re.compile(r"^[\"'(\[]*(?:[A-Za-z]:)?[\\/]")
+
+
+def _refusal_prose(envelope) -> str:
+    """The refusal's own words, lowercased, with absolute paths dropped."""
+    text = " ".join([envelope["error_message"], *envelope["suggestions"]])
+    return " ".join(word for word in text.split() if not _ABSOLUTE_PATH_TOKEN.match(word)).lower()
+
+
 def _refusal_records(audit_zone):
     """Every executor record this identity filed — the ledger is per-identity."""
     from osprey.audit.envelope import SURFACE_EXECUTOR
@@ -146,11 +163,51 @@ async def test_readwrite_wording_does_not_blame_readonly_mode(execution_mode, au
             execution_mode=execution_mode,
         )
 
-    text = " ".join([ctx["envelope"]["error_message"], *ctx["envelope"]["suggestions"]])
+    prose = _refusal_prose(ctx["envelope"])
     if execution_mode == "readwrite":
-        assert "readonly" not in text.lower()
+        assert "readonly" not in prose
     else:
-        assert "readwrite will not lift this" in text
+        assert "readwrite will not lift this" in prose
+
+
+class TestTheProseCheckIsBlindToTheCheckoutName:
+    """``_refusal_prose`` must drop the quoted paths and nothing else.
+
+    Both directions are pinned here because a helper that silently dropped too
+    much would turn the test above into one that can no longer fail: the point
+    of that test is that a readwrite caller is never told to try readwrite, and
+    the only reason to strip anything is that the protected root is spelled
+    with the checkout's own directory name in it.
+    """
+
+    def test_a_protected_root_under_a_readonly_named_checkout_is_not_blame(self):
+        envelope = {
+            "error_message": (
+                "This code writes into a location the deployment protects. "
+                "The path policy applies in every execution mode."
+            ),
+            "suggestions": [
+                "Write to 'build/config.yml' via open() is not allowed: the path is "
+                "inside the protected location "
+                "'/home/dev/checkouts/readonly-guard-hotfix/build'",
+                "Write analysis output under the agent data zone instead.",
+                "The write posture permits control-system writes; it does not "
+                "permit edits to OSPREY's own configuration.",
+            ],
+        }
+
+        assert "readonly" not in _refusal_prose(envelope)
+
+    def test_prose_that_blames_readonly_mode_is_still_caught(self):
+        envelope = {
+            "error_message": (
+                "This code writes into a location the deployment protects. "
+                "The path policy applies in every execution mode."
+            ),
+            "suggestions": ["Re-run this in readonly mode instead."],
+        }
+
+        assert "readonly" in _refusal_prose(envelope)
 
 
 @BOTH_MODES


### PR DESCRIPTION
Three security hotfixes for the python executor and ARIEL SQL search, plus one commit of repairs to the local CI gate and its tests.

## What was wrong

- **Readonly guard patched the name, not the object.** `aioca.caput`, p4p flavour Contexts and PyTango's `DeviceProxy` writes all survived the guard under a second spelling (`aioca._catools.caput`, `p4p.client.raw.Context.put`, `tango.Connection.command_inout`) and reached the machine. The guard now follows each attribute back to its defining module and refuses it there, matching on identity.
- **SQL allowlist resolved one identifier per FROM/JOIN.** `FROM enhanced_entries, pg_shadow` read an unchecked table; quoted identifiers, comments, `E'\''` strings, parenthesised joins and `TABLE name` hid targets the same way. The FROM list is now tokenised per depth; commas in a FROM clause, `"`, `--`, `/*`, `$` and backslash are refused; `TABLE name` is checked like a FROM target; CTE names count only where Postgres sees a declaration.
- **Limits checking covered pyepics, Tango attributes, caproto and DOOCS only.** aioca, pvaPy `Channel` setters, p4p's raw client and direct `epics.ca.put` bypassed the limits database, and a p4p payload passed as a JSON string passed a validator that could not read it. pyepics wrappers collapse onto the `ca.put` choke point; aioca, pvaPy and p4p raw are wrapped; p4p payloads are reduced to the number they carry.

## Deviations from the proposal

- Rows `("p4p._p4p", ("ClientOperation",))` and `("p4p.client.raw", ("_ClientOperation",))` are **not** added. The second breaks PVAccess reads (`raw.Context.get` resolves the same module global as `put`; confirmed in a subprocess probe). The first holds only by import order and is already covered by the import denylist. The immutable C type behind both is documented as a floor.
- Rows `("tango.Connection", ("command_inout", "command_inout_asynch"))` and `("tango.Group", (4 writes))` are **added**: PyTango defines the commands on `Connection`, so a `DeviceProxy`-only patch is a shadow; Group writes fan one value to every matched device.
- `pvaccess.Channel` row widened to `asyncPut`, `parsePut`, `parsePutGet`.
- In limits-checked runs all four Tango `Group` writes and all Tango commands are refused outright (per-device values are not bounded). `_LIMITS_NOT_YET_WRAPPED` holds exactly ten rows; a parity test pins the four-bucket partition to the table.
- The Tango monkeypatch success line now reports one clause per patched class; operator-visible text changed.

## CI and test hygiene (4th commit)

- `scripts/ci_check.sh`: `! make clean && make html` short-circuited so the docs step never built; `graph_index/test_scale.py` ignored as in ci.yml.
- `version.py`: dirty-tree date now UTC to match setuptools-scm node-and-date (parity test failed west of Greenwich).
- Three tests no longer write into `<repo>/var/agent_data` or `<repo>/var/audit`.
- `test_readwrite_wording_does_not_blame_readonly_mode` no longer fails in a checkout whose path contains "readonly".

## Not in this PR

- Two live-browser web_terminal tests flake under runner load (fail at `-n 4` loaded, pass quiet). Deferred to follow-ups; web_terminal tests are untouched here.
- Docs linkcheck's six broken links (four localhost examples, two external 403) pre-exist on main.
