### PR TITLE
feat(docs): publish pre-release tags into the version switcher

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,10 @@
 #   /            written ONLY by the newest release tag, so the site root always
 #                shows the newest release — never a development build.
 #   /vX.Y.Z/     one directory per vX.Y.Z release tag, rewritten only when that
-#                tag is re-published. Pre-release and component tags
-#                (v1.0.0rc1, osprey-connectors-v*) build but are not published.
+#                tag is re-published. A pre-release tag (v2026.9.0b1) publishes
+#                the same way — its own directory and switcher entry, never the
+#                root. Component tags (osprey-connectors-v*) build but are not
+#                published.
 #   /latest/     the development build from main, which renders a banner saying
 #                so and points readers at the released docs.
 #

--- a/scripts/ci/docs_publish.py
+++ b/scripts/ci/docs_publish.py
@@ -53,8 +53,18 @@ SITE_URL = "https://als-apg.github.io/osprey/"
 # but must never be treated as the stable release.
 RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
+# A pre-release of a release triple: the triple with a PEP 440 pre-segment
+# (`v2026.9.0b1`, `v1.0.0rc2`). A pre-release publishes into its own
+# directory and appears in the version switcher, but the site root and the
+# switcher's `preferred` entry always belong to a full release.
+PRE_RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(a|b|rc)(\d+)$")
+
+# Orders PEP 440 pre-segments within one release triple: `a` < `b` < `rc`,
+# and a full release outranks all three.
+_PRE_RANK = {"a": 0, "b": 1, "rc": 2}
+
 # Root entries a release's root refresh must not delete, beyond the `vX.Y.Z`
-# directories `RELEASE_TAG_RE` matches. `latest` is the development build;
+# directories `RELEASE_TAG_RE` and `PRE_RELEASE_TAG_RE` match. `latest` is the development build;
 # `CNAME` is GitHub Pages' custom-domain file, which no Sphinx build produces
 # and whose deletion takes the custom domain offline.
 ROOT_KEEP = frozenset({"latest", "CNAME"})
@@ -108,6 +118,32 @@ def release_tags(tags: Iterable[str]) -> list[str]:
     return [tag for _, tag in parsed]
 
 
+def pre_release_tags(tags: Iterable[str]) -> list[str]:
+    """Return the pre-release tags among `tags`, newest first.
+
+    Same tolerance as `release_tags` for raw `git tag` output. Ordered by the
+    release triple, then the pre-segment (`a` < `b` < `rc`), then its number,
+    so `v2026.9.0rc1` outranks `v2026.9.0b2`.
+    """
+    parsed: list[tuple[tuple[int, int, int, int, int], str]] = []
+    for raw in tags:
+        tag = raw.strip()
+        if not tag:
+            continue
+        match = PRE_RELEASE_TAG_RE.fullmatch(tag)
+        if match is None:
+            continue
+        major, minor, patch, segment, number = match.groups()
+        parsed.append(
+            (
+                (int(major), int(minor), int(patch), _PRE_RANK[segment], int(number)),
+                tag,
+            )
+        )
+    parsed.sort(key=lambda item: item[0], reverse=True)
+    return [tag for _, tag in parsed]
+
+
 def plan(ref: str, event: str, input_tag: str, tags: Iterable[str]) -> Plan:
     """Decide what the current build publishes, and where.
 
@@ -118,11 +154,13 @@ def plan(ref: str, event: str, input_tag: str, tags: Iterable[str]) -> Plan:
        any branch. It must be a full `vX.Y.Z`; anything else raises
        `PlanError` rather than guessing at what was meant.
     2. A `refs/tags/vX.Y.Z` push publishes that release into its own
-       directory, and rewrites the site root if it is the newest release.
-    3. Any other tag ref -- `v2026.7`, `v1.0.0rc1`,
-       `osprey-connectors-v0.1.0` -- builds but does not deploy. This
-       workflow and `release.yml` share loose `v*`-style triggers, so such
-       refs arrive here routinely and must not reach the site.
+       directory, and rewrites the site root if it is the newest release. A
+       pre-release tag push (`vX.Y.Z{a|b|rc}N`) publishes into its own
+       directory and switcher entry only -- never the root.
+    3. Any other tag ref -- `v2026.7`, `osprey-connectors-v0.1.0`,
+       `checkpoint-*` -- builds but does not deploy. This workflow and
+       `release.yml` share loose `v*`-style triggers, so such refs arrive
+       here routinely and must not reach the site.
     4. `refs/heads/main` publishes `/latest/` and is **never** `is_latest` --
        for every possible tag list, including one where the tag `git
        describe` would name on main is the newest release, and including no
@@ -149,22 +187,31 @@ def plan(ref: str, event: str, input_tag: str, tags: Iterable[str]) -> Plan:
     """
     tag = input_tag.strip()
     if tag:
