### PR TITLE
fix(core): honour existing seams (facility timezone, connector timeout, web.theme, shell argv)

### DIFF
--- a/changelog.d/execution-metadata-offset.fixed.md
+++ b/changelog.d/execution-metadata-offset.fixed.md
@@ -1,0 +1,5 @@
+Execution metadata written by an agent Python run now carries a UTC offset on
+its `start_time` and `end_time`, matching every other timestamp OSPREY reports
+and making the records orderable against them. The executor timeout also has
+one default: the value the config builder falls back to and the value the
+executor falls back to are now the same constant.

--- a/changelog.d/facility-timestamps.fixed.md
+++ b/changelog.d/facility-timestamps.fixed.md
@@ -1,0 +1,5 @@
+Operator-facing timestamps now carry the facility timezone. The header of the
+notebook written for an executed script shows the facility offset instead of a
+UTC literal, and a Phoebus Data Browser plot opened without an explicit time
+range spans the last 24 hours of facility-local wall clock rather than the
+container's.

--- a/changelog.d/login-theme.added.md
+++ b/changelog.d/login-theme.added.md
@@ -1,0 +1,5 @@
+The sign-in page now wears the deployment's theme and names the facility. It
+reads the same `web.theme` the landing page and the terminals behind it use,
+and shows `facility.name` above the OSPREY wordmark, instead of always
+rendering in the framework palette under a bare wordmark. A deployment that
+sets neither is unchanged.

--- a/changelog.d/shell-argv.added.md
+++ b/changelog.d/shell-argv.added.md
@@ -1,0 +1,7 @@
+`web_terminal.shell` now accepts a full argv, so a facility whose harness needs
+arguments no longer has to hide them in a wrapper script. Write it as a string
+(`harness --profile ops`, quoting honoured) or as a YAML list
+(`["harness", "--profile", "ops"]`); only the first element is resolved to an
+absolute path and the rest are passed through. The `--shell` flag takes the
+same spellings. A single-command value behaves exactly as before, and the PTY
+still appends its own session and effort flags to whatever is set.

--- a/changelog.d/validate-channel-timeout.fixed.md
+++ b/changelog.d/validate-channel-timeout.fixed.md
@@ -1,0 +1,4 @@
+The EPICS connector's channel-existence probe now uses the `timeout` the
+deployment configured for it, like its reads and writes already did, instead of
+a fixed 2 seconds. A facility on a slow or distant gateway can raise the one
+key and have every probe follow.

--- a/docs/source/how-to/web-terminal/theming.rst
+++ b/docs/source/how-to/web-terminal/theming.rst
@@ -105,12 +105,14 @@ user somewhere else, add ``theme`` to their entry in the user list:
            theme: desy-light
 
 The value takes the same two forms as ``web.theme``: a family, or a specific
-theme to also pin light or dark. It applies to that user only, and their own
-pick in the display menu still wins over it.
+theme to also pin light or dark. It overrides ``web.theme`` for that user's
+terminal only, and their own pick in the display menu still wins over it.
 
 The landing page that lists everyone's terminals uses the deployment-wide
-``web.theme``. It is shown before anyone has said who they are, so there is no
-personal setting to apply yet.
+``web.theme``, and so does the sign-in page a user reaches from it, which also
+shows the facility name from ``facility.name`` above the OSPREY wordmark. Both
+are shown before anyone has said who they are, so there is no personal setting
+to apply yet.
 
 A navy-and-teal terminal
 ------------------------

--- a/packages/osprey-connectors/src/osprey_connectors/config.py
+++ b/packages/osprey-connectors/src/osprey_connectors/config.py
@@ -147,6 +147,11 @@ def resolve_env_vars(data: Any, *, environ: "Mapping[str, str] | None" = None) -
 # Jupyter kernel gateway OSPREY does not ship.
 EXECUTION_METHOD_SUBPROCESS = "subprocess"
 
+#: Wall-clock budget one agent Python execution gets when the deployment does not
+#: set ``python_executor.execution_timeout_seconds``. Defined once here and read
+#: by the executor so both ends of the timeout agree.
+DEFAULT_EXECUTION_TIMEOUT_SECONDS = 600
+
 # Module-level latch so the ``container`` deprecation is logged once per process
 # rather than on every config read (the executor resolves per tool call).
 # Tests reset it via ``osprey_connectors.config._container_method_warned = False``.
@@ -635,7 +640,7 @@ class ConfigBuilder:
 
         # Otherwise, provide sensible defaults
         return {
-            "execution_timeout_seconds": 600,
+            "execution_timeout_seconds": DEFAULT_EXECUTION_TIMEOUT_SECONDS,
         }
 
     def _build_configurable(self) -> dict[str, Any]:

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -1338,7 +1338,7 @@ class EPICSConnector(ControlSystemConnector):
         Returns:
             True if channel can be accessed
         """
-        timeout = 2.0
+        timeout = self._timeout
         try:
             if self._is_pva_channel(channel_address):
                 await asyncio.to_thread(self._read_metadata_pva, channel_address, timeout)

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -867,6 +867,10 @@ def _resolve_web_shell_command(
     Precedence (highest first):
       1. ``--shell`` CLI flag (user-explicit; defeats the pin)
       2. ``web_terminal.shell`` config field (also defeats the pin)
+
+    Both are argv, written as a string or as a list, and both go through
+    :func:`~osprey.utils.shell_resolver.normalize_shell_command`, which resolves
+    argv[0] and passes the harness's own arguments through.
       3. ``claude_code.cli_version`` pin via ``build_claude_launch_argv()``
       4. bare ``claude`` (current default)
 
@@ -878,12 +882,12 @@ def _resolve_web_shell_command(
     consumers can unpack safely.
     """
     from osprey.utils.claude_launcher import build_claude_launch_argv
-    from osprey.utils.shell_resolver import resolve_shell_command
+    from osprey.utils.shell_resolver import normalize_shell_command, resolve_shell_command
 
     if shell_override:
-        return [resolve_shell_command(shell_override)]
+        return normalize_shell_command(shell_override)
     if wt_config.get("shell"):
