### PR TITLE
fix(platform): derive browser-facing URLs from the deployment origin; stop hard-coding runtime, container paths and browser/OS specifics

### DIFF
--- a/changelog.d/deployment-origin.fixed.md
+++ b/changelog.d/deployment-origin.fixed.md
@@ -1,0 +1,6 @@
+Browser-facing links now follow the deployment's own origin — the dispatcher's
+telemetry link, the login URL `osprey web` prints, the CI environment URL — and
+are omitted rather than guessed where no origin is derivable. Assumptions about
+the machine are checked instead of asserted: the container runtime, container
+paths, the home directory, Docker Desktop, and the browser and OS the terminal
+is open in.

--- a/docs/source/how-to/deploy-project/project-image.rst
+++ b/docs/source/how-to/deploy-project/project-image.rst
@@ -521,15 +521,19 @@ Two kinds of state are worth persisting across container restarts:
   it lands in the same place whether the project is flat, a deployment
   repository, or this image — unless the deployment relocates
   ``agent_data.base_dir``, which moves the backups with it.
-- ``/home/osprey`` — the agent CLI's per-user state (sessions, credentials);
-  set ``CLAUDE_CONFIG_DIR`` if you want it somewhere more explicit.
+- ``/home/osprey`` — the agent CLI's per-user state (sessions, credentials).
+  Set ``CLAUDE_CONFIG_DIR`` to this directory: it is the only variable that
+  names the durable store scaffold claims are recorded in, and without it a
+  claim made from the running deployment is lost when the container is
+  recreated. The deployment logs a warning at startup when it is unset.
 
 Kubernetes notes
 ----------------
 
-- Give each user/instance a PVC for ``/home/osprey`` (or
-  ``CLAUDE_CONFIG_DIR``) and one for ``var/agent_data/`` — session state does
-  not survive pod rescheduling otherwise.
+- Give each user/instance a PVC for ``/home/osprey`` and one for
+  ``var/agent_data/`` — session state does not survive pod rescheduling
+  otherwise. Point ``CLAUDE_CONFIG_DIR`` at that first PVC; scaffold claims are
+  recorded there and nowhere else.
 - The image has no ``USER``: it starts as root and drops to uid 1000 itself
   (see `The Privilege Split`_). A ``securityContext`` with
   ``runAsNonRoot: true`` therefore refuses the pod, and one pinning

--- a/docs/source/how-to/health-and-monitoring/monitor-agent.rst
+++ b/docs/source/how-to/health-and-monitoring/monitor-agent.rst
@@ -419,3 +419,12 @@ Caveats
   the store's published port (``services.openobserve.port``, 10050 by default)
   beyond the host without putting authentication and transport security in
   front of it.
+- **The dashboard's per-run telemetry link follows the deployment's origin.**
+  The event dispatcher's dashboard links each run to its own records only when
+  it can name a host a browser will resolve. On a loopback-bound store that host
+  is ``localhost``. On a store published to the network it is the host of
+  ``modules.web_terminals.external_origin`` (or ``deploy.fqdn`` when that is
+  unset). A store published to the network by a deployment that declares
+  neither gets no link at all, rather than one pointing at whichever machine the
+  operator's browser happens to be. The link is rendered at deploy time, so
+  changing either value takes effect at the next ``osprey up``.

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -475,6 +475,12 @@ it as a bare origin — scheme, host, port if non-default, no path.
 host; with nothing terminating TLS, anyone watching the traffic can become
 that user.
 
+A single-user ``osprey web`` behind the same kind of TLS terminator sets
+``OSPREY_TERMINAL_EXTERNAL_ORIGIN`` to that address instead. It is the same
+origin every terminal checks a state-changing request against, and the login
+URL ``osprey web`` prints is built from it — without it the printed URL names
+the bind address, and a browser arriving from it has every write refused.
+
 Passwords, and where they live
 ==============================
 

--- a/docs/source/reference/contracts/ariel.rst
+++ b/docs/source/reference/contracts/ariel.rst
@@ -301,7 +301,7 @@ The web interface discovers its search modes and tunable parameters dynamically 
 
          1. **Registry bootstrap** --- pre-creates the framework registry singleton (without an application registry path) so that ARIEL's search module discovery works even when running outside a full Osprey application.
 
-         2. **Config loading** --- searches for ``config.yml`` in four locations: the provided ``config_path``, ``/app/config.yml`` (Docker mount), the ``CONFIG_FILE`` environment variable, and the current directory. The DSN is then resolved by ``resolve_ariel_dsn``, which applies the ``ARIEL_DATABASE_HOST`` and ``ARIEL_DATABASE_PORT`` overrides for Docker networking.
+         2. **Config loading** --- searches for ``config.yml`` in four locations: the provided ``config_path``, the ``CONFIG_FILE`` environment variable, ``/app/config.yml`` (a hand-authored container mount), and the current directory. The DSN is then resolved by ``resolve_ariel_dsn``, which applies the ``ARIEL_DATABASE_HOST`` and ``ARIEL_DATABASE_PORT`` overrides for Docker networking.
 
          3. **Service creation** --- creates the ``ARIELSearchService`` from the loaded config and stores it in ``app.state.ariel_service``.
 

--- a/packages/osprey-connectors/src/osprey_connectors/config.py
+++ b/packages/osprey-connectors/src/osprey_connectors/config.py
@@ -1007,20 +1007,19 @@ def get_agent_dir(sub_dir: str, host_path: bool = False) -> str:
             path = project_root_path / agent_data_root / sub_dir_path
         else:
             if not project_root_path.exists():
-                container_project_roots = ["/app", "/pipelines", "/jupyter"]
-                detected_container_root = None
-
-                for container_root in container_project_roots:
-                    container_path = Path(container_root)
-                    if container_path.exists() and (container_path / agent_data_root).exists():
-                        detected_container_root = container_path
-                        break
-
-                if detected_container_root:
+                # A configured root written on the host does not exist inside a
+                # container. ``CONFIG_FILE`` names the config this process
+                # actually loaded, so its directory IS the project root here —
+                # a fact rather than the guess at a container layout this used
+                # to make.
+                config_file = os.environ.get("CONFIG_FILE")
+                anchor = Path(config_file).parent if config_file else None
+                if anchor is not None and anchor.exists():
                     logger.debug(
-                        f"Container environment detected: using {detected_container_root} instead of {project_root}"
+                        f"Configured project root {project_root} is absent; anchoring on "
+                        f"CONFIG_FILE's directory {anchor}"
                     )
-                    path = detected_container_root / agent_data_root / sub_dir_path
+                    path = anchor / agent_data_root / sub_dir_path
                 else:
                     logger.warning(f"Configured project root does not exist: {project_root}")
                     logger.warning("Falling back to relative path resolution")

--- a/src/osprey/cli/deploy_scaffold_templates.py
+++ b/src/osprey/cli/deploy_scaffold_templates.py
@@ -240,6 +240,11 @@ class CIContext:
         deploy_path: The checkout's absolute path on that host.
         service_images: Profile-owned services that get an image-build job.
         external_projects: Other projects' images this deployment also pulls.
+        environment_url: The address browsers open this deployment at, or
+            ``None`` when it has no web tier to link to. The forge shows it as
+            the environment's link, so it is derived from the one origin
+            authority rather than assembled here (see
+            :func:`_environment_url`).
         runs_verify_on_up: Whether ``osprey up`` runs the health check itself.
             True only with the web tier enabled — the post-up hook that runs
             ``scripts/verify.sh`` sits on the deploy's web-terminal branch, so
@@ -259,6 +264,7 @@ class CIContext:
     deploy_path: str
     service_images: list[str] = field(default_factory=list)
     external_projects: list[dict[str, str]] = field(default_factory=list)
+    environment_url: str | None = None
     runs_verify_on_up: bool = False
 
     @property
@@ -505,8 +511,59 @@ def build_ci_context(
             }
             for project in deploy.external_projects
         ],
+        environment_url=_environment_url(profile),
         runs_verify_on_up=_web_terminals(profile) is not None,
     )