-        if RELEASE_TAG_RE.fullmatch(tag) is None:
+        if RELEASE_TAG_RE.fullmatch(tag) is None and PRE_RELEASE_TAG_RE.fullmatch(tag) is None:
             raise PlanError(
-                f"tag input {tag!r} is not a release tag; expected the form "
-                "vX.Y.Z, for example v2026.6.2"
+                f"tag input {tag!r} is not a release or pre-release tag; "
+                "expected the form vX.Y.Z or vX.Y.Z{a|b|rc}N, for example "
+                "v2026.6.2 or v2026.9.0b1"
             )
     elif ref.startswith("refs/tags/"):
         candidate = ref[len("refs/tags/") :]
-        if RELEASE_TAG_RE.fullmatch(candidate) is None:
-            # A build of a pre-release or a component tag: useful to have
-            # succeed, but it has no place on the published site.
+        if (
+            RELEASE_TAG_RE.fullmatch(candidate) is None
+            and PRE_RELEASE_TAG_RE.fullmatch(candidate) is None
+        ):
+            # A build of a component or otherwise unrecognized tag: useful to
+            # have succeed, but it has no place on the published site.
             return Plan(version="dev", deploy_dir="pr-preview", is_latest=False, deploy=False)
         tag = candidate
     elif ref == "refs/heads/main":
         return Plan(version="dev", deploy_dir="latest", is_latest=False, deploy=True)
     else:
         return Plan(version="dev", deploy_dir="pr-preview", is_latest=False, deploy=False)