-        return [resolve_shell_command(wt_config["shell"])]
+        return normalize_shell_command(wt_config["shell"])
     argv = build_claude_launch_argv(cc_config)
     if argv[0] == "claude":
         return [resolve_shell_command(argv[0]), *argv[1:]]

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -1346,6 +1346,17 @@ def render_web_terminals(
         # only inside the block it already gates on `sidecar_active`,
         # because a deployment with no sidecar service has nothing to mount them
         # into.
+        # What the login page wears. The sidecar sits one hop before the
+        # terminals and had no way to know either, so it fell back to the
+        # framework palette and the bare OSPREY wordmark while everything
+        # behind it carried the deployment's own. The THEME ID travels here,
+        # never rendered CSS: palettes have exactly one producer
+        # (design_system.theme_config), and the sidecar resolves the id through
+        # it the same way the landing page does. Both are emitted
+        # unconditionally and gated in the template, so an unset value emits no
+        # env line and the page keeps its built-in fallbacks.
+        "web_theme": str(as_dict(root.get("web")).get("theme") or ""),
+        "web_app_name": resolve_facility_name(root, ""),
         "auth_audit_identity": AUTH_SIDECAR_AUDIT_IDENTITY,
         "auth_audit_mount_source": _audit_mount_source(AUTH_SIDECAR_AUDIT_IDENTITY),
         "auth_audit_dir": _container_audit_dir(

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -1729,6 +1729,7 @@ def _create_lifespan(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         from osprey.utils.claude_launcher import build_claude_launch_argv
+        from osprey.utils.shell_resolver import normalize_shell_command
 
         config = _load_web_config(config_path)
 
@@ -1743,7 +1744,7 @@ def _create_lifespan(
         if shell_command:
             app.state.shell_command = list(shell_command)
         elif config.get("shell"):
-            app.state.shell_command = [str(config["shell"])]
+            app.state.shell_command = normalize_shell_command(config["shell"])
         else:
             app.state.shell_command = build_claude_launch_argv(
                 _load_claude_code_config(config_path)

--- a/src/osprey/mcp_server/phoebus/plt_generator.py
+++ b/src/osprey/mcp_server/phoebus/plt_generator.py
@@ -27,6 +27,8 @@ import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from osprey.utils.config import get_facility_timezone
+
 from .models import PlotConfig
 
 logger = logging.getLogger(__name__)
@@ -100,7 +102,7 @@ def create_plt_from_config(
         else:
             end_str = str(plot_config.time_range.end)
     else:
-        end_time = datetime.now()
+        end_time = datetime.now(get_facility_timezone())
         start_time = end_time - timedelta(hours=24)
         start_str = start_time.strftime("%Y-%m-%d %H:%M:%S.000")
         end_str = end_time.strftime("%Y-%m-%d %H:%M:%S.999")

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -199,12 +199,15 @@ def _read_config() -> dict:
     """
     from osprey.utils.config import resolve_execution_method
     from osprey.utils.workspace import load_osprey_config
+    from osprey_connectors.config import DEFAULT_EXECUTION_TIMEOUT_SECONDS
 
     config = load_osprey_config()
 
     return {
         "execution_method": resolve_execution_method(config),
-        "timeout": config.get("python_executor", {}).get("execution_timeout_seconds", 600),
+        "timeout": config.get("python_executor", {}).get(
+            "execution_timeout_seconds", DEFAULT_EXECUTION_TIMEOUT_SECONDS
+        ),
     }
 
 

--- a/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
+++ b/src/osprey/mcp_server/workspace/execution/sandbox_executor.py
@@ -333,7 +333,7 @@ _execution_dir.mkdir(parents=True, exist_ok=True)
 # Execution metadata
 # ---------------------------------------------------------------------------
 execution_metadata = {{
-    "start_time": datetime.now().isoformat(),
+    "start_time": datetime.now().astimezone().isoformat(),
     "success": True,
     "error": None,
     "stdout": "",
@@ -372,7 +372,7 @@ finally:
 
     execution_metadata["stdout"] = stdout_capture.getvalue()
     execution_metadata["stderr"] = stderr_capture.getvalue()
-    execution_metadata["end_time"] = datetime.now().isoformat()
+    execution_metadata["end_time"] = datetime.now().astimezone().isoformat()
 
     # Write execution metadata
     try:

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1236,7 +1236,7 @@ keys:
   execution.environment.inherit_exclude: {forward-declared: true, default: no-fallback, default_note: "the build derives it from the deployment's Python environment; no runtime reader"}
   python_executor:
     rendered: false
-    evidence: 'config\.get\("python_executor", \{\}\)\.get\("execution_timeout_seconds", 600\)'
+    evidence: 'config\.get\("python_executor", \{\}\)\.get\(\s*"execution_timeout_seconds", DEFAULT_EXECUTION_TIMEOUT_SECONDS'
     note: >-
       The sandbox's own block. One key today, carried commented in all four
       presets — the ceiling is a facility property (how long a legitimate

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -783,6 +783,14 @@ config:
   # The terminal process itself (`osprey web`), every key at its default. The
   # multi-user compose sets OSPREY_TERMINAL_BIND_HOST on every container, which
   # outranks `host`; `shell` REPLACES the launcher and defeats the CLI pin.
+  # `shell` is argv, written either way — a string (quoting honoured) or a
+  # list; only the first word is resolved to an absolute path and the rest are
+  # passed through:
+  #   web_terminal.shell: /opt/harness/run --profile ops
+  #   web_terminal.shell: ["/opt/harness/run", "--profile", "ops"]
+  # The PTY spawn still appends `--session-id`/`--resume` and `--effort` to
+  # whatever is set here, so a harness that does not take those flags needs a
+  # wrapper that drops them.
   # web_terminal.host: 127.0.0.1
   # web_terminal.port: <a port outside this deployment's block>
   # web_terminal.max_background_sessions: 5

--- a/src/osprey/services/auth_sidecar/app.py
+++ b/src/osprey/services/auth_sidecar/app.py
@@ -129,6 +129,17 @@ ENV_USERS = "OSPREY_AUTH_USERS"
 ENV_PW_HASH_PREFIX = "OSPREY_AUTH_PW_HASH_"
 """Per-user stored hash: ``OSPREY_AUTH_PW_HASH_<SUFFIX>``."""
 
+ENV_WEB_THEME = "OSPREY_WEB_THEME"
+ENV_WEB_APP_NAME = "OSPREY_WEB_APP_NAME"
+"""What the login page wears, in the deployment's own vocabulary.
+
+The two names the per-user terminals already read, deliberately reused rather
+than given ``OSPREY_AUTH_`` spellings of their own: they carry the deployment's
+``web.theme`` and facility name, not an auth setting, and a second spelling for
+one page would be a second thing to keep in step. Both are optional — unset
+leaves the login page on the framework palette and shows the wordmark alone.
+"""
+
 ENV_OIDC_ISSUER = "OSPREY_AUTH_OIDC_ISSUER"
 ENV_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID_ENV"
 ENV_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET_ENV"
@@ -387,6 +398,12 @@ class AuthSettings:
         oidc_claim: Which ID-token claim carries the identity to map onto a
             roster user.
         oidc_subjects: ``{username: expected claim value}`` from the roster.
+        web_theme: The deployment's ``web.theme`` value — a family or a
+            concrete theme id — for the login page to resolve through the design
+            system. Empty when unset, and the page then wears the framework
+            default.
+        web_app_name: The facility name shown above the login page's wordmark.
+            Empty when the deployment names none.
         roster_access: ``{username: admitted principals}`` for every roster
             user, as :func:`_access_principals` read the entry's
             ``OSPREY_AUTH_ROSTER_ACCESS_<SUFFIX>``. :data:`OWNER_ONLY` for the
@@ -412,6 +429,8 @@ class AuthSettings:
     oidc_claim: str = DEFAULT_OIDC_CLAIM
     oidc_subjects: Mapping[str, str] = field(default_factory=dict)
     roster_access: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    web_theme: str = ""
+    web_app_name: str = ""
 
     @classmethod
     def from_env(cls, env: Mapping[str, str] | None = None) -> AuthSettings:
@@ -480,6 +499,8 @@ class AuthSettings:
             oidc_claim=(source.get(ENV_OIDC_CLAIM) or "").strip() or DEFAULT_OIDC_CLAIM,
             oidc_subjects=oidc_subjects,
             roster_access=roster_access,
+            web_theme=(source.get(ENV_WEB_THEME) or "").strip(),
+            web_app_name=(source.get(ENV_WEB_APP_NAME) or "").strip(),
         )
 
     def missing_requirements(self) -> tuple[str, ...]:

--- a/src/osprey/services/auth_sidecar/routes/login.py
+++ b/src/osprey/services/auth_sidecar/routes/login.py
@@ -229,11 +229,14 @@ quietly off-palette.
 """
 
 _DEFAULT_THEME_FAMILY = "main"
-"""Which family's dark/light pair to bake in.
+"""Which family's dark/light pair to bake in when the deployment names none.
 
 The sidecar has no theme setting of its own — it authenticates, it does not
-render terminals — so the login page wears the framework default rather than
-inventing a configuration surface for one page.
+render terminals — so it wears the deployment's ``web.theme``, which reaches it
+as :data:`~osprey.services.auth_sidecar.app.ENV_WEB_THEME` and arrives here as
+``settings.web_theme``. A theme *id* travels, never rendered CSS: the design
+system stays the one producer of palettes, and this route resolves the id
+through it exactly as the landing page one hop earlier does.
 """
 
 _SAFE_CSS_VALUE_RE = re.compile(r"[#A-Za-z0-9 ,.()%/_-]+")
@@ -250,14 +253,18 @@ what would let a value break out of the declaration it was baked into.
 """
 
 
-@lru_cache(maxsize=1)
-def _theme_blocks() -> tuple[dict[str, Any], ...]:
+@lru_cache(maxsize=8)
+def _theme_blocks(configured: str) -> tuple[dict[str, Any], ...]:
     """The design-system token values to bake into the page, resolved once.
 
-    Two blocks, in the shape ``login.html`` and the landing page share: the
-    default family's dark values unconditionally, and its light values behind a
-    ``prefers-color-scheme`` query, so the login page follows the viewer's OS the
-    way the terminals behind it do.
+    The shape ``login.html`` and the landing page share, resolved the same way:
+    a *family* gives two blocks — its dark values unconditionally and its light
+    values behind a ``prefers-color-scheme`` query, so the page follows the
+    viewer's OS the way the terminals behind it do — while a concrete id
+    (``"desy-light"``) pins one block and one mode.
+
+    Args:
+        configured: The deployment's theme value, a family or a concrete id.
 
     Returns:
         Block dicts, or an empty tuple when the token tree cannot be read or
@@ -268,16 +275,24 @@ def _theme_blocks() -> tuple[dict[str, Any], ...]:
     """
     try:
         from osprey.interfaces.design_system.theme_config import (
+            family_of,
             load_theme_registry,
+            resolve_pinned_mode,
+            resolve_theme_id,
             theme_css_variables,
         )
 
-        _, defaults = load_theme_registry()
-        family = defaults[_DEFAULT_THEME_FAMILY]
-        wanted = (
-            (None, "dark", family["dark"]),
-            ("(prefers-color-scheme: light)", "light", family["light"]),
-        )
+        entries, defaults = load_theme_registry()
+        resolved_id = resolve_theme_id(configured, entries, defaults, config_key="web.theme")
+        pinned_mode = resolve_pinned_mode(configured, entries)
+        if pinned_mode is not None:
+            wanted = ((None, pinned_mode, resolved_id),)
+        else:
+            family = defaults[family_of(resolved_id, entries) or _DEFAULT_THEME_FAMILY]
+            wanted = (
+                (None, "dark", family["dark"]),
+                ("(prefers-color-scheme: light)", "light", family["light"]),
+            )
         blocks = []
         for media, color_scheme, theme_id in wanted:
             values = theme_css_variables(theme_id, _THEME_VARIABLES)
@@ -377,6 +392,7 @@ def _page(
     Returns:
         The rendered page.
     """
+    settings = get_settings(request)
     return _templates.TemplateResponse(
         request,
         TEMPLATE_NAME,
@@ -385,7 +401,8 @@ def _page(
             "next": target,
             "error": error,
             "login_path": LOGIN_PATH,
-            "theme_blocks": _theme_blocks(),
+            "theme_blocks": _theme_blocks(settings.web_theme or _DEFAULT_THEME_FAMILY),
+            "app_name": settings.web_app_name,
             "shared": shared,
             "opener": opener,
         },

--- a/src/osprey/services/auth_sidecar/templates/login.html
+++ b/src/osprey/services/auth_sidecar/templates/login.html
@@ -52,6 +52,11 @@
       below therefore carries a literal fallback, so a page with no token block
       still renders in the framework's default dark palette rather than
       unstyled.
+
+    app_name: str, possibly empty
+      The facility this deployment belongs to, shown above the wordmark. Empty
+      for a deployment that names none, and the page then shows the wordmark
+      alone.
 #}
 <!DOCTYPE html>
 <html lang="en">
@@ -96,6 +101,12 @@
       border-radius: 10px;
       background: var(--bg-panel, #181b1f);
       box-shadow: var(--shadow-dropdown, 0 8px 24px rgba(0, 0, 0, 0.4));
+    }
+    .login-facility {
+      margin: 0 0 0.25rem;
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.3;
     }
     .login-mark {
       margin: 0 0 1.5rem;
@@ -175,6 +186,12 @@
 </head>
 <body>
   <main class="login-card">
+    {#- The facility this deployment belongs to, when it names one. The
+        wordmark stays below it either way, so a page with no configured name
+        looks exactly as it did. #}
+    {%- if app_name %}
+    <p class="login-facility">{{ app_name|e }}</p>
+    {%- endif %}
     <p class="login-mark">OSPREY</p>
     {#- The acceptance gate: the username is stated, never asked for — except on
         a shared card, where the person opening it names themselves below. #}

--- a/src/osprey/services/bluesky_bridge/preflight.py
+++ b/src/osprey/services/bluesky_bridge/preflight.py
@@ -23,12 +23,13 @@ Two properties are deliberate:
 
 **The bound is the probe's own.** Each ``validate_channel`` call is wrapped in
 ``asyncio.wait_for(..., timeout_s)`` even though some connectors bound
-themselves — the EPICS connector probes with a 2 s timeout, the DOOCS one is
-unbounded — because a pre-flight gate that inherits a per-connector timeout
-gives a different, and sometimes infinite, worst case per lane. The constants
-here bound every lane alike, and the refusal quotes whichever of them the
-verdict actually rested on (:attr:`ProbeOutcome.timeout_s` for an address that
-failed a probe, :attr:`ProbeOutcome.budget_s` for one the sweep never reached).
+themselves — the EPICS connector probes with its configured ``timeout``, the
+DOOCS one is unbounded — because a pre-flight gate that inherits a per-connector
+timeout gives a different, and sometimes infinite, worst case per lane. The
+constants here bound every lane alike, and the refusal quotes whichever of them
+the verdict actually rested on (:attr:`ProbeOutcome.timeout_s` for an address
+that failed a probe, :attr:`ProbeOutcome.budget_s` for one the sweep never
+reached).
 
 **One retry, and a budget that scales with the sweep.** A gateway under load
 can drop a first probe for a channel that is perfectly healthy, and turning

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -1799,7 +1799,7 @@ if not _execution_dir.exists():
             """
             # Execution metadata
             execution_metadata = {
-                "start_time": _datetime.now().isoformat(),
+                "start_time": _datetime.now().astimezone().isoformat(),
                 "success": True,
                 "error": None,
                 "traceback": None,
@@ -1863,14 +1863,14 @@ if not _execution_dir.exists():
         # Mark successful execution
         execution_metadata["success"] = True
         execution_metadata["error_type"] = None
-        execution_metadata["end_time"] = _datetime.now().isoformat()
+        execution_metadata["end_time"] = _datetime.now().astimezone().isoformat()
 
     except Exception as user_code_error:
         # Capture user code errors
         execution_metadata["success"] = False
         execution_metadata["error_type"] = type(user_code_error).__name__
         execution_metadata["error_message"] = str(user_code_error)
-        execution_metadata["end_time"] = _datetime.now().isoformat()
+        execution_metadata["end_time"] = _datetime.now().astimezone().isoformat()
         raise
 """
 
@@ -1924,7 +1924,7 @@ if not _execution_dir.exists():
 
                 execution_metadata["stdout"] = stdout_capture.getvalue()
                 execution_metadata["stderr"] = stderr_capture.getvalue()
-                execution_metadata["end_time"] = _datetime.now().isoformat()
+                execution_metadata["end_time"] = _datetime.now().astimezone().isoformat()
 
                 # Switch to execution directory for file persistence (results,
                 # figures, metadata).  User code ran with cwd=project_root;

--- a/src/osprey/stores/notebook_renderer.py
+++ b/src/osprey/stores/notebook_renderer.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import nbformat
 
+from osprey.utils.config import to_facility_iso
+
 logger = logging.getLogger("osprey.stores.notebook_renderer")
 
 
@@ -36,7 +38,7 @@ def create_notebook_from_code(
 
     # Header cell
     status = "Error" if stderr else "Success"
-    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    timestamp = to_facility_iso(datetime.now(UTC))
     header = (
         f"# {description}\n\n"
         f"**Status:** {status}  \n"

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -658,6 +658,21 @@ services:
 {%- endif %}
     environment:
       - TZ={{ facility_timezone | default("UTC") }}
+      {#- What the login page wears: the deployment's theme id (never rendered
+         CSS — the sidecar resolves the id through the design system, the one
+         producer of palettes) and the facility name shown above the wordmark.
+         Both are guarded: an unset value emits no line and the page keeps its
+         built-in palette and bare wordmark. tojson quotes the WHOLE `KEY=value`
+         as one double-quoted YAML scalar, the same way the per-user containers
+         below carry these two variables: the compose `- KEY=value` list form
+         has no per-value quoting, so a facility name containing a `": "` or a
+         `" #"` would otherwise parse as a mapping or lose its tail. #}
+      {%- if web_theme %}
+      - {{ ("OSPREY_WEB_THEME=" ~ web_theme) | tojson }}
+      {%- endif %}
+      {%- if web_app_name %}
+      - {{ ("OSPREY_WEB_APP_NAME=" ~ web_app_name) | tojson }}
+      {%- endif %}
       {#- The sidecar's audit identity and the directory it writes to. It is one
          service rather than one per user, so the identity is the FIXED name
          `sidecar` (render.AUTH_SIDECAR_AUDIT_IDENTITY) — the users its login and

--- a/src/osprey/utils/shell_resolver.py
+++ b/src/osprey/utils/shell_resolver.py
@@ -9,6 +9,7 @@ and to augment the child environment so *their* subprocesses can too.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 from pathlib import Path
 
@@ -67,8 +68,9 @@ def resolve_shell_command(command: str) -> str:
             return command
         raise FileNotFoundError(
             f"{command!r} does not exist or is not executable. "
-            f"Check the path or set web_terminal.shell under `config:` in "
-            f"profile.yml and run `osprey build`."
+            f"Check the path, or set web_terminal.shell under `config:` in "
+            f"profile.yml — a command name, an absolute path, or an argv list "
+            f"whose first element is one of those — and run `osprey build`."
         )
 
     # Normal PATH lookup.
@@ -87,6 +89,53 @@ def resolve_shell_command(command: str) -> str:
     raise FileNotFoundError(
         f"{command!r} not found on PATH or in common install locations "
         f"({', '.join(str(d) for d in _user_bin_candidates())}). "
-        f"Install it, or set web_terminal.shell to an absolute path under "
-        f"`config:` in profile.yml and run `osprey build`."
+        f"Install it, or set web_terminal.shell under `config:` in profile.yml "
+        f"to an absolute path — or to an argv list starting with one — and run "
+        f"`osprey build`."
     )
+
+
+def normalize_shell_command(value: str | list[str]) -> list[str]:
+    """Normalize a configured shell command into argv, resolving only argv[0].
+
+    ``web_terminal.shell`` is argv, and it may be written either way: a single
+    string (``"claude"``, ``"/opt/harness/run --profile ops"``, quoting
+    honoured by :func:`shlex.split`) or a YAML list
+    (``["/opt/harness/run", "--profile", "ops"]``). Both reach the PTY as the
+    same argv, so a facility whose harness needs arguments no longer has to
+    hide them in a wrapper script.
+
+    Only the first element is resolved to an absolute path — the arguments are
+    the harness's own and are passed through untouched.
+
+    Args:
+        value: The configured command, as a string or an argv list.
+
+    Returns:
+        argv with an absolute executable at index 0.
+
+    Raises:
+        FileNotFoundError: If argv[0] cannot be found (see
+            :func:`resolve_shell_command`).
+        ValueError: If *value* is neither a string nor a list, is empty, or
+            parses to no words at all.
+    """
+    # YAML admits shapes the key does not — a bare number, a mapping, a `shell:`
+    # written with no value at all. Each names the key, like the empty case
+    # below; the alternative is whatever shlex.split raises on a non-string.
+    if isinstance(value, list):
+        parts = [str(part) for part in value]
+    elif isinstance(value, str):
+        parts = shlex.split(value)
+    else:
+        raise ValueError(
+            f"web_terminal.shell must be a command string or an argv list, not "
+            f"{type(value).__name__}. Set it to a command, an absolute path, or "
+            f"an argv list, or remove the key to use the default launcher."
+        )
+    if not parts:
+        raise ValueError(
+            "web_terminal.shell is empty. Set it to a command, an absolute path, "
+            "or an argv list, or remove the key to use the default launcher."
+        )
+    return [resolve_shell_command(parts[0]), *parts[1:]]

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -130,6 +130,27 @@ class TestResolveWebShellCommand:
         assert cmd == ["/abs/custom"]
         mock_resolve.assert_called_once_with("my-shell")
 
+    @patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness")
+    def test_config_shell_keeps_its_arguments(self, mock_resolve):
+        """A configured argv reaches the PTY whole, not collapsed to one token."""
+        cmd = _resolve_web_shell_command({}, None, {"shell": "harness --profile ops"})
+
+        assert cmd == ["/abs/harness", "--profile", "ops"]
+        mock_resolve.assert_called_once_with("harness")
+
+    @patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness")
+    def test_config_shell_accepts_a_list(self, mock_resolve):
+        cmd = _resolve_web_shell_command({}, None, {"shell": ["harness", "--profile", "ops"]})
+
+        assert cmd == ["/abs/harness", "--profile", "ops"]
+        mock_resolve.assert_called_once_with("harness")
+
+    @patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness")
+    def test_shell_flag_keeps_its_arguments(self, mock_resolve):
+        cmd = _resolve_web_shell_command({}, "harness --profile ops", {})
+
+        assert cmd == ["/abs/harness", "--profile", "ops"]
+
 
 # -- help / backward compat ------------------------------------------------
 

--- a/tests/connectors/test_epics_connector.py
+++ b/tests/connectors/test_epics_connector.py
@@ -672,6 +672,32 @@ class TestValidateChannelAndMetadata:
         assert await connector.validate_channel("SR:CH") is True
 
     @pytest.mark.asyncio
+    async def test_validate_channel_probes_with_the_configured_timeout(self, monkeypatch):
+        """The probe uses the connector's own ``timeout``, not a literal of its own."""
+        value = ChannelValue(value=1.0, timestamp=None, metadata=ChannelMetadata())
+        read = AsyncMock(return_value=value)
+        connector = _connector(timeout=17.0)
+        monkeypatch.setattr(connector, "read_channel", read)
+
+        assert await connector.validate_channel("SR:CH") is True
+        assert read.await_args.kwargs["timeout"] == 17.0
+
+    @pytest.mark.asyncio
+    async def test_validate_channel_pva_probes_with_the_configured_timeout(self, monkeypatch):
+        """The PVA metadata-only probe is bounded by the same configured timeout."""
+        seen: list[float] = []
+        connector = _connector(timeout=17.0)
+        connector._pva_channel_globs = ("SR:CH",)
+        monkeypatch.setattr(
+            connector,
+            "_read_metadata_pva",
+            lambda address, timeout: seen.append(timeout),
+        )
+
+        assert await connector.validate_channel("SR:CH") is True
+        assert seen == [17.0]
+
+    @pytest.mark.asyncio
     async def test_validate_channel_false_on_read_error(self, monkeypatch):
         connector = _connector()
         monkeypatch.setattr(

--- a/tests/connectors/test_pva_lifecycle.py
+++ b/tests/connectors/test_pva_lifecycle.py
@@ -368,12 +368,13 @@ class TestGetMetadataOverPva:
 
 class TestValidateChannelOverPva:
     @pytest.mark.asyncio
-    async def test_reachable_channel_validates_true_with_a_short_timeout(self):
+    async def test_reachable_channel_validates_true_with_the_configured_timeout(self):
+        """The probe is bounded by the connector's own ``timeout``, not a literal."""
         context = FakeContext(reply=_metadata_value())
         connector = _pva_connector(context=context)
 
         assert await connector.validate_channel(PVA_ADDRESS) is True
-        assert context.gets == [{"name": PVA_ADDRESS, "request": METADATA_REQUEST, "timeout": 2.0}]
+        assert context.gets == [{"name": PVA_ADDRESS, "request": METADATA_REQUEST, "timeout": 3.0}]
 
     @pytest.mark.asyncio
     async def test_timeout_validates_false(self):

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -50,6 +50,7 @@ from osprey.services.auth_sidecar.app import (
     ENV_STATE_SECRET,
     ENV_TLS_ENABLED,
     ENV_USERS,
+    ENV_WEB_APP_NAME,
 )
 from osprey.utils.workspace import agent_data_base_dir
 
@@ -3332,6 +3333,10 @@ def test_auth_sidecar_service_environment_is_exactly_the_non_secret_settings() -
     # Assert
     assert _env_names(auth) == [
         "TZ",
+        # What the login page wears. Non-secret and deployment-wide: the theme
+        # id (absent here, since this config names none) and the facility name
+        # the terminals behind the sidecar already carry.
+        ENV_WEB_APP_NAME,
         # The sidecar's audit identity and the directory it writes its login and
         # denial events to. Neither is a secret: one is the fixed name
         # `sidecar`, the other a container path.

--- a/tests/deployment/web_terminals/test_sidecar_theme_env.py
+++ b/tests/deployment/web_terminals/test_sidecar_theme_env.py
@@ -1,0 +1,83 @@
+"""The login page's theme and facility name cross the compose overlay.
+
+The auth sidecar sits one hop before the terminals, and it had no way to know
+either: it fell back to the framework palette and the bare wordmark while
+everything behind it carried the deployment's own. The two values reach it over
+the same seam every other sidecar setting uses — the rendered ``environment:``
+block — under the names the per-user terminals already read, and are read back
+by the sidecar's own parser here so a rename on either side fails.
+
+The theme *id* travels, never rendered CSS: the design system stays the one
+producer of palettes and the sidecar resolves the id through it.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from osprey.deployment.web_terminals.render import render_web_terminals
+from osprey.services.auth_sidecar.app import ENV_WEB_APP_NAME, ENV_WEB_THEME, AuthSettings
+
+
+def _config(*, facility_name: str | None = "Demo Light Source", theme: str | None = None) -> dict:
+    """A sidecar-bearing render config, optionally naming a facility and a theme."""
+    config: dict = {
+        "facility": {"prefix": "dls", "timezone": "America/Los_Angeles"},
+        "registry": {"url": "git.dls.example.org:5050/physics/production/dls-profiles"},
+        "deploy": {"host": "dls-deploy", "fqdn": "dls-deploy.dls.example.org"},
+        "modules": {
+            "web_terminals": {
+                "enabled": True,
+                "users": ["alice", "bob"],
+                # The render refuses any auth method over cleartext otherwise;
+                # that gate has its own coverage and is not this file's subject.
+                "auth": {"method": "password", "allow_insecure_http": True},
+            }
+        },
+    }
+    if facility_name is not None:
+        config["facility"]["name"] = facility_name
+    if theme is not None:
+        config["web"] = {"theme": theme}
+    return config
+
+
+def _sidecar_env(config: dict) -> dict[str, str]:
+    """The sidecar's rendered environment, as the mapping its parser reads."""
+    overlay = yaml.safe_load(render_web_terminals(config)["docker-compose.web.yml"])
+    lines = overlay["services"]["auth"]["environment"]
+    return dict(line.split("=", 1) for line in lines)
+
+
+def test_the_configured_theme_and_facility_name_reach_the_sidecar() -> None:
+    env = _sidecar_env(_config(theme="desy-light"))
+
+    assert env[ENV_WEB_THEME] == "desy-light"
+    assert env[ENV_WEB_APP_NAME] == "Demo Light Source"
+
+
+def test_the_rendered_values_round_trip_through_the_sidecars_own_parser() -> None:
+    settings = AuthSettings.from_env(_sidecar_env(_config(theme="desy-light")))
+
+    assert settings.web_theme == "desy-light"
+    assert settings.web_app_name == "Demo Light Source"
+
+
+def test_neither_line_is_emitted_when_the_deployment_names_neither() -> None:
+    """An unset value emits no line, so the page keeps its built-in fallbacks."""
+    env = _sidecar_env(_config(facility_name=None))
+
+    assert ENV_WEB_THEME not in env
+    assert ENV_WEB_APP_NAME not in env
+
+
+def test_a_facility_name_carrying_yaml_punctuation_arrives_whole() -> None:
+    """``: `` and `` #`` are YAML structure in a bare scalar, but not in a name.
+
+    The compose ``- KEY=value`` list form has no per-value quoting, so the whole
+    ``KEY=value`` is quoted as one scalar — the same shape the per-user
+    containers use for this variable.
+    """
+    env = _sidecar_env(_config(facility_name="Ring: Two #2"))
+
+    assert env[ENV_WEB_APP_NAME] == "Ring: Two #2"

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -923,6 +923,14 @@ config:
   # The terminal process itself (`osprey web`), every key at its default. The
   # multi-user compose sets OSPREY_TERMINAL_BIND_HOST on every container, which
   # outranks `host`; `shell` REPLACES the launcher and defeats the CLI pin.
+  # `shell` is argv, written either way — a string (quoting honoured) or a
+  # list; only the first word is resolved to an absolute path and the rest are
+  # passed through:
+  #   web_terminal.shell: /opt/harness/run --profile ops
+  #   web_terminal.shell: ["/opt/harness/run", "--profile", "ops"]
+  # The PTY spawn still appends `--session-id`/`--resume` and `--effort` to
+  # whatever is set here, so a harness that does not take those flags needs a
+  # wrapper that drops them.
   # web_terminal.host: 127.0.0.1
   # web_terminal.port: <a port outside this deployment's block>
   # web_terminal.max_background_sessions: 5

--- a/tests/interfaces/web_terminal/test_shell_argv.py
+++ b/tests/interfaces/web_terminal/test_shell_argv.py
@@ -1,0 +1,62 @@
+"""``web_terminal.shell`` is argv in the ``--reload`` reader too.
+
+``osprey web`` resolves the PTY argv in :mod:`osprey.cli.web_cmd`, but uvicorn's
+factory bypass under ``--reload`` never reaches that code — the app's own
+lifespan reads the key instead. Both readers must reach the same argv, or a
+configured harness loses its arguments in exactly one of the two ways a
+deployment can be started.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from osprey.interfaces.web_terminal import app as web_app
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    (tmp_path / "_agent_data").mkdir(exist_ok=True)
+    monkeypatch.delenv("CONFIG_FILE", raising=False)
+    monkeypatch.delenv("OSPREY_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _shell_command_for(project, monkeypatch, shell) -> list[str]:
+    """Start the app with ``web_terminal.shell`` set to *shell*, return the argv."""
+    monkeypatch.setattr(
+        web_app,
+        "_load_web_config",
+        lambda *_a, **_k: {"shell": shell, "watch_dir": str(project / "_agent_data")},
+    )
+    monkeypatch.setattr(web_app, "_log_claude_cli_versions", lambda *_a, **_k: None)
+
+    app = web_app.create_app(
+        config_path=str(project / "config.yml"),
+        project_dir=str(project),
+    )
+    with (
+        patch("osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness"),
+        TestClient(app),
+    ):
+        return list(app.state.shell_command)
+
+
+def test_string_shell_keeps_its_arguments(project, monkeypatch):
+    assert _shell_command_for(project, monkeypatch, "harness --profile ops") == [
+        "/abs/harness",
+        "--profile",
+        "ops",
+    ]
+
+
+def test_list_shell_keeps_its_arguments(project, monkeypatch):
+    assert _shell_command_for(project, monkeypatch, ["harness", "--profile", "ops"]) == [
+        "/abs/harness",
+        "--profile",
+        "ops",
+    ]

--- a/tests/mcp_server/python_executor/test_executor_adapter.py
+++ b/tests/mcp_server/python_executor/test_executor_adapter.py
@@ -22,6 +22,7 @@ from osprey.mcp_server.python_executor.executor import (
     execute_code,
     resolve_agent_interpreter,
 )
+from osprey_connectors.config import DEFAULT_EXECUTION_TIMEOUT_SECONDS, ConfigBuilder
 
 
 @pytest.fixture(autouse=True)
@@ -131,11 +132,25 @@ def test_config_reads_timeout(tmp_path, monkeypatch):
 
 @pytest.mark.unit
 def test_config_timeout_default(tmp_path, monkeypatch):
-    """When timeout config absent, defaults to 600 seconds."""
+    """When timeout config absent, the adapter falls back to the shared default."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "config.yml").write_text(yaml.dump({}))
     config = _read_config()
-    assert config["timeout"] == 600
+    assert config["timeout"] == DEFAULT_EXECUTION_TIMEOUT_SECONDS
+
+
+@pytest.mark.unit
+def test_config_timeout_default_matches_the_builder_default(tmp_path, monkeypatch):
+    """Both ends of the executor timeout read the same constant."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(yaml.dump({}))
+    builder = ConfigBuilder(config_path=str(tmp_path / "config.yml"))
+
+    assert (
+        builder._get_python_executor_config()["execution_timeout_seconds"]
+        == _read_config()["timeout"]
+        == DEFAULT_EXECUTION_TIMEOUT_SECONDS
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp_server/test_notebook_renderer.py
+++ b/tests/mcp_server/test_notebook_renderer.py
@@ -7,6 +7,8 @@ Covers:
 """
 
 import time
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import nbformat
 import pytest
@@ -177,3 +179,22 @@ class TestGetOrRenderHtml:
         html, html_path2 = get_or_render_html(nb_path, cache_dir=cache_dir)
         assert html_path2.stat().st_mtime > first_mtime
         assert "STALE_UPDATED_MARKER" in html
+
+
+TOKYO = ZoneInfo("Asia/Tokyo")  # UTC+9, no DST
+
+
+@pytest.mark.unit
+def test_header_timestamp_is_in_the_facility_zone(monkeypatch):
+    """The header an operator opens carries the facility offset, not a UTC literal."""
+    monkeypatch.setattr(
+        "osprey.utils.config.get_facility_timezone",
+        lambda: TOKYO,
+    )
+    nb = create_notebook_from_code(code="print(1)", description="Zone test")
+    line = next(ln for ln in nb.cells[0].source.splitlines() if ln.startswith("**Timestamp:**"))
+    stamp = line.removeprefix("**Timestamp:**").strip()
+
+    parsed = datetime.fromisoformat(stamp)
+    assert parsed.utcoffset().total_seconds() == 9 * 3600
+    assert "UTC" not in stamp

--- a/tests/mcp_server/test_phoebus_plt_generator.py
+++ b/tests/mcp_server/test_phoebus_plt_generator.py
@@ -7,7 +7,9 @@ must be facility-neutral: no default archiver URL, and no ALS-specific string
 anywhere in the migrated source.
 """
 
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import defusedxml.ElementTree as ET
 
@@ -164,3 +166,22 @@ def test_file_written_under_workspace_dir_with_plt_suffix(tmp_path):
     assert p.exists()
     assert p.suffix == ".plt"
     assert p.parent == tmp_path
+
+
+def test_default_time_window_is_facility_local(tmp_path, monkeypatch):
+    """With no explicit range the default 24 h window is facility wall-clock."""
+    tokyo = ZoneInfo("Asia/Tokyo")  # UTC+9, no DST
+    monkeypatch.setattr(
+        "osprey.mcp_server.phoebus.plt_generator.get_facility_timezone",
+        lambda: tokyo,
+    )
+    plt_path = plt_generator.create_plt_from_config(
+        _minimal_config(time_range=None), workspace_dir=tmp_path
+    )
+    root = ET.fromstring(Path(plt_path).read_text())
+
+    end = datetime.strptime(root.find("end").text, "%Y-%m-%d %H:%M:%S.%f")
+    start = datetime.strptime(root.find("start").text, "%Y-%m-%d %H:%M:%S.%f")
+    expected = datetime.now(tokyo).replace(tzinfo=None)
+    assert abs((end - expected).total_seconds()) < 60
+    assert abs((end - start).total_seconds() - 24 * 3600) < 1

--- a/tests/mcp_server/workspace/test_sandbox_executor.py
+++ b/tests/mcp_server/workspace/test_sandbox_executor.py
@@ -2,6 +2,7 @@
 
 import json
 import textwrap
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -386,6 +387,21 @@ class TestExecuteSandboxCode:
 
         assert not result.success
         assert result.error_message is not None
+
+    async def test_execution_metadata_timestamps_carry_an_offset(
+        self, execution_folder, workspace_root
+    ):
+        """The child stamps offset-aware times, so its metadata is orderable."""
+        with patch(
+            "osprey.utils.workspace.resolve_workspace_root",
+            return_value=workspace_root,
+        ):
+            result = await execute_sandbox_code(code="x = 1", execution_folder=execution_folder)
+
+        assert result.success
+        metadata = json.loads((execution_folder / "execution_metadata.json").read_text())
+        for field in ("start_time", "end_time"):
+            assert datetime.fromisoformat(metadata[field]).utcoffset() is not None
 
     async def test_stdout_captured(self, execution_folder, workspace_root):
         code = "print('hello from sandbox')"

--- a/tests/services/auth_sidecar/test_login.py
+++ b/tests/services/auth_sidecar/test_login.py
@@ -1425,3 +1425,41 @@ def test_a_username_carrying_newlines_cannot_forge_a_log_line(
 
     assert "'mally\\nWARNING forged'" in caplog.text
     assert "\nWARNING forged" not in caplog.text
+
+
+# ── the page wears the deployment ──────────────────────────────────────────
+
+
+def _page_body(env_extra: dict[str, str] | None = None) -> str:
+    """The login page as a browser navigating to it would receive it."""
+    client = _client({**PASSWORD_ENV, **(env_extra or {})})
+    response = client.get(f"{LOGIN_PATH}?user=alice", headers=BROWSER_ACCEPT)
+    assert response.status_code == 200
+    return response.text
+
+
+def test_login_page_wears_the_configured_theme_and_names_the_facility():
+    """The theme id and facility name the terminals behind it already carry."""
+    from osprey.services.auth_sidecar.routes.login import _theme_blocks
+
+    _theme_blocks.cache_clear()
+    body = _page_body({"OSPREY_WEB_THEME": "desy-light", "OSPREY_WEB_APP_NAME": "Example Light"})
+
+    assert '<p class="login-facility">Example Light</p>' in body
+    # A concrete id pins one mode, so the page carries no prefers-color-scheme
+    # block — the marker that the configured value, not the default family,
+    # decided the palette.
+    assert "color-scheme: light" in body
+    assert "prefers-color-scheme" not in body
+
+
+def test_login_page_still_renders_with_neither_set():
+    """Nothing configured: the framework palette and the bare wordmark."""
+    from osprey.services.auth_sidecar.routes.login import _theme_blocks
+
+    _theme_blocks.cache_clear()
+    body = _page_body()
+
+    assert '<p class="login-mark">OSPREY</p>' in body
+    assert '<p class="login-facility"' not in body
+    assert "prefers-color-scheme" in body

--- a/tests/services/python_executor/execution/test_metadata_timestamps.py
+++ b/tests/services/python_executor/execution/test_metadata_timestamps.py
@@ -1,0 +1,34 @@
+"""Execution-metadata timestamps emitted by the wrapper carry a UTC offset.
+
+The wrapper emits *source text* that runs inside the executor child, so the
+timestamps it stamps are only observable by running that text. A naive
+``isoformat()`` there is unreadable next to the offset-carrying times the
+in-process producer writes, and unorderable against any other subsystem's.
+"""
+
+from datetime import datetime
+from datetime import datetime as _datetime
+
+import pytest
+
+from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
+
+
+@pytest.mark.unit
+def test_start_time_parses_with_tzinfo():
+    """``start_time`` in the emitted metadata is offset-aware."""
+    namespace: dict = {"_datetime": _datetime}
+    exec(compile(ExecutionWrapper()._get_metadata_init(), "<wrapper>", "exec"), namespace)
+
+    start = datetime.fromisoformat(namespace["execution_metadata"]["start_time"])
+    assert start.tzinfo is not None
+    assert start.utcoffset() is not None
+
+
+@pytest.mark.unit
+def test_no_naive_timestamp_left_in_the_emitted_wrapper():
+    """Every ``end_time`` branch stamps an aware time too, not just ``start_time``."""
+    source = ExecutionWrapper().create_wrapper("x = 1")
+
+    assert "_datetime.now().isoformat()" not in source
+    assert "_datetime.now().astimezone().isoformat()" in source

--- a/tests/utils/test_shell_resolver.py
+++ b/tests/utils/test_shell_resolver.py
@@ -12,7 +12,11 @@ from unittest.mock import patch
 
 import pytest
 
-from osprey.utils.shell_resolver import resolve_shell_command, user_bin_dirs
+from osprey.utils.shell_resolver import (
+    normalize_shell_command,
+    resolve_shell_command,
+    user_bin_dirs,
+)
 
 
 class TestUserBinDirs:
@@ -160,3 +164,56 @@ class TestAnAccountWithNoHome:
 
         with pytest.raises(FileNotFoundError, match="not found on PATH"):
             resolve_shell_command("definitely-not-a-real-command")
+
+
+class TestNormalizeShellCommand:
+    """``web_terminal.shell`` is argv, in either spelling."""
+
+    def test_bare_command_resolves_to_one_element(self):
+        with patch(
+            "osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness"
+        ):
+            assert normalize_shell_command("harness") == ["/abs/harness"]
+
+    def test_string_with_arguments_splits_and_keeps_the_tail(self):
+        with patch(
+            "osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness"
+        ) as resolve:
+            assert normalize_shell_command("harness --profile ops") == [
+                "/abs/harness",
+                "--profile",
+                "ops",
+            ]
+        resolve.assert_called_once_with("harness")
+
+    def test_quoting_is_honoured(self):
+        with patch(
+            "osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness"
+        ):
+            assert normalize_shell_command('harness --note "two words"') == [
+                "/abs/harness",
+                "--note",
+                "two words",
+            ]
+
+    def test_list_resolves_only_the_first_element(self):
+        with patch(
+            "osprey.utils.shell_resolver.resolve_shell_command", return_value="/abs/harness"
+        ) as resolve:
+            assert normalize_shell_command(["harness", "--profile", "ops"]) == [
+                "/abs/harness",
+                "--profile",
+                "ops",
+            ]
+        resolve.assert_called_once_with("harness")
+
+    def test_empty_value_is_refused(self):
+        for value in ("", "   ", []):
+            with pytest.raises(ValueError, match="web_terminal.shell"):
+                normalize_shell_command(value)
+
+    def test_a_value_that_is_neither_string_nor_list_is_refused_by_name(self):
+        """YAML admits scalars and mappings the key does not; each names the key."""
+        for value in (5, True, {"command": "harness"}, None):
+            with pytest.raises(ValueError, match="web_terminal.shell"):
+                normalize_shell_command(value)


### PR DESCRIPTION
Honour four seams a deployment already configures but four sites bypassed, and add no config keys.

- `fix(stores,mcp): operator-facing timestamps use the facility zone`
- `fix(executor): execution metadata timestamps carry an offset`
- `fix(connectors): channel validation honours the configured timeout`
- `feat(web-terminal): list-valued web_terminal.shell through one normalizer`
- `fix(auth): login page wears the deployment theme and names the facility`

## Why

Each of these was a tunable a facility will hit, sitting as a literal beside a
sibling the deployment already sets. The notebook header an operator opens and
the default Data Browser window now read the facility timezone through the same
`to_facility_iso`/`get_facility_timezone` seam the shipped agent rule promises,
instead of stamping UTC or the container's offset. The metadata an agent Python
run writes carries an offset on `start_time`/`end_time`, matching the in-process
producer, so records from the two are orderable against each other — and the
executor's timeout default is now one constant both ends read rather than two
`600` literals. The EPICS connector's existence probe uses the `timeout` the
deployment configured for it, like its reads and writes already did, so a
facility on a slow gateway raises one key and every probe follows.
`web_terminal.shell` is argv in both readers: a facility whose harness needs
arguments writes them as a string or a YAML list instead of shipping a wrapper
script, and only argv[0] is path-resolved. And the sign-in page — the one
surface a user meets before the terminals — wears the deployment's `web.theme`
and names the facility, resolving the theme id through the design system rather
than carrying rendered CSS of its own.

## Not in this PR

- No new config keys: every value here is one the deployment already sets
  (`system.timezone`, the connector `timeout`, `web.theme`, `facility.name`,
  `web_terminal.shell`). Adding keys is the companion PR's job.
- The PTY spawn still appends `--session-id`/`--resume` and `--effort` to
  whatever `web_terminal.shell` names, so a harness that does not take those
  flags still needs a wrapper. Making that append launcher-aware is a separate
  change; the preset comment states the fact.
- `plt_generator`'s filename prefix and the artifact viewer's browser clock stay
  as they are — a file name is not an operator-facing timestamp, and a viewer's
  clock is correctly the viewer's.