+
+
+def _environment_url(profile: dict[str, Any]) -> str | None:
+    """The address browsers open this deployment at, or ``None``.
+
+    The forge renders this as the environment's link, so it is the same
+    browser-facing address the landing page carries and every terminal checks a
+    write against — which the deployment already derives once
+    (:func:`osprey.deployment.web_terminals.render._external_origin`). Deriving
+    it a second time here is what produced ``https://$DEPLOY_HOST``: the SSH
+    coordinate under an asserted scheme, with the published port dropped.
+
+    A profile's ``config:`` overlay is a flat bag of dotted keys rather than a
+    rendered config, so it is re-wrapped into the shape the resolver takes —
+    the same re-wrap the landing-page probe does.
+
+    Args:
+        profile: The resolved raw profile dict.
+
+    Returns:
+        The origin, or ``None`` when this deployment has no web tier, names no
+        ``deploy.fqdn`` and declares no ``external_origin`` — there is then no
+        address to link to, and the pipeline emits no ``url:`` at all rather
+        than one nothing answers on.
+    """
+    from osprey.deployment.web_terminals.render import (
+        _auth_tls_context,
+        _external_origin,
+        resolve_nginx_port,
+    )
+
+    web = _web_terminals(profile)
+    if web is None:
+        return None
+    profile_config = _config_block(profile)
+    root = {
+        "deployment": {"port_base": _dotted(profile_config, PORT_BASE_CONFIG_KEY)},
+        "modules": {"web_terminals": web},
+        "deploy": {"fqdn": _dotted(profile_config, "deploy.fqdn")},
+    }
+    tls = _auth_tls_context(web)
+    try:
+        return _external_origin(
+            root,
+            resolve_nginx_port(root),
+            tls_enabled=bool(tls["tls_enabled"]),
+            tls_port=int(tls["tls_port"]),
+        )
+    except ValueError:
+        return None
 
 
 def build_verify_context(

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -1439,9 +1439,10 @@ def init(
             # and continuing without one walks into the stale-volume refusal
             # further down, whose remedy is `osprey reset`: the very thing that
             # just declined. Stop here and name the actual obstacle instead.
-            survivors = _surviving_project_resources(target)
+            runtime = _runtime_binary()
+            survivors = _surviving_project_resources(target, runtime)
             if survivors:
-                _abort_incomplete_reset(target, survivors)
+                _abort_incomplete_reset(target, survivors, runtime)
 
         if start:
             _chain_up(ctx, target, detached=detached, dev=dev)
@@ -1454,7 +1455,7 @@ def init(
         print_summary_card(target, "running" if start else "created")
 
 
-def _surviving_project_resources(target: Path) -> list[str]:
+def _surviving_project_resources(target: Path, runtime: str) -> list[str]:
     """Containers and volumes still labelled for this project after a reset.
 
     Read-only, and label-scoped to the compose project rather than to the
@@ -1465,14 +1466,20 @@ def _surviving_project_resources(target: Path) -> list[str]:
     An unreachable runtime yields ``[]`` — a reset that could not run at all has
     already failed loudly, and inventing a second failure here would only bury
     the first.
+
+    Args:
+        target: The project directory ``--reset`` was asked to clear.
+        runtime: The container runtime binary this host resolves
+            (:func:`_runtime_binary`). Passed in rather than resolved here so
+            the probe and the refusal that reports its findings can only ever
+            name the same binary.
     """
     from osprey.deployment.compose_generator import resolve_project_name
     from osprey.deployment.reset import RuntimeProbe
-    from osprey.deployment.runtime_helper import get_runtime_command
 
     project = resolve_project_name({"project_name": target.name})
     try:
-        probe = RuntimeProbe(get_runtime_command({})[0])
+        probe = RuntimeProbe(runtime)
         return [
             f"{resource.kind} {resource.name}"
             for resource in (
@@ -1520,8 +1527,35 @@ def _abort_foreign_reset(
     raise click.Abort()
 
 
-def _abort_incomplete_reset(target: Path, survivors: list[str]) -> None:
-    """Stop a ``--reset`` that could not actually clear the name it was given."""
+def _runtime_binary() -> str:
+    """The container runtime binary this host resolves.
+
+    Resolved once for the ``--reset`` sweep: the probe below runs it and the
+    refusal prints it, and a remedy naming a runtime other than the one that
+    found the resources would not be a command the operator can paste. An
+    unresolvable runtime falls back to ``docker`` — the refusal must still
+    print something to run, and a probe against a runtime that is not there
+    fails the same way either resolution would.
+    """
+    from osprey.deployment.runtime_helper import get_runtime_command
+
+    try:
+        return get_runtime_command({})[0]
+    except Exception:
+        return "docker"
+
+
+def _abort_incomplete_reset(target: Path, survivors: list[str], runtime: str) -> None:
+    """Stop a ``--reset`` that could not actually clear the name it was given.
+
+    Args:
+        target: The project directory ``--reset`` was asked to clear.
+        survivors: The labelled resources the sweep left behind.
+        runtime: The container runtime binary this host resolves
+            (:func:`_runtime_binary`), which the printed commands are spelled
+            with. The compose project LABEL keeps its ``com.docker.compose``
+            name on every runtime — podman-compose writes it too.
+    """
     logger.error(
         "✗ --reset could not clear %s: %d resource(s) of this project remain.\n\n%s\n\n"
         "`osprey reset` removes only what carries this checkout's `com.osprey.repo-id` "
@@ -1530,15 +1564,19 @@ def _abort_incomplete_reset(target: Path, survivors: list[str]) -> None:
         "from destroying another's.\n\n"
         "Remove them yourself, once, and every later deployment of this name will carry the "
         "label and reset cleanly:\n"
-        "    docker ps -aq --filter label=com.docker.compose.project=%s | xargs docker rm -f\n"
-        "    docker volume ls -q --filter label=com.docker.compose.project=%s | xargs docker "
+        "    %s ps -aq --filter label=com.docker.compose.project=%s | xargs %s rm -f\n"
+        "    %s volume ls -q --filter label=com.docker.compose.project=%s | xargs %s "
         "volume rm\n\n"
         "Nothing was built and nothing was started.",
         target.name,
         len(survivors),
         "\n".join(f"    {line}" for line in survivors),
+        runtime,
         target.name,
+        runtime,
+        runtime,
         target.name,
+        runtime,
     )
     raise click.Abort()
 

--- a/src/osprey/cli/sim.py
+++ b/src/osprey/cli/sim.py
@@ -152,7 +152,9 @@ def _echo_physics_notice(config: dict, rendered: dict[str, str]) -> None:
     else:
         output.report("Cleared the previous scenario's physics fault from .env.")
     output.note("The virtual accelerator reads this only when its container is created.")
-    output.note("Run 'osprey up' to recreate it. 'docker restart' reuses the old environment.")
+    output.note(
+        "Run 'osprey up' to recreate it. Restarting the container reuses the old environment."
+    )
 
 
 def _confirm_archive_rewrite(store: dict) -> None:

--- a/src/osprey/cli/summary_card.py
+++ b/src/osprey/cli/summary_card.py
@@ -35,9 +35,12 @@ logger = get_logger("cli.summary_card")
 
 #: What to do next, per state. Only ``running`` is reachable-anywhere, so it is
 #: the only state whose card carries endpoints.
+#: ``osprey web`` is named alongside ``osprey up -d`` because a deployment that
+#: declares no containerized services has no other way in, and nothing else on
+#: this card says so.
 _NEXT_STEPS = {
-    "created": "osprey build · osprey up -d",
-    "built": "osprey up -d · osprey status",
+    "created": "osprey build · osprey up -d  (no containers: osprey web)",
+    "built": "osprey up -d · osprey status  (no containers: osprey web)",
     "running": "osprey status · osprey logs · osprey down",
     "stopped": "osprey up -d · osprey status",
 }
@@ -117,7 +120,7 @@ def _card_parts(repo_root: Path | str, state: str) -> tuple[str, list[tuple[str,
         rows += [
             (service, address)
             for _tier, service, address in as_built_endpoint_entries(root)
-            if address.startswith("http://")
+            if address.startswith(("http://", "https://"))
         ]
     if as_built_dangerously_allows_bash(root):
         # Above the housekeeping rows, on every state: a waiver of a safety

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -35,6 +35,7 @@ from typing import Any
 
 import click
 
+from osprey.deployment.qmd_service import is_loopback_bind
 from osprey.port_layout import default_port, resolve_port_base
 from osprey.utils.workspace import STATE_DIR_NAME, agent_data_base_dir, anchored_path
 
@@ -1050,17 +1051,19 @@ def web(
             raise SystemExit(1)
         _clear_preflight_marker()
 
+    # Above the detached return: a backgrounded server is exposed exactly the
+    # same way, and is the shape most likely to be left running.
+    if not is_loopback_bind(host):
+        output.warn(
+            f"Binding to {host or '0.0.0.0'} exposes the terminal to the network",
+            "This is a single-user tool. Add authentication before you expose it.",
+        )
+
     if detach:
         _start_detached(host, port, user_shell_override, repo_root)
         return
 
     # -- foreground (original behavior) ------------------------------------
-
-    if host == "0.0.0.0":
-        output.warn(
-            "Binding to 0.0.0.0 exposes the terminal to the network",
-            "This is a single-user tool. Add authentication before you expose it.",
-        )
 
     # Pre-flight: check if port is already in use. SO_REUSEADDR matches
     # uvicorn's own bind semantics — without it, TIME_WAIT sockets from a

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -21,6 +21,7 @@ import stat
 import tempfile
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
@@ -1280,6 +1281,43 @@ def _standin_perturbation(config, repo_root):
     return lattice, default_bpm_errors_for_lattice(lattice)
 
 
+def _telemetry_link_host(config):
+    """The host the dashboard's per-run telemetry link names, or ``None``.
+
+    The link is rendered into the dispatcher's compose file and followed in the
+    OPERATOR's browser, which is outside the compose network — so it cannot use
+    the store's compose DNS name, and ``localhost`` is only right when the
+    browser runs on the host that publishes the store. Which host it should name
+    instead is a question this deployment already answers once, for the landing
+    page and for the origin every terminal checks a write against
+    (:func:`~osprey.deployment.web_terminals.render.deployment_external_origin`),
+    so the link is derived from that rather than from a second rule.
+
+    Three outcomes, and the third is deliberate: a store published on loopback
+    is reached at ``localhost`` (a browser reaching that dashboard is on the
+    host anyway); a store published on an interface takes the declared origin's
+    host; and a store published on an interface by a deployment that declares no
+    origin renders nothing at all. An unset variable is already the dashboard's
+    "hide the link" signal, which beats a link that resolves to the operator's
+    own machine.
+
+    :param config: The project config being rendered.
+    :return: The host to render, or ``None`` to emit no variable.
+    :rtype: str | None
+    """
+    from osprey.deployment.qmd_service import is_loopback_bind, resolve_bind_address
+
+    if is_loopback_bind(resolve_bind_address(config)):
+        return "localhost"
+    try:
+        from osprey.deployment.web_terminals.render import deployment_external_origin
+
+        origin = deployment_external_origin(config)
+    except Exception:
+        return None
+    return urlsplit(origin).hostname or None
+
+
 def _inject_project_metadata(config):
     """Add project tracking metadata for container labels.
 
@@ -1591,6 +1629,13 @@ def _inject_project_metadata(config):
     # (the template gates it on the stand-in branch), so this is inert for every
     # project that has not asked for a second instance.
     _, config_with_labels["standin_bpm_errors_default"] = _standin_perturbation(config, repo_root)
+
+    # The host the dispatcher dashboard's per-run telemetry link names, derived
+    # from the one external-origin authority (:func:`_telemetry_link_host`).
+    # ``None`` renders no variable at all, which the dashboard reads as "hide
+    # the link" — the honest answer for a deployment that publishes the store on
+    # the network but declares no origin a browser can resolve.
+    config_with_labels["osprey_telemetry_host"] = _telemetry_link_host(config)
 
     return config_with_labels
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -6412,13 +6412,13 @@ def _published_on_all_interfaces(compose_files: list[str]) -> list[str]:
     when it rendered ``deployment.bind_address`` into every ``ports:`` entry, so
     at start time this is a fact to be discovered, not a setting to be applied.
     """
-    from osprey.deployment.host_ports import _WILDCARD_HOSTS
+    from osprey.deployment.qmd_service import WILDCARD_BIND_ADDRESSES
 
     return sorted(
         {
             binding.service
             for binding in parse_host_port_bindings(compose_files)
-            if binding.host_ip in _WILDCARD_HOSTS
+            if binding.host_ip in WILDCARD_BIND_ADDRESSES
         }
     )
 

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -355,8 +355,9 @@ _TERMINAL_FAMILY = "web"
 
 #: The service column of the one row that reports the bands nothing serves.
 #: Public because the tests key on it rather than on its spelling, and because
-#: a reader filtering the entries (the summary card keeps only ``http://``
-#: addresses) should be able to name it rather than pattern-match the text.
+#: a reader filtering the entries (the summary card keeps only the rows whose
+#: address is a URL) should be able to name it rather than pattern-match the
+#: text.
 RESERVED_BANDS_LABEL = "(reserved)"
 
 #: Sort position of that row inside the panels tier. Above every real family

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -50,12 +50,12 @@ from osprey.deployment.graphdb_service import (
     GRAPHDB_SERVICE_NAME,
 )
 from osprey.deployment.host_ports import (
-    _WILDCARD_HOSTS,
     _WORKER_SERVICE_PREFIX,
     HostPortBinding,
     derive_host_network_bindings,
     parse_host_port_bindings,
 )
+from osprey.deployment.qmd_service import dial_address
 from osprey.deployment.web_terminals.ports import resolve_nginx_port
 from osprey.port_layout import (
     LAYOUT,
@@ -293,8 +293,7 @@ def _binding_address(binding: HostPortBinding) -> str:
         HTTP on that container port. A wildcard bind is shown on loopback,
         where a service bound to every interface always answers.
     """
-    host = "127.0.0.1" if binding.host_ip in _WILDCARD_HOSTS else binding.host_ip
-    address = f"{host}:{binding.host_port}"
+    address = f"{dial_address(binding.host_ip)}:{binding.host_port}"
     if _http_service(binding.service, binding.container_port):
         return f"http://{address}"
     return address

--- a/src/osprey/deployment/docker_desktop.py
+++ b/src/osprey/deployment/docker_desktop.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import http.client
 import json
 import socket
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -195,21 +196,82 @@ def host_networking_enabled() -> bool | None:
     return _from_settings_store()
 
 
+#: Name Docker Desktop gives the context it installs on Linux. The active
+#: context is what says which engine the CLI actually talks to, which is the
+#: question here — the product's files sit on the host either way.
+_DESKTOP_LINUX_CONTEXT = "desktop-linux"
+
+#: How long the context probe waits. It is a local CLI read of a config file;
+#: anything slower than this is a CLI that is not going to answer.
+_CONTEXT_TIMEOUT_S = 5.0
+
+
+def _active_docker_context() -> str | None:
+    """The docker context this host's CLI is currently pointed at, or ``None``.
+
+    ``None`` means the question could not be asked — no CLI, a CLI that failed,
+    an empty answer — not that the answer is "not Desktop". A caller that gets
+    it falls back to the install-presence test rather than concluding either
+    way.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "context", "show"],
+            capture_output=True,
+            text=True,
+            timeout=_CONTEXT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _desktop_backend_on_linux() -> bool:
+    """Whether a Linux host's docker CLI is talking to Docker Desktop's engine.
+
+    The active context decides it: Docker Desktop for Linux installs its own
+    context and the CLI runs against the bare engine until something selects it.
+    Testing for the product's files instead would answer ``True`` on a host that
+    has Desktop installed and runs its containers on the engine directly, which
+    is a real shape and the one where being wrong costs the most.
+
+    The presence test is the fallback for a host whose CLI cannot be asked at
+    all — better than assuming either answer for a question nothing answered.
+    """
+    context = _active_docker_context()
+    if context is not None:
+        return context == _DESKTOP_LINUX_CONTEXT
+    socket_path = backend_socket_path()
+    if socket_path is not None and socket_path.exists():
+        return True
+    return any(path.is_file() for path in settings_store_paths())
+
+
 def on_docker_desktop(config: dict) -> bool:
     """Whether this deployment's containers run under Docker Desktop.
 
-    Docker Desktop is the macOS and Windows product, so the platform check is
-    what distinguishes it from a Linux host running the engine directly -- where
-    ``network_mode: host`` binds on the machine itself and none of this applies.
-    Podman on macOS runs its own machine with its own port handling and is not
-    Docker Desktop, hence the runtime check as well.
+    Docker Desktop runs containers inside a VM and forwards published ports
+    into it on every platform it ships for — macOS, Windows and Linux. What
+    distinguishes it is the backend, not the operating system: a Linux host
+    running the engine directly binds ``network_mode: host`` on the machine
+    itself and none of this applies, while the same host running Docker Desktop
+    has exactly the VM and port handling this module is about. Podman is not
+    Docker Desktop anywhere, hence the runtime check.
 
-    The platform is read first so that a Linux host never invokes the runtime
-    resolver at all, which is what keeps this cheap on the hosts where the
-    answer is structurally ``False``.
+    So the runtime settles it first (a podman host is answered without asking
+    anything else), then macOS and Windows are Desktop by construction, and a
+    Linux host is decided by which engine its CLI is pointed at
+    (:func:`_desktop_backend_on_linux`). A platform Desktop does not ship for
+    short-circuits before the runtime is resolved at all.
 
     :param config: Raw deploy config, read only for which runtime it selects.
     """
-    if sys.platform not in ("darwin", "win32"):
+    if sys.platform not in ("darwin", "win32") and not sys.platform.startswith("linux"):
         return False
-    return get_runtime_command(config)[0] == "docker"
+    if get_runtime_command(config)[0] != "docker":
+        return False
+    if sys.platform in ("darwin", "win32"):
+        return True
+    return _desktop_backend_on_linux()

--- a/src/osprey/deployment/host_ports.py
+++ b/src/osprey/deployment/host_ports.py
@@ -54,6 +54,7 @@ from osprey.deployment.graphdb_service import (
     GRAPHDB_SERVICE_NAME,
 )
 from osprey.deployment.qmd_service import PORT_CONFIG_KEY as QMD_PORT_CONFIG_KEY
+from osprey.deployment.qmd_service import dial_host
 from osprey.deployment.runtime_helper import get_ps_command, runtime_env
 from osprey.deployment.web_terminals.personas import normalize_users
 from osprey.deployment.web_terminals.ports import allocate_ports, base_ports_from_config
@@ -209,10 +210,6 @@ _HOST_NETWORK_BIND = "127.0.0.1"
 # Stand-in for ``HostPortBinding.compose_file`` on a derived binding: these
 # bindings come from the rendered config, not from any compose file.
 _DERIVED_SOURCE = "<rendered config>"
-
-# Addresses that mean "listening on every interface" — probe them on loopback,
-# where a service bound to all interfaces is always reachable.
-_WILDCARD_HOSTS = {"", "0.0.0.0", "::", "*"}
 
 # Connect-probe timeout (seconds). Loopback probes resolve in well under this;
 # the cap only bounds a wildcard bind whose interface is slow to refuse.
@@ -774,7 +771,7 @@ def derive_web_terminal_bindings(config):
 
 def _probe_host(host_ip):
     """Return the address a published port is reachable on for probing."""
-    return "127.0.0.1" if host_ip in _WILDCARD_HOSTS else host_ip
+    return dial_host(host_ip)
 
 
 def _port_is_free(host_ip, host_port):
@@ -784,13 +781,14 @@ def _port_is_free(host_ip, host_port):
         it succeeds (something is listening)
     :rtype: bool
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(_PROBE_TIMEOUT)
-        try:
-            sock.connect((_probe_host(host_ip), host_port))
-        except OSError:
-            return True
-        return False
+    # ``create_connection`` rather than a pinned-family socket: a wildcard IPv6
+    # bind is probed at ``::1``, which an AF_INET socket cannot reach and would
+    # report as free.
+    try:
+        with socket.create_connection((_probe_host(host_ip), host_port), _PROBE_TIMEOUT):
+            return False
+    except OSError:
+        return True
 
 
 def _run_runtime_ps(config=None):

--- a/src/osprey/deployment/openobserve_provision.py
+++ b/src/osprey/deployment/openobserve_provision.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import httpx
 
 from osprey.cli import output
+from osprey.deployment.qmd_service import DEFAULT_BIND_ADDRESS, dial_address
 from osprey.port_layout import default_port, resolve_port_base
 from osprey.utils.logger import get_logger
 
@@ -85,7 +86,6 @@ HARVEST_BANNER = "Harvested OpenObserve ingest token (osprey up)"
 # an unset ``services.openobserve.port`` means the store sits at the layout's
 # ``openobserve`` slot, which moves with this project's own ``port_base`` and so
 # can only be read off the config in hand (see :func:`store_base_url`).
-_DEFAULT_BIND = "127.0.0.1"
 _DEFAULT_ORG = "default"
 
 #: Readiness budget. The store answered ``/healthz`` about a second after start
@@ -185,7 +185,9 @@ def store_base_url(config: Mapping[str, Any]) -> str:
         config: The rendered project config.
 
     Returns:
-        ``http://<bind>:<port>`` — no path, no trailing slash.
+        ``http://<host>:<port>`` — no path, no trailing slash. The host is the
+        bind address as :func:`~osprey.deployment.qmd_service.dial_address`
+        resolves it, so a wildcard publish is dialed on loopback.
 
     Raises:
         ValueError: ``deployment.port_base`` is set to a base no block can
@@ -193,9 +195,9 @@ def store_base_url(config: Mapping[str, Any]) -> str:
     """
     services = config.get("services") or {}
     settings = services.get(SERVICE) or {}
-    bind = (config.get("deployment") or {}).get("bind_address", _DEFAULT_BIND)
+    bind = (config.get("deployment") or {}).get("bind_address", DEFAULT_BIND_ADDRESS)
     port = settings.get("port", default_port("openobserve", base=resolve_port_base(config)))
-    return f"http://{bind}:{port}"
+    return f"http://{dial_address(bind)}:{port}"
 
 
 def store_org(config: Mapping[str, Any]) -> str:

--- a/src/osprey/deployment/qmd_service.py
+++ b/src/osprey/deployment/qmd_service.py
@@ -42,6 +42,7 @@ whatever can route to that interface.
 
 from __future__ import annotations
 
+import ipaddress
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -71,7 +72,23 @@ DEFAULT_PORT = default_port(QMD_SERVICE_NAME)
 
 #: Interface every deployed service publishes on when ``deployment`` is absent.
 #: Matches the ``| default('127.0.0.1')`` the service compose templates spell.
+#:
+#: This is the project-wide default for ``deployment.bind_address``, not a
+#: qmd-specific one: the provisioner, the health categories and the host-port
+#: preflight all read the same key and so share this constant rather than
+#: keeping a copy each.
 DEFAULT_BIND_ADDRESS = "127.0.0.1"
+
+#: Addresses that mean "listen on every interface". They are bind targets, not
+#: destinations — connecting to one is undefined on some platforms — so a
+#: host-side caller dials the matching loopback instead
+#: (:func:`dial_host`).
+WILDCARD_BIND_ADDRESSES = frozenset({"", "0.0.0.0", "::", "*"})
+
+#: Loopback address of the family a wildcard bind belongs to. ``::`` publishes
+#: on the IPv6 wildcard, which is reached at ``::1``; every other spelling is
+#: IPv4 or family-agnostic and is reached at :data:`DEFAULT_BIND_ADDRESS`.
+_WILDCARD_LOOPBACK = {"::": "::1"}
 
 #: Seconds between fallback corpus sweeps, and NOT the expected freshness lag —
 #: a corpus writer touches its ``.qmd-touch`` marker, which triggers an update
@@ -140,11 +157,13 @@ class QMDServiceConfig:
     def base_url(self) -> str:
         """URL a client on the host reaches the sidecar at.
 
-        Always loopback, never ``bind_address``: a wildcard publish
-        (``0.0.0.0``) is an address to *listen* on, not one to connect to, and
-        a host-side caller reaches every published port over loopback anyway.
+        The address comes from :func:`dial_address`, the one rule every
+        host-side dial of a published port follows: a wildcard publish is an
+        address to *listen* on rather than one to connect to and is dialed on
+        loopback, while a concrete interface is published only on that
+        interface and is dialed there.
         """
-        return f"http://127.0.0.1:{self.port}"
+        return f"http://{dial_address(self.bind_address)}:{self.port}"
 
 
 def resolve_qmd_service_config(config: Mapping[str, Any] | None) -> QMDServiceConfig | None:
@@ -212,6 +231,75 @@ def resolve_bind_address(config: Mapping[str, Any] | None) -> str:
     if not isinstance(address, str) or not address.strip():
         return DEFAULT_BIND_ADDRESS
     return address.strip()
+
+
+def is_loopback_bind(bind: str) -> bool:
+    """Whether a service bound to *bind* is reachable only from this machine.
+
+    The question every "is this on the network" reader asks, from the exposure
+    warning ``osprey web`` prints to the decision of which host a browser-facing
+    link can name. Keyed on "is loopback" rather than on a literal, because
+    ``0.0.0.0`` is one of several spellings that expose the port: ``::``
+    publishes on every IPv6 interface, an empty address is the wildcard uvicorn
+    defaults to, and a concrete interface address is on the network by
+    definition.
+
+    Args:
+        bind: A configured bind address or host.
+
+    Returns:
+        ``True`` only for an address nothing off this machine can reach. A name
+        that is not an IP literal is loopback only when it is ``localhost``;
+        anything else counts as exposed, because resolving it would make the
+        answer depend on DNS.
+    """
+    address = (bind or "").strip()
+    if address in WILDCARD_BIND_ADDRESSES:
+        return False
+    try:
+        return ipaddress.ip_address(address).is_loopback
+    except ValueError:
+        return address == "localhost"
+
+
+def dial_host(bind: str) -> str:
+    """Return the host a published port bound to *bind* is reached on.
+
+    One rule for every host-side reader of ``deployment.bind_address``: a
+    wildcard is a bind target, not a destination, so it is dialed on its
+    family's loopback address; a concrete interface is published only on that
+    interface, so it is dialed there. Standardising on loopback instead would
+    dial nothing on a deployment that pinned an interface.
+
+    Args:
+        bind: A configured bind address, wildcard or concrete.
+
+    Returns:
+        A bare host — no brackets, suitable for :func:`socket.create_connection`
+        and for :func:`socket.getaddrinfo`. Use :func:`dial_address` to build a
+        URL authority from it.
+    """
+    address = (bind or "").strip()
+    if address in WILDCARD_BIND_ADDRESSES:
+        return _WILDCARD_LOOPBACK.get(address, DEFAULT_BIND_ADDRESS)
+    return address
+
+
+def dial_address(bind: str) -> str:
+    """Return the URL authority a published port bound to *bind* is reached at.
+
+    :func:`dial_host` with an IPv6 literal bracketed, which is what a URL's
+    authority component requires and what every ``http://{address}:{port}``
+    caller needs.
+
+    Args:
+        bind: A configured bind address, wildcard or concrete.
+
+    Returns:
+        The dialable host, bracketed when it is an IPv6 literal.
+    """
+    host = dial_host(bind)
+    return f"[{host}]" if ":" in host else host
 
 
 def preflight_qmd_models_dir(config: Mapping[str, Any] | None) -> None:

--- a/src/osprey/deployment/runtime_helper.py
+++ b/src/osprey/deployment/runtime_helper.py
@@ -166,6 +166,22 @@ def get_runtime_command(config: Mapping[str, Any] | None = None) -> list[str]:
         )
 
 
+def no_container_runtime_installed() -> bool:
+    """Whether neither container runtime is on this host's PATH.
+
+    The narrower half of the failure :func:`get_runtime_command` raises: "no
+    runtime is installed" and "a runtime is installed but is not answering" both
+    leave a caller without a runtime, but only the first can be a deliberate
+    state — a deployment that runs no containers has no use for one. Exposed as
+    a predicate so a caller distinguishes them by asking rather than by matching
+    on the message text.
+
+    Returns:
+        ``True`` when neither ``docker`` nor ``podman`` resolves on ``PATH``.
+    """
+    return shutil.which("docker") is None and shutil.which("podman") is None
+
+
 def reset_runtime_cache() -> None:
     """Clear every memoized runtime command so the next call re-detects.
 

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -362,8 +362,34 @@ def _query_containers(config):
         output.fail("Could not parse container data", str(e))
         return None
     except Exception as e:
+        if _no_runtime_and_none_needed(config):
+            output.note(
+                "this deployment declares no containerized services; no container runtime installed"
+            )
+            return None
         output.fail("Could not query container status", str(e))
         return None
+
+
+def _no_runtime_and_none_needed(config):
+    """Whether "no containers" is this deployment's declared state, not a fault.
+
+    Both halves are required. A host with no runtime that HAS declared services
+    is broken and keeps its failure; so does a host whose runtime is installed
+    but not answering, whatever it declares. Only the conjunction — nothing
+    installed and nothing declared — describes a deployment that never wanted a
+    container runtime, and reporting that as a failure leaves a permanent red
+    banner on a status that is entirely correct.
+
+    :param config: Rendered config, or ``None``
+    :return: ``True`` when a missing runtime is the declared state
+    :rtype: bool
+    """
+    from osprey.deployment.runtime_helper import no_container_runtime_installed
+
+    if (config or {}).get("deployed_services"):
+        return False
+    return no_container_runtime_installed()
 
 
 def _existing_volume_names(config):

--- a/src/osprey/health/core/openobserve.py
+++ b/src/osprey/health/core/openobserve.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from osprey.deployment.qmd_service import DEFAULT_BIND_ADDRESS, dial_address
 from osprey.health.models import CheckResult, Status
 from osprey.port_layout import default_port, resolve_port_base
 
@@ -36,7 +37,6 @@ CATEGORY = "openobserve"
 
 _HEALTHZ_TIMEOUT_S = 5.0
 _RETENTION_FLOOR_DAYS = 3
-_DEFAULT_BIND = "127.0.0.1"
 _DEFAULT_RETENTION_DAYS = 14  # mirror the compose default
 
 
@@ -72,7 +72,7 @@ def openobserve(
         # number on the host — on a two-deployment host, the other store — and
         # report its health as this one's.
         port = oo.get("port", default_port("openobserve", base=resolve_port_base(cfg)))
-        bind = (cfg.get("deployment", {}) or {}).get("bind_address", _DEFAULT_BIND)
+        bind = (cfg.get("deployment", {}) or {}).get("bind_address", DEFAULT_BIND_ADDRESS)
         retention = oo.get("retention_days", _DEFAULT_RETENTION_DAYS)
 
         return [
@@ -86,8 +86,13 @@ def openobserve(
 async def _check_healthz(
     bind: str, port: Any, transport: httpx.AsyncBaseTransport | None
 ) -> CheckResult:
-    """Probe the ``/healthz`` readiness endpoint; ``running`` is not ``ready``."""
-    url = f"http://{bind}:{port}/healthz"
+    """Probe the ``/healthz`` readiness endpoint; ``running`` is not ``ready``.
+
+    The bind address is resolved to a dialable host first
+    (:func:`~osprey.deployment.qmd_service.dial_address`): a wildcard publish is
+    reached on loopback, a pinned interface on that interface.
+    """
+    url = f"http://{dial_address(bind)}:{port}/healthz"
     try:
         async with httpx.AsyncClient(timeout=_HEALTHZ_TIMEOUT_S, transport=transport) as client:
             resp = await client.get(url)

--- a/src/osprey/health/core/python_environment.py
+++ b/src/osprey/health/core/python_environment.py
@@ -19,6 +19,7 @@ import importlib.util
 import sys
 from typing import TYPE_CHECKING, Any
 
+from osprey.health.derive import _in_container
 from osprey.health.models import CheckResult, Status
 
 if TYPE_CHECKING:
@@ -73,11 +74,29 @@ def _check_python_version() -> CheckResult:
 
 
 def _check_virtual_environment() -> CheckResult:
+    """Whether this interpreter is isolated from anything else on the machine.
+
+    A container image is isolation by construction: the shipped image installs
+    OSPREY into the system interpreter because nothing else lives there, and
+    warning about it put a permanent amber row on the core category of every
+    containerised deployment for the deployment working as designed. On a bare
+    host the warning stands — a system interpreter there really is shared.
+
+    This row is not a guard on whether OSPREY can run. That is
+    ``core_dependencies``.
+    """
     in_venv = hasattr(sys, "real_prefix") or (
         hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
     )
     if in_venv:
         return CheckResult("virtual_environment", CATEGORY, Status.OK, "Virtual environment active")
+    if _in_container():
+        return CheckResult(
+            "virtual_environment",
+            CATEGORY,
+            Status.OK,
+            "System interpreter inside a container image",
+        )
     return CheckResult(
         "virtual_environment", CATEGORY, Status.WARNING, "Not in a virtual environment"
     )

--- a/src/osprey/interfaces/ariel/app.py
+++ b/src/osprey/interfaces/ariel/app.py
@@ -39,7 +39,14 @@ CONFIG_STATUS_INVALID = "configuration_invalid"
 
 #: Remedies are derived from the error class, never written per call site, so
 #: the banner, ``/api/capabilities`` and the UI name the same operator action.
-REMEDY_NO_CONFIG_FILE = "mount config.yml at /app/config.yml or set CONFIG_FILE, then restart"
+REMEDY_NO_CONFIG_FILE = "set CONFIG_FILE to this deployment's config.yml, then restart"
+
+#: Legacy container mount point, kept as a last resort before the working
+#: directory. Nothing in the shipped image writes a config here — the project
+#: lands at ``/app/<project>/`` — so it names only a hand-authored mount, and it
+#: is searched after ``CONFIG_FILE`` so an explicitly declared config always
+#: wins over one somebody left mounted.
+_CONTAINER_CONFIG_PATH = Path("/app/config.yml")
 REMEDY_NAMED_KEY = "fix the named key in config.yml and restart"
 
 
@@ -50,9 +57,14 @@ def load_ariel_config_with_path(
 
     Looks for config in:
     1. Provided config_path argument
-    2. /app/config.yml (Docker mount)
-    3. CONFIG_FILE environment variable
+    2. ``CONFIG_FILE`` environment variable
+    3. :data:`_CONTAINER_CONFIG_PATH` (a hand-authored container mount)
     4. Current directory config.yml
+
+    ``CONFIG_FILE`` outranks the mount: it is what a deployment declares, and
+    the shipped image puts its config at ``/app/<project>/config.yml`` rather
+    than at the mount point, so a file at that path can only be one somebody
+    left behind.
 
     The DSN is resolved by
     :func:`osprey.services.ariel_search.config.resolve_ariel_dsn`, which reads
@@ -77,8 +89,8 @@ def load_ariel_config_with_path(
     """
     config_paths = [
         Path(config_path) if config_path else None,
-        Path("/app/config.yml"),
         Path(os.environ.get("CONFIG_FILE", "")) if os.environ.get("CONFIG_FILE") else None,
+        _CONTAINER_CONFIG_PATH,
         Path("config.yml"),
     ]
 
@@ -117,8 +129,8 @@ def load_ariel_config_with_path(
             return ariel_config, path
 
     raise RuntimeError(
-        "No config.yml found. Set CONFIG_FILE environment variable "
-        "or mount config.yml at /app/config.yml"
+        "No config.yml found. Set the CONFIG_FILE environment variable to this "
+        f"deployment's config.yml, or mount one at {_CONTAINER_CONFIG_PATH}"
     )
 
 

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/draft-client.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/draft-client.js
@@ -38,6 +38,7 @@
  */
 
 import { flashElement } from '/design-system/js/highlight.js';
+import { uuid4 } from '/design-system/js/uuid.js';
 
 /**
  * @typedef {object} DraftSnapshot
@@ -355,19 +356,17 @@ export function resolvePinnedRevision(flushResult, lastAppliedRevision) {
 }
 
 /**
- * A per-tab id for frame `origin`/PATCH `client_id` echo suppression. Falls
- * back to a `Math.random()`-based id when `crypto.randomUUID` is unavailable
- * (a non-secure-context deployment) so the whole panel — including the
- * always-available manual flow — degrades gracefully instead of dying on a
- * `TypeError` just because the live-draft feature can't mint a "real" UUID.
+ * A per-tab id for frame `origin`/PATCH `client_id` echo suppression.
+ *
+ * Delegates to the shared minter, which produces a v4-shaped id whether or not
+ * `crypto.randomUUID` exists — so a non-secure-context deployment gets a real
+ * id rather than a differently-shaped stand-in, and the whole panel degrades
+ * gracefully instead of dying on a `TypeError`.
  *
  * @returns {string}
  */
 export function generateClientId() {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `tab-${Math.random().toString(36).slice(2)}${Date.now()}`;
+  return uuid4();
 }
 
 /**

--- a/src/osprey/interfaces/design_system/static/js/platform.js
+++ b/src/osprey/interfaces/design_system/static/js/platform.js
@@ -1,0 +1,30 @@
+// @ts-check
+/* What the viewer's keyboard actually looks like.
+ *
+ * One reader, because two surfaces answer to it: the command palette binds
+ * Cmd+K on macOS and Ctrl+K everywhere else, and the tour TEACHES that chord.
+ * A tour that names a chord the palette does not bind is worse than no tour.
+ */
+
+/**
+ * Whether this browser is on macOS or iPadOS, where the modifier is Cmd.
+ *
+ * `userAgentData.platform` where the browser offers it, `navigator.platform`
+ * otherwise — deprecated but still the only answer several engines give.
+ *
+ * @returns {boolean}
+ */
+export function isMacPlatform() {
+  const nav = /** @type {Navigator & { userAgentData?: { platform?: string } }} */ (navigator);
+  const platform = nav.userAgentData?.platform || nav.platform || '';
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+/**
+ * The command palette's chord, as this viewer's platform spells it.
+ *
+ * @returns {string} `⌘K` on macOS, `Ctrl+K` elsewhere.
+ */
+export function paletteChord() {
+  return isMacPlatform() ? '⌘K' : 'Ctrl+K';
+}

--- a/src/osprey/interfaces/design_system/static/js/uuid.js
+++ b/src/osprey/interfaces/design_system/static/js/uuid.js
@@ -1,0 +1,61 @@
+// @ts-check
+/* A v4-shaped identifier, on every deployment topology.
+ *
+ * `crypto.randomUUID` exists only in a secure context — HTTPS, or localhost.
+ * A deployment served as plain HTTP on a non-loopback host is a documented
+ * OSPREY topology (`auth.allow_insecure_http`, for a facility terminator that
+ * fronts this app), and there the property is simply absent: reading it throws
+ * a `TypeError` and whichever surface was minting an id never mounts.
+ *
+ * `crypto.getRandomValues` IS available in an insecure context, so the id can
+ * still be a real random one. `Math.random` is the last resort, for an engine
+ * that has neither.
+ *
+ * The grammar matters as much as the randomness: server-side stores key on a
+ * bare `8-4-4-4-12` UUID, and an id of some other shape does not fail — it
+ * silently lands somewhere else. So every fallback here produces the same
+ * shape as the API it stands in for.
+ */
+
+/**
+ * Sixteen random bytes, from the strongest source this engine offers.
+ *
+ * @returns {Uint8Array}
+ */
+function randomBytes() {
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    crypto.getRandomValues(bytes);
+    return bytes;
+  }
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return bytes;
+}
+
+/**
+ * A random RFC 4122 version-4 UUID, lowercase, unbracketed.
+ *
+ * Uses `crypto.randomUUID` where it exists and builds the same shape by hand
+ * where it does not.
+ *
+ * @returns {string} `8-4-4-4-12` lowercase hex.
+ */
+export function uuid4() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = randomBytes();
+  // Version 4, variant 10xx — the two fields a v4 UUID pins.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20)
+  ].join('-');
+}

--- a/src/osprey/interfaces/web_auth.py
+++ b/src/osprey/interfaces/web_auth.py
@@ -1023,7 +1023,11 @@ def mint_and_announce(host: str, port: int, *, path: str = "/") -> str:
             appended, so a path already carrying a query would produce two.
 
     Returns:
-        ``http://<host>:<port><path>?token=<operator secret>``.
+        ``<origin><path>?token=<operator secret>``. The origin is
+        :data:`~osprey.interfaces.common_middleware.EXTERNAL_ORIGIN_ENV` when
+        that is set — the address a deployment declares browsers actually reach
+        it at, and the one the origin gate and the session cookie's ``Secure``
+        flag are derived from — and ``http://<host>:<port>`` otherwise.
 
     **The token in the URL is the operator secret itself**, not a second
     credential the holder tracks alongside it. That is forced by how the
@@ -1090,12 +1094,23 @@ def mint_and_announce(host: str, port: int, *, path: str = "/") -> str:
 
     if not path.startswith("/"):
         path = f"/{path}"
-    authority = f"[{host}]" if ":" in host and not host.startswith("[") else host
     # A minted secret is already URL-safe, so this is a no-op for one. A
     # deployment-supplied secret is not: it comes out of a ``.env`` and may
     # hold anything, and an unescaped ``&`` or ``#`` there would truncate the
     # token the browser sends back into something that authenticates nobody.
     token = urllib.parse.quote(credentials.operator_secret, safe="")
+    # A declared external origin is the address browsers actually reach this
+    # process at, and it is the one the origin gate and the cookie's ``Secure``
+    # flag are already derived from (``common_middleware``). Announcing the bind
+    # address instead would hand out a URL from which every write is refused.
+    # Imported here, not at module scope: ``common_middleware`` imports this
+    # module, so the dependency only runs in one direction at import time.
+    from osprey.interfaces.common_middleware import EXTERNAL_ORIGIN_ENV
+
+    configured = os.environ.get(EXTERNAL_ORIGIN_ENV, "").strip()
+    if configured:
+        return f"{configured.rstrip('/')}{path}?token={token}"
+    authority = f"[{host}]" if ":" in host and not host.startswith("[") else host
     return f"http://{authority}:{port}{path}?token={token}"
 
 

--- a/src/osprey/interfaces/web_terminal/ownership.py
+++ b/src/osprey/interfaces/web_terminal/ownership.py
@@ -82,6 +82,20 @@ logger = logging.getLogger(__name__)
 #: compose service (it is also $HOME inside that container).
 CLAUDE_CONFIG_ENV = "CLAUDE_CONFIG_DIR"
 
+#: What a deployment with no durable store is told, in the log at startup and
+#: in the gallery's refusal. One sentence, one spelling: an operator who reads
+#: it in either place has to be able to act on it without reading the other.
+NO_DURABLE_STORE = (
+    f"No durable per-user store is mounted here. Set {CLAUDE_CONFIG_ENV} to a directory "
+    "that survives container recreation, or scaffold claims made from this deployment "
+    "are lost when the container is recreated."
+)
+
+#: Whether the notice above has already been logged in this process. It states
+#: a fact about the deployment, not about the call, so once is the honest count
+#: — ``resolve_ownership`` runs on every request.
+_store_notice_logged = False
+
 #: Set to ``1`` by ``Dockerfile.j2`` on every image the build produces, and by
 #: nothing else. Its literal meaning is "the render zone in this image is
 #: root-owned"; its consequence for ownership is the stronger statement that
@@ -841,6 +855,10 @@ def resolve_ownership(project_dir: Path, env: dict[str, str] | None = None) -> O
     4. The manifest names no profile at all → CONFIG. A pre-profile project,
        where config.yml is what ownership has always meant.
 
+    Reaching 3 or 4 inside a container render means no claim made here outlives
+    the next recreation, and both modes are otherwise silent about it, so the
+    resolution logs :data:`NO_DURABLE_STORE` once per process on that path.
+
     Args:
         project_dir: The render whose claims are being resolved.
         env: Environment to read, for tests. Defaults to ``os.environ``.
@@ -856,10 +874,40 @@ def resolve_ownership(project_dir: Path, env: dict[str, str] | None = None) -> O
     if store is not None:
         return Ownership(OwnershipMode.VOLUME, store=store)
 
+    if is_container_render(environ):
+        _log_no_durable_store()
+
     if _names_a_profile(project_dir):
         return Ownership(OwnershipMode.DEGRADED)
 
     return Ownership(OwnershipMode.CONFIG)
+
+
+def _log_no_durable_store() -> None:
+    """Say once that nothing here will outlive the container.
+
+    Neither of the modes reached past this point records a claim anywhere that
+    survives a recreation, and both are silent about it — the artifact is
+    written, the operator is told it was written, and it is gone at the next
+    ``osprey up``. Naming the variable that would fix it is the whole notice.
+
+    Scoped to a container render, because that is the topology the sentence is
+    true of. A bare host reaching CONFIG is a pre-profile project writing to
+    its own ``config.yml``, which is durable and is recreated by nothing; the
+    warning there would name a variable that fixes a problem the operator does
+    not have.
+    """
+    global _store_notice_logged
+    if _store_notice_logged:
+        return
+    _store_notice_logged = True
+    logger.warning(NO_DURABLE_STORE)
+
+
+def _reset_store_notice() -> None:
+    """Re-arm the once-per-process notice. For tests."""
+    global _store_notice_logged
+    _store_notice_logged = False
 
 
 def is_container_render(environ: Mapping[str, str] | None = None) -> bool:

--- a/src/osprey/interfaces/web_terminal/scaffold_gallery_service.py
+++ b/src/osprey/interfaces/web_terminal/scaffold_gallery_service.py
@@ -353,6 +353,7 @@ class ScaffoldGalleryService:
         if self._ownership.mode is not OwnershipMode.DEGRADED:
             return
         from osprey.cli.scaffold_cmd import OWNERSHIP_LIVES_IN_THE_PROFILE, ScaffoldClaimError
+        from osprey.interfaces.web_terminal.ownership import NO_DURABLE_STORE
 
         raise ScaffoldClaimError(
             f"{self.project_dir} was built from a profile, and that profile cannot be "
@@ -360,7 +361,8 @@ class ScaffoldGalleryService:
             f"{OWNERSHIP_LIVES_IN_THE_PROFILE}\n\n"
             "  Restore the profile this project names — its manifest records the path as\n"
             "  build_args.profile_path_abs — or rebuild from the profile you want to own\n"
-            "  this artifact, and try again."
+            "  this artifact, and try again.\n\n"
+            f"  {NO_DURABLE_STORE}"
         )
 
     def _write_body(self, output_path: str, content: str, name: str | None = None) -> bool:

--- a/src/osprey/interfaces/web_terminal/static/js/app.js
+++ b/src/osprey/interfaces/web_terminal/static/js/app.js
@@ -21,7 +21,7 @@ import { initCommandPalette } from './palette-boot.js';
 import { getFamily, initTheme, subscribe as subscribeTheme } from '/design-system/js/theme-manager.js';
 import { onModeChange } from '/design-system/js/frame-params.js';
 import '/design-system/js/components/osprey-display-menu.js';
-import { initChat, enterFromExpert } from './chat.js';
+import { initChat, enterFromExpert, renderChatBootFailure } from './chat.js';
 import { initDockWorkspace, applyDockMode } from './dock-workspace.js';
 import { initHeaderContrib } from './tile-header-contrib.js';
 import { initIdentityMenu } from './identity-menu.js';
@@ -63,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initChat('operator-container');
   } catch (err) {
     console.error('Failed to init operator chat:', err);
+    renderChatBootFailure('operator-container');
   }
   // Before the panel manager creates any iframe, so no contribution can
   // arrive without a listener.

--- a/src/osprey/interfaces/web_terminal/static/js/chat.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat.js
@@ -22,6 +22,8 @@
  * simply hidden in expert mode — never torn down or toggled from here.
  */
 
+import { uuid4 } from '/design-system/js/uuid.js';
+
 import { fetchHistory, interrupt, requestHandoff, sendPrompt } from './chat-client.js';
 import { createChatRenderer, elem } from './chat-render.js';
 import { buildEmptyState, onKindChange, onSettled, renderEmptyStateContent } from './first-contact.js';
@@ -298,7 +300,7 @@ export function initChat(containerId = 'operator-container') {
    * slot, so a second key here would be a second conversation.
    * @type {string}
    */
-  let boundKey = adopted ?? crypto.randomUUID();
+  let boundKey = adopted ?? uuid4();
   if (!adopted) setPointer(boundKey);
 
   /** Which hand-off attempt is current; a retry supersedes the one before it. */
@@ -639,7 +641,7 @@ export function initChat(containerId = 'operator-container') {
    * left alone — it is a session the operator can still resume.
    */
   function newConversation() {
-    const key = crypto.randomUUID();
+    const key = uuid4();
     // Claim it before the pointer notifies, so the subscription below sees the
     // key the console is already on and does not replay an empty transcript.
     boundKey = key;
@@ -680,4 +682,24 @@ export function initChat(containerId = 'operator-container') {
     if (adopted) void bindTo(adopted);
     else notifySessionChange(boundKey);
   }
+}
+
+/**
+ * Put a visible failure where the operator console would have been.
+ *
+ * A console that threw during init leaves an EMPTY container, and in Simple
+ * view an empty container is indistinguishable from an agent with nothing to
+ * say — the operator waits at a page that is never going to answer. A console
+ * log line is not a user-facing surface; this is.
+ *
+ * @param {string} containerId
+ */
+export function renderChatBootFailure(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const notice = document.createElement('p');
+  notice.className = 'chat-boot-failure';
+  notice.textContent =
+    'The operator console failed to start. Reload the page, or switch to the Expert view.';
+  container.replaceChildren(notice);
 }

--- a/src/osprey/interfaces/web_terminal/static/js/palette-boot.js
+++ b/src/osprey/interfaces/web_terminal/static/js/palette-boot.js
@@ -40,14 +40,8 @@ import { openPalette, closePalette, isOpen } from './palette.js';
 import { enterEditMode } from './bar-customize.js';
 import { logout } from './logout.js';
 import { pickUiMode } from '/design-system/js/frame-params.js';
+import { isMacPlatform } from '/design-system/js/platform.js';
 import { isFeedbackModalOpen } from './feedback-modal.js';
-
-/** True on macOS/iPadOS, where the palette hotkey is Cmd+K instead of Ctrl+K. */
-function isMacPlatform() {
-  const nav = /** @type {Navigator & { userAgentData?: { platform?: string } }} */ (navigator);
-  const platform = nav.userAgentData?.platform || nav.platform || '';
-  return /Mac|iPhone|iPad|iPod/i.test(platform);
-}
 
 /** @returns {'expert'|'simple'} the resolved ui mode from the authoritative <html> attribute. */
 function currentUiMode() {

--- a/src/osprey/interfaces/web_terminal/static/js/tour.js
+++ b/src/osprey/interfaces/web_terminal/static/js/tour.js
@@ -39,6 +39,7 @@
  */
 
 import { installFocusTrap, removeFocusTrap } from '/design-system/js/focus-trap.js';
+import { isMacPlatform, paletteChord } from '/design-system/js/platform.js';
 import { scopedStorageKey } from '/design-system/js/storage-scope.js';
 import { isLive } from './bar-host.js';
 import { capabilitySentence, chipRow, starterPrompts } from './first-contact.js';
@@ -280,11 +281,21 @@ const STEPS = [
   {
     anchor: () => document.querySelector('#command-palette-btn'),
     title: 'Search everything',
-    body: () => [
-      'Press ',
-      strong('⌘K'),
-      ' to search settings, panels, and actions. The fastest way to find anything in this terminal.',
-    ],
+    body: () => {
+      // The chord this viewer's platform actually binds (palette-boot.js reads
+      // the same helper), never the macOS spelling on every machine.
+      const parts = [
+        'Press ',
+        strong(paletteChord()),
+        ' to search settings, panels, and actions. The fastest way to find anything in this terminal.',
+      ];
+      if (!isMacPlatform()) {
+        // Off macOS the chord is Ctrl+K, which inside the terminal stays
+        // readline's kill-line — so it is bound outside the terminal only.
+        parts.push(' It works outside the terminal; inside it, use this button.');
+      }
+      return parts;
+    },
   },
   {
     anchor: () => document.querySelector('.panel-rail-button[data-panel-id="artifacts"]'),

--- a/src/osprey/mcp_server/workspace/tools/provenance_locator.py
+++ b/src/osprey/mcp_server/workspace/tools/provenance_locator.py
@@ -76,15 +76,48 @@ def _service_name() -> str:
     return "claude-code"
 
 
-def _org() -> str:
-    """OpenObserve org, parsed from the OTLP endpoint ``.../api/<org>``."""
-    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "")
-    marker = "/api/"
-    if marker in endpoint:
-        tail = endpoint.split(marker, 1)[1].strip("/")
-        if tail:
-            return tail.split("/", 1)[0]
-    return "default"
+#: Backend whose records are addressed by an organization and a stream. Any
+#: other backend is addressed some other way, and OpenObserve's coordinates
+#: would be meaningless in it.
+_OPENOBSERVE_BACKEND = "openobserve"
+
+#: The stream OSPREY's OTLP records land in. One value, spelled once — it is
+#: not derived from anything yet, and inventing a key for it would be a knob
+#: nothing turns.
+_DEFAULT_STREAM = "default"
+
+
+def _store_coordinates() -> dict[str, str]:
+    """Store-specific coordinates for the configured telemetry backend.
+
+    Read from ``claude_code.telemetry`` rather than re-parsed out of the OTLP
+    endpoint URL: the org is a configured value, and deriving it a second time
+    from a URL the exporter built out of it is a producer that can disagree with
+    the store it points at. The org itself comes from
+    :func:`osprey.deployment.openobserve_provision.store_org`, the one resolver
+    the provisioner and the exporter already share — a hand-rolled read here
+    would be a third producer, and one that gets the empty-org case wrong: the
+    default belongs to an ABSENT key, and an explicit ``org: ""`` is a value.
+
+    Only ``openobserve`` is addressed by an org and a stream. Every other
+    backend gets neither key at all — not a null, and not a placeholder: a
+    consumer templating these into a filed issue must not be able to render an
+    empty coordinate that reads as a real one.
+
+    Returns:
+        ``{"org": …, "stream": …}`` for the OpenObserve backend, else ``{}``.
+    """
+    try:
+        from osprey.deployment.openobserve_provision import store_org
+        from osprey.utils.workspace import load_osprey_config
+
+        config = load_osprey_config()
+        telemetry = ((config.get("claude_code") or {}).get("telemetry")) or {}
+        if str(telemetry.get("backend") or "").strip().lower() != _OPENOBSERVE_BACKEND:
+            return {}
+        return {"org": store_org(config), "stream": _DEFAULT_STREAM}
+    except Exception:
+        return {}
 
 
 @mcp.tool()
@@ -96,9 +129,11 @@ async def provenance_locator() -> str:
     truth) instead of trusting a reconstructed narration. No parameters.
 
     Returns:
-        JSON ``{session_id, service_name, org, stream, since, emitted_at}``.
-        ``session_id`` is ``null`` (with a ``note``) when no id resolves or
-        telemetry is unavailable/degraded for this run. Never raises.
+        JSON ``{session_id, service_name, since, emitted_at}``, plus ``org`` and
+        ``stream`` when the configured telemetry backend is addressed by them
+        (:func:`_store_coordinates`). ``session_id`` is ``null`` (with a
+        ``note``) when no id resolves or telemetry is unavailable/degraded for
+        this run. Never raises.
     """
     emitted_at = datetime.now(UTC).isoformat()
     try:
@@ -125,8 +160,7 @@ async def provenance_locator() -> str:
             {
                 "session_id": session_id,
                 "service_name": _service_name(),
-                "org": _org(),
-                "stream": "default",
+                **_store_coordinates(),
                 "since": os.environ.get(OSPREY_TELEMETRY_SESSION_START_ENV) or None,
                 "emitted_at": emitted_at,
             },

--- a/src/osprey/templates/claude_code/claude/skills/sim-scenarios/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/sim-scenarios/SKILL.md
@@ -79,7 +79,7 @@ osprey sim apply nominal              # back to clean baseline
   One exception: a scenario with a `physics` block on a deployment that runs
   the virtual accelerator is written to `.env`, which the VA container reads
   only when it is created. `apply` prints a notice when this happens; follow
-  it with `osprey up` (not `docker restart`, which reuses the old environment).
+  it with `osprey up` — restarting the container reuses the old environment.
 
 **Important:** applying scenarios resets the simulated machine — any setpoint
 changes written during the session are cleared. Warn the user before switching

--- a/src/osprey/templates/deploy/gitlab-ci.yml.j2
+++ b/src/osprey/templates/deploy/gitlab-ci.yml.j2
@@ -211,7 +211,12 @@ deploy:
       REMOTE
   environment:
     name: production
-    url: https://$DEPLOY_HOST
+{% if ctx.environment_url %}
+    # The address browsers open this deployment at, derived from the same
+    # origin the landing page carries and every terminal checks a write
+    # against — not the SSH host the job connects to.
+    url: {{ ctx.environment_url }}
+{% endif %}
   resource_group: production
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
+++ b/src/osprey/templates/services/event_dispatcher/docker-compose.yml.j2
@@ -112,20 +112,23 @@ services:
     on attribute access against an undefined name, so testing `claude_code.telemetry`
     on a config that omits the whole `claude_code:` block would fail the render
     rather than fall through to the off state. #}
-{% if 'openobserve' in (deployed_services | default([])) and claude_code is defined and claude_code.telemetry is defined and claude_code.telemetry and claude_code.telemetry.enabled %}
+{% if 'openobserve' in (deployed_services | default([])) and claude_code is defined and claude_code.telemetry is defined and claude_code.telemetry and claude_code.telemetry.enabled and osprey_telemetry_host %}
       # Browser-reachable base URL of the telemetry store, so the dashboard can
-      # link a run to its own OTEL records. Deliberately localhost-and-host-port,
-      # NOT the `openobserve` compose DNS name the containers talk to: the value
-      # is rendered into a link the OPERATOR's browser follows, and the browser
-      # is outside the compose network. This mirrors how the store's UI is
-      # reached today (the service binds to localhost by design).
+      # link a run to its own OTEL records. The host is `osprey_telemetry_host`,
+      # derived at render time from the same external-origin authority every
+      # other browser-facing URL comes from — NOT the `openobserve` compose DNS
+      # name the containers talk to, because the value is rendered into a link
+      # the OPERATOR's browser follows and the browser is outside the compose
+      # network. The store publishes its own host port directly, so the scheme
+      # stays http and the port is the store's.
       #
-      # Emitted only when the store is deployed AND agent telemetry is on —
-      # either being off leaves the var unset, which the dashboard reads as
-      # "hide the link" rather than offering one that resolves to nothing.
-      # Render-time gate: toggling telemetry in config.yml afterwards needs a
-      # redeploy to take effect here, same as every other value in this block.
-      OSPREY_TELEMETRY_URL: "http://localhost:{{ services.openobserve.port | default(osprey_ports.openobserve, true) }}"
+      # Emitted only when the store is deployed, agent telemetry is on, AND a
+      # host is derivable — any of the three being false leaves the var unset,
+      # which the dashboard reads as "hide the link" rather than offering one
+      # that resolves to nothing. Render-time gate: toggling telemetry in
+      # config.yml afterwards needs a redeploy to take effect here, same as
+      # every other value in this block.
+      OSPREY_TELEMETRY_URL: "http://{{ osprey_telemetry_host }}:{{ services.openobserve.port | default(osprey_ports.openobserve, true) }}"
 {% endif %}
       TZ: {{ system.timezone }}
 {{- hostenv.passthrough(services.event_dispatcher) }}

--- a/src/osprey/utils/shell_resolver.py
+++ b/src/osprey/utils/shell_resolver.py
@@ -12,18 +12,38 @@ import os
 import shutil
 from pathlib import Path
 
-# Well-known user-local bin directories, checked in order.
-_USER_BIN_CANDIDATES = [
-    Path.home() / ".local" / "bin",
-    Path.home() / ".cargo" / "bin",
-    Path("/usr/local/bin"),
-]
+#: Bin directories under the invoking user's home, relative to it.
+_HOME_RELATIVE_BINS = (Path(".local") / "bin", Path(".cargo") / "bin")
+
+#: Bin directories that exist independently of any account.
+_SYSTEM_BINS = (Path("/usr/local/bin"),)
+
+
+def _user_bin_candidates() -> list[Path]:
+    """Well-known user-local bin directories, in search order.
+
+    Built on call rather than at import, and tolerant of an account with no
+    home: a uid with no passwd entry and no ``HOME`` — ordinary under a
+    random-uid cluster policy — makes ``Path.home()`` raise, and doing that at
+    import turned a shorter PATH into an ImportError in every module that
+    imports this one at module scope. The same degrade-not-raise posture
+    :func:`osprey.utils.identity.resolve_identity` takes.
+
+    Returns:
+        The home-relative directories followed by the system ones, or only the
+        system ones when no home resolves.
+    """
+    try:
+        home = Path.home()
+    except (RuntimeError, OSError):
+        return list(_SYSTEM_BINS)
+    return [home / relative for relative in _HOME_RELATIVE_BINS] + list(_SYSTEM_BINS)
 
 
 def user_bin_dirs() -> list[str]:
     """Return existing user-local bin directories not already on PATH."""
     current = set(os.environ.get("PATH", "").split(os.pathsep))
-    return [str(d) for d in _USER_BIN_CANDIDATES if d.is_dir() and str(d) not in current]
+    return [str(d) for d in _user_bin_candidates() if d.is_dir() and str(d) not in current]
 
 
 def resolve_shell_command(command: str) -> str:
@@ -66,7 +86,7 @@ def resolve_shell_command(command: str) -> str:
 
     raise FileNotFoundError(
         f"{command!r} not found on PATH or in common install locations "
-        f"({', '.join(str(d) for d in _USER_BIN_CANDIDATES)}). "
+        f"({', '.join(str(d) for d in _user_bin_candidates())}). "
         f"Install it, or set web_terminal.shell to an absolute path under "
         f"`config:` in profile.yml and run `osprey build`."
     )

--- a/tests/cli/test_init_verb.py
+++ b/tests/cli/test_init_verb.py
@@ -1375,7 +1375,7 @@ class TestResetFlag:
         monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _completed_reset)
         monkeypatch.setattr(
             "osprey.cli.init_cmd._surviving_project_resources",
-            lambda target: ["container old-thing", "volume old-thing_data"],
+            lambda target, runtime: ["container old-thing", "volume old-thing_data"],
         )
 
         result = runner.invoke(
@@ -1387,9 +1387,44 @@ class TestResetFlag:
         assert "old-thing" in result.output
         assert "com.osprey.repo-id" in result.output
 
+    def test_the_remedy_names_the_runtime_this_host_actually_resolves(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """The commands to paste have to be runnable on the host reading them.
+
+        The probe two lines above already resolved the runtime binary; the
+        remedy printed ``docker`` regardless, so a podman host was handed three
+        commands it has no binary for.
+        """
+        monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _completed_reset)
+        monkeypatch.setattr(
+            "osprey.cli.init_cmd._surviving_project_resources",
+            lambda target, runtime: ["container old-thing"],
+        )
+        monkeypatch.setattr(
+            "osprey.deployment.runtime_helper.get_runtime_command",
+            lambda _config: ["podman"],
+        )
+
+        result = runner.invoke(
+            cli,
+            ["init", str(tmp_path / "demo"), "--preset", "hello-world", "--no-git", "--reset"],
+        )
+
+        # The report is wrapped to the terminal width, so compare on one line.
+        printed = " ".join(result.output.split())
+
+        assert result.exit_code != 0
+        assert "podman ps -aq" in printed
+        assert "podman volume ls -q" in printed
+        assert "xargs podman rm -f" in printed
+        assert "docker " not in printed.replace("com.docker.compose.project", "")
+
     def test_it_proceeds_when_the_sweep_was_complete(self, runner, tmp_path, monkeypatch):
         monkeypatch.setattr("osprey.deployment.reset.reset_for_reinit", _completed_reset)
-        monkeypatch.setattr("osprey.cli.init_cmd._surviving_project_resources", lambda target: [])
+        monkeypatch.setattr(
+            "osprey.cli.init_cmd._surviving_project_resources", lambda target, runtime: []
+        )
 
         result = runner.invoke(
             cli,

--- a/tests/cli/test_reset_plan_parity.py
+++ b/tests/cli/test_reset_plan_parity.py
@@ -150,7 +150,7 @@ def no_survivor_check(monkeypatch: pytest.MonkeyPatch) -> None:
     in ``tmp_path``. What it guards is pinned in ``tests/cli/test_init_verb.py``;
     it is not this file's subject.
     """
-    monkeypatch.setattr(init_cmd, "_surviving_project_resources", lambda repo_root: [])
+    monkeypatch.setattr(init_cmd, "_surviving_project_resources", lambda repo_root, runtime: [])
 
 
 def run_init_reset(target: Path) -> Result:

--- a/tests/cli/test_scaffold_ci.py
+++ b/tests/cli/test_scaffold_ci.py
@@ -795,3 +795,67 @@ def test_list_still_works_before_the_first_build(runner: CliRunner, repo: Path) 
 
     assert result.exit_code == 0, result.output
     assert "Framework-managed" in result.output
+
+
+# ── The environment URL ──────────────────────────────────────────────────────
+
+
+class TestEnvironmentUrl:
+    """The pipeline's environment URL is the deployment's own origin.
+
+    ``https://$DEPLOY_HOST`` was a third spelling of an address this deployment
+    already derives once: it asserted TLS on a profile serving plain HTTP,
+    dropped a non-default port, and named the SSH host rather than the address
+    browsers open. All three are the same defect — a browser-facing URL that did
+    not come from the origin authority.
+    """
+
+    def _context(self, profile: dict, fqdn: str = "ctl-01.example.org"):
+        from osprey.cli.build_profile_deploy import DeployConfig, DeployHost
+        from osprey.cli.deploy_scaffold_templates import build_ci_context
+
+        deploy = DeployConfig(
+            ci="gitlab",
+            host=DeployHost(name="ctl-01", project_path="/srv/d", user="svc", fqdn=fqdn),
+        )
+        return build_ci_context(profile, deploy, Path("."), "d")
+
+    def _profile(self, **config: object) -> dict:
+        return {
+            "name": "d",
+            "config": {
+                "modules.web_terminals": {"enabled": True, **config.pop("web", {})},
+                **config,
+            },
+        }
+
+    def test_plain_http_takes_the_scheme_and_the_published_port(self) -> None:
+        ctx = self._context(self._profile(**{"deploy.fqdn": "ctl-01.example.org"}))
+
+        assert ctx.environment_url == "http://ctl-01.example.org:10000"
+
+    def test_tls_on_a_non_default_port_keeps_the_port(self) -> None:
+        profile = self._profile(
+            **{
+                "deploy.fqdn": "ctl-01.example.org",
+                "web": {"tls": {"enabled": True, "port": 8443}},
+            }
+        )
+
+        assert self._context(profile).environment_url == "https://ctl-01.example.org:8443"
+
+    def test_a_declared_external_origin_wins_verbatim(self) -> None:
+        profile = self._profile(
+            **{
+                "deploy.fqdn": "ctl-01.example.org",
+                "web": {"external_origin": "https://terminals.example.org"},
+            }
+        )
+
+        assert self._context(profile).environment_url == "https://terminals.example.org"
+
+    def test_a_deployment_with_no_web_tier_declares_no_url(self) -> None:
+        """A backend-only deployment has no landing page to link to."""
+        ctx = self._context({"name": "d", "config": {}})
+
+        assert ctx.environment_url is None

--- a/tests/cli/test_sim_physics_env.py
+++ b/tests/cli/test_sim_physics_env.py
@@ -177,7 +177,10 @@ class TestRenderAndNotice:
         assert "osprey up" in result.output
         # A plain restart reuses the old environment -- the user has to be told
         # that specifically, or they will "restart" and see the old physics.
-        assert "docker restart" in result.output
+        # Said without naming a runtime binary: the notice is printed on hosts
+        # that run podman too.
+        assert "Restarting the container reuses the old environment" in result.output
+        assert "docker" not in result.output
 
     def test_identical_reapply_emits_no_notice(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)

--- a/tests/cli/test_summary_card.py
+++ b/tests/cli/test_summary_card.py
@@ -302,6 +302,29 @@ class TestCardContent:
         assert "postgres" not in card
         assert "not configured" not in card
 
+    def test_an_https_landing_row_is_not_dropped(self, repo: Path, monkeypatch) -> None:
+        """The front door is ``https://`` on the documented TLS/fqdn shape.
+
+        A scheme test that named only ``http://`` dropped the one row the card
+        exists to print, on exactly the deployments an operator most needs it
+        for.
+        """
+        from osprey.deployment import deploy_summary
+
+        monkeypatch.setattr(
+            deploy_summary,
+            "as_built_endpoint_entries",
+            lambda root: [
+                ("gateway", "web terminal", "https://terminals.example.org  (landing page)"),
+                ("dispatch", "event-dispatcher", "http://127.0.0.1:10010"),
+            ],
+        )
+
+        card = "\n".join(format_summary_card(repo, "running"))
+
+        assert "https://terminals.example.org" in card
+        assert "http://127.0.0.1:10010" in card
+
     def test_the_card_keeps_the_order_the_block_puts_the_endpoints_in(
         self, repo: Path, monkeypatch
     ) -> None:
@@ -336,7 +359,8 @@ class TestCardContent:
     ) -> None:
         """Nothing answers on them, and a URL printed under `down` reads as an
         invitation to open something that is not there."""
-        assert "http://" not in "\n".join(format_summary_card(repo, state))
+        card = "\n".join(format_summary_card(repo, state))
+        assert "http://" not in card and "https://" not in card
 
     def test_the_card_says_where_the_command_output_went(self, repo: Path) -> None:
         """The spool directory is the one thing a quiet run cannot be read back
@@ -1000,3 +1024,15 @@ class TestStaleSeededLogins:
         printed = "\n".join(recorder.lines)
         assert "alice / alice · bob / bob" in printed
         assert "passwd" not in printed
+
+
+class TestNextStepCopy:
+    """The card names the verb that opens a deployment with no containers."""
+
+    @pytest.mark.parametrize("state", ["created", "built"])
+    def test_osprey_web_is_offered_before_anything_is_up(self, repo: Path, state: str) -> None:
+        """``osprey up -d`` is not the only way in, and for a deployment that
+        runs no containers it is not a way in at all."""
+        card = "\n".join(format_summary_card(repo, state))
+
+        assert "osprey web" in card

--- a/tests/cli/test_web_bind.py
+++ b/tests/cli/test_web_bind.py
@@ -600,3 +600,62 @@ class TestCompanionProbeAttribution:
 
         self._render(lifecycle_repo, monkeypatch, roster=True)
         assert _probe_companion_ports() == []
+
+
+class TestExposureWarning:
+    """The "this is on the network" warning keys on "not loopback"."""
+
+    def _stub(self, monkeypatch):
+        monkeypatch.delenv(DECLARED_BIND_ENV, raising=False)
+        monkeypatch.setattr("osprey.interfaces.web_terminal.run_web", lambda **_kw: None)
+        monkeypatch.setattr("osprey.mcp_env.load_dotenv_from_project", lambda: None)
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::", "10.0.0.7"])
+    def test_detached_start_warns_before_it_returns(self, runner, monkeypatch, host):
+        """`osprey web -d` printed nothing: the warning sat below the return.
+
+        Also the only path that reaches the check with a non-IPv4 host: the
+        foreground branch's own bind probe is AF_INET and refuses ``::`` first.
+        """
+        self._stub(monkeypatch)
+        monkeypatch.setattr("osprey.cli.web_cmd._start_detached", lambda *_a, **_kw: None)
+
+        result = runner.invoke(
+            web,
+            [
+                "--host",
+                host,
+                "--detach",
+                "--port",
+                str(_free_port()),
+                "--shell",
+                "true",
+                "--skip-preflight",
+            ],
+            catch_exceptions=False,
+        )
+        assert "exposes the terminal to the network" in result.stderr
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+    def test_loopback_bind_stays_quiet(self, runner, monkeypatch, host):
+        """Both spellings of "this machine only": the literal and the name.
+
+        ``localhost`` is the one hostname the check accepts as loopback, so it
+        is the case that would regress first if the rule went back to comparing
+        against ``0.0.0.0``.
+        """
+        self._stub(monkeypatch)
+        result = runner.invoke(
+            web,
+            [
+                "--host",
+                host,
+                "--port",
+                str(_free_port()),
+                "--shell",
+                "true",
+                "--skip-preflight",
+            ],
+            catch_exceptions=False,
+        )
+        assert "exposes the terminal to the network" not in result.stderr

--- a/tests/cli/test_write_once_dirs.py
+++ b/tests/cli/test_write_once_dirs.py
@@ -277,7 +277,9 @@ def _reset_runs_without_a_container_runtime(monkeypatch: pytest.MonkeyPatch) -> 
         "osprey.deployment.reset.reset_for_reinit",
         lambda repo_root, **kw: ResetOutcome.COMPLETED,
     )
-    monkeypatch.setattr("osprey.cli.init_cmd._surviving_project_resources", lambda target: [])
+    monkeypatch.setattr(
+        "osprey.cli.init_cmd._surviving_project_resources", lambda target, runtime: []
+    )
 
 
 @needs_packaged_seed

--- a/tests/connectors/test_agent_dir_container_anchor.py
+++ b/tests/connectors/test_agent_dir_container_anchor.py
@@ -1,0 +1,72 @@
+"""Where ``get_agent_dir`` anchors when the configured project root is not here.
+
+A container runs with a ``project_root`` written on the host, so the configured
+path frequently does not exist inside the image. What to do then used to be a
+guess: try ``/app``, ``/pipelines``, ``/jupyter`` in turn and take the first that
+happens to hold an agent-data directory. Two of those names belong to an
+execution method that no longer ships, and the one that remains never fires in
+the shipped layout — the image puts the project at ``/app/<project>/``, not at
+``/app``.
+
+``CONFIG_FILE`` already names the config this process actually loaded, and its
+directory IS the project root by construction. These tests hold the fallback to
+that, and to the cwd-with-a-warning it always had when even that is unset.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from osprey_connectors import config as connectors_config
+
+
+@pytest.fixture
+def agent_dir(monkeypatch):
+    """Call ``get_agent_dir`` against a config whose project root is elsewhere."""
+
+    def _call(project_root: str, raw: dict | None = None):
+        class _Config:
+            raw_config = raw or {}
+
+            def get(self, key, default=None):
+                return {"project_root": project_root, "file_paths": {}}.get(key, default)
+
+        monkeypatch.setattr(connectors_config, "_get_config", lambda: _Config())
+        return Path(connectors_config.get_agent_dir("api_calls_dir"))
+
+    return _call
+
+
+def test_config_file_names_the_project_root(agent_dir, monkeypatch, tmp_path):
+    project = tmp_path / "facility"
+    project.mkdir()
+    (project / "config.yml").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CONFIG_FILE", str(project / "config.yml"))
+
+    resolved = agent_dir(str(tmp_path / "does-not-exist"))
+
+    assert resolved.is_relative_to(project)
+    assert resolved.name == "api_calls_dir"
+
+
+def test_without_config_file_it_still_falls_back_to_the_cwd(agent_dir, monkeypatch, tmp_path):
+    monkeypatch.delenv("CONFIG_FILE", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    resolved = agent_dir(str(tmp_path / "does-not-exist"))
+
+    assert resolved.is_absolute()
+    assert resolved.name == "api_calls_dir"
+
+
+def test_no_container_root_is_guessed(agent_dir, monkeypatch, tmp_path):
+    """``/app`` is not a project root in the shipped layout, and never was one
+    this could prove."""
+    monkeypatch.delenv("CONFIG_FILE", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    resolved = agent_dir(str(tmp_path / "does-not-exist"))
+
+    assert not str(resolved).startswith(("/app", "/pipelines", "/jupyter"))

--- a/tests/deployment/test_dial_address.py
+++ b/tests/deployment/test_dial_address.py
@@ -1,0 +1,98 @@
+"""One rule for every host-side dial of a published port.
+
+``deployment.bind_address`` says where a service *listens*. Turning it into an
+address to *connect to* is a separate question, and three modules used to answer
+it three ways: the provisioner and the health category dialed the bind literal
+(unreachable for a wildcard on some platforms), the qmd sidecar always dialed
+loopback (wrong for a pinned interface), and the host-port preflight had the
+rule the others should have had. These tests hold every reader to that one rule.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+import httpx
+import pytest
+
+from osprey.deployment import openobserve_provision as provision
+from osprey.deployment.host_ports import _probe_host
+from osprey.deployment.qmd_service import (
+    QMDServiceConfig,
+    dial_address,
+    dial_host,
+    is_loopback_bind,
+)
+from osprey.health.core.openobserve import openobserve
+
+#: Every spelling of "listen on every interface", with the loopback address of
+#: the family it belongs to.
+WILDCARDS = {"": "127.0.0.1", "0.0.0.0": "127.0.0.1", "*": "127.0.0.1", "::": "::1"}
+
+#: Addresses that name one interface and are therefore dialed as written.
+PINNED = ["10.0.0.7", "192.168.1.4", "myhost.example.org", "127.0.0.1"]
+
+
+@pytest.mark.parametrize(("bind", "loopback"), WILDCARDS.items())
+def test_wildcard_dials_its_family_loopback(bind: str, loopback: str) -> None:
+    assert dial_host(bind) == loopback
+
+
+@pytest.mark.parametrize("bind", PINNED)
+def test_pinned_interface_is_dialed_as_written(bind: str) -> None:
+    """Not "always loopback": a pinned bind publishes on that interface only."""
+    assert dial_host(bind) == bind
+
+
+def test_ipv6_literal_is_bracketed_for_a_url_authority() -> None:
+    assert dial_address("::") == "[::1]"
+    assert dial_address("::1") == "[::1]"
+    assert dial_address("0.0.0.0") == "127.0.0.1"
+
+
+def test_probe_host_is_the_same_rule() -> None:
+    """The preflight's prober and the URL builders cannot drift apart."""
+    for bind, loopback in WILDCARDS.items():
+        assert _probe_host(bind) == loopback
+
+
+@pytest.mark.parametrize(("bind", "loopback"), WILDCARDS.items())
+def test_no_wildcard_survives_into_a_dialed_url(bind: str, loopback: str) -> None:
+    """Parity: every URL built for a wildcard bind names a loopback address."""
+    config = {
+        "deployed_services": ["openobserve"],
+        "services": {"openobserve": {"port": 15080}},
+        "deployment": {"bind_address": bind},
+    }
+    urls = [
+        provision.store_base_url(config),
+        QMDServiceConfig(port=8180, bind_address=bind).base_url,
+        _healthz_url(config),
+    ]
+    expected = f"[{loopback}]" if ":" in loopback else loopback
+    for url in urls:
+        assert urlsplit(url).netloc.rsplit(":", 1)[0] == expected, url
+
+
+def _healthz_url(config: dict) -> str:
+    """The URL the openobserve health category actually requests."""
+    captured: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(str(request.url))
+        return httpx.Response(200)
+
+    import asyncio
+
+    asyncio.run(openobserve(config, transport=httpx.MockTransport(handler))())
+    return captured[0]
+
+
+@pytest.mark.parametrize("bind", ["127.0.0.1", "::1", "localhost", "127.0.0.2"])
+def test_loopback_spellings_are_not_exposed(bind: str) -> None:
+    assert is_loopback_bind(bind) is True
+
+
+@pytest.mark.parametrize("bind", ["0.0.0.0", "::", "", "*", "10.0.0.7", "myhost.example"])
+def test_everything_else_is_exposed(bind: str) -> None:
+    assert is_loopback_bind(bind) is False

--- a/tests/deployment/test_dispatcher_telemetry_link.py
+++ b/tests/deployment/test_dispatcher_telemetry_link.py
@@ -1,0 +1,92 @@
+"""The dispatcher dashboard's telemetry link follows the deployment's origin.
+
+The link is rendered into the compose file at build time and followed in the
+OPERATOR's browser, which sits outside the compose network. It used to be
+``http://localhost:<port>`` unconditionally — correct only where the operator's
+browser runs on the host that publishes the store. Anywhere else it named the
+operator's own machine, and the link either failed or, worse, reached a store
+that is not this deployment's.
+
+The rule these tests hold it to:
+
+* a loopback-bound store keeps ``localhost`` — a browser reaching that dashboard
+  is on the host anyway, so it is the correct name for it;
+* an exposed store takes the host of the deployment's declared external origin
+  (``modules.web_terminals.external_origin``, else ``deploy.fqdn``), the same
+  authority every other browser-facing URL comes from;
+* an exposed store with no derivable origin renders NOTHING. An unset variable
+  already means "hide the link", which beats a link nothing serves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment.compose_generator import _telemetry_link_host
+
+TELEMETRY_ON = {
+    "deployed_services": ["openobserve"],
+    "claude_code": {"telemetry": {"enabled": True}},
+}
+
+
+def _config(bind: str, **root: object) -> dict:
+    return {**TELEMETRY_ON, "deployment": {"bind_address": bind}, **root}
+
+
+class TestLinkHost:
+    """What the build-time derivation resolves the link's host to."""
+
+    @pytest.mark.parametrize("bind", ["127.0.0.1", "localhost", "::1"])
+    def test_loopback_store_keeps_localhost(self, bind: str) -> None:
+        assert _telemetry_link_host(_config(bind)) == "localhost"
+
+    def test_unset_bind_is_loopback(self) -> None:
+        assert _telemetry_link_host(dict(TELEMETRY_ON)) == "localhost"
+
+    def test_exposed_store_takes_the_declared_external_origin(self) -> None:
+        config = _config(
+            "0.0.0.0",
+            modules={"web_terminals": {"external_origin": "https://terminals.example.org:8443"}},
+        )
+        assert _telemetry_link_host(config) == "terminals.example.org"
+
+    def test_exposed_store_falls_back_to_the_deploy_fqdn(self) -> None:
+        config = _config("0.0.0.0", deploy={"fqdn": "ctl-01.example.org"})
+        assert _telemetry_link_host(config) == "ctl-01.example.org"
+
+    def test_exposed_store_with_no_derivable_origin_emits_nothing(self) -> None:
+        """Unset already means "hide the link"; a guess would be worse."""
+        assert _telemetry_link_host(_config("0.0.0.0")) is None
+
+    def test_pinned_interface_is_still_not_loopback(self) -> None:
+        config = _config("10.0.0.7", deploy={"fqdn": "ctl-01.example.org"})
+        assert _telemetry_link_host(config) == "ctl-01.example.org"
+
+
+class TestRender:
+    """What the dispatcher compose template does with it."""
+
+    def _render(self, host: str | None) -> str:
+        from tests.deployment.test_compose_generator import (
+            _dispatcher_context,
+            _packaged_compose_template,
+        )
+
+        context = _dispatcher_context()
+        context.update(
+            TELEMETRY_ON,
+            services={**context["services"], "openobserve": {"port": 15080}},
+            osprey_telemetry_host=host,
+        )
+        return _packaged_compose_template("services/event_dispatcher/docker-compose.yml.j2").render(
+            **context
+        )
+
+    def test_host_is_rendered_into_the_url(self) -> None:
+        assert 'OSPREY_TELEMETRY_URL: "http://ctl-01.example.org:15080"' in self._render(
+            "ctl-01.example.org"
+        )
+
+    def test_no_host_renders_no_variable(self) -> None:
+        assert "OSPREY_TELEMETRY_URL" not in self._render(None)

--- a/tests/deployment/test_docker_desktop.py
+++ b/tests/deployment/test_docker_desktop.py
@@ -252,19 +252,74 @@ class TestTheDockerDesktopPredicate:
 
         assert docker_desktop.on_docker_desktop({}) is True
 
-    def test_a_linux_host_is_not(self, monkeypatch):
+    def test_a_linux_host_on_the_bare_engine_is_not(self, monkeypatch):
         """There ``network_mode: host`` binds on the machine itself, so an
         unreachable port means something else entirely."""
         monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+        monkeypatch.setattr(docker_desktop, "get_runtime_command", lambda config: ["docker"])
+        monkeypatch.setattr(docker_desktop, "_active_docker_context", lambda: "default")
 
         assert docker_desktop.on_docker_desktop({}) is False
 
-    def test_the_runtime_is_not_resolved_on_a_linux_host(self, monkeypatch):
-        """The platform is checked first so the cheap answer stays cheap."""
+    def test_docker_desktop_on_linux_is_docker_desktop(self, monkeypatch):
+        """Its Linux build has the same VM and the same port handling.
+
+        Keying on ``sys.platform`` answered ``False`` here, which is why the
+        two Linux path readers in this very module were unreachable code.
+        """
         monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+        monkeypatch.setattr(docker_desktop, "get_runtime_command", lambda config: ["docker"])
+        monkeypatch.setattr(docker_desktop, "_active_docker_context", lambda: "desktop-linux")
+
+        assert docker_desktop.on_docker_desktop({}) is True
+
+    def test_desktop_installed_but_containers_on_the_bare_engine_is_not(self, monkeypatch):
+        """Presence of the install is not the question; which engine runs is.
+
+        Docker Desktop's files sit on the host whether or not the active
+        context points at it, so the presence test alone is a false positive on
+        exactly the shape it would matter for.
+        """
+        monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+        monkeypatch.setattr(docker_desktop, "get_runtime_command", lambda config: ["docker"])
+        monkeypatch.setattr(docker_desktop, "_active_docker_context", lambda: "default")
+        monkeypatch.setattr(
+            docker_desktop, "backend_socket_path", lambda: pytest.fail("presence must not decide")
+        )
+
+        assert docker_desktop.on_docker_desktop({}) is False
+
+    def test_an_unreadable_context_falls_back_to_the_install(self, monkeypatch, tmp_path):
+        """A CLI that cannot be asked leaves the presence test as the answer."""
+        monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+        monkeypatch.setattr(docker_desktop, "get_runtime_command", lambda config: ["docker"])
+        monkeypatch.setattr(docker_desktop, "_active_docker_context", lambda: None)
+        socket_path = tmp_path / "backend.sock"
+        socket_path.touch()
+        monkeypatch.setattr(docker_desktop, "backend_socket_path", lambda: socket_path)
+
+        assert docker_desktop.on_docker_desktop({}) is True
+
+    def test_podman_on_linux_never_asks_for_a_context(self, monkeypatch):
+        """The runtime settles it, so the subprocess is not spent."""
+        monkeypatch.setattr(docker_desktop.sys, "platform", "linux")
+        monkeypatch.setattr(
+            docker_desktop, "get_runtime_command", lambda config: ["podman", "compose"]
+        )
+        monkeypatch.setattr(
+            docker_desktop,
+            "_active_docker_context",
+            lambda: pytest.fail("the runtime already answered"),
+        )
+
+        assert docker_desktop.on_docker_desktop({}) is False
+
+    def test_a_platform_with_no_desktop_build_is_not(self, monkeypatch):
+        """No runtime is resolved where the product does not exist."""
+        monkeypatch.setattr(docker_desktop.sys, "platform", "freebsd13")
 
         def fail(config: dict) -> list[str]:
-            raise AssertionError("the runtime should not be resolved on Linux")
+            raise AssertionError("the runtime should not be resolved here")
 
         monkeypatch.setattr(docker_desktop, "get_runtime_command", fail)
 

--- a/tests/deployment/test_openobserve_provision.py
+++ b/tests/deployment/test_openobserve_provision.py
@@ -787,7 +787,7 @@ def test_the_address_is_the_one_this_deploy_publishes(env_file):
         "deployment": {"bind_address": "0.0.0.0"},
     }
 
-    assert provision.store_base_url(config) == "http://0.0.0.0:15080"
+    assert provision.store_base_url(config) == "http://127.0.0.1:15080"
     assert provision.store_base_url(CONFIG) == "http://127.0.0.1:5080"
     assert provision.store_org(CONFIG) == "default"
 

--- a/tests/deployment/test_qmd_service_config.py
+++ b/tests/deployment/test_qmd_service_config.py
@@ -116,7 +116,7 @@ class TestValidation:
 
 
 class TestBaseUrl:
-    """Clients connect over loopback regardless of the publish interface."""
+    """Clients dial the address the publish interface is actually reached on."""
 
     def test_uses_configured_port(self) -> None:
         assert QMDServiceConfig(port=8180).base_url == "http://127.0.0.1:8180"
@@ -124,6 +124,12 @@ class TestBaseUrl:
     def test_wildcard_publish_still_dials_loopback(self) -> None:
         assert QMDServiceConfig(port=8180, bind_address="0.0.0.0").base_url == (
             "http://127.0.0.1:8180"
+        )
+
+    def test_pinned_interface_is_dialed_there_not_on_loopback(self) -> None:
+        """A concrete bind publishes on that interface only, so dial it."""
+        assert QMDServiceConfig(port=8180, bind_address="10.0.0.7").base_url == (
+            "http://10.0.0.7:8180"
         )
 
 

--- a/tests/deployment/test_status_display.py
+++ b/tests/deployment/test_status_display.py
@@ -409,3 +409,54 @@ def test_the_endpoints_section_resolves_personas_against_the_live_checkout(
     status_display._print_endpoints_section({"project_name": "demo"}, [], tmp_path)
 
     assert seen["project_root"] == tmp_path
+
+
+class TestNoRuntimeInstalled:
+    """ "No runtime here" and "the runtime is not answering" are different facts.
+
+    ``_query_containers`` reported both as ``Could not query container status``,
+    so a deployment that declares no containerized services — a perfectly
+    supported shape — carried a permanent red banner on every ``osprey status``
+    for a tool it does not need. The distinction is a conjunction: nothing
+    installed AND nothing declared. "Installed but down" and "no runtime but
+    services declared" both stay failures, because both are.
+    """
+
+    def _query(self, monkeypatch, config, *, installed: bool) -> object:
+        def _refuse(*_a, **_kw):
+            raise RuntimeError("No container runtime found.")
+
+        monkeypatch.setattr(status_display, "get_ps_command", _refuse)
+        monkeypatch.setattr(
+            "osprey.deployment.runtime_helper.no_container_runtime_installed",
+            lambda: not installed,
+        )
+        return status_display._query_containers(config)
+
+    def test_nothing_installed_and_nothing_declared_is_a_note(self, monkeypatch, rendered) -> None:
+        assert self._query(monkeypatch, {"deployed_services": []}, installed=False) is None
+
+        printed = rendered.export_text()
+        assert "declares no containerized services" in printed
+        assert "Could not query container status" not in printed
+
+    def test_no_config_at_all_is_also_nothing_declared(self, monkeypatch, rendered) -> None:
+        assert self._query(monkeypatch, None, installed=False) is None
+
+        assert "declares no containerized services" in rendered.export_text()
+
+    def test_services_declared_still_fails(self, monkeypatch, rendered) -> None:
+        """A deployment that needs a runtime and has none is broken, and says so."""
+        result = self._query(monkeypatch, {"deployed_services": ["openobserve"]}, installed=False)
+        assert result is None
+
+        printed = rendered.export_text()
+        assert "Could not query container status" in printed
+        assert "declares no containerized services" not in printed
+
+    def test_installed_but_not_answering_still_fails(self, monkeypatch, rendered) -> None:
+        assert self._query(monkeypatch, {"deployed_services": []}, installed=True) is None
+
+        printed = rendered.export_text()
+        assert "Could not query container status" in printed
+        assert "declares no containerized services" not in printed

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -2407,7 +2407,10 @@ deploy:
       REMOTE
   environment:
     name: production
-    url: https://$DEPLOY_HOST
+    # The address browsers open this deployment at, derived from the same
+    # origin the landing page carries and every terminal checks a write
+    # against — not the SSH host the job connects to.
+    url: http://127.0.0.1:10000
   resource_group: production
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/tests/health/core/test_python_environment.py
+++ b/tests/health/core/test_python_environment.py
@@ -76,9 +76,28 @@ def test_virtual_environment_warns_when_absent(monkeypatch) -> None:
     monkeypatch.delattr(sys, "real_prefix", raising=False)
     monkeypatch.setattr(sys, "base_prefix", "/usr")
     monkeypatch.setattr(sys, "prefix", "/usr")
+    monkeypatch.setattr("osprey.health.core.python_environment._in_container", lambda: False)
     row = _run()["virtual_environment"]
     assert row.status is Status.WARNING
     assert "Not in a virtual environment" in row.message
+
+
+def test_system_interpreter_inside_a_container_is_ok(monkeypatch) -> None:
+    """The shipped image installs into system Python, so this row is a false alarm.
+
+    The isolation a virtualenv provides on a shared host is what the image
+    itself provides: nothing else lives in it. Warning here put a permanent
+    amber row on the core category of every containerised deployment, for a
+    condition that is the deployment working as designed. Whether OSPREY can
+    actually run is ``core_dependencies``, which is untouched.
+    """
+    monkeypatch.delattr(sys, "real_prefix", raising=False)
+    monkeypatch.setattr(sys, "base_prefix", "/usr")
+    monkeypatch.setattr(sys, "prefix", "/usr")
+    monkeypatch.setattr("osprey.health.core.python_environment._in_container", lambda: True)
+    row = _run()["virtual_environment"]
+    assert row.status is Status.OK
+    assert "container" in row.message
 
 
 def test_core_dependencies_ok_when_all_present() -> None:

--- a/tests/interfaces/ariel/test_app_config_lifecycle.py
+++ b/tests/interfaces/ariel/test_app_config_lifecycle.py
@@ -269,3 +269,49 @@ def test_load_ariel_config_with_path_returns_the_resolved_file(tmp_path: Path):
     assert config_dict["database"]["uri"] == DSN
     # The old entry point stays a pure delegation.
     assert load_ariel_config(config_file) == config_dict
+
+
+class TestConfigSearchPrecedence:
+    """``CONFIG_FILE`` outranks the container guess, in both readers.
+
+    Two orders lived in one package: the loader searched ``/app/config.yml``
+    before ``CONFIG_FILE``, the settings routes searched ``CONFIG_FILE`` before
+    ``/app``. Nothing puts a config at ``/app/config.yml`` in the shipped layout
+    (the image lands the project at ``/app/<project>/``), so the loader's order
+    was both wrong and a way for a stale mount to win over the variable an
+    operator explicitly set.
+    """
+
+    def test_config_file_outranks_the_container_mount(self, tmp_path, monkeypatch):
+        from osprey.interfaces.ariel.app import load_ariel_config_with_path
+
+        (tmp_path / "declared").mkdir()
+        declared = _write_config(tmp_path / "declared", {"database": {"uri": DSN}})
+        mounted = tmp_path / "mounted" / "config.yml"
+        mounted.parent.mkdir(parents=True, exist_ok=True)
+        mounted.write_text("ariel: {database: {uri: 'postgresql://stale/stale'}}\n")
+
+        monkeypatch.setenv("CONFIG_FILE", str(declared))
+        monkeypatch.setattr("osprey.interfaces.ariel.app._CONTAINER_CONFIG_PATH", mounted)
+
+        _, path = load_ariel_config_with_path()
+
+        assert path == declared
+
+    def test_an_explicit_argument_still_wins(self, tmp_path, monkeypatch):
+        from osprey.interfaces.ariel.app import load_ariel_config_with_path
+
+        (tmp_path / "argument").mkdir()
+        (tmp_path / "other").mkdir()
+        argument = _write_config(tmp_path / "argument", {"database": {"uri": DSN}})
+        other = _write_config(tmp_path / "other", {"database": {"uri": DSN}})
+        monkeypatch.setenv("CONFIG_FILE", str(other))
+
+        _, path = load_ariel_config_with_path(argument)
+
+        assert path == argument
+
+    def test_the_remedy_leads_with_the_variable(self):
+        from osprey.interfaces.ariel.app import REMEDY_NO_CONFIG_FILE
+
+        assert REMEDY_NO_CONFIG_FILE.startswith("set CONFIG_FILE")

--- a/tests/interfaces/bluesky_web/draft-client.test.mjs
+++ b/tests/interfaces/bluesky_web/draft-client.test.mjs
@@ -1801,11 +1801,19 @@ describe('generateClientId', () => {
     expect(generateClientId()).toBe('11111111-1111-1111-1111-111111111111');
   });
 
-  test('falls back to a Math.random-based id when crypto.randomUUID is unavailable', () => {
+  test('still mints a v4-shaped id when crypto.randomUUID is unavailable', () => {
+    // A non-secure-context deployment has no randomUUID. The id was a
+    // `tab-<base36>` stand-in there; it is now the same UUID grammar every
+    // other surface mints, so one shape reaches the server from every
+    // topology.
     vi.stubGlobal('crypto', {});
     const id = generateClientId();
-    expect(id).toMatch(/^tab-/);
-    expect(id.length).toBeGreaterThan(4);
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  test('two ids in a row differ', () => {
+    vi.stubGlobal('crypto', {});
+    expect(generateClientId()).not.toBe(generateClientId());
   });
 });
 

--- a/tests/interfaces/test_web_auth.py
+++ b/tests/interfaces/test_web_auth.py
@@ -19,7 +19,7 @@ from types import SimpleNamespace
 import pytest
 from starlette.applications import Starlette
 
-from osprey.interfaces import web_auth
+from osprey.interfaces import common_middleware, web_auth
 from osprey.interfaces.common_middleware import WEB_PORT_ENV
 from osprey.interfaces.web_auth import (
     _SESSION_DECOY,
@@ -1700,3 +1700,50 @@ def test_configure_interface_app_resolves_before_it_closes(
     configure_interface_app(app, static_dir=tmp_path)
 
     assert get_web_credentials().operator_secret == "the-value-nginx-forwards"
+
+
+class TestAnnouncedOriginFollowsTheConfiguredOne:
+    """The announcement names the origin the app actually checks writes against.
+
+    ``OSPREY_TERMINAL_EXTERNAL_ORIGIN`` is where a deployment declares the
+    address browsers really reach it at — a TLS terminator in front of this
+    process, whose scheme and host nothing derivable from the bind can name. The
+    origin gate reads it (``common_middleware._resolve_external_origin``) and so
+    does the ``Secure`` decision on the session cookie, so an announcement built
+    from the bind address alone was a second producer of one origin: it handed
+    out ``http://127.0.0.1:8765/?token=`` for a deployment whose every request
+    from that URL would be refused.
+    """
+
+    def test_configured_origin_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(common_middleware.EXTERNAL_ORIGIN_ENV, "https://terminals.example.org")
+
+        url = web_auth.mint_and_announce("127.0.0.1", 8765)
+
+        assert url.startswith("https://terminals.example.org/?token=")
+
+    def test_the_path_is_kept(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            common_middleware.EXTERNAL_ORIGIN_ENV, "https://terminals.example.org:8443"
+        )
+
+        url = web_auth.mint_and_announce("127.0.0.1", 8765, path="static/session.html")
+
+        assert url.startswith("https://terminals.example.org:8443/static/session.html?token=")
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_an_empty_declaration_falls_back_to_the_bind(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv(common_middleware.EXTERNAL_ORIGIN_ENV, value)
+
+        url = web_auth.mint_and_announce("127.0.0.1", 8765)
+
+        assert url.startswith("http://127.0.0.1:8765/?token=")
+
+    def test_unset_falls_back_to_the_bind(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(common_middleware.EXTERNAL_ORIGIN_ENV, raising=False)
+
+        url = web_auth.mint_and_announce("127.0.0.1", 8765)
+
+        assert url.startswith("http://127.0.0.1:8765/?token=")

--- a/tests/interfaces/web_terminal/chat.test.mjs
+++ b/tests/interfaces/web_terminal/chat.test.mjs
@@ -553,3 +553,68 @@ describe('a prompt refused by the other view', () => {
     expect(logEntries()).toEqual(['status?']);
   });
 });
+
+describe('minting a session key without crypto.randomUUID', () => {
+  /** @type {any} */
+  let savedRandomUUID;
+
+  beforeEach(() => {
+    savedRandomUUID = globalThis.crypto?.randomUUID;
+    if (globalThis.crypto) {
+      // A plain-http, non-localhost origin is a documented OSPREY topology,
+      // and there the property is simply absent.
+      delete (/** @type {any} */ (globalThis.crypto).randomUUID);
+    }
+  });
+
+  afterEach(() => {
+    if (globalThis.crypto && savedRandomUUID) {
+      /** @type {any} */ (globalThis.crypto).randomUUID = savedRandomUUID;
+    }
+  });
+
+  test('the console still mounts', async () => {
+    await mountChat();
+
+    expect(container.querySelector('.op-send-btn')).toBeTruthy();
+  });
+
+  test('the minted key keeps the bare-UUID grammar the store keys on', async () => {
+    await mountChat();
+
+    const key = localStorage.getItem(STORAGE_KEY);
+    expect(key).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+
+  test('a new conversation mints one too', async () => {
+    await mountChat();
+    const first = localStorage.getItem(STORAGE_KEY);
+
+    /** @type {HTMLButtonElement} */ (one('.op-session-new')).click();
+
+    const second = localStorage.getItem(STORAGE_KEY);
+    expect(second).not.toBe(first);
+    expect(second).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+});
+
+describe('renderChatBootFailure', () => {
+  test('a console that never mounted says so where it would have been', async () => {
+    const { renderChatBootFailure } = await import(CHAT_JS);
+    const host = document.createElement('div');
+    host.id = 'operator-container';
+    host.textContent = 'stale';
+    document.body.append(host);
+
+    renderChatBootFailure('operator-container');
+
+    expect(host.textContent).toContain('failed to start');
+    expect(host.textContent).not.toContain('stale');
+  });
+
+  test('a missing container is not an error of its own', async () => {
+    const { renderChatBootFailure } = await import(CHAT_JS);
+
+    expect(() => renderChatBootFailure('nothing-here')).not.toThrow();
+  });
+});

--- a/tests/interfaces/web_terminal/test_operator_session.py
+++ b/tests/interfaces/web_terminal/test_operator_session.py
@@ -304,7 +304,7 @@ class TestBuildCleanEnv:
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
 
-        monkeypatch.setattr("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", [bin_dir])
+        monkeypatch.setattr("osprey.utils.shell_resolver._user_bin_candidates", lambda: [bin_dir])
         monkeypatch.setenv("PATH", "/usr/bin")
 
         env = build_clean_env()

--- a/tests/interfaces/web_terminal/test_pty_manager.py
+++ b/tests/interfaces/web_terminal/test_pty_manager.py
@@ -218,7 +218,7 @@ class TestPtySessionPathAugmentation:
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
 
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", [bin_dir]):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: [bin_dir]):
             with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=False):
                 session = PtySession("/bin/sh")
                 session.start()

--- a/tests/interfaces/web_terminal/test_scaffold_gallery_service.py
+++ b/tests/interfaces/web_terminal/test_scaffold_gallery_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -15,6 +16,7 @@ from osprey.cli.build_cmd import build
 from osprey.cli.init_cmd import init
 from osprey.cli.profile_conventions import NOT_PROJECT_RELATIVE_CHANNEL
 from osprey.interfaces.web_terminal.ownership import (
+    Ownership,
     OwnershipMode,
     OwnershipStore,
     reserved_write_channel,
@@ -3712,3 +3714,77 @@ class TestRestoreRefusesBodiesThatEscapeTheStore:
         svc.save_override(WRITABLE_ARTIFACT, "# Channel finder\nMine.\n")
 
         assert restore_scaffold_bodies(pristine) == [WRITABLE_ARTIFACT]
+
+
+class TestNoDurableStoreIsSaidOutLoud:
+    """A container deployment with nowhere durable to write says so, once.
+
+    ``CLAUDE_CONFIG_DIR`` is the only variable that names the per-user store.
+    Without it a containerised deployment resolves DEGRADED or CONFIG and every
+    claim is silently lost on the next container recreation — with no log line
+    naming the variable that would have fixed it, and a deploy guide calling it
+    optional.
+    """
+
+    def _in_a_container(self, ownership_module, **extra):
+        return {ownership_module.RENDER_ZONE_READONLY_ENV: "1", **extra}
+
+    def test_a_missing_store_names_the_variable_it_needs(self, tmp_path, caplog):
+        from osprey.interfaces.web_terminal import ownership as ownership_module
+
+        ownership_module._reset_store_notice()
+        with caplog.at_level(logging.WARNING, logger=ownership_module.__name__):
+            resolve_ownership(tmp_path, env=self._in_a_container(ownership_module))
+
+        assert ownership_module.CLAUDE_CONFIG_ENV in caplog.text
+        assert "durable" in caplog.text
+
+    def test_it_is_said_once_per_process(self, tmp_path, caplog):
+        from osprey.interfaces.web_terminal import ownership as ownership_module
+
+        ownership_module._reset_store_notice()
+        with caplog.at_level(logging.WARNING, logger=ownership_module.__name__):
+            resolve_ownership(tmp_path, env=self._in_a_container(ownership_module))
+            resolve_ownership(tmp_path, env=self._in_a_container(ownership_module))
+
+        assert caplog.text.count(ownership_module.CLAUDE_CONFIG_ENV) == 1
+
+    def test_a_mounted_store_says_nothing(self, tmp_path, caplog):
+        from osprey.interfaces.web_terminal import ownership as ownership_module
+
+        ownership_module._reset_store_notice()
+        env = self._in_a_container(
+            ownership_module, **{ownership_module.CLAUDE_CONFIG_ENV: str(tmp_path)}
+        )
+        with caplog.at_level(logging.WARNING, logger=ownership_module.__name__):
+            resolve_ownership(tmp_path, env=env)
+
+        assert ownership_module.CLAUDE_CONFIG_ENV not in caplog.text
+
+    def test_a_bare_host_project_says_nothing(self, tmp_path, caplog):
+        """CONFIG on a host is config.yml, which nothing recreates.
+
+        The notice is about a container's writable layer. A pre-profile project
+        on a bare host resolves the same mode for an entirely different reason,
+        and telling that operator their claims are lost on recreation would be
+        a warning about a machine they are not running.
+        """
+        from osprey.interfaces.web_terminal import ownership as ownership_module
+
+        ownership_module._reset_store_notice()
+        with caplog.at_level(logging.WARNING, logger=ownership_module.__name__):
+            assert resolve_ownership(tmp_path, env={}).mode is OwnershipMode.CONFIG
+
+        assert ownership_module.CLAUDE_CONFIG_ENV not in caplog.text
+
+    def test_the_gallery_refusal_carries_the_same_sentence(self):
+        from osprey.interfaces.web_terminal.ownership import NO_DURABLE_STORE
+
+        service = ScaffoldGalleryService.__new__(ScaffoldGalleryService)
+        service._ownership = Ownership(OwnershipMode.DEGRADED)
+        service.project_dir = Path("/srv/demo")
+
+        with pytest.raises(Exception) as excinfo:
+            service._require_durable_config_surface()
+
+        assert NO_DURABLE_STORE in str(excinfo.value)

--- a/tests/interfaces/web_terminal/tour.test.mjs
+++ b/tests/interfaces/web_terminal/tour.test.mjs
@@ -434,3 +434,45 @@ describe('prompt chips', () => {
     expect(term.paste).not.toHaveBeenCalled();
   });
 });
+
+describe('the palette chord it teaches', () => {
+  /**
+   * Walk the tour to the palette step and return that card's body text.
+   * @returns {string}
+   */
+  function paletteStepBody() {
+    mountFullShell();
+    applyTourConfig({ tour: { policy: 'never' } });
+    startTour();
+    for (let i = 0; i < 4; i += 1) {
+      click(nextBtn());
+      vi.advanceTimersByTime(200);
+    }
+    expect(cardTitle()).toBe('Search everything');
+    return cardBody();
+  }
+
+  /** @param {string} value */
+  function stubPlatform(value) {
+    Object.defineProperty(navigator, 'platform', { value, configurable: true });
+    Object.defineProperty(navigator, 'userAgentData', { value: undefined, configurable: true });
+  }
+
+  test('macOS is taught the chord macOS binds', () => {
+    stubPlatform('MacIntel');
+
+    expect(paletteStepBody()).toContain('⌘K');
+  });
+
+  test('everywhere else is taught Ctrl+K, and where it works', () => {
+    stubPlatform('Linux x86_64');
+
+    const body = paletteStepBody();
+
+    expect(body).toContain('Ctrl+K');
+    expect(body).not.toContain('⌘');
+    // Off macOS the palette binds the chord outside the terminal only, so the
+    // tour has to say what to do inside it.
+    expect(body).toContain('outside the terminal');
+  });
+});

--- a/tests/mcp_server/workspace/test_provenance_locator.py
+++ b/tests/mcp_server/workspace/test_provenance_locator.py
@@ -38,16 +38,25 @@ def _clean_env(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def _enable_telemetry(monkeypatch, org="default"):
+def _enable_telemetry(monkeypatch, org="default", backend="openobserve"):
     monkeypatch.setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", f"http://localhost:5080/api/{org}")
+    telemetry: dict = {"enabled": True}
+    if backend is not None:
+        telemetry["backend"] = backend
+    if org is not None:
+        telemetry[backend or "openobserve"] = {"org": org}
+    monkeypatch.setattr(
+        "osprey.utils.workspace.load_osprey_config",
+        lambda: {"claude_code": {"telemetry": telemetry}},
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_env_hit_returns_forced_id(monkeypatch):
     """The OSPREY-forced id + telemetry on → full coordinates for that id."""
-    _enable_telemetry(monkeypatch, org="als")
+    _enable_telemetry(monkeypatch, org="example")
     monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
     monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_START", "2026-07-15T00:00:00+00:00")
     monkeypatch.setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=claude-code,host=x")
@@ -56,7 +65,7 @@ async def test_env_hit_returns_forced_id(monkeypatch):
 
     assert result["session_id"] == "sess-abc-123"
     assert result["service_name"] == "claude-code"
-    assert result["org"] == "als"
+    assert result["org"] == "example"
     assert result["stream"] == "default"
     assert result["since"] == "2026-07-15T00:00:00+00:00"
     assert "note" not in result
@@ -128,3 +137,100 @@ async def test_since_optional(monkeypatch):
 
     assert result["session_id"] == "sess-1"
     assert result["since"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_a_generic_backend_carries_no_org_or_stream(monkeypatch):
+    """Org and stream address OpenObserve records and nothing else.
+
+    They were emitted unconditionally, the org re-parsed out of the OTLP
+    endpoint URL and the stream hard-coded, so a deployment on any other
+    backend handed a consumer two coordinates that name nothing in its store.
+    Omitted rather than nulled: a null still templates into a filed issue.
+    """
+    _enable_telemetry(monkeypatch, org="example", backend="generic")
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] == "sess-abc-123"
+    assert "org" not in result
+    assert "stream" not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_the_org_comes_from_config_not_from_the_endpoint_url(monkeypatch):
+    """One producer: the exporter's URL is built FROM the org, not the reverse."""
+    monkeypatch.setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:5080/api/stale")
+    monkeypatch.setattr(
+        "osprey.utils.workspace.load_osprey_config",
+        lambda: {
+            "claude_code": {
+                "telemetry": {"backend": "openobserve", "openobserve": {"org": "example"}}
+            }
+        },
+    )
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+
+    result = json.loads(await _fn()())
+
+    assert result["org"] == "example"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_an_explicitly_empty_org_is_reported_as_written(monkeypatch):
+    """The default belongs to an absent key; an explicit ``org: ""`` is a value.
+
+    The provisioner resolves it that way because the exporter does, and the
+    locator has to agree with both: rewriting an empty org to ``default`` here
+    would point a maintainer at an organization the deployment never writes to.
+    """
+    monkeypatch.setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:5080/api/")
+    monkeypatch.setattr(
+        "osprey.utils.workspace.load_osprey_config",
+        lambda: {
+            "claude_code": {"telemetry": {"backend": "openobserve", "openobserve": {"org": ""}}}
+        },
+    )
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+
+    result = json.loads(await _fn()())
+
+    assert result["org"] == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_an_absent_org_falls_back_to_the_default_organization(monkeypatch):
+    """No ``org`` key at all is the one case the default is for."""
+    monkeypatch.setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:5080/api/default")
+    monkeypatch.setattr(
+        "osprey.utils.workspace.load_osprey_config",
+        lambda: {"claude_code": {"telemetry": {"backend": "openobserve"}}},
+    )
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+
+    result = json.loads(await _fn()())
+
+    assert result["org"] == "default"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_an_unreadable_config_omits_the_coordinates(monkeypatch):
+    """Degrade by saying less, never by guessing a coordinate."""
+    monkeypatch.setenv("CLAUDE_CODE_ENABLE_TELEMETRY", "1")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:5080/api/example")
+    monkeypatch.setattr("osprey.utils.workspace.load_osprey_config", lambda: {})
+    monkeypatch.setenv("OSPREY_TELEMETRY_SESSION_ID", "sess-abc-123")
+
+    result = json.loads(await _fn()())
+
+    assert result["session_id"] == "sess-abc-123"
+    assert "org" not in result

--- a/tests/utils/test_shell_resolver.py
+++ b/tests/utils/test_shell_resolver.py
@@ -7,6 +7,7 @@ are missing from the default PATH.
 
 import os
 import stat
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -24,7 +25,7 @@ class TestUserBinDirs:
         missing = tmp_path / "nope"
 
         candidates = [existing, missing]
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", candidates):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: candidates):
             with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=False):
                 result = user_bin_dirs()
 
@@ -37,7 +38,7 @@ class TestUserBinDirs:
         d.mkdir()
 
         candidates = [d]
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", candidates):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: candidates):
             with patch.dict(os.environ, {"PATH": str(d)}, clear=False):
                 result = user_bin_dirs()
 
@@ -49,7 +50,7 @@ class TestUserBinDirs:
         d.mkdir()
 
         candidates = [d]
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", candidates):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: candidates):
             with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=False):
                 result = user_bin_dirs()
 
@@ -75,7 +76,7 @@ class TestResolveShellCommand:
         fake_cmd.chmod(fake_cmd.stat().st_mode | stat.S_IEXEC)
 
         candidates = [bin_dir]
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", candidates):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: candidates):
             with patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=False):
                 result = resolve_shell_command("my-shell")
 
@@ -99,13 +100,63 @@ class TestResolveShellCommand:
     def test_not_found_anywhere_raises(self, tmp_path):
         """Commands not on PATH or in user dirs raise FileNotFoundError."""
         candidates = [tmp_path / "empty"]
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", candidates):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: candidates):
             with pytest.raises(FileNotFoundError, match="not found on PATH"):
                 resolve_shell_command("this-command-definitely-does-not-exist-anywhere")
 
     def test_error_message_includes_config_hint(self, tmp_path):
         """The error message mentions config.yml as an escape hatch."""
         candidates = [tmp_path / "empty"]
-        with patch("osprey.utils.shell_resolver._USER_BIN_CANDIDATES", candidates):
+        with patch("osprey.utils.shell_resolver._user_bin_candidates", lambda: candidates):
             with pytest.raises(FileNotFoundError, match="web_terminal.shell"):
                 resolve_shell_command("nonexistent-cmd")
+
+
+class TestAnAccountWithNoHome:
+    """A uid with no passwd entry and no ``HOME`` degrades; it does not raise.
+
+    A random-uid cluster policy gives a container neither. ``Path.home()`` then
+    raises ``RuntimeError``, and this module used to make that call twice at
+    import — so a module that merely imports this one (``agent_runner.clean_env``
+    does, at module scope) failed as an ImportError chain rather than running
+    with a shorter PATH, which is all this list is for.
+    """
+
+    def _no_home(self, monkeypatch):
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        monkeypatch.setattr(
+            "osprey.utils.shell_resolver.Path.home",
+            staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("no home"))),
+        )
+
+    def test_user_bin_dirs_still_answers(self, monkeypatch):
+        self._no_home(monkeypatch)
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        assert isinstance(user_bin_dirs(), list)
+
+    def test_the_home_relative_entries_are_skipped(self, monkeypatch):
+        from osprey.utils import shell_resolver
+
+        self._no_home(monkeypatch)
+
+        candidates = shell_resolver._user_bin_candidates()
+
+        assert candidates == [Path("/usr/local/bin")]
+
+    def test_a_command_on_path_still_resolves(self, monkeypatch, tmp_path):
+        self._no_home(monkeypatch)
+        binary = tmp_path / "tool"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+        monkeypatch.setenv("PATH", str(tmp_path))
+
+        assert resolve_shell_command("tool") == str(binary)
+
+    def test_the_not_found_message_still_renders(self, monkeypatch):
+        self._no_home(monkeypatch)
+        monkeypatch.setenv("PATH", "/nonexistent")
+
+        with pytest.raises(FileNotFoundError, match="not found on PATH"):
+            resolve_shell_command("definitely-not-a-real-command")


### PR DESCRIPTION
Browser-facing URLs now come from the one external-origin authority this deployment already has, and assumptions about the machine underneath — container runtime, container paths, browser and OS capabilities — are checked rather than asserted. No new configuration keys.

## Commits

1. `fix(deployment): one dial_address() for every host-side probe of a published port` — three modules turned `deployment.bind_address` into a dialable address three different ways. One rule now, beside `resolve_bind_address`: a wildcard is dialed on its family's loopback, a pinned interface is dialed there.
2. `fix(cli): exposure warning keys on "not loopback", and fires on the detached path too` — `osprey web` warned only for the literal `0.0.0.0`, and never at all under `-d`.
3. `fix(dispatch): telemetry link host comes from the deployment origin, hidden when not browser-reachable` — the dashboard's per-run link was `http://localhost:<port>` regardless of who was looking at it.
4. `fix(interfaces): announce the login URL on the configured external origin` — the printed URL and the origin every write is checked against were two producers of one address.
5. `fix(cli): summary card keeps every openable endpoint row, and says osprey web` — a scheme test naming only `http://` dropped the `https://` landing row, which is the one row the card exists to print.
6. `fix(scaffold): CI environment URL is the deployment origin, not https://$DEPLOY_HOST` — the pipeline asserted TLS on a plain-HTTP deployment, dropped a non-default port, and named the SSH host.
7. `fix(cli): operator remedies name the resolved container runtime` — the caller had already resolved the binary and printed `docker` anyway.
8. `fix(deployment): osprey status distinguishes "no runtime installed" from "runtime not answering"` — a deployment that declares no containerized services carried a permanent red banner.
9. `fix(health): virtual_environment row reports OK inside a container image` — the shipped image installs into system Python by design, so every containerised deployment carried a permanent amber core row.
10. `fix(deployment): Docker Desktop detection keyed on the Desktop backend, not sys.platform` — which left this module's own Linux path readers unreachable.
11. `fix(ariel,connectors): CONFIG_FILE outranks the /app guess; delete the container-root guess list` — two search orders in one package, and a guess list that never fires in the shipped layout.
12. `fix(workspace): provenance locator emits org/stream only for the openobserve backend` — the org is a configured value, not something to re-parse out of the exporter URL it produced.
13. `fix(utils): resolve the home directory lazily and tolerate a HOME-less account` — two `Path.home()` calls at import turned a shorter PATH into an ImportError chain.
14. `fix(web-terminal): say so when no durable per-user store was located` — claims were silently lost at the next container recreation, with the deploy guide calling the variable optional.
15. `fix(web-terminal): mint the chat id without crypto.randomUUID; render a visible failure state` — on a plain-HTTP non-localhost origin the Simple-view console silently never mounted.
16. `fix(web-terminal): tour teaches the palette chord for the viewer's platform` — the tour said `⌘K` everywhere; the palette binds `Ctrl+K` off macOS.

## Why

Every one of these had a value that a deployment already declares once, and a second place that guessed it instead: a URL host assembled from the bind address rather than taken from `modules.web_terminals.external_origin` / `deploy.fqdn`; a runtime binary printed as `docker` next to a call that had just resolved it; a container path guessed from a list of names; a browser capability inferred from `sys.platform` or from `navigator.platform`. The second producer is what breaks a deployment that is not shaped like the one the code was written on.

After this, a deployment fronted by a TLS terminator gets links that resolve and writes that are accepted; a podman host gets remedies it can paste; a Linux Docker Desktop host is recognised as one; a containerised deployment stops carrying two permanent false-alarm health signals; a plain-HTTP deployment gets a console that mounts; and a non-macOS viewer is taught the chord the terminal actually binds. Where nothing can be derived — a store published to the network by a deployment that declares no origin — the link is omitted rather than guessed, because an unset variable already means "hide it".

## Not in this PR

- `services.openobserve.external_url`. A facility fronting the telemetry store with its own TLS proxy is the one case commit 3 does not cover, and it is a product decision rather than a mechanical fix.
- `OSPREY_USER_STATE_DIR`. Renaming the per-user store path would be a second producer of one path and would strand every already-claimed artifact; commit 14 is the mechanical half only.
- Trusting `X-Forwarded-Proto` in `_resolve_external_origin`. A single-user terminal behind its own TLS terminator needs a decision on forwarded headers, not a derivation.
- Deleting the `virtual_environment` health row outright (one reviewer's smaller alternative to commit 9) — worth putting to the owner, not required here.