+
+    if PRE_RELEASE_TAG_RE.fullmatch(tag):
+        # A pre-release owns its own directory and nothing else: the root and
+        # `is_latest` belong to full releases only.
+        return Plan(version=tag[1:], deploy_dir=tag, is_latest=False, deploy=True)
 
     known = release_tags(tags)
     return Plan(
@@ -204,7 +251,8 @@ def stage(
     root forever, still linked from search engines and still claiming to be
     current documentation. Clearing the root first makes removals propagate.
 
-    That clearing skips `latest/` and every `vX.Y.Z/` directory, because those
+    That clearing skips `latest/` and every release and pre-release
+    directory, because those
     are other builds' output, not stale copies of this one. Wiping them would
     take every archived release and the development build offline the moment a
     release was published -- and the release's own directory is itself a
@@ -232,7 +280,11 @@ def stage(
 
     if p.is_latest:
         for entry in sorted(deployment.iterdir()):
-            if entry.name in ROOT_KEEP or RELEASE_TAG_RE.fullmatch(entry.name):
+            if (
+                entry.name in ROOT_KEEP
+                or RELEASE_TAG_RE.fullmatch(entry.name)
+                or PRE_RELEASE_TAG_RE.fullmatch(entry.name)
+            ):
                 continue
             _remove(entry)
         _copy_into(build, deployment)
@@ -293,9 +345,39 @@ def versions(tags: Iterable[str], deployment: Path) -> list[dict[str, object]]:
                 "preferred": True,
             }
         )
-        for tag in rt[1:]:
-            if (deployment / tag).is_dir():
-                entries.append({"name": tag, "version": tag[1:], "url": f"{SITE_URL}{tag}/"})
+    # Older releases and pre-releases share the non-preferred rows, ordered by
+    # version so a pre-release sits beside the releases it precedes; a full
+    # release outranks its own pre-releases. Entries appear only when their
+    # directory exists in `deployment`.
+    ranked: list[tuple[tuple[int, int, int, int, int], dict[str, object]]] = []
+    for tag in rt[1:]:
+        if (deployment / tag).is_dir():
+            match = RELEASE_TAG_RE.fullmatch(tag)
+            assert match is not None
+            major, minor, patch = (int(g) for g in match.groups())
+            ranked.append(
+                (
+                    (major, minor, patch, len(_PRE_RANK), 0),
+                    {"name": tag, "version": tag[1:], "url": f"{SITE_URL}{tag}/"},
+                )
+            )
+    for tag in pre_release_tags(tags):
+        if (deployment / tag).is_dir():
+            match = PRE_RELEASE_TAG_RE.fullmatch(tag)
+            assert match is not None
+            major, minor, patch, segment, number = match.groups()
+            ranked.append(
+                (
+                    (int(major), int(minor), int(patch), _PRE_RANK[segment], int(number)),
+                    {
+                        "name": f"{tag} (pre-release)",
+                        "version": tag[1:],
+                        "url": f"{SITE_URL}{tag}/",
+                    },
+                )
+            )
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    entries.extend(entry for _, entry in ranked)
     if (deployment / "latest").is_dir():
         entries.append(
             {

--- a/tests/deployment/conftest.py
+++ b/tests/deployment/conftest.py
@@ -32,12 +32,16 @@ def running_a_released_osprey(monkeypatch):
     checkout, so without this every argv-shape test here would trip that refusal
     instead of asserting on the argv it cares about.
 
-    Tests that are *about* the refusal re-patch these inside the test body, which
-    takes precedence — see ``TestResolvePipSpec`` in
-    ``test_container_lifecycle.py``.
+    Only ``is_release`` is patched — the refusal is keyed on it alone.
+    ``get_release_version`` stays real: pinning it to a literal here would
+    disagree with any provenance stamped outside this fixture's function scope
+    (a module-scoped fixture builds before autouse function fixtures apply), and
+    the staleness advisory reads that disagreement as drift on an untouched
+    build. Tests that assert an exact pin string patch ``get_release_version``
+    inside their own bodies, which takes precedence — see ``TestResolvePipSpec``
+    in ``test_container_lifecycle.py``.
     """
     monkeypatch.setattr("osprey.version.is_release", lambda: True)
-    monkeypatch.setattr("osprey.version.get_release_version", lambda: "2026.6.2")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/deployment/test_container_project_layout.py
+++ b/tests/deployment/test_container_project_layout.py
@@ -302,13 +302,18 @@ def built_repo(tmp_path_factory) -> Path:
     ``seed_env=True`` because a repo with no ``.env`` cannot show that the
     contexts carry none: the secret has to exist to be kept out.
     """
-    from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, build_exemplar_repo
+    from tests.fixtures.lifecycle_repo import (
+        EXEMPLAR_DIRNAME,
+        build_exemplar_repo,
+        preserved_environ,
+    )
 
     repo = build_exemplar_repo(tmp_path_factory.mktemp("layout") / EXEMPLAR_DIRNAME, seed_env=True)
     previous = Path.cwd()
     os.chdir(repo)
     try:
-        result = CliRunner().invoke(build_command, ["--skip-deps", "--skip-lifecycle"])
+        with preserved_environ():
+            result = CliRunner().invoke(build_command, ["--skip-deps", "--skip-lifecycle"])
     finally:
         os.chdir(previous)
     assert result.exit_code == 0, result.output
@@ -557,7 +562,11 @@ def test_a_regenerable_file_under_a_fold_input_is_neither_folded_nor_shipped(
     before). Reversing the order passes the first and fails the second.
     """
     from osprey.deployment.staleness import DriftState, check_drift
-    from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, build_exemplar_repo
+    from tests.fixtures.lifecycle_repo import (
+        EXEMPLAR_DIRNAME,
+        build_exemplar_repo,
+        preserved_environ,
+    )
 
     repo = build_exemplar_repo(tmp_path_factory.mktemp("regenerable") / EXEMPLAR_DIRNAME)
     data_root = repo / "data"
@@ -569,7 +578,8 @@ def test_a_regenerable_file_under_a_fold_input_is_neither_folded_nor_shipped(
     previous = Path.cwd()
     os.chdir(repo)
     try:
-        result = CliRunner().invoke(build_command, ["--skip-deps", "--skip-lifecycle"])
+        with preserved_environ():
+            result = CliRunner().invoke(build_command, ["--skip-deps", "--skip-lifecycle"])
     finally:
         os.chdir(previous)
     assert result.exit_code == 0, result.output

--- a/tests/deployment/test_live_standin_persona_render.py
+++ b/tests/deployment/test_live_standin_persona_render.py
@@ -52,7 +52,11 @@ from osprey.cli.build_cmd import build as build_command
 from osprey.deployment.reach import reach_errors
 from osprey.mcp_server.control_system.connector_host_manager import target_display_metadata
 from osprey_connectors.standin import archive_belongs_to_standin
-from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, build_exemplar_repo
+from tests.fixtures.lifecycle_repo import (
+    EXEMPLAR_DIRNAME,
+    build_exemplar_repo,
+    preserved_environ,
+)
 
 #: Every test here renders a deployment and its personas for real.
 pytestmark = pytest.mark.slow
@@ -103,7 +107,8 @@ def _build_exemplar(dest: Path, *, standin: int | None) -> Path:
     previous = Path.cwd()
     os.chdir(repo)
     try:
-        result = CliRunner().invoke(build_command, CI_FLAGS)
+        with preserved_environ():
+            result = CliRunner().invoke(build_command, CI_FLAGS)
     finally:
         os.chdir(previous)
     assert result.exit_code == 0, result.output

--- a/tests/deployment/test_persona_render_e2e.py
+++ b/tests/deployment/test_persona_render_e2e.py
@@ -40,7 +40,11 @@ from osprey.cli.repo_resolver import PROFILE_FILENAME
 from osprey.deployment.staleness import DriftState, check_drift
 from osprey.deployment.web_terminals.persona_images import verify_persona_renders
 from osprey.deployment.web_terminals.personas import resolve_personas
-from tests.fixtures.lifecycle_repo import EXEMPLAR_DIRNAME, build_exemplar_repo
+from tests.fixtures.lifecycle_repo import (
+    EXEMPLAR_DIRNAME,
+    build_exemplar_repo,
+    preserved_environ,
+)
 
 #: Every test here renders for real — seconds each, not milliseconds — which is
 #: the property that makes them worth having and the reason they are marked.
@@ -61,7 +65,8 @@ def _run_build(repo: Path) -> None:
     previous = Path.cwd()
     os.chdir(repo)
     try:
-        result = CliRunner().invoke(build_command, CI_FLAGS)
+        with preserved_environ():
+            result = CliRunner().invoke(build_command, CI_FLAGS)
     finally:
         os.chdir(previous)
     assert result.exit_code == 0, result.output
@@ -300,7 +305,8 @@ def test_a_persona_that_will_not_resolve_leaves_the_previous_build_untouched(bui
     previous = Path.cwd()
     os.chdir(built_repo)
     try:
-        result = CliRunner().invoke(build_command, CI_FLAGS)
+        with preserved_environ():
+            result = CliRunner().invoke(build_command, CI_FLAGS)
     finally:
         os.chdir(previous)
     assert result.exit_code != 0, result.output

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -74,6 +74,7 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 import subprocess
@@ -3019,6 +3020,27 @@ def exemplar_source_files(*, with_ci: bool = False) -> dict[str, str]:
     if with_ci:
         files.update(CI_PIPELINE_FILES)
     return {path: expand_sentinels(text) for path, text in files.items()}
+
+
+@contextlib.contextmanager
+def preserved_environ():
+    """Confine a repo's ``.env`` to the code run inside this block.
+
+    Loading a project config exports its ``.env`` into ``os.environ``
+    (``ConfigBuilder`` → ``load_dotenv(override=True)``) — correct for the real
+    CLI, where the process exits afterwards, but an in-process build in a test
+    shares its process with every test after it. A leaked seeded token then
+    changes later tests' behavior: the service-token mint treats a var already
+    present in the process env as operator-provided and writes no ``.env`` at
+    all. Wrap every in-process ``osprey build`` (or config load) of a repo that
+    carries a ``.env`` in this guard.
+    """
+    snapshot = os.environ.copy()
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(snapshot)
 
 
 def build_exemplar_repo(

--- a/tests/scripts/test_docs_publish.py
+++ b/tests/scripts/test_docs_publish.py
@@ -132,7 +132,6 @@ class TestPlan:
         "ref",
         [
             "refs/tags/v2026.7",
-            "refs/tags/v1.0.0rc1",
             "refs/tags/v1.0.0-rc1",
             "refs/tags/osprey-connectors-v0.1.0",
             "refs/tags/checkpoint-final",
@@ -143,6 +142,32 @@ class TestPlan:
         result = docs_publish.plan(ref, "push", "", ["v2026.6.2"])
         assert result == docs_publish.Plan(
             version="dev", deploy_dir="pr-preview", is_latest=False, deploy=False
+        )
+
+    # -- rule 2, pre-release half ---------------------------------------------
+
+    def test_pre_release_tag_deploys_to_its_own_directory_only(self):
+        """A pre-release owns its directory; the root belongs to full releases."""
+        result = docs_publish.plan(
+            "refs/tags/v2026.9.0b1", "push", "", ["v2026.6.2", "v2026.9.0b1"]
+        )
+        assert result == docs_publish.Plan(
+            version="2026.9.0b1", deploy_dir="v2026.9.0b1", is_latest=False, deploy=True
+        )
+
+    def test_pre_release_is_not_latest_even_as_the_newest_tag(self):
+        """Newest by version still never rewrites the site root."""
+        result = docs_publish.plan("refs/tags/v2026.9.0b1", "push", "", ["v2026.9.0b1"])
+        assert result.deploy is True
+        assert result.is_latest is False
+
+    def test_pre_release_input_tag_is_accepted(self):
+        """A pre-release can be re-published via workflow_dispatch."""
+        result = docs_publish.plan(
+            "refs/heads/main", "workflow_dispatch", "v2026.9.0b1", ["v2026.6.2"]
+        )
+        assert result == docs_publish.Plan(
+            version="2026.9.0b1", deploy_dir="v2026.9.0b1", is_latest=False, deploy=True
         )
 
     # -- rule 5: everything else ----------------------------------------------
@@ -287,6 +312,7 @@ class TestStage:
                 "_static/old.css": "old css",
                 "latest/index.html": "development build",
                 "v2026.6.1/index.html": "archived release",
+                "v2026.9.0b1/index.html": "beta docs",
             },
         )
         deployment = tmp_path / "deployment"
@@ -297,6 +323,7 @@ class TestStage:
             _release_plan("v2026.6.2", is_latest=True),
         )
 
+        assert (deployment / "v2026.9.0b1" / "index.html").read_text() == "beta docs"
         assert not (deployment / "how-to").exists()
         assert not (deployment / "_static" / "old.css").exists()
         assert (deployment / "index.html").read_text() == "new root"
@@ -466,6 +493,34 @@ class TestVersions:
         _seed(tmp_path, {"v2026.6.2/index.html": "", "v2026.6.1/index.html": ""})
         entries = docs_publish.versions(["v2026.6.1", "v2026.6.2"], tmp_path)
         assert [entry["name"] for entry in entries] == ["v2026.6.2 (stable)", "v2026.6.1"]
+
+    def test_pre_release_appears_labeled_and_never_preferred(self, tmp_path):
+        """A published pre-release is offered, but the stable root stays preferred."""
+        _seed(tmp_path, {"v2026.9.0b1/index.html": "", "v2026.6.1/index.html": ""})
+        entries = docs_publish.versions(["v2026.6.1", "v2026.6.2", "v2026.9.0b1"], tmp_path)
+        assert [entry["name"] for entry in entries] == [
+            "v2026.6.2 (stable)",
+            "v2026.9.0b1 (pre-release)",
+            "v2026.6.1",
+        ]
+        assert [entry for entry in entries if entry.get("preferred")][0]["name"] == (
+            "v2026.6.2 (stable)"
+        )
+
+    def test_pre_release_without_a_directory_is_skipped(self, tmp_path):
+        """A pre-release tag with no published tree must not become a dead link."""
+        entries = docs_publish.versions(["v2026.6.2", "v2026.9.0b1"], tmp_path)
+        assert all("pre-release" not in str(entry["name"]) for entry in entries)
+
+    def test_pre_release_ranks_below_its_own_full_release(self, tmp_path):
+        """Once vX.Y.Z ships, its pre-releases sort beneath it, not above."""
+        _seed(tmp_path, {"v2026.9.0/index.html": "", "v2026.9.0b1/index.html": ""})
+        entries = docs_publish.versions(["v2026.9.0", "v2026.9.0b1", "v2026.10.0"], tmp_path)
+        assert [entry["name"] for entry in entries] == [
+            "v2026.10.0 (stable)",
+            "v2026.9.0",
+            "v2026.9.0b1 (pre-release)",
+        ]
 
     def test_stray_and_non_release_tags_are_ignored(self, tmp_path):
         """The switcher must not offer a backup tag as a documentation version."""


### PR DESCRIPTION
Pre-release tags (`v2026.9.0b1`) now publish like releases minus the root: their own `/vX.Y.ZbN/` directory and a version-switcher entry labeled *(pre-release)*, never `preferred`. The root refresh keeps pre-release directories, and `workflow_dispatch` accepts a pre-release tag input for re-publishing.

Motivation: the beta shipped with no docs entry in the picker — the docs workflow built the tag but deliberately dropped it. After merge, dispatching docs.yml with tag `v2026.9.0b1` publishes the beta docs (the workflow prefers the default-branch copy of the helper for tag builds).