### PR TITLE
feat(config): promote per-facility limits to the blocks their siblings already use

### DIFF
--- a/changelog.d/ariel-attachment-cap.added.md
+++ b/changelog.d/ariel-attachment-cap.added.md
@@ -1,0 +1,4 @@
+The largest file a logbook entry may attach is now a config key,
+`ariel.attachments.max_file_mb` (default 10, the previous fixed bound). The
+refusal names the limit in force. Attachments live in the same Postgres as the
+logbook, so raising it spends database storage.

--- a/changelog.d/ariel-index-lists.added.md
+++ b/changelog.d/ariel-index-lists.added.md
@@ -1,0 +1,5 @@
+The pgvector IVFFlat `lists` count for ARIEL's embedding index is now a config
+key, `ariel.enhancement_modules.text_embedding.index_lists` (default 224, the
+previous fixed value). The rule of thumb is roughly one list per 1000 entries.
+The value is fixed when the index is created, so changing it later means
+dropping the index and recreating it.

--- a/changelog.d/ariel-semantic-input-budget.added.md
+++ b/changelog.d/ariel-semantic-input-budget.added.md
@@ -1,0 +1,6 @@
+How much of a logbook entry ARIEL's semantic processor sends for keywords and a
+summary is now a config key,
+`ariel.enhancement_modules.semantic_processor.max_input_chars` (default 8000,
+the previous fixed slice). An entry longer than the budget is still cut, but
+the cut is now logged naming the entry, so a summary that covers only an
+opening says so.

--- a/changelog.d/artifacts-timeseries-cap.added.md
+++ b/changelog.d/artifacts-timeseries-cap.added.md
@@ -1,0 +1,5 @@
+The largest timeseries file the artifact gallery will chart or tabulate is now
+a config key, `artifact_server.max_timeseries_file_mb` (default 200, the
+previous fixed bound). Over the cap those two views still refuse with a 413 and
+the file stays downloadable; raising it costs resident memory on the machine
+serving the gallery, since the handler loads the whole file to build the view.

--- a/changelog.d/bluesky-live-buffer.added.md
+++ b/changelog.d/bluesky-live-buffer.added.md
@@ -1,0 +1,5 @@
+Two new build-profile keys bound the Bluesky bridge's in-memory run data:
+`bluesky.live_max_runs` (default 50) is how many finished runs stay readable,
+and `bluesky.live_max_rows_per_run` (default 10000) is how many rows of one run
+are stored. Both were fixed in the code before. Rows past the cap are still
+counted, so a long run reports its true length over a truncated buffer.

--- a/changelog.d/bluesky-settle.added.md
+++ b/changelog.d/bluesky-settle.added.md
@@ -1,0 +1,8 @@
+Two new build-profile keys bound how long a Bluesky plan waits for a device to
+settle after a write: `bluesky.settle_timeout_s` (default 5.0 seconds) and
+`bluesky.settle_tolerance` (default `1e-9`, an absolute difference). The
+previous values were fixed in the code and suited only devices whose readback
+echoes the setpoint exactly; a magnet or an insertion-device gap can now be
+given the room it needs. Running out of budget still fails the plan, and a
+value the settle loop cannot use fails the worker's start rather than the first
+plan that writes.

--- a/changelog.d/channel-finder-query-cap.added.md
+++ b/changelog.d/channel-finder-query-cap.added.md
@@ -1,0 +1,4 @@
+The number of rows the middle-layer `run_sql` tool hands back is now a config
+key, `channel_finder.query_max_rows` (default 500, the previous fixed cap). A
+truncated answer now says which key cut it and at what number, so the agent
+narrows the query rather than presenting a partial list as complete.

--- a/changelog.d/dispatch-max-turns.added.md
+++ b/changelog.d/dispatch-max-turns.added.md
@@ -1,0 +1,5 @@
+How many agentic turns one dispatched run may take is now a build-profile key,
+`dispatch.max_turns` (default 25), beside the two clock budgets. A trigger can
+also name its own `max_turns:` in its `action:` block — a whole number of turns,
+refused when the triggers file loads if it is not; one that names none gets the
+deployment's number instead of a fixed 25.

--- a/changelog.d/facility-service-http.added.md
+++ b/changelog.d/facility-service-http.added.md
@@ -1,0 +1,4 @@
+A service your deployment brings with it can now say that it answers HTTP, with
+`services.<name>.config.http: true`. The deploy summary then prints its address
+as a link you can open instead of a bare `host:port`. Default off, so a service
+speaking a binary protocol is never shown as a link that cannot open.

--- a/changelog.d/graphdb-bolt-wait.fixed.md
+++ b/changelog.d/graphdb-bolt-wait.fixed.md
@@ -1,0 +1,5 @@
+A first deploy no longer skips seeding the facility knowledge graph. The wait
+for the graph store to accept a connection was shorter than the store's own
+healthcheck grace period, so on a first start the deploy gave up while the
+container was still coming up — and the deployment came up with an empty graph
+and nothing to say why.

--- a/changelog.d/graphdb-database-key.added.md
+++ b/changelog.d/graphdb-database-key.added.md
@@ -1,0 +1,5 @@
+An external graph store whose corpus lives in a database other than `neo4j` can
+now be named with `services.graphdb.database`. Both halves — the seeder's
+writes and the agent's reads — open every session against it, so they cannot
+end up on different databases. The store OSPREY runs for itself serves one
+database and is unaffected.

--- a/changelog.d/mcp-ready-timeout.fixed.md
+++ b/changelog.d/mcp-ready-timeout.fixed.md
@@ -1,0 +1,5 @@
+The MCP readiness budget is now `OSPREY_MCP_READY_TIMEOUT`, and it is
+documented. It gates every run — `osprey query` exits 1 when a declared server
+has not registered in time — not only the end-to-end tests its old
+`OSPREY_E2E_MCP_READY_TIMEOUT` name implied. The old name is still read and
+will be dropped after one release.

--- a/changelog.d/oidc-scopes.added.md
+++ b/changelog.d/oidc-scopes.added.md
@@ -1,0 +1,6 @@
+Single sign-on deployments can now name the scopes requested at the provider's
+authorization endpoint, with `modules.web_terminals.auth.oidc.scopes`. The
+previous fixed list (`openid profile email`) is still the default, so a
+provider that publishes its identity claim under some other scope no longer
+needs a code change. A list that drops `openid` is refused: without it there is
+no ID token to check.

--- a/changelog.d/qmd-first-index-grace.added.md
+++ b/changelog.d/qmd-first-index-grace.added.md
@@ -1,0 +1,5 @@
+How long the qmd sidecar's health check waits out its first full index build is
+now a config key, `services.qmd.first_index_grace` (seconds, default 3600 — the
+previous fixed value). The sidecar does not open its port until the index
+exists and is non-empty, so a corpus that takes longer than the grace period to
+index would otherwise report a working container as failed.

--- a/changelog.d/step-read-timeout.added.md
+++ b/changelog.d/step-read-timeout.added.md
@@ -1,0 +1,6 @@
+How long a `max_step` check waits for a channel's present value before a write
+is now a config key, `control_system.connector.<type>.step_read_timeout_s`
+(default 2.0 seconds, the previous fixed value), beside the connector's own
+`timeout`. Raise it for a slow gateway: running out of budget still refuses the
+write, so it buys room and never a weaker check. The Python executor's sandbox
+applies the same number as the connector.

--- a/changelog.d/va-poll-and-noise.added.md
+++ b/changelog.d/va-poll-and-noise.added.md
@@ -1,0 +1,5 @@
+The Virtual Accelerator's telemetry cadence and noise level are now set from
+the deployment's `.env`: `VA_POLL_INTERVAL_S` (default 1.0 seconds) and
+`VA_NOISE_LEVEL` (default 0.01). The noise level previously could not be
+changed at all — the IOC never read the one it was given. Both are refused at
+boot if they are not a number or are out of range, rather than being clamped.

--- a/docs/source/architecture/mcp-servers.rst
+++ b/docs/source/architecture/mcp-servers.rst
@@ -101,7 +101,7 @@ lookups and validation.
 - ``inspect_fields`` -- Inspect the field structure of a device family.
 - ``validate`` -- Validate that channel names exist in the database.
 - ``statistics`` -- Get database statistics (total channels, systems, families).
-- ``run_sql`` -- Run a read-only SQL query directly against the channel finder DuckDB database (``channels``, ``systems``, ``families`` tables).
+- ``run_sql`` -- Run a read-only SQL query directly against the channel finder DuckDB database (``channels``, ``systems``, ``families`` tables). Answers are bounded by ``channel_finder.query_max_rows``; a truncated reply says so and names the key, so a partial list is never presented as complete.
 
 ``channel_finder_graph``
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/how-to/agent-interfaces/cli-agent.rst
+++ b/docs/source/how-to/agent-interfaces/cli-agent.rst
@@ -172,7 +172,10 @@ Exit Codes
      - Verdict fail
      - The agent ran but the outcome was unsatisfactory: a required MCP
        server was missing from the session, the agent returned an error
-       result, or the run hit its cost budget (USD) or turn limit.
+       result, or the run hit its cost budget (USD) or turn limit. "Missing"
+       includes a declared server that did not register in time: the run waits
+       ``OSPREY_MCP_READY_TIMEOUT`` seconds (default 90) for every server the
+       project declares, and a busy or cold host can need longer than that.
    * - ``2``
      - Infra / usage error
      - The run never started: no project found at the resolved path, the

--- a/docs/source/how-to/agent-interfaces/event-dispatch.rst
+++ b/docs/source/how-to/agent-interfaces/event-dispatch.rst
@@ -236,12 +236,22 @@ Authoring Triggers
             prompt: >-
               Reply with a single sentence confirming the pipeline works.
             allowed_tools: []            # tools this run may use
+            max_turns: 25                # optional; defaults to dispatch.max_turns
           on_error:                      # optional: retry if the worker is unreachable
             action: retry
             max_retries: 2
             backoff_sec: 1.0
 
    Each webhook trigger is reachable at ``POST /webhook/<name>``.
+
+   **Turn ceiling.** How many agentic turns one dispatched run may take is
+   ``dispatch.max_turns`` in the build profile (default 25) — the third budget
+   beside ``dispatch.timeout_sec`` and ``dispatch.inactivity_sec``, and the one
+   about the work rather than the clock. A trigger that needs more, or less,
+   than the deployment's number states its own ``max_turns:`` in ``action:``;
+   a trigger that names none gets the deployment's. A trigger's own value must
+   be a whole number of turns of at least one, and the dispatcher refuses the
+   triggers file at load if it is not.
 
    **Tool denylist (defence in depth).** The worker enforces a server-side tool
    denylist regardless of what a trigger requests: ``WebFetch``, ``WebSearch``,

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -141,9 +141,16 @@ The built-in enhancement modules:
              text_embedding:
                enabled: true
                provider: ollama
+               index_lists: 224
                models:
                  - name: nomic-embed-text
                    dimension: 768
+
+      ``index_lists`` (default 224) sizes the pgvector IVFFlat index. The rule of
+      thumb is roughly one list per 1000 entries, up to about a million entries.
+      It cannot be worked out for you --- ``osprey ariel migrate`` creates the
+      index before a single entry is embedded --- and the value is baked in at
+      creation, so changing it later means dropping the index and recreating it.
 
       **Requirements:** Ollama (or another embedding provider) running with the specified model.
 

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -153,9 +153,16 @@ The built-in enhancement modules:
              semantic_processor:
                enabled: true
                provider: cborg
+               max_input_chars: 8000
                model:
                  model_id: anthropic/claude-haiku
                  max_tokens: 256
+
+      ``max_input_chars`` (default 8000) is how much of an entry is sent. A
+      longer entry is cut at that point and the cut is logged, naming the
+      entry, so a summary that describes only an opening says so somewhere.
+      Raise it if your entries run long and your provider's context window has
+      the room.
 
    .. tab-item:: qmd Export
 

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -105,6 +105,15 @@ The filename is a facility convention, not a standard, so each adapter declares 
 
 The default is ``("metadata.json",)``. Matching is case-insensitive, and a name that never appears is simply a no-op --- there is no switch to turn this off. If an entry has attachments and none of them matched, ingestion says so at debug level rather than staying silent about metadata it did not collect.
 
+Attachment Size
+~~~~~~~~~~~~~~~
+
+``ariel.attachments.max_file_mb`` (default 10) is the largest file one entry may
+attach; a bigger one is refused, naming the file and the limit. Attachments are
+stored as rows in the same Postgres the logbook lives in, so this number is a
+storage decision in both directions --- raise it for a facility that attaches
+raw traces, lower it to keep the database small.
+
 
 .. _`Enhancement Pipeline`:
 

--- a/docs/source/how-to/ariel/search-sidecar.rst
+++ b/docs/source/how-to/ariel/search-sidecar.rst
@@ -61,12 +61,13 @@ Configuration
        path: ./services/qmd
        port: 10060     # host port clients talk to
        interval: 30    # fallback corpus-sweep period, seconds
+       first_index_grace: 3600   # seconds the health check waits out the first build
 
    deployed_services:
      - qmd
 
-Those three keys are the whole schema for a host that can reach the internet;
-a fourth, ``models_dir``, covers one that cannot (see `Building without
+Those four keys are the whole schema for a host that can reach the internet;
+a fifth, ``models_dir``, covers one that cannot (see `Building without
 egress`_). Notably **there is no ``bind_address`` here** --- see `Where the
 sidecar listens`_ below.
 
@@ -136,11 +137,13 @@ trees, and everything that *writes* them lives outside the container.
 
 The index itself lives in a named volume rather than a bind mount. It is
 derived data the sidecar owns end to end, it is large, and rebuilding it costs
-about **41 minutes** at ALS scale --- which is precisely why it must survive a
-container recreate. The service's health check allows a one-hour start period
-for the same reason: the sidecar refuses to open its port until the index is
-built and provably non-empty, and a container that is working correctly should
-not be reported unhealthy for most of its first hour.
+a full index build --- long on a large corpus --- which is precisely why it
+must survive a container recreate. The service's health check waits out that
+build for the same reason: the sidecar refuses to open its port until the index
+is built and provably non-empty, so until then a container that is working
+correctly would be reported unhealthy. ``first_index_grace`` is how long it
+waits, in seconds, and it defaults to an hour. Scale it with your corpus:
+shorter than the build and the first boot is reported as a failure.
 
 Sharing the knowledge bundle
 ----------------------------

--- a/docs/source/how-to/bluesky/write-plans.rst
+++ b/docs/source/how-to/bluesky/write-plans.rst
@@ -155,6 +155,16 @@ recorded and never written. The name is what a plan and the agent refer to, and
 it is also the column heading in the run's data, so each name may appear only
 once across both lists.
 
+When a plan drives a settable, the write is followed by a poll of the readback
+until it reaches the demand. Two profile keys bound that wait:
+``bluesky.settle_timeout_s`` (default 5.0 seconds) is how long the poll runs
+before the move fails and the plan aborts, and ``bluesky.settle_tolerance``
+(default ``1e-9``) is how close the readback must come, as an absolute
+difference. The defaults suit a setpoint a controller echoes back exactly; a
+device that physically moves — a magnet, an insertion-device gap — needs both
+raised. Running out of budget always fails the plan: neither key can turn an
+unsettled move into a successful one.
+
 Nothing in the file is split on any character, which is the point of writing it
 this way: an address containing a comma — as some real magnet power supplies
 have — is written out plainly and needs no escaping.

--- a/docs/source/how-to/control-systems/use-virtual-accelerator.rst
+++ b/docs/source/how-to/control-systems/use-virtual-accelerator.rst
@@ -259,6 +259,33 @@ boundary. The project's ``virtual_accelerator`` connector block is configured to
 match and sets ``EPICS_CA_NAME_SERVERS`` itself, so no client-side EPICS
 environment setup is needed.
 
+What the IOC serves, and how often
+==================================
+
+Two numbers about the served values are set in the deployment's ``.env`` rather
+than fixed in the image, because both are properties of the machine you are
+standing in for rather than of OSPREY:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Variable
+     - What it does
+   * - ``VA_POLL_INTERVAL_S``
+     - Seconds between telemetry ticks --- how often the IOC republishes the
+       values it reads out of the simulation engine. Default ``1.0``. Lower it
+       for a demo that should look live; raise it on a very large namespace.
+   * - ``VA_NOISE_LEVEL``
+     - Fractional noise on the synthesised channel values, default ``0.01``.
+       ``0`` serves them flat, which is what a test that compares readings
+       wants.
+
+Both are refused at boot if they are not a number, or out of range, rather than
+being clamped --- so a typo shows up in ``docker logs`` instead of quietly
+changing what the machine looks like. Leave either empty and the default
+applies.
+
 Running from a source checkout
 ==============================
 

--- a/docs/source/how-to/deploy-a-facility.rst
+++ b/docs/source/how-to/deploy-a-facility.rst
@@ -224,6 +224,7 @@ line and the commented ``mcp_servers:`` example with:
        template: services/facility-mcp
        config:
          port: 10900
+         http: true
 
    mcp_servers:
      facility:
@@ -233,7 +234,13 @@ line and the commented ``mcp_servers:`` example with:
          allow: [machine_status]
 
 ``template:`` is profile-relative, so the next thing to do is write that
-directory. The port appears twice because it is the same fact told to two
+directory. ``http: true`` says this service answers HTTP on the port it
+publishes, so the deploy summary prints its address as a link rather than as a
+bare ``host:port`` — the framework recognises its own services by name and has
+no way to know what protocol sits behind yours. Leave it out for a service that
+speaks anything else; a link that cannot open is worse than no link.
+
+The port appears twice because it is the same fact told to two
 parties: the container publishes it, and the agent dials it. ``10900`` is the
 first port of the facility band, the hundred ports the framework publishes
 nothing in so that a facility's own services can claim them without ever

--- a/docs/source/how-to/facility-knowledge/use-facility-graph.rst
+++ b/docs/source/how-to/facility-knowledge/use-facility-graph.rst
@@ -349,6 +349,12 @@ Which differences are refused and which are only reported is set out under
 :ref:`Preset drift, and osprey profile expand <profile-preset-drift>` in the
 profile reference.
 
+If the corpus lives in a database other than ``neo4j`` on that store, name it
+with ``services.graphdb.database``. The store this deployment runs is a
+Community image that serves exactly one database, so the key matters only here:
+it is what every session — the seeder's writes and the agent's reads alike — is
+opened against, so both halves reach the same corpus.
+
 Put that account's password in the project ``.env`` as ``GRAPHDB_PASSWORD``.
 Nothing mints one here — the store belongs to somebody else, so OSPREY starts
 nothing and bootstraps nothing, and it seeds nothing on its own: the corpus is

--- a/docs/source/how-to/use-channel-finder.rst
+++ b/docs/source/how-to/use-channel-finder.rst
@@ -139,7 +139,11 @@ Middle Layer Pipeline
 A React agent explores the database using query tools
 (``list_systems``, ``list_families``, ``inspect_fields``,
 ``list_channels``, ``get_common_names``, ``statistics``, ``validate``, and —
-when DuckDB is installed — ``run_sql``).
+when DuckDB is installed — ``run_sql``). What ``run_sql`` hands back is bounded
+by ``channel_finder.query_max_rows`` (default 500): a longer result is cut and
+flagged, naming the key, so the agent narrows the query instead of presenting a
+partial list. The cap is on the agent's context, not on the database, which is
+why it is set per deployment.
 
 The database follows MATLAB Middle Layer (MML) functional organization
 (System -> Family -> Field -> ChannelNames). Convert from MML exports:

--- a/docs/source/how-to/web-terminal/multi-user/login.rst
+++ b/docs/source/how-to/web-terminal/multi-user/login.rst
@@ -110,10 +110,19 @@ user's terminal:
            client_id_env: OSPREY_AUTH_OIDC_CLIENT_ID      # names in .env.auth
            client_secret_env: OSPREY_AUTH_OIDC_CLIENT_SECRET
            claim: sub
+           scopes: [openid, profile, email]
        users:
          - name: alice
            index: 0
            oidc_subject: "8f4c1e02-..."     # alice's value of that claim
+
+``scopes`` is what is asked for at the authorization endpoint, and it decides
+which claims the provider releases: a claim that was never requested is simply
+absent, and an absent claim is a denied login. The three above are the default,
+so a deployment whose provider publishes its identity claim under ``profile``
+or ``email`` can leave the line out. ``openid`` may not be dropped — without it
+the provider issues no ID token at all, and the sidecar refuses to serve rather
+than run a login it cannot check.
 
 A login matches when the asserted claim equals the card's ``oidc_subject``.
 The comparison is exact for every claim except ``email``, which is compared

--- a/docs/source/reference/configuration/config.rst
+++ b/docs/source/reference/configuration/config.rst
@@ -710,6 +710,15 @@ restart.
 The four commented stanzas in the shipped presets have nothing to do but say
 this: a shipped value would be one facility's vocabulary handed to every other.
 
+One other key sits in this block. ``artifact_server.max_timeseries_file_mb``
+(default 200) is the largest timeseries data file the gallery will draw as a
+chart or lay out as a table. Over it, those two views refuse with a ``413`` and
+say so; the file itself stays downloadable either way. The handler reads the
+whole file into memory to build the view, so raising the number spends that
+much memory on the machine serving the gallery — which is why it is a facility's
+to set rather than a fixed bound: how big an export gets is a property of your
+archiver, and how much memory the gallery host has is a property of your site.
+
 .. _config-python-executor:
 
 ``python_executor:`` — how long one agent script may run

--- a/docs/source/reference/configuration/environment-variables.rst
+++ b/docs/source/reference/configuration/environment-variables.rst
@@ -79,6 +79,14 @@ deployment, which is why none of them is a config key.
        and ``application.registry_path`` is accepted as an alias. All three
        resolve through one function, so the registry that loads is the one
        ``osprey health`` reports on.
+   * - ``OSPREY_MCP_READY_TIMEOUT``
+     - Seconds a run waits for every MCP server the project declares to finish
+       connecting before it goes ahead without them, default ``90``. A host
+       property, not a deployment one: a cold or oversubscribed machine takes
+       longer to start the same servers. Too low and ``osprey query`` exits 1
+       for a server that was still starting. The former spelling
+       ``OSPREY_E2E_MCP_READY_TIMEOUT`` is still read and will be dropped after
+       one release; the budget was never specific to tests.
    * - ``OSPREY_TERMINAL_BIND_HOST``
      - The address ``osprey web`` binds to, and **authoritative over both
        ``--host`` and the config**. The multi-user compose sets it on every

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -1293,6 +1293,16 @@ build** and prints the valid set:
        is served a page at a time and can be narrowed by an exact name
        prefix. The same number decides when a refusal for an unknown device
        stops listing every device it does know and gives a count instead.
+   * - ``settle_timeout_s``
+     - How long a plan write waits for the readback to reach its demand
+       before the move fails and the plan aborts (default 5.0 seconds). Raise
+       it for devices that physically move; it never turns an unsettled move
+       into a successful one.
+   * - ``settle_tolerance``
+     - How close the readback must come to the demand to count as settled, as
+       an absolute difference (default ``1e-9``). The default is a float-noise
+       bound, right for a setpoint a controller echoes back exactly and far
+       too strict for a magnet or a gap.
 
 Whether a deployment can execute plans at all is not set here: it follows from
 the control system the deployment runs. See :doc:`/how-to/bluesky/queue` for

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -1303,6 +1303,14 @@ build** and prints the valid set:
        an absolute difference (default ``1e-9``). The default is a float-noise
        bound, right for a setpoint a controller echoes back exactly and far
        too strict for a magnet or a gap.
+   * - ``live_max_runs``
+     - How many runs' live data the bridge keeps in memory, oldest dropped
+       first (default 50). This is what decides how long a finished run stays
+       readable in the web panel.
+   * - ``live_max_rows_per_run``
+     - How many rows of one run the bridge stores (default 10000). Rows past
+       the cap are still counted, so a long run reports its true length over a
+       truncated buffer.
 
 Whether a deployment can execute plans at all is not set here: it follows from
 the control system the deployment runs. See :doc:`/how-to/bluesky/queue` for

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -747,6 +747,11 @@ itself:
 Writing ``env:`` on either half's own service block is refused for the same
 reason ``network:`` there is: the build would overwrite it.
 
+A third ``config`` key the build reads is ``http``, default false: it says the
+service answers HTTP on the port it publishes, and the deploy summary prints
+its address as a link instead of a bare ``host:port``. Leave it out for a
+service that speaks any other protocol.
+
 .. _profile-graph-mode:
 
 Graph-mode channel finding

--- a/docs/source/reference/contracts/connectors.rst
+++ b/docs/source/reference/contracts/connectors.rst
@@ -264,6 +264,15 @@ layers above the connector — the ``channel_write`` tool and the limits hook �
 hold no client, so they apply every other limit and leave this one to the
 connector, which makes it on the write itself.
 
+That read is bounded: ``control_system.connector.<type>.step_read_timeout_s``
+(default 2.0 seconds) is how long it waits, beside the connector's own
+``timeout`` and for the same reason — a gateway two hops away answers more
+slowly than an IOC on the deploy host. The bound is fail-closed: a channel that
+does not answer inside it reads as "could not be measured", which refuses the
+write. Raising it buys a slow channel room, never a weaker check. The python
+executor's sandbox applies the same number, so a script's step check and the
+connector's wait the same length of time for the same channel.
+
 A refusal about an unlisted channel — and the target switch's
 ``limits_posture`` refusal — names the key that answered, the per-type one where
 a block spoke and the deployment-wide one where none did, so an operator edits

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/epics_connector.py
@@ -24,7 +24,10 @@ from osprey_connectors.control_system.base import (
     is_readonly_run,
     values_match,
 )
-from osprey_connectors.control_system.limits_validator import STEP_READ_TIMEOUT_SECONDS
+from osprey_connectors.control_system.limits_validator import (
+    DEFAULT_STEP_READ_TIMEOUT_SECONDS,
+    step_read_timeout_seconds,
+)
 from osprey_connectors.logger import get_logger
 from osprey_connectors.types import writes_enabled_key
 
@@ -303,6 +306,11 @@ class EPICSConnector(ControlSystemConnector):
 
     def __init__(self):
         self._connected = False
+        # The `max_step` fresh-read budget, replaced from the connector's own
+        # config block on connect. Set here so the reader is usable on a
+        # connector that has not connected — the fallback is the same number
+        # the block's default resolves to.
+        self._step_read_timeout = DEFAULT_STEP_READ_TIMEOUT_SECONDS
         self._subscriptions: dict[str, Any] = {}
         self._pv_cache: dict[str, Any] = {}
         self._pv_cache_lock = threading.Lock()  # Thread safety for PV cache
@@ -436,6 +444,13 @@ class EPICSConnector(ControlSystemConnector):
             self._epics_configured = True
 
         self._timeout = config.get("timeout", 5.0)
+        # The ceiling on the fresh read a `max_step` check makes before a
+        # write. A facility-network fact like `timeout` above, and read from
+        # the same block: a gateway two hops away answers slower than a soft
+        # IOC on this host. Running out of budget answers None, which refuses
+        # the write — raising it buys a slow channel more room, never a
+        # weaker check.
+        self._step_read_timeout = step_read_timeout_seconds(config, self._connector_type)
 
         # Configure PVAccess routing. Addresses matching one of these globs are
         # served by the p4p client; every other address keeps using Channel
@@ -909,7 +924,7 @@ class EPICSConnector(ControlSystemConnector):
         def read_current(channel_address: str) -> Any:
             if self._is_pva_channel(channel_address):
                 return None
-            return self._epics.caget(channel_address, timeout=STEP_READ_TIMEOUT_SECONDS)
+            return self._epics.caget(channel_address, timeout=self._step_read_timeout)
 
         return read_current
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
@@ -46,10 +46,59 @@ ConfigLookup = Callable[[str, Any], Any]
 #: agree on how, so the caller that is about to write supplies its own.
 CurrentValueReader = Callable[[str], Any]
 
-#: Ceiling on the fresh read a ``max_step`` check makes, in seconds. The check
-#: sits in front of a write an operator is waiting on, so a channel that does
-#: not answer must fail closed quickly rather than hold the write open.
-STEP_READ_TIMEOUT_SECONDS = 2.0
+#: Ceiling on the fresh read a ``max_step`` check makes, in seconds, when the
+#: deployment names none. The check sits in front of a write an operator is
+#: waiting on, so a channel that does not answer must fail closed quickly
+#: rather than hold the write open: running out of budget answers ``None``,
+#: which refuses the write.
+#:
+#: How long that read takes is a property of the facility's control network,
+#: exactly like the connector's own ``timeout`` — a gateway two hops away
+#: answers slower than a soft IOC on the same host — so a deployment overrides
+#: it with ``control_system.connector.<type>.step_read_timeout_s``.
+DEFAULT_STEP_READ_TIMEOUT_SECONDS = 2.0
+
+#: The per-connector key that overrides it, spelled once so the connector and
+#: the python-executor sandbox cannot read two different names.
+STEP_READ_TIMEOUT_KEY = "step_read_timeout_s"
+
+
+def step_read_timeout_seconds(
+    config: Mapping[str, Any] | None, connector_type: str | None = None
+) -> float:
+    """The ``max_step`` fresh-read budget one connector block declares.
+
+    Args:
+        config: A connector's own config section — the mapping
+            ``control_system.connector.<type>`` resolves to.
+        connector_type: The type that block belongs to, so a warning names the
+            key an operator has to go and fix. ``None`` leaves the type a
+            placeholder in that message.
+
+    Returns:
+        The declared budget, or :data:`DEFAULT_STEP_READ_TIMEOUT_SECONDS` when
+        the block declares none or declares something that is not a positive
+        number. A value that cannot be used is warned about, naming the key and
+        what was found, and then falls back rather than raising: this resolves
+        on the write path, and a typo in a tuning key must not be the thing
+        that takes writes down.
+    """
+    if not isinstance(config, Mapping):
+        return DEFAULT_STEP_READ_TIMEOUT_SECONDS
+    declared = config.get(STEP_READ_TIMEOUT_KEY)
+    if declared is None:
+        return DEFAULT_STEP_READ_TIMEOUT_SECONDS
+    if isinstance(declared, bool) or not isinstance(declared, int | float) or declared <= 0:
+        logger.warning(
+            "control_system.connector.%s.%s must be a positive number of seconds, "
+            "got %r — falling back to %s",
+            connector_type or "<type>",
+            STEP_READ_TIMEOUT_KEY,
+            declared,
+            DEFAULT_STEP_READ_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_STEP_READ_TIMEOUT_SECONDS
+    return float(declared)
 
 
 def mapping_config_lookup(config: Mapping[str, Any]) -> ConfigLookup:

--- a/src/osprey/agent_runner/primitives.py
+++ b/src/osprey/agent_runner/primitives.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -705,7 +706,36 @@ async def _drain_response(
 # Callers that spawn the CLI should hand the same figure to the CLI's own
 # ``MCP_TIMEOUT`` (its stdio-startup limit, 30s by default), or the CLI marks a
 # slow server failed before this barrier would have seen it connect.
-MCP_READY_TIMEOUT_S = float(os.environ.get("OSPREY_E2E_MCP_READY_TIMEOUT", "90"))
+#
+# The variable is ``OSPREY_MCP_READY_TIMEOUT``. It is a HOST property — how long
+# this machine takes to start the servers a deployment declares — not a
+# deployment one, which is why it is an environment variable and not a config
+# key; the dispatch worker takes its own budgets from container env for the
+# same reason. It gates production ``osprey query`` as much as it gates a test,
+# which is what the old ``OSPREY_E2E_`` spelling denied. That spelling is still
+# read, so a host that sets it keeps working; it goes after one release.
+MCP_READY_TIMEOUT_ENV = "OSPREY_MCP_READY_TIMEOUT"
+_LEGACY_MCP_READY_TIMEOUT_ENV = "OSPREY_E2E_MCP_READY_TIMEOUT"
+_MCP_READY_TIMEOUT_DEFAULT_S = 90.0
+
+
+def _mcp_ready_timeout_from_env(environ: Mapping[str, str]) -> float:
+    """The readiness ceiling an environment declares, in seconds.
+
+    Args:
+        environ: The environment to read, ``os.environ`` in production.
+
+    Returns:
+        The new name's value, else the legacy one's, else the default. An
+        unparseable value raises rather than falling back: a host that meant to
+        widen the budget and typed it wrong should hear about it at import,
+        not run every session on a ceiling it did not choose.
+    """
+    declared = environ.get(MCP_READY_TIMEOUT_ENV) or environ.get(_LEGACY_MCP_READY_TIMEOUT_ENV)
+    return float(declared) if declared else _MCP_READY_TIMEOUT_DEFAULT_S
+
+
+MCP_READY_TIMEOUT_S = _mcp_ready_timeout_from_env(os.environ)
 _MCP_READY_TIMEOUT_S = MCP_READY_TIMEOUT_S
 _MCP_READY_POLL_S = 0.3
 

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -1039,6 +1039,10 @@ def _facility_plan_keys(bluesky: BlueskyConfig) -> dict[str, Any]:
         keys["excluded_plans"] = os.pathsep.join(bluesky.excluded_plans)
     if bluesky.device_page_size != BlueskyConfig.device_page_size:
         keys["device_page_size"] = bluesky.device_page_size
+    if bluesky.settle_timeout_s != BlueskyConfig.settle_timeout_s:
+        keys["settle_timeout_s"] = bluesky.settle_timeout_s
+    if bluesky.settle_tolerance != BlueskyConfig.settle_tolerance:
+        keys["settle_tolerance"] = bluesky.settle_tolerance
     return keys
 
 

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -1043,6 +1043,10 @@ def _facility_plan_keys(bluesky: BlueskyConfig) -> dict[str, Any]:
         keys["settle_timeout_s"] = bluesky.settle_timeout_s
     if bluesky.settle_tolerance != BlueskyConfig.settle_tolerance:
         keys["settle_tolerance"] = bluesky.settle_tolerance
+    if bluesky.live_max_runs != BlueskyConfig.live_max_runs:
+        keys["live_max_runs"] = bluesky.live_max_runs
+    if bluesky.live_max_rows_per_run != BlueskyConfig.live_max_rows_per_run:
+        keys["live_max_rows_per_run"] = bluesky.live_max_rows_per_run
     return keys
 
 

--- a/src/osprey/cli/build_injectors.py
+++ b/src/osprey/cli/build_injectors.py
@@ -638,6 +638,7 @@ def _inject_dispatch(dispatch: DispatchConfig, profile_dir: Path, project_path: 
         "workspace_mode": dispatch.workspace_mode,
         "timeout_sec": dispatch.timeout_sec,
         "inactivity_sec": dispatch.inactivity_sec,
+        "max_turns": dispatch.max_turns,
     }
     if declared_env:
         dispatcher_config["env"] = list(declared_env)

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -1019,6 +1019,24 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             raise BuildProfileError(
                 f"bluesky.device_page_size must be an integer >= 1 (got {device_page_size!r})"
             )
+        settle_timeout_s = bluesky_raw.get("settle_timeout_s", BlueskyConfig.settle_timeout_s)
+        if (
+            not isinstance(settle_timeout_s, int | float)
+            or isinstance(settle_timeout_s, bool)
+            or settle_timeout_s <= 0
+        ):
+            raise BuildProfileError(
+                f"bluesky.settle_timeout_s must be a number > 0 (got {settle_timeout_s!r})"
+            )
+        settle_tolerance = bluesky_raw.get("settle_tolerance", BlueskyConfig.settle_tolerance)
+        if (
+            not isinstance(settle_tolerance, int | float)
+            or isinstance(settle_tolerance, bool)
+            or settle_tolerance < 0
+        ):
+            raise BuildProfileError(
+                f"bluesky.settle_tolerance must be a number >= 0 (got {settle_tolerance!r})"
+            )
         external_raw = bluesky_raw.get("external")
         external = None
         if external_raw is not None:
@@ -1053,6 +1071,8 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             excluded_plans=excluded_plans,
             devices_file=devices_file,
             device_page_size=device_page_size,
+            settle_timeout_s=float(settle_timeout_s),
+            settle_tolerance=float(settle_tolerance),
             external=external,
         )
 

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -965,6 +965,11 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
         # Checked on the merged block, like bluesky's: parents, -O layers and
         # --set pairs are all folded in by the time the parser runs.
         _reject_unknown_block_keys(dispatch_raw, _KNOWN_DISPATCH_KEYS, "dispatch")
+        max_turns = dispatch_raw.get("max_turns", DispatchConfig.max_turns)
+        if not isinstance(max_turns, int) or isinstance(max_turns, bool) or max_turns < 1:
+            raise BuildProfileError(
+                f"dispatch.max_turns must be an integer >= 1 (got {max_turns!r})"
+            )
         dispatch = DispatchConfig(
             triggers=dispatch_raw.get("triggers", ""),
             worker_count=dispatch_raw.get("worker_count", 1),
@@ -982,6 +987,7 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             ),
             timeout_sec=dispatch_raw.get("timeout_sec", 300),
             inactivity_sec=dispatch_raw.get("inactivity_sec", 120),
+            max_turns=max_turns,
             facility_name=dispatch_raw.get("facility_name", ""),
             pv_strip_prefix=dispatch_raw.get("pv_strip_prefix", ""),
             network=dispatch_raw.get("network", "bridge"),

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -1028,6 +1028,27 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             raise BuildProfileError(
                 f"bluesky.settle_timeout_s must be a number > 0 (got {settle_timeout_s!r})"
             )
+        live_max_runs = bluesky_raw.get("live_max_runs", BlueskyConfig.live_max_runs)
+        if (
+            not isinstance(live_max_runs, int)
+            or isinstance(live_max_runs, bool)
+            or live_max_runs < 1
+        ):
+            raise BuildProfileError(
+                f"bluesky.live_max_runs must be an integer >= 1 (got {live_max_runs!r})"
+            )
+        live_max_rows_per_run = bluesky_raw.get(
+            "live_max_rows_per_run", BlueskyConfig.live_max_rows_per_run
+        )
+        if (
+            not isinstance(live_max_rows_per_run, int)
+            or isinstance(live_max_rows_per_run, bool)
+            or live_max_rows_per_run < 1
+        ):
+            raise BuildProfileError(
+                "bluesky.live_max_rows_per_run must be an integer >= 1 "
+                f"(got {live_max_rows_per_run!r})"
+            )
         settle_tolerance = bluesky_raw.get("settle_tolerance", BlueskyConfig.settle_tolerance)
         if (
             not isinstance(settle_tolerance, int | float)
@@ -1073,6 +1094,8 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             device_page_size=device_page_size,
             settle_timeout_s=float(settle_timeout_s),
             settle_tolerance=float(settle_tolerance),
+            live_max_runs=live_max_runs,
+            live_max_rows_per_run=live_max_rows_per_run,
             external=external,
         )
 

--- a/src/osprey/cli/build_profile_model.py
+++ b/src/osprey/cli/build_profile_model.py
@@ -61,6 +61,7 @@ from .build_profile_schema import (
     ServiceDef,
     VAConfig,
     env_names_errors,
+    http_errors,
     network_mode_errors,
 )
 from .build_profile_va_faults import (
@@ -679,6 +680,24 @@ class BuildProfile:
             else:
                 errors.extend(network_mode_errors(value, key))
 
+        return errors
+
+    def _validate_http_axis(self) -> list[str]:
+        """Return validation errors for every ``http:`` declaration.
+
+        Same two authoring surfaces as the network axis, and the same
+        as-authored timing. Unlike ``network:`` there is no dispatch-pair rule:
+        the pair's halves are framework services the summary already recognises
+        by name, so a declaration on one is merely redundant rather than
+        something the build would overwrite.
+
+        Returns:
+            Human-readable error messages; empty when every declaration is a
+            boolean.
+        """
+        errors: list[str] = []
+        for _name, value, key in self._service_axis_declarations("http"):
+            errors.extend(http_errors(value, key))
         return errors
 
     def _validate_env_axis(self) -> list[str]:
@@ -1414,6 +1433,7 @@ class BuildProfile:
         errors.extend(self._validate_service_key_shapes())
         errors.extend(self._validate_network_axis())
         errors.extend(self._validate_env_axis())
+        errors.extend(self._validate_http_axis())
 
         # Validate lifecycle steps
         for phase_name in ("pre_build", "post_build", "validate"):

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -388,6 +388,16 @@ class DispatchConfig:
 
     timeout_sec: int = 300
     inactivity_sec: int = 120
+
+    max_turns: int = 25
+    """How many agentic turns one dispatched run may take before the SDK stops it.
+
+    The third budget beside :attr:`timeout_sec` and :attr:`inactivity_sec`, and
+    the one that is about the WORK rather than the clock: a facility whose
+    triggers ask for a multi-step investigation raises it, one that dispatches
+    single-shot summaries lowers it. A trigger may still name its own
+    ``max_turns``; this is what a trigger that names none is given."""
+
     facility_name: str = ""
     pv_strip_prefix: str = ""
 

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -294,6 +294,9 @@ class ServiceDef:
       :data:`DEFAULT_NETWORK_MODE`; read through :meth:`network_mode`.
     - ``env:`` — host environment variable NAMES the service passes through to
       its container, defaulting to none; read through :meth:`env_names`.
+    - ``http:`` — whether the service answers HTTP on the port it publishes, so
+      the deploy summary shows its address as a link; defaults to
+      :data:`DEFAULT_SPEAKS_HTTP`, read through :meth:`speaks_http`.
     """
 
     template: str  # Path to template dir (relative to profile dir)
@@ -339,6 +342,56 @@ class ServiceDef:
         if not isinstance(names, list):
             return []
         return [name for name in names if isinstance(name, str)]
+
+    def speaks_http(self) -> bool:
+        """Whether the service answers HTTP on the port it publishes.
+
+        The framework's own services are recognised by name; a facility's are
+        not, and nothing about a service definition says what protocol sits
+        behind its port. This is the service telling the deploy summary, so its
+        address is printed as a link an operator can open rather than as a bare
+        ``host:port``.
+
+        Returns:
+            The declared value, or :data:`DEFAULT_SPEAKS_HTTP` when the service
+            declares none. A non-boolean means the profile never passed
+            :meth:`BuildProfile.validate`; it reads as the default rather than
+            being coerced, since the wrong direction hands out a dead link.
+        """
+        if not isinstance(self.config, dict):
+            return DEFAULT_SPEAKS_HTTP
+        declared = self.config.get("http", DEFAULT_SPEAKS_HTTP)
+        return declared if isinstance(declared, bool) else DEFAULT_SPEAKS_HTTP
+
+
+DEFAULT_SPEAKS_HTTP = False
+"""Whether a declared service is fronted by HTTP when it says nothing.
+
+False, because that is the safe direction: a binary-protocol service shown as a
+bare address is merely terse, while one shown as ``http://…`` hands an operator
+a link that cannot open."""
+
+
+def http_errors(value: Any, key: str) -> list[str]:
+    """Return the problems with one ``http:`` declaration (empty when valid).
+
+    The twin of :func:`network_mode_errors`, and accumulating for the same
+    reason: :meth:`BuildProfile.validate` reports every axis problem at once.
+
+    Args:
+        value: The declared value, exactly as it came out of the YAML.
+        key: Dotted path of the declaration (e.g.
+            ``"services.facility-mcp.http"``), used verbatim in the message.
+
+    Returns:
+        Human-readable error messages; empty when *value* is a boolean.
+    """
+    if isinstance(value, bool):
+        return []
+    return [
+        f"{key} must be true or false — whether this service answers HTTP on the "
+        f"port it publishes (got {value!r})"
+    ]
 
 
 @dataclass

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -669,6 +669,29 @@ class BlueskyConfig:
     the bridge falls back to the same default when the env var is absent.
     """
 
+    live_max_runs: int = 50
+    """How many run buffers the bridge keeps in memory, oldest evicted first.
+
+    This is what lets a completed run's data stay readable after the run ends.
+    Authored per facility because how many runs are worth holding is a property
+    of how a facility uses the data — and of how much memory the deployment
+    host has.
+
+    At the default value this key renders NOTHING into the compose file, and
+    the bridge falls back to the same default when the env var is absent.
+    """
+
+    live_max_rows_per_run: int = 10_000
+    """How many rows one run's buffer stores before it stops growing.
+
+    A safety valve against a runaway or never-ending plan, not a normal-case
+    limit: rows past the cap are still COUNTED, so the run-data route keeps
+    reporting the true total over a truncated buffer.
+
+    At the default value this key renders NOTHING into the compose file, and
+    the bridge falls back to the same default when the env var is absent.
+    """
+
     external: BlueskyExternalConfig | None = None
     """Attach this lane to an externally-run RE Manager instead of deploying
     one (``bluesky.external:``) — see :class:`BlueskyExternalConfig`. ``None``

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -640,6 +640,35 @@ class BlueskyConfig:
     when the env var is absent.
     """
 
+    settle_timeout_s: float = 5.0
+    """How long a plan write waits for the readback to reach its demand.
+
+    ``ConnectorSettable.set()`` writes the setpoint, then polls the readback
+    channel until it arrives within :attr:`settle_tolerance` — or until this
+    budget runs out, at which point the move raises and the RunEngine aborts.
+    Fail-closed by construction: raising this key gives a slow device more
+    room, and never turns an unsettled move into a successful one.
+
+    Authored per facility because settling time is a property of the DEVICES a
+    plan drives — an aliased software setpoint returns immediately, a magnet or
+    an insertion-device gap does not.
+
+    At the default value this key renders NOTHING into the compose file, and
+    the bridge falls back to the same default when the env var is absent.
+    """
+
+    settle_tolerance: float = 1e-9
+    """How close the readback must come to the demand to count as settled.
+
+    An ABSOLUTE bound on ``abs(readback - demand)``. The default is a
+    float-noise bound: the right value for a setpoint/readback pair the IOC
+    keeps in exact software sync, and far too strict for a device that
+    physically moves, which is exactly why a facility authors it.
+
+    At the default value this key renders NOTHING into the compose file, and
+    the bridge falls back to the same default when the env var is absent.
+    """
+
     external: BlueskyExternalConfig | None = None
     """Attach this lane to an externally-run RE Manager instead of deploying
     one (``bluesky.external:``) — see :class:`BlueskyExternalConfig`. ``None``

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -573,7 +573,10 @@ def seed_graph(ttl: Path | None, force: bool) -> None:
 
     try:
         with graph_seeder.open_session(
-            connection.uri, connection.username, connection.password
+            connection.uri,
+            connection.username,
+            connection.password,
+            database=connection.database,
         ) as session:
             if force:
                 graph_seeder.wipe(session)

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -931,7 +931,8 @@ def _resolve_qmd_render_context(config, repo_root):
     :type config: dict
     :param repo_root: The deployment repo root, for relative bind sources
     :type repo_root: str
-    :return: ``port``, ``bind_address``, ``interval_seconds`` and ``corpora``
+    :return: ``port``, ``bind_address``, ``interval_seconds``,
+        ``first_index_grace_seconds`` and ``corpora``
     :rtype: dict
     """
     from osprey.deployment.qmd_service import (
@@ -947,6 +948,7 @@ def _resolve_qmd_render_context(config, repo_root):
         "port": resolved.port,
         "bind_address": resolved.bind_address,
         "interval_seconds": resolved.interval_seconds,
+        "first_index_grace_seconds": resolved.first_index_grace_seconds,
         "corpora": _resolve_qmd_corpora(config, repo_root),
     }
 

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -5193,10 +5193,18 @@ def _stage_ariel_store(config, compose_files, env, project_dir, *, provider=None
 # ---------------------------------------------------------------------------
 
 # How long the staged graph store gets to accept a bolt connection. The same
-# budget ARIEL's store gets, and for the same reason: Neo4j opens its port only
-# once the store is recovered and the plugins the image fetches at every start
-# are loaded, so what this waits out is a refusal rather than a slow answer.
-_GRAPHDB_HEALTH_TIMEOUT_S = 90.0
+# budget the archiver's store gets, and for the same reason: Neo4j opens its
+# port only once the store is recovered and the plugins the image fetches at
+# every start are loaded, so what this waits out is a refusal rather than a slow
+# answer.
+#
+# It must OUTLAST the graphdb template's own healthcheck ``start_period``, which
+# is the container's own estimate of how long that first start takes. Under it,
+# this wait gives up while the store is still doing exactly what the template
+# says it does, and the corpus seed is skipped on a deployment that was working
+# — silently, because nothing is wrong. ``test_the_graph_store_wait_outlasts_
+# its_own_healthcheck_start_period`` pins the pair so the two cannot drift.
+_GRAPHDB_HEALTH_TIMEOUT_S = 180.0
 _GRAPHDB_HEALTH_POLL_S = 2.0
 
 # Trivial round-trip that proves the store is up, authenticated and answering

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -5317,7 +5317,10 @@ def _wait_for_graphdb_store(connection, deadline: float) -> None:
     while True:
         try:
             with graph_seeder.open_session(
-                connection.uri, connection.username, connection.password
+                connection.uri,
+                connection.username,
+                connection.password,
+                database=connection.database,
             ) as session:
                 session.run(_GRAPHDB_PING_CYPHER).consume()
                 return
@@ -5361,7 +5364,10 @@ def _bootstrap_and_seed_graphdb(config: dict, project_dir: Path, connection) -> 
     ttl_path = settings.ttl_path if settings is not None else None
 
     with graph_seeder.open_session(
-        connection.uri, connection.username, connection.password
+        connection.uri,
+        connection.username,
+        connection.password,
+        database=connection.database,
     ) as session:
         bootstrapped = graph_seeder.bootstrap(session)
         if not bootstrapped.ok:

--- a/src/osprey/deployment/deploy_summary.py
+++ b/src/osprey/deployment/deploy_summary.py
@@ -170,7 +170,48 @@ _HOST_NETWORK_NOTE = "  (host network)"
 _ADDRESS_SEPARATOR = " · "
 
 
-def _http_service(service: str, container_port: int | None = None) -> bool:
+def _declared_http_services(config: dict) -> frozenset[str]:
+    """Compose service names a deployment declares as speaking HTTP.
+
+    Read off the rendered ``config.yml`` rather than off any table here: a
+    facility's own service is not in :data:`_HTTP_SERVICES` and never can be,
+    since the framework does not know its name. ``services.<name>.http: true``
+    is that service saying so for itself.
+
+    Each block is answered through the schema's own accessor rather than by
+    reaching for the key, so the axis default lives in exactly one place and
+    this module never spells it — the same route
+    :func:`osprey.cli.build_cmd._service_network_mode` takes for the
+    ``network:`` axis. The import is local because the deployment side does not
+    otherwise depend on the CLI package.
+
+    Args:
+        config: Loaded configuration dictionary.
+
+    Returns:
+        The names whose block declares HTTP. Anything else — absent, a
+        non-boolean, a malformed block — is not in the set, which leaves the
+        address a bare ``host:port``.
+    """
+    from osprey.cli.build_profile_schema import ServiceDef
+
+    services = config.get("services") if isinstance(config, dict) else None
+    if not isinstance(services, dict):
+        return frozenset()
+    return frozenset(
+        name
+        for name, block in services.items()
+        if isinstance(name, str)
+        and isinstance(block, dict)
+        and ServiceDef(template="", config=block).speaks_http()
+    )
+
+
+def _http_service(
+    service: str,
+    container_port: int | None = None,
+    declared_http: frozenset[str] = frozenset(),
+) -> bool:
     """Whether a binding is fronted by HTTP, so its address is shown as a URL.
 
     Multi-port services resolve per binding, on the port inside the container:
@@ -185,11 +226,19 @@ def _http_service(service: str, container_port: int | None = None) -> bool:
     :mod:`osprey.deployment.host_ports` makes to find their remedy key. They
     reach the summary only on the host network, where they bind directly.
 
+    A service the deployment itself declared as HTTP (``services.<name>.http:
+    true``) is answered after the per-port roles and before the framework name
+    table: roles describe a service this module knows two ports of, and no
+    declaration should be able to relabel one of them, while the name table
+    only ever knows framework services.
+
     Args:
         service: Compose service name.
         container_port: Port inside the container this binding maps to, when
             known. ``None`` reads as "not one of the HTTP ports" for a
             multi-port service, and is ignored for every single-port one.
+        declared_http: Service names the deployment declared as speaking HTTP,
+            from :func:`_declared_http_services`.
 
     Returns:
         True when the address should carry an ``http://`` scheme.
@@ -197,6 +246,8 @@ def _http_service(service: str, container_port: int | None = None) -> bool:
     roles = _MULTI_PORT_ROLES.get(service)
     if roles is not None:
         return roles.get(container_port or 0, ("", False))[1]
+    if service in declared_http:
+        return True
     return service in _HTTP_SERVICES or service.startswith(f"{_WORKER_SERVICE_PREFIX}-")
 
 
@@ -281,12 +332,13 @@ def _placement(service: str, host_port: int = 0, base: int | None = None) -> tup
     return (slot.tier, slot.offset)
 
 
-def _binding_address(binding: HostPortBinding) -> str:
+def _binding_address(binding: HostPortBinding, declared_http: frozenset[str] = frozenset()) -> str:
     """The address one published or derived binding answers at.
 
     Args:
         binding: One host port, parsed from a compose file or derived from the
             rendered config.
+        declared_http: Service names the deployment declared as speaking HTTP.
 
     Returns:
         ``host:port``, carrying an ``http://`` scheme when the service speaks
@@ -294,12 +346,16 @@ def _binding_address(binding: HostPortBinding) -> str:
         where a service bound to every interface always answers.
     """
     address = f"{dial_address(binding.host_ip)}:{binding.host_port}"
-    if _http_service(binding.service, binding.container_port):
+    if _http_service(binding.service, binding.container_port, declared_http):
         return f"http://{address}"
     return address
 
 
-def _service_address(service: str, bindings: list[HostPortBinding]) -> str:
+def _service_address(
+    service: str,
+    bindings: list[HostPortBinding],
+    declared_http: frozenset[str] = frozenset(),
+) -> str:
     """One service's whole address, however many ports it answers at.
 
     A service is one thing, so it gets one row: the graph store's bolt port and
@@ -313,6 +369,7 @@ def _service_address(service: str, bindings: list[HostPortBinding]) -> str:
         service: Compose service name.
         bindings: Every binding that service publishes or derives. A single
             binding renders exactly as it did before roles existed.
+        declared_http: Service names the deployment declared as speaking HTTP.
 
     Returns:
         The addresses joined by :data:`_ADDRESS_SEPARATOR`, with the
@@ -330,7 +387,7 @@ def _service_address(service: str, bindings: list[HostPortBinding]) -> str:
     all_host_network = all(binding.host_network for binding in ordered)
     parts: list[str] = []
     for binding in ordered:
-        address = _binding_address(binding)
+        address = _binding_address(binding, declared_http)
         label = roles.get(binding.container_port or 0, ("", False))[0]
         if label and len(ordered) > 1:
             address = f"{label} {address}"
@@ -720,6 +777,8 @@ def endpoint_entries(
     except Exception:
         pass
 
+    declared_http = _declared_http_services(config)
+
     by_service: dict[str, list[HostPortBinding]] = {}
     for binding in bindings:
         by_service.setdefault(binding.service, []).append(binding)
@@ -743,7 +802,7 @@ def endpoint_entries(
                 (_TIER_ORDER.index(tier), offset, first_port, service),
                 tier,
                 service,
-                _service_address(service, service_bindings),
+                _service_address(service, service_bindings, declared_http),
             )
         )
 

--- a/src/osprey/deployment/graphdb_service.py
+++ b/src/osprey/deployment/graphdb_service.py
@@ -90,6 +90,7 @@ __all__ = [
     "DEFAULT_PAGECACHE_SIZE",
     "DEFAULT_PASSWORD",
     "DEFAULT_PORT",
+    "DEFAULT_DATABASE",
     "DEFAULT_USERNAME",
     "GRAPHDB_BUILD_INDEX_COMMAND",
     "GRAPHDB_HTTP_PORT_CONFIG_KEY",
@@ -172,6 +173,14 @@ DEFAULT_PAGECACHE_SIZE = "512m"
 #: it. It is a *default* only for an external store reached through an explicit
 #: ``uri``, where the operator names whichever account they provisioned.
 DEFAULT_USERNAME = "neo4j"
+
+#: Database every session is opened against, named explicitly so the driver
+#: skips the home-database lookup round-trip. Like :data:`DEFAULT_USERNAME` this
+#: is a default only for an EXTERNAL store: the shipped Community image serves
+#: exactly one database and this is its name, while an operator whose own
+#: cluster keeps the corpus in a differently-named database says so with
+#: ``services.graphdb.database``.
+DEFAULT_DATABASE = "neo4j"
 
 #: Environment variable both ends of the credential read: the compose service
 #: interpolates it into ``NEO4J_AUTH``, and this module reads it back to dial the
@@ -288,9 +297,10 @@ class GraphdbServiceConfig:
 class GraphdbConnection:
     """Everything needed to open a driver session against the graph store.
 
-    Three fields rather than one DSN string, because that is the shape the neo4j
-    driver actually takes: ``GraphDatabase.driver(uri, auth=(username,
-    password))``. Credentials therefore never enter the URI — no
+    Separate fields rather than one DSN string, because that is the shape the
+    neo4j driver actually takes: ``GraphDatabase.driver(uri, auth=(username,
+    password))``, then ``driver.session(database=...)``. Credentials therefore
+    never enter the URI — no
     ``bolt://user:pass@host`` to leak into a log line, an error message, or a
     ``docker compose`` label. This is the archiver's ``password_env`` split
     rather than the Postgres embedded-DSN one.
@@ -307,11 +317,15 @@ class GraphdbConnection:
         password: The store's password. Not part of ``repr``, so a dataclass that
             lands in a traceback or a debug log does not carry the credential
             with it; it still participates in equality and comparison.
+        database: Database every session is opened against, named explicitly so
+            the driver skips the home-database lookup round-trip. See
+            :data:`DEFAULT_DATABASE`.
     """
 
     uri: str
     username: str
     password: str = field(repr=False)
+    database: str = DEFAULT_DATABASE
 
 
 def resolve_graphdb_service_config(
@@ -544,10 +558,14 @@ def resolve_graphdb_connection(
     """
     section = graphdb_section or {}
 
+    database = _text(section.get("database"), DEFAULT_DATABASE, "services.graphdb.database")
+
     uri = _optional_text(section.get("uri"), "services.graphdb.uri")
     if uri is not None:
         username = _text(section.get("username"), DEFAULT_USERNAME, "services.graphdb.username")
-        return GraphdbConnection(uri=uri, username=username, password=_password(env))
+        return GraphdbConnection(
+            uri=uri, username=username, password=_password(env), database=database
+        )
 
     port = _port(
         (services if services is not None else section).get("port_host"),
@@ -558,6 +576,7 @@ def resolve_graphdb_connection(
         uri=f"bolt://localhost:{port}",
         username=DEFAULT_USERNAME,
         password=_password(env),
+        database=database,
     )
 
 

--- a/src/osprey/deployment/qmd_service.py
+++ b/src/osprey/deployment/qmd_service.py
@@ -103,6 +103,14 @@ _WILDCARD_LOOPBACK = {"::": "::1"}
 #: marker-driven updates keep freshness regardless.
 DEFAULT_INTERVAL_SECONDS = 30
 
+#: Seconds Docker waits before an unhealthy sidecar counts against its retry
+#: budget, when ``services.qmd.first_index_grace`` is unset. The entrypoint
+#: refuses to open the port until the index is built and provably non-empty, so
+#: a first boot is unhealthy for as long as the full build takes — an hour is
+#: generous for a corpus of a few hundred thousand documents. A corpus much
+#: larger than that needs more, and a small one can have far less.
+DEFAULT_FIRST_INDEX_GRACE_SECONDS = 3600
+
 #: Config key an operator edits to move the published host port. Spelled once
 #: so the deploy-time port-conflict remedy and the schema cannot drift apart.
 PORT_CONFIG_KEY = f"services.{QMD_SERVICE_NAME}.port"
@@ -142,6 +150,9 @@ class QMDServiceConfig:
             project-wide ``deployment.bind_address``.
         interval_seconds: Fallback corpus-sweep period for the sidecar's
             update loop.
+        first_index_grace_seconds: How long the container's healthcheck holds
+            off before an unhealthy result counts, covering the first full
+            index build.
         models_dir: Absolute host directory holding the pre-staged GGUF models,
             or ``None`` (the default) to bake them into the image at build
             time. Validated for shape here and for contents by
@@ -151,6 +162,7 @@ class QMDServiceConfig:
     port: int = DEFAULT_PORT
     bind_address: str = DEFAULT_BIND_ADDRESS
     interval_seconds: int = DEFAULT_INTERVAL_SECONDS
+    first_index_grace_seconds: int = DEFAULT_FIRST_INDEX_GRACE_SECONDS
     models_dir: str | None = None
 
     @property
@@ -207,6 +219,11 @@ def resolve_qmd_service_config(config: Mapping[str, Any] | None) -> QMDServiceCo
         bind_address=resolve_bind_address(config),
         interval_seconds=_positive_int(
             block.get("interval"), DEFAULT_INTERVAL_SECONDS, "services.qmd.interval"
+        ),
+        first_index_grace_seconds=_positive_int(
+            block.get("first_index_grace"),
+            DEFAULT_FIRST_INDEX_GRACE_SECONDS,
+            "services.qmd.first_index_grace",
         ),
         models_dir=_absolute_path(block.get("models_dir"), MODELS_DIR_CONFIG_KEY),
     )

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -67,6 +67,7 @@ from osprey.deployment.web_terminals.render import (
     _configured_external_origin,
     _external_origin,
     _port_int,
+    _scope_list,
 )
 from osprey.interfaces.web_auth import DEFAULT_SESSION_LIFETIME
 from osprey.port_layout import _MAX_PORT, default_port, resolve_port_base
@@ -83,7 +84,9 @@ from osprey_connectors.types import TYPE_WRITES_ENABLED_LEAF, WRITES_ENABLED_KEY
 # `render._port_int`, the one reader that says which values reach a `listen`
 # directive at all — the checks below resolve a configured port exactly as
 # render resolves it, which is what makes a finding that says "render falls
-# back" true across the whole invalid domain.
+# back" true across the whole invalid domain. `render._scope_list` is imported
+# for the same reason: the shapes it reads as unset are exactly the ones whose
+# scopes never reach the sidecar.
 
 # The credential env-var stem a roster username is keyed into
 # (`OSPREY_AUTH_PW_HASH_<SUFFIX>`), quoted only inside this module's collision
@@ -3034,10 +3037,10 @@ def _check_auth_transport(root: dict[str, Any], web_terminals: dict[str, Any]) -
 
 
 def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> list[Finding]:
-    """``method: oidc`` needs an issuer, usable client env-var names, safe
-    subjects, and an origin.
+    """``method: oidc`` needs an issuer, usable client env-var names, readable
+    scopes, safe subjects, and an origin.
 
-    Four ERRORs, all config-visible and all fatal at *request* time rather
+    Five ERRORs, all config-visible and all fatal at *request* time rather
     than deploy time if they slip through — a sidecar that cannot complete a
     login flow locks the whole roster out (or, for a ``$``-bearing subject,
     one named user out):
@@ -3051,6 +3054,10 @@ def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> lis
       to something unusable (empty, wrong type) is not — render silently
       restores the default, so the sidecar would read a variable the operator
       never set.
+    * **Scopes.** ``auth.oidc.scopes`` is a list of scope strings (or one
+      space-separated string). Any other shape renders no scopes line at all,
+      so the sidecar's default applies and the authored scopes are gone
+      without a trace.
     * **External origin.** The OIDC ``redirect_uri`` is built from the
       deployment's one external origin, which needs ``deploy.fqdn``. An IdP
       rejects a callback whose ``redirect_uri`` isn't character-for-character
@@ -3095,6 +3102,29 @@ def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> lis
                 ),
             )
         )
+
+    # `scopes` is read the same way and fails the same way: render joins a list
+    # of strings (or an already-joined string) into the env line and treats
+    # every other shape as unset, so a wrong-typed value renders nothing and
+    # the sidecar's own default applies — the authored scopes are gone with no
+    # trace. Only the SHAPE is checked here; the sidecar refuses a list without
+    # `openid` at startup, where it also knows what the IdP was asked for.
+    if "scopes" in oidc:
+        scopes = oidc.get("scopes")
+        joined = _scope_list(scopes)
+        if joined is None:
+            findings.append(
+                Finding(
+                    severity="error",
+                    code="web_terminals.auth_oidc_invalid_scopes",
+                    message=(
+                        f"modules.web_terminals.auth.oidc.scopes {scopes!r} is neither a "
+                        "non-empty list of scope strings nor a space-separated string; "
+                        "render would emit no scopes line and the sidecar would fall "
+                        "back to its own default, silently dropping what was authored"
+                    ),
+                )
+            )
 
     # A roster entry's `oidc_subject` is the one OIDC value that travels through
     # the compose *document* (an `environment:` entry on the sidecar), not an

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -2057,6 +2057,13 @@ def _auth_tls_context(web_terminals: dict[str, Any], *, base: int | None = None)
         # compose service emits no OSPREY_AUTH_OIDC_CLAIM at all and the
         # sidecar's own documented default applies — one default, in one place.
         "auth_oidc_claim": _non_empty_str(oidc.get("claim"), "") or None,
+        # The scopes to request at the authorization endpoint. Left as None
+        # when unset — as with `claim`, an unauthored list emits no env line at
+        # all and the sidecar's own documented default applies, so the default
+        # lives in one place. `openid` is not enforced here: the sidecar
+        # refuses a list without it, which keeps one rule in one place and
+        # keeps a config edit from being the thing that removes it.
+        "auth_oidc_scopes": _scope_list(oidc.get("scopes")),
         "tls_enabled": bool(tls.get("enabled", False)),
         "tls_port": _port_int(tls.get("port"), TLS_LISTEN_PORT),
         # Carried alongside so the template's "is this the port a browser
@@ -2326,6 +2333,22 @@ def _port_int(value: Any, default: int) -> int:
 def _non_empty_str(value: Any, default: str) -> str:
     """A config value read as a non-empty string, falling back to ``default``."""
     return value if isinstance(value, str) and value.strip() else default
+
+
+def _scope_list(value: Any) -> str | None:
+    """``auth.oidc.scopes`` read as the space-separated string OAuth spells.
+
+    A list of strings is the authored shape; a bare string is accepted as
+    already-joined scopes, because that is what an operator who has copied the
+    line out of their IdP's documentation will write. Anything else — and an
+    empty list — reads as unset, which renders no env line and leaves the
+    sidecar's own default in force.
+    """
+    if isinstance(value, str):
+        return " ".join(value.split()) or None
+    if isinstance(value, list | tuple) and all(isinstance(item, str) for item in value):
+        return " ".join(item.strip() for item in value if item.strip()) or None
+    return None
 
 
 #: The audit identities that belong to a SERVICE rather than to a person: the

--- a/src/osprey/dispatch/server.py
+++ b/src/osprey/dispatch/server.py
@@ -132,6 +132,12 @@ async def _dispatch_with_policy(
     source_default_surface_tools: list[str] | None = None
     surface_tools = action.get("surface_tools") or source_default_surface_tools
 
+    # An optional per-trigger turn ceiling, already parsed and type-checked off
+    # ``action.max_turns`` when the trigger file was loaded (TriggerConfig).
+    # Omitted when unset, in which case the worker applies the deployment's own
+    # ``dispatch.max_turns``.
+    max_turns = trigger.max_turns
+
     # Fold the event payload into the prompt so payload-driven triggers can act
     # on it. The payload is UNTRUSTED input (a webhook body); the per-trigger
     # tool allowlist and the worker's denylist — not the prompt — are the
@@ -148,6 +154,7 @@ async def _dispatch_with_policy(
             surface_prompt=surface_prompt,
             surface_tools=surface_tools,
             input_files=input_files,
+            max_turns=max_turns,
         )
         await registry.record_event(trigger.name, payload, "dispatched")
         return result

--- a/src/osprey/dispatch/trigger_config.py
+++ b/src/osprey/dispatch/trigger_config.py
@@ -31,6 +31,9 @@ class TriggerConfig:
         surface_prompt: Optional free-text fragment appended to the agent's
             system prompt at run time. ``None`` when ``action.surface_prompt``
             is absent.
+        max_turns: Optional per-trigger ceiling on agentic turns. ``None`` when
+            ``action.max_turns`` is absent, in which case the worker applies
+            the deployment's own ``dispatch.max_turns``.
     """
 
     name: str
@@ -40,6 +43,7 @@ class TriggerConfig:
     source_config: dict[str, Any] = field(default_factory=dict)
     surface: str | None = None
     surface_prompt: str | None = None
+    max_turns: int | None = None
 
 
 @dataclass
@@ -70,6 +74,18 @@ def _parse_trigger(raw: dict[str, Any], index: int) -> TriggerConfig:
     if surface_prompt is not None and not isinstance(surface_prompt, str):
         raise ValueError(f"Trigger '{name}' field 'action.surface_prompt' must be a string")
 
+    # The worker refuses an unusable ceiling with a 422 at dispatch time, which
+    # is the moment an event fires — long after this file was authored — so the
+    # value is typed here, where the author is still looking at it. ``bool`` is
+    # an ``int`` subclass, so ``max_turns: true`` would otherwise mean one turn.
+    max_turns = action.get("max_turns")
+    if max_turns is not None and (
+        isinstance(max_turns, bool) or not isinstance(max_turns, int) or max_turns < 1
+    ):
+        raise ValueError(
+            f"Trigger '{name}' field 'action.max_turns' must be an integer >= 1 (got {max_turns!r})"
+        )
+
     on_error_raw = raw.get("on_error")
     if on_error_raw is None:
         on_error = dict(_DEFAULT_ON_ERROR)
@@ -90,6 +106,7 @@ def _parse_trigger(raw: dict[str, Any], index: int) -> TriggerConfig:
         source_config=source_config,
         surface=surface,
         surface_prompt=surface_prompt,
+        max_turns=max_turns,
     )
 
 

--- a/src/osprey/dispatch/worker_client.py
+++ b/src/osprey/dispatch/worker_client.py
@@ -112,6 +112,7 @@ async def dispatch_to_worker(
     surface_prompt: str | None = None,
     surface_tools: list[str] | None = None,
     input_files: list[dict[str, Any]] | None = None,
+    max_turns: int | None = None,
 ) -> dict[str, Any]:
     """POST a prompt to a dispatch worker's /dispatch endpoint.
 
@@ -134,6 +135,9 @@ async def dispatch_to_worker(
             each item ``{"filename", "mime", "content_b64", "ingest"}``. Omitted from
             the payload when ``None`` or empty, so a worker predating the field sees an
             unchanged request.
+        max_turns: Optional per-trigger ceiling on agentic turns. Omitted from the
+            payload when ``None``, in which case the worker applies the deployment's
+            own ``dispatch.max_turns``.
 
     Returns:
         Response JSON dict (typically contains ``run_id`` and ``status``).
@@ -157,6 +161,8 @@ async def dispatch_to_worker(
         payload["surface_tools"] = surface_tools
     if input_files:
         payload["input_files"] = input_files
+    if max_turns is not None:
+        payload["max_turns"] = max_turns
 
     # A dispatch body carrying input_files can reach ~24 MB. httpx's single-float
     # timeout would apply that same short window to the write phase and abort the

--- a/src/osprey/interfaces/artifacts/app.py
+++ b/src/osprey/interfaces/artifacts/app.py
@@ -426,7 +426,45 @@ class _SSEBroadcaster:
                     pass  # Drop if client is too slow
 
 
-MAX_TIMESERIES_FILE_BYTES = 200 * 1024 * 1024  # 200 MB
+#: Used when ``artifact_server.max_timeseries_file_mb`` is unset.
+DEFAULT_MAX_TIMESERIES_FILE_MB = 200
+
+
+def _max_timeseries_file_bytes() -> int:
+    """Largest timeseries file the chart/table views will render, in bytes.
+
+    The handler reads the WHOLE file into memory to build a chart or a table,
+    so this bound is about the gallery host's memory rather than about the
+    data: raising it lets a bigger run be plotted in the browser and costs that
+    much resident memory on the machine serving the gallery. A facility whose
+    archiver exports run larger than the default says so with
+    ``artifact_server.max_timeseries_file_mb``; the file itself is always
+    downloadable whatever this says.
+
+    Read on every call — never cached at import — so a test and a re-primed
+    process see the value their config declares.
+    """
+    megabytes = DEFAULT_MAX_TIMESERIES_FILE_MB
+    try:
+        from osprey.utils.config import get_config_value
+
+        configured = get_config_value(
+            "artifact_server.max_timeseries_file_mb", DEFAULT_MAX_TIMESERIES_FILE_MB
+        )
+    except Exception:
+        logger.debug(
+            "No config available for artifact_server.max_timeseries_file_mb", exc_info=True
+        )
+        configured = None
+    if isinstance(configured, int) and not isinstance(configured, bool) and configured > 0:
+        megabytes = configured
+    elif configured is not None and configured != DEFAULT_MAX_TIMESERIES_FILE_MB:
+        logger.warning(
+            "artifact_server.max_timeseries_file_mb must be an integer >= 1 (got %r); using %d MB",
+            configured,
+            DEFAULT_MAX_TIMESERIES_FILE_MB,
+        )
+    return megabytes * 1024 * 1024
 
 
 def _union_timestamp_axis(series: dict[str, dict]) -> Collection:
@@ -804,7 +842,7 @@ def create_app(workspace_root: Path | None = None) -> FastAPI:
             )
 
         file_size = filepath.stat().st_size
-        if file_size > MAX_TIMESERIES_FILE_BYTES:
+        if file_size > _max_timeseries_file_bytes():
             raise HTTPException(
                 status_code=413,
                 detail=(

--- a/src/osprey/mcp_server/channel_finder_middle_layer/server_context.py
+++ b/src/osprey/mcp_server/channel_finder_middle_layer/server_context.py
@@ -16,12 +16,23 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from osprey.mcp_server.channel_finder_common import load_cf_config, resolve_cf_path
+from osprey.mcp_server.config_values import positive_int
 from osprey.utils.facility import resolve_facility_name
 
 if TYPE_CHECKING:
     from osprey.services.channel_finder.databases.middle_layer import MiddleLayerDatabase
 
 logger = logging.getLogger("osprey.mcp_server.channel_finder_middle_layer.server_context")
+
+#: Rows one ``run_sql`` answer may carry. A cap rather than an agent-supplied
+#: limit because the caller is a language model writing SQL: a ``SELECT *`` over
+#: a facility's channel table answers with tens of thousands of rows, and the
+#: cost of that lands in the agent's context rather than in the database.
+QUERY_MAX_ROWS_CONFIG_KEY = "channel_finder.query_max_rows"
+
+#: Used when the key is unset. Enough that a normal exploratory query is never
+#: cut, small enough that a runaway one does not fill a turn.
+DEFAULT_QUERY_MAX_ROWS = 500
 
 
 class ChannelFinderMLContext:
@@ -39,6 +50,7 @@ class ChannelFinderMLContext:
         self._database: MiddleLayerDatabase | None = None
         self._facility_name: str = "control system"
         self._duckdb_path: str | None = None
+        self._query_max_rows: int = DEFAULT_QUERY_MAX_ROWS
         self._initialized = False
 
     def initialize(self) -> None:
@@ -77,6 +89,13 @@ class ChannelFinderMLContext:
             self._duckdb_path = resolve_cf_path(duckdb_path)
             logger.info("ChannelFinderMLContext: DuckDB path configured at %s", self._duckdb_path)
 
+        self._query_max_rows = positive_int(
+            cf_config.get("query_max_rows"),
+            DEFAULT_QUERY_MAX_ROWS,
+            QUERY_MAX_ROWS_CONFIG_KEY,
+            logger=logger,
+        )
+
         self._facility_name = resolve_facility_name(self._raw_config, "control system")
 
         self._initialized = True
@@ -106,6 +125,16 @@ class ChannelFinderMLContext:
     def duckdb_path(self) -> str | None:
         """Path to the DuckDB channel database, or None if not configured."""
         return self._duckdb_path
+
+    @property
+    def query_max_rows(self) -> int:
+        """Rows one ``run_sql`` answer may carry (``channel_finder.query_max_rows``).
+
+        How many rows are worth a turn of the agent's context is a facility's
+        call: a small namespace can afford to hand back more of it than a large
+        one, and the number that fits also depends on how wide the rows are.
+        """
+        return self._query_max_rows
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/channel_finder_middle_layer/tools/run_sql.py
+++ b/src/osprey/mcp_server/channel_finder_middle_layer/tools/run_sql.py
@@ -11,12 +11,13 @@ import duckdb
 from fastmcp.exceptions import ToolError
 
 from osprey.mcp_server.channel_finder_middle_layer.server import make_error, mcp
-from osprey.mcp_server.channel_finder_middle_layer.server_context import get_cf_ml_context
+from osprey.mcp_server.channel_finder_middle_layer.server_context import (
+    QUERY_MAX_ROWS_CONFIG_KEY,
+    get_cf_ml_context,
+)
 from osprey.services.channel_finder.databases.duckdb_fts import ensure_fts
 
 logger = logging.getLogger("osprey.mcp_server.channel_finder_middle_layer.tools.run_sql")
-
-_MAX_ROWS = 500
 
 
 @mcp.tool()
@@ -46,7 +47,9 @@ def run_sql(sql: str) -> str:
         ORDER BY score DESC
         LIMIT 20
 
-    Only SELECT queries are allowed.  Results are capped at 500 rows.
+    Only SELECT queries are allowed.  Results are capped at the deployment's
+    ``channel_finder.query_max_rows``; a truncated answer says the number it was
+    cut at.
 
     Args:
         sql: A SQL SELECT statement to execute.
@@ -75,26 +78,36 @@ def run_sql(sql: str) -> str:
                 ["Rewrite your query as a SELECT statement."],
             )
 
+        # Read per call rather than baked into the docstring above: a
+        # docstring is fixed at decoration time, and a deployment that raised
+        # the cap would otherwise have the tool advertising the old number.
+        max_rows = ctx.query_max_rows
+
         con = duckdb.connect(duckdb_path, read_only=True)
         try:
             ensure_fts(con)
             result = con.execute(stripped)
             columns = [desc[0] for desc in result.description]
-            rows = result.fetchmany(_MAX_ROWS)
+            rows = result.fetchmany(max_rows)
             row_count = len(rows)
 
             # Convert to list of dicts for JSON serialisation
             data = [dict(zip(columns, row, strict=True)) for row in rows]
 
-            return json.dumps(
-                {
-                    "columns": columns,
-                    "rows": data,
-                    "row_count": row_count,
-                    "truncated": row_count >= _MAX_ROWS,
-                },
-                default=str,
-            )
+            truncated = row_count >= max_rows
+            payload: dict[str, object] = {
+                "columns": columns,
+                "rows": data,
+                "row_count": row_count,
+                "truncated": truncated,
+            }
+            if truncated:
+                payload["guidance"] = [
+                    f"Result was cut at {QUERY_MAX_ROWS_CONFIG_KEY} = {max_rows} rows; "
+                    "add a LIMIT, aggregate, or narrow the WHERE clause."
+                ]
+
+            return json.dumps(payload, default=str)
         finally:
             con.close()
 

--- a/src/osprey/mcp_server/config_values.py
+++ b/src/osprey/mcp_server/config_values.py
@@ -1,0 +1,42 @@
+"""Config-value guards shared by the MCP servers' startup paths.
+
+A server context reads its tuning keys once, at startup, from a config file an
+operator wrote by hand. A value that cannot be used is therefore a typo, not a
+protocol error, and the response that keeps the deployment working is the same
+everywhere: warn, naming the key and what was found, and carry on with the
+shipped default. Raising instead would leave the agent with no tools at all
+from that server — a far larger outage than a cap that is not the one the
+facility asked for.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+__all__ = ["positive_int"]
+
+
+def positive_int(value: Any, default: int, key: str, *, logger: logging.Logger) -> int:
+    """Coerce a config value to a positive integer, or fall back to ``default``.
+
+    Args:
+        value: The raw value read from config.
+        default: Value to use when it is absent or unusable.
+        key: Dotted config key, named in the warning.
+        logger: The reading server's own logger, so the warning arrives under
+            the component an operator is already reading.
+
+    Returns:
+        The value when it is a positive integer, otherwise ``default``. ``bool``
+        is rejected explicitly — it is an ``int`` subclass, so
+        ``query_max_rows: true`` would otherwise resolve to a cap of one.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        logger.warning(
+            "%s must be a positive integer, got %r — falling back to %s", key, value, default
+        )
+        return default
+    return int(value)

--- a/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
+++ b/src/osprey/mcp_server/dispatch_worker/dispatch_api.py
@@ -66,6 +66,13 @@ logger = logging.getLogger("osprey.mcp_server.dispatch_worker")
 # ---------------------------------------------------------------------------
 
 DISPATCH_TIMEOUT_SEC = int(os.environ.get("DISPATCH_TIMEOUT_SEC", "300"))
+
+#: How many agentic turns one dispatched run may take when the request names no
+#: ceiling of its own. Authored per facility as ``dispatch.max_turns`` in the
+#: build profile and rendered into this container's environment, beside the two
+#: clock budgets — a facility whose triggers ask for a multi-step investigation
+#: needs a different number from one that dispatches single-shot summaries.
+DISPATCH_MAX_TURNS = int(os.environ.get("DISPATCH_MAX_TURNS", "25"))
 _QUEUE_TTL_SEC = 60  # discard unconsumed SSE queues after this many seconds post-completion
 
 # Explicit request-body ceiling. A legit /dispatch body carrying an input-files
@@ -465,11 +472,15 @@ class DispatchRequest(BaseModel):
     ``input_files`` is likewise additive and defaults to ``None``. When present
     it is validated fail-closed at request time (see :func:`dispatch`); this
     model only carries the batch — ingestion is a downstream task.
+
+    ``max_turns`` defaults to :data:`DISPATCH_MAX_TURNS`, this deployment's own
+    ceiling, so a caller that names none gets the facility's number rather than
+    a framework literal.
     """
 
     prompt: str
     allowed_tools: list[str]
-    max_turns: int = 25
+    max_turns: int = DISPATCH_MAX_TURNS
     surface_prompt: str | None = None
     surface_tools: list[str] | None = None
     input_files: list[InputFile] | None = None

--- a/src/osprey/mcp_server/graph/server_context.py
+++ b/src/osprey/mcp_server/graph/server_context.py
@@ -66,6 +66,7 @@ from osprey.deployment.graphdb_service import (
     resolve_graphdb_connection,
     resolve_graphdb_service_config,
 )
+from osprey.mcp_server.config_values import positive_int
 from osprey.port_layout import resolve_port_base
 from osprey.utils.config import get_config_value
 from osprey.utils.workspace import load_osprey_config
@@ -372,15 +373,17 @@ class GraphContext:
             return
 
         config = self._load_config()
-        self.query_timeout_s = _positive_int(
+        self.query_timeout_s = positive_int(
             self._setting(QUERY_TIMEOUT_CONFIG_KEY, DEFAULT_QUERY_TIMEOUT_S),
             DEFAULT_QUERY_TIMEOUT_S,
             QUERY_TIMEOUT_CONFIG_KEY,
+            logger=logger,
         )
-        self.query_max_rows = _positive_int(
+        self.query_max_rows = positive_int(
             self._setting(QUERY_MAX_ROWS_CONFIG_KEY, DEFAULT_QUERY_MAX_ROWS),
             DEFAULT_QUERY_MAX_ROWS,
             QUERY_MAX_ROWS_CONFIG_KEY,
+            logger=logger,
         )
         self._resolve_connection(config)
 
@@ -605,31 +608,6 @@ class GraphContext:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _positive_int(value: Any, default: int, key: str) -> int:
-    """Coerce a config value to a positive integer, or fall back to ``default``.
-
-    Args:
-        value: The raw value read from config.
-        default: Value to use when it is absent or unusable.
-        key: Dotted config key, named in the warning.
-
-    Returns:
-        The value when it is a positive integer, otherwise ``default``. A bad
-        value warns rather than raises: this runs at MCP-server startup, and a
-        typo in a tuning key should not leave the agent with no graph tools at
-        all. ``bool`` is rejected explicitly — it is an ``int`` subclass, so
-        ``query_max_rows: true`` would otherwise resolve to a cap of one.
-    """
-    if value is None:
-        return default
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        logger.warning(
-            "%s must be a positive integer, got %r — falling back to %s", key, value, default
-        )
-        return default
-    return int(value)
 
 
 def _describe(exc: Exception) -> str:

--- a/src/osprey/mcp_server/graph/server_context.py
+++ b/src/osprey/mcp_server/graph/server_context.py
@@ -103,10 +103,6 @@ DEFAULT_QUERY_MAX_ROWS = 200
 #: trading the one property that makes a down store legible for nothing.
 CONNECTION_TIMEOUT_S = 3.0
 
-#: Database named explicitly on every session so the driver skips the
-#: home-database lookup round-trip. Matches the seeder's ``DEFAULT_DATABASE``.
-DATABASE = "neo4j"
-
 #: Counts the corpus rather than the store's own bookkeeping: ``:Resource`` is
 #: the label neosemantics gives every imported RDF subject, and a bootstrapped
 #: store carries ``_GraphConfig`` and namespace nodes whether or not a corpus was
@@ -446,7 +442,13 @@ class GraphContext:
             raise GraphNotConfigured(_NOT_CONFIGURED_MESSAGE)
 
         cap = self.query_max_rows if max_rows is None else max(1, int(max_rows))
-        driver = self._driver_or_raise()
+        # The connection comes back beside the driver because the database name
+        # is named explicitly on every session, so the driver skips the
+        # home-database lookup round-trip. The name comes off the resolved
+        # connection (`services.graphdb.database`), so the store the seeder
+        # wrote to and the one this reads from cannot be two different
+        # databases.
+        driver, connection = self._driver_or_raise()
 
         from neo4j import unit_of_work
 
@@ -462,7 +464,7 @@ class GraphContext:
             return rows
 
         try:
-            with driver.session(database=DATABASE) as session:
+            with driver.session(database=connection.database) as session:
                 fetched = session.execute_read(_read)
         except Exception as exc:
             raise _map_driver_error(exc) from exc
@@ -560,23 +562,29 @@ class GraphContext:
             )
             self.configured = False
 
-    def _driver_or_raise(self) -> Any:
-        """Return the cached driver, creating it on first use.
+    def _driver_or_raise(self) -> tuple[Any, GraphdbConnection]:
+        """Return the cached driver and the connection it was opened from.
+
+        The connection travels with the driver because a caller that has a
+        driver also needs the database name to open a session on, and the two
+        must come from the same resolution.
 
         Returns:
-            An open neo4j driver. Construction does not dial the store, so a
-            store that is down surfaces on the query rather than here.
+            An open neo4j driver and its resolved connection. Construction does
+            not dial the store, so a store that is down surfaces on the query
+            rather than here.
 
         Raises:
+            GraphNotConfigured: No ``services.graphdb`` block resolved.
             GraphUnreachable: The driver could not be constructed — which for
                 this path means the resolved address is not one it can use.
         """
-        if self._driver is not None:
-            return self._driver
-
         connection = self._connection
         if connection is None:
             raise GraphNotConfigured(_NOT_CONFIGURED_MESSAGE)
+
+        if self._driver is not None:
+            return self._driver, connection
 
         from neo4j import GraphDatabase
 
@@ -591,7 +599,7 @@ class GraphContext:
             raise GraphUnreachable(
                 f"Cannot open a connection to the graph store at {connection.uri}: {_describe(exc)}"
             ) from exc
-        return self._driver
+        return self._driver, connection
 
 
 # ---------------------------------------------------------------------------

--- a/src/osprey/mcp_server/python_executor/executor.py
+++ b/src/osprey/mcp_server/python_executor/executor.py
@@ -413,6 +413,55 @@ def _load_limits_validator(target: str | None):
         return None
 
 
+def _step_read_timeout_seconds(target: str) -> float:
+    """The ``max_step`` fresh-read budget the run's own connector reads with.
+
+    Resolved here, beside the limits posture and from the same target, because
+    both answer to the machine this run was stamped for: the budget bounds the
+    fresh read the ``max_step`` half of that policy makes, and taking it from a
+    different connector's block would be exactly the disagreement between the
+    script's check and the connector's that the key exists to prevent. The
+    sandbox is a fresh process holding no config, so the resolved number
+    travels into its source as a literal.
+
+    Args:
+        target: The control target this run is stamped against, as
+            :func:`_apply_target_stamp` resolved it. A target that names no
+            machine on this deployment reads the deployment's own connector
+            block — the same reading
+            :func:`osprey_connectors.types.target_limits_posture` takes for the
+            posture, so the two cannot describe different machines.
+
+    Returns:
+        The budget that block declares, or the connectors package's own default
+        when no config is reachable, the block declares none, or what it
+        declares is unusable. A config that cannot be read must not be what
+        takes the bound off the read, and the default fails closed just as
+        quickly.
+    """
+    from osprey_connectors.control_system.limits_validator import (
+        DEFAULT_STEP_READ_TIMEOUT_SECONDS,
+        step_read_timeout_seconds,
+    )
+
+    try:
+        from osprey_connectors.config import get_config_value
+        from osprey_connectors.types import resolve_target
+
+        raw = get_config_value("control_system", {})
+        section = raw if isinstance(raw, dict) else {}
+        try:
+            connector_type = resolve_target(section, target)
+        except ValueError:
+            connector_type = section.get("type")
+        table = section.get("connector")
+        block = table.get(connector_type) if isinstance(table, dict) else None
+    except Exception:
+        logger.debug("No config available for step_read_timeout_s", exc_info=True)
+        return DEFAULT_STEP_READ_TIMEOUT_SECONDS
+    return step_read_timeout_seconds(block, connector_type)
+
+
 class _SwitchInProgress(Exception):
     """A run that cannot be admitted because the deployment is mid-switch.
 
@@ -842,6 +891,12 @@ async def _execute_via_local(
         # renderer's caveat rather than any stronger one this module could
         # claim.
         perimeter_denied_ports=_perimeter_denied_ports(os.environ),
+        # Resolved from the target this run was just stamped with, for the same
+        # reason the limits posture above is: the budget bounds a read that
+        # policy makes, and the connector the sandbox builds reads with its own
+        # block's value. Deriving it inside the child would find the baseline
+        # block rather than the stamped one.
+        step_read_timeout_s=_step_read_timeout_seconds(control_target),
     )
     wrapped_code = wrapper.create_wrapper(code, execution_folder)
 

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1618,6 +1618,16 @@ keys:
   ariel.enhancement_modules.semantic_processor.model: {covered-by: ariel.enhancement_modules.semantic_processor, default: {}}
   ariel.enhancement_modules.semantic_processor.model.model_id: {covered-by: ariel.enhancement_modules.semantic_processor.model, default: n/a}
   ariel.enhancement_modules.semantic_processor.model.max_tokens: {evidence: 'max_tokens', default: n/a}
+  ariel.attachments.max_file_mb:
+    rendered: false
+    evidence: 'get_config_value\("ariel\.attachments\.max_file_mb"'
+    note: >-
+      Largest file one logbook entry may attach, in megabytes. Commented in the
+      two presets that ship an `ariel:` block: attachments are BYTEA rows in
+      the same Postgres the logbook lives in, so both raising and lowering it
+      is a site storage decision. A value that is not a positive integer is
+      logged and the default kept.
+    default: 10
   ariel.enhancement_modules.semantic_processor.max_input_chars:
     rendered: false
     evidence: 'config\.get\("max_input_chars", DEFAULT_MAX_INPUT_CHARS\)'

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1643,6 +1643,18 @@ keys:
   ariel.enhancement_modules.text_embedding.enabled: {covered-by: ariel.enhancement_modules.text_embedding, default: false}
   ariel.enhancement_modules.text_embedding.provider: {covered-by: ariel.enhancement_modules.text_embedding, default: null}
   ariel.enhancement_modules.text_embedding.models: {covered-by: ariel.enhancement_modules.text_embedding, default: null}
+  ariel.enhancement_modules.text_embedding.index_lists:
+    rendered: false
+    evidence: 'module_config\.settings\.get\("index_lists"\)'
+    note: >-
+      IVFFlat `lists` for the pgvector index, fixed when the index is created.
+      Commented in the two presets that ship an `ariel:` block: the rule of
+      thumb is rows/1000, and how many entries a facility's logbook holds is
+      not something the migration can see — `osprey ariel migrate` runs against
+      an empty table. Changing it afterwards needs the index dropped and
+      recreated; a value that is not a positive integer is refused when the
+      migration is built.
+    default: 224
   # The markdown mirror the qmd sidecar indexes — one file per logbook entry,
   # written during ingestion. Paired with `ariel.search_modules.hybrid` above: the
   # export without the search mode indexes a corpus nobody queries, and the

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -906,6 +906,20 @@ keys:
   control_system.connector.mock.noise_level: {rendered: false, evidence: 'noise_level', default: 0.01}
   control_system.connector.epics: {covered-by: control_system.connector, default: n/a}
   control_system.connector.epics.timeout: {covered-by: control_system.connector.epics, default: 5.0}
+  control_system.connector.epics.step_read_timeout_s:
+    rendered: false
+    evidence: 'config\.get\(STEP_READ_TIMEOUT_KEY\)'
+    note: >-
+      Ceiling on the fresh read a `max_step` check makes before a write, in
+      seconds. A facility-network fact like `timeout` beside it — a gateway two
+      hops away answers slower than a soft IOC on the deploy host — and read
+      from the same connector block, by the connector and by the python
+      executor's sandbox alike, so a script's step check and the connector's
+      wait the same length of time. Running out of budget answers `None`, which
+      REFUSES the write, so raising this buys a slow channel room and never a
+      weaker check. No preset ships a value: the default suits a control system
+      the deployment can reach directly.
+    default: 2.0
   # The nine EPICS gateway keys are `rendered: false` together, for one reason:
   # a facility's Channel Access gateways cannot be guessed and shipping someone
   # else's would point a control system at a stranger's machine. control-
@@ -942,6 +956,10 @@ keys:
   control_system.connector.epics.gateways.write_access.use_name_server: {rendered: false, evidence: 'use_name_server', default: false}
   control_system.connector.virtual_accelerator: {covered-by: control_system.connector, default: n/a}
   control_system.connector.virtual_accelerator.timeout: {covered-by: control_system.connector.virtual_accelerator, default: 5.0}
+  # The VA connector subclasses the EPICS one and hands its own block to
+  # `super().connect()`, so the step-read budget above is read from this type's
+  # block too; the evidence is that one site.
+  control_system.connector.virtual_accelerator.step_read_timeout_s: {rendered: false, covered-by: control_system.connector.virtual_accelerator, default: 2.0}
   control_system.connector.virtual_accelerator.simulation_file: {evidence: 'simulation_file', default: derived, default_note: falls through to control_system.connector.mock.simulation_file}
   control_system.connector.virtual_accelerator.gateways:
     evidence: 'gateways = config\.get\("gateways"\)'
@@ -2524,7 +2542,7 @@ render_contexts:
     panels_on: web.panels.channel-finder.enabled
     default_panel_set: web.default_panel
     panel_presets_set: web.presets
-  expected_union_size: 357
+  expected_union_size: 355
   note_union_size: >-
     Informational, not an assertion — it moves whenever the framework template
     or a preset gains or loses a key, and the guard reports a diff against it

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -341,6 +341,17 @@ keys:
       primary trigger. Default 30 s; a no-op sweep costs ~12.5 s at 135k
       documents, so a large corpus should raise it.
     default: 30
+  services.qmd.first_index_grace:
+    rendered: false
+    evidence: 'block\.get\("first_index_grace"\)'
+    note: >-
+      Seconds the container healthcheck holds off before an unhealthy result
+      counts, covering the first full index build. Commented in the two presets
+      that deploy the sidecar, because how long that build takes scales with
+      the corpus. The entrypoint does not open the port until the index exists
+      and is non-empty, so a grace period shorter than the build reports a
+      working container as failed. Rendered as the template's `start_period`.
+    default: 3600
   services.qmd.models_dir:
     rendered: false
     evidence: '_absolute_path\(block\.get\("models_dir"\)'

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1692,6 +1692,18 @@ keys:
       startup and from the artifact gallery's app factory; a malformed leaf is
       skipped with a warning rather than failing the launch.
     default: {}
+  artifact_server.max_timeseries_file_mb:
+    rendered: false
+    evidence: 'get_config_value\(\s*"artifact_server\.max_timeseries_file_mb"'
+    note: >-
+      Largest timeseries data file the gallery renders as a chart or a table,
+      in megabytes. Commented in all four presets, because the number that
+      fits is a property of the host serving the gallery and of the exports a
+      facility's archiver produces. The handler loads the whole file to build
+      the view, so raising it costs that much resident memory; over the cap the
+      two parsed formats refuse with a 413 and the raw download is unaffected.
+      A value that is not a positive integer is logged and the default kept.
+    default: 200
   artifact_server.example_artifact:
     evidence: 'get_config_value\("artifact_server\.example_artifact"'
 

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1439,6 +1439,17 @@ keys:
   channel_finder.pipelines.middle_layer.database: {covered-by: channel_finder.pipelines.middle_layer, default: {}}
   channel_finder.pipelines.middle_layer.database.type: {covered-by: channel_finder.pipelines.middle_layer.database, default: template}
   channel_finder.pipelines.middle_layer.database.path: {covered-by: channel_finder.pipelines.middle_layer.database, default: ''}
+  channel_finder.query_max_rows:
+    evidence: 'positive_int\(\s*cf_config\.get\("query_max_rows"\)'
+    note: >-
+      Rows one `run_sql` answer carries before it is truncated; the tool reports
+      the truncation and names this key, so a partial answer is never mistaken
+      for a complete one. Bounds what a question costs the AGENT's context
+      window rather than what it costs DuckDB, which is why it is a query-time
+      key and not a pipeline one — it sits outside the derived
+      `channel_finder.pipelines` prefix a profile may not spell, beside
+      `services.graphdb.query_max_rows`, the same bound for the graph paradigm.
+    default: 500
   channel_finder.benchmark:
     evidence: 'channel_finder\.benchmark\.dataset_path'
     note: >-

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -475,6 +475,18 @@ keys:
   # qmd's is — every service publishes on the project-wide
   # `deployment.bind_address`, and graphdb reuses that one reading.
     default: 200
+  services.graphdb.database:
+    rendered: false
+    evidence: '_text\(section\.get\("database"\), DEFAULT_DATABASE, "services\.graphdb\.database"\)'
+    note: >-
+      Which database on the store holds the corpus. Hidden like `uri`, and for
+      the same reason: the store this deployment runs is a Community image
+      serving exactly one database, so the key means something only against an
+      EXTERNAL store whose own naming a shipped default could only guess at.
+      Read by `resolve_graphdb_connection` onto `GraphdbConnection.database`,
+      which is the one name both the seeder's sessions and the graph MCP
+      server's reads open against.
+    default: neo4j
   services.graphdb.uri:
     rendered: false
     evidence: '_optional_text\(section\.get\("uri"\), "services\.graphdb\.uri"\)'

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1618,6 +1618,17 @@ keys:
   ariel.enhancement_modules.semantic_processor.model: {covered-by: ariel.enhancement_modules.semantic_processor, default: {}}
   ariel.enhancement_modules.semantic_processor.model.model_id: {covered-by: ariel.enhancement_modules.semantic_processor.model, default: n/a}
   ariel.enhancement_modules.semantic_processor.model.max_tokens: {evidence: 'max_tokens', default: n/a}
+  ariel.enhancement_modules.semantic_processor.max_input_chars:
+    rendered: false
+    evidence: 'config\.get\("max_input_chars", DEFAULT_MAX_INPUT_CHARS\)'
+    note: >-
+      How many characters of an entry are sent for keyword extraction and
+      summarising. Commented in the two presets that ship an `ariel:` block,
+      because the number that fits depends on how long a facility's entries run
+      and on the context window its provider serves. A cut is logged at INFO
+      naming the entry; a value that is not a positive integer is refused at
+      configure time.
+    default: 8000
   ariel.enhancement_modules.text_embedding: {evidence: 'text_embedding', default: {}}
   ariel.enhancement_modules.text_embedding.enabled: {covered-by: ariel.enhancement_modules.text_embedding, default: false}
   ariel.enhancement_modules.text_embedding.provider: {covered-by: ariel.enhancement_modules.text_embedding, default: null}

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -2080,6 +2080,15 @@ keys:
   modules.web_terminals.auth.allow_insecure_http:
     evidence: 'bool\(auth\.get\("allow_insecure_http", False\)\)'
     default: false
+  modules.web_terminals.auth.oidc.scopes:
+    rendered: false
+    evidence: 'oidc\.get\("scopes"\)'
+    note: >-
+      Scopes requested at the IdP's authorization endpoint. Rendered only by a
+      profile that authors an `auth.oidc:` stanza, which no preset ships, so no
+      shipped deployment carries the key. `openid` may not be dropped: the auth
+      sidecar refuses a list without it rather than putting it back.
+    default: [openid, profile, email]
   modules.web_terminals.landing: {evidence: 'as_dict\(web_terminals\.get\("landing"\)\)', default: {}}
   modules.web_terminals.landing.notices:
     evidence: 'if "notices" not in landing_cfg'

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -173,6 +173,9 @@ config:
   # GRAPHDB_PASSWORD in this repo's .env yourself.
   # services.graphdb.uri: bolt://graph.example.org:7687
   # services.graphdb.username: neo4j
+  # Which database on that store holds the corpus. The store this deployment
+  # runs serves exactly one, called `neo4j`; a cluster of your own may not.
+  # services.graphdb.database: neo4j
   # Which declared services `osprey up` launches. qmd and graphdb each go
   # together with their `services.<name>.*` keys above: remove both or neither.
   deployed_services:

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -302,6 +302,10 @@ config:
   ariel.enhancement_modules.semantic_processor.enabled: false
   # Token budget for each of its LLM calls.
   ariel.enhancement_modules.semantic_processor.model.max_tokens: 256
+  # How much of an entry is sent for keywords and summary. Longer entries are
+  # cut here — the cut is logged, naming the entry — so this is what a facility
+  # with long entries and a roomy context window raises.
+  # ariel.enhancement_modules.semantic_processor.max_input_chars: 8000
   # Text embedding for semantic search. Degrades gracefully when Ollama or
   # pgvector is unavailable.
   ariel.enhancement_modules.text_embedding.enabled: true

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -134,6 +134,11 @@ config:
   # is the primary re-index trigger, so this is the ceiling on staleness.
   # Raise it on a large corpus, where a no-op sweep is not free.
   services.qmd.interval: 30
+  # How long the container's healthcheck holds off, in seconds, while the first
+  # full index is built — the sidecar does not open its port until the index
+  # exists and is non-empty, so until then it is legitimately unhealthy. Scale
+  # it with the corpus: too short reports a working container as failed.
+  # services.qmd.first_index_grace: 3600
   # Neo4j graph store holding a DISPOSABLE mirror of an RDF/Turtle corpus. The
   # TTL on disk stays the source of truth and `osprey knowledge seed-graph`
   # rebuilds the graph from it. It answers the multi-hop questions keyword and

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -229,6 +229,10 @@ config:
   # point adapter and source_url at your logbook system and run
   # `osprey ariel ingest`.
   ariel.ingestion.adapter: generic_json
+  # Largest file one entry may attach, in MB. Attachments are stored as rows in
+  # the same Postgres the logbook lives in, so this number is a storage
+  # decision in both directions.
+  # ariel.attachments.max_file_mb: 10
   ariel.ingestion.source_url: data/logbook_seed/demo_logbook.json
   # TLS on the logbook fetch. Verification is ON — an ingest that cannot verify
   # the logbook's certificate fails rather than trusting whatever answered.

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -318,6 +318,11 @@ config:
   ariel.enhancement_modules.text_embedding.models:
     - name: nomic-embed-text
       dimension: 768
+  # IVFFlat `lists` for the vector index, chosen when the index is created.
+  # Rule of thumb: rows/1000 for corpora up to a million entries. It cannot be
+  # derived — `osprey ariel migrate` runs against an empty table — and changing
+  # it later needs the index dropped and recreated.
+  # ariel.enhancement_modules.text_embedding.index_lists: 224
   # qmd export: one markdown file per entry into the mirror tree the sidecar
   # indexes. On for the same reason `hybrid` above is; an enabled export with
   # no mirror_path is refused at startup.

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -379,6 +379,11 @@ config:
   # has no env override.
   artifact_server.host: 127.0.0.1
   artifact_server.auto_launch: true
+  # Largest timeseries data file the gallery will chart or tabulate, in MB.
+  # The handler loads the whole file to build the view, so raising this spends
+  # memory on the machine serving the gallery. Over the cap the browser views
+  # refuse with a 413; the file itself stays downloadable either way.
+  # artifact_server.max_timeseries_file_mb: 200
   # Extra artifact categories on top of the ones the gallery ships, so a badge
   # reads in this facility's own vocabulary. One dotted line per category, each
   # value a `label` and a `#RRGGBB` `color`. An artifact handed in under a

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -178,6 +178,11 @@ config:
   # has no env override.
   artifact_server.host: 127.0.0.1
   artifact_server.auto_launch: true
+  # Largest timeseries data file the gallery will chart or tabulate, in MB.
+  # The handler loads the whole file to build the view, so raising this spends
+  # memory on the machine serving the gallery. Over the cap the browser views
+  # refuse with a 413; the file itself stays downloadable either way.
+  # artifact_server.max_timeseries_file_mb: 200
   # Extra artifact categories on top of the ones the gallery ships, so a badge
   # reads in this facility's own vocabulary. One dotted line per category, each
   # value a `label` and a `#RRGGBB` `color`. An artifact handed in under a

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -132,6 +132,10 @@ config:
   # No benchmark query set ships here. `osprey channel-finder benchmark` still
   # runs with `--queries-path FILE`; to make a file the default, name it here.
   # channel_finder.benchmark.dataset_path: data/benchmarks/queries.json
+  # Rows one `run_sql` answer carries before it is cut. The cap is on the
+  # AGENT's context, not on DuckDB: a truncated answer says so and names this
+  # key, so the agent narrows the query rather than presenting a partial list.
+  channel_finder.query_max_rows: 500
 
   # ── Approval ───────────────────────────────────────────────────────────────
   # The channel finder is read-only, so no control-system write is gated here.

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -703,6 +703,11 @@ config:
   # is the primary re-index trigger, so this is the ceiling on staleness.
   # Raise it on a large corpus, where a no-op sweep is not free.
   services.qmd.interval: 30
+  # How long the container's healthcheck holds off, in seconds, while the first
+  # full index is built — the sidecar does not open its port until the index
+  # exists and is non-empty, so until then it is legitimately unhealthy. Scale
+  # it with the corpus: too short reports a working container as failed.
+  # services.qmd.first_index_grace: 3600
   # Neo4j graph store holding a DISPOSABLE mirror of an RDF/Turtle corpus. The
   # TTL on disk stays the source of truth and `osprey knowledge seed-graph`
   # rebuilds the graph from it. It answers the multi-hop questions keyword and

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -397,6 +397,10 @@ config:
   # build; `osprey channel-finder benchmark` runs it (`--queries-path FILE`
   # for another).
   channel_finder.benchmark.dataset_path: data/benchmarks/queries.json
+  # Rows one `run_sql` answer carries before it is cut. The cap is on the
+  # AGENT's context, not on DuckDB: a truncated answer says so and names this
+  # key, so the agent narrows the query rather than presenting a partial list.
+  channel_finder.query_max_rows: 500
   # osprey:panel-port channel_finder
   # The CHANNELS tab's own web server. It launches when `channel-finder` is in
   # `web_panels:` above, on this deployment's channel-finder slot;

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -558,6 +558,11 @@ config:
   ariel.enhancement_modules.text_embedding.models:
     - name: nomic-embed-text
       dimension: 768
+  # IVFFlat `lists` for the vector index, chosen when the index is created.
+  # Rule of thumb: rows/1000 for corpora up to a million entries. It cannot be
+  # derived — `osprey ariel migrate` runs against an empty table — and changing
+  # it later needs the index dropped and recreated.
+  # ariel.enhancement_modules.text_embedding.index_lists: 224
   # qmd export: one markdown file per entry into the mirror tree the sidecar
   # indexes. On for the same reason `hybrid` above is; an enabled export with
   # no mirror_path is refused at startup.

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -762,6 +762,11 @@ config:
   # thing that stops it. `host` has no env override.
   artifact_server.host: 127.0.0.1
   artifact_server.auto_launch: true
+  # Largest timeseries data file the gallery will chart or tabulate, in MB.
+  # The handler loads the whole file to build the view, so raising this spends
+  # memory on the machine serving the gallery. Over the cap the browser views
+  # refuse with a 413; the file itself stays downloadable either way.
+  # artifact_server.max_timeseries_file_mb: 200
   # Extra artifact categories on top of the ones the gallery ships, so a badge
   # reads in this facility's own vocabulary. One dotted line per category, each
   # value a `label` and a `#RRGGBB` `color`. An artifact handed in under a

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -733,6 +733,9 @@ config:
   # GRAPHDB_PASSWORD in this repo's .env yourself.
   # services.graphdb.uri: bolt://graph.example.org:7687
   # services.graphdb.username: neo4j
+  # Which database on that store holds the corpus. The store this deployment
+  # runs serves exactly one, called `neo4j`; a cluster of your own may not.
+  # services.graphdb.database: neo4j
   # Which declared services `osprey up` launches. qmd and graphdb each go
   # together with their `services.<name>.*` keys above: remove both or neither.
   deployed_services:

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -925,6 +925,16 @@ config:
       # Accepts login over plain HTTP, which fits 127.0.0.1 and nothing else.
       # For any reachable host, delete this line and configure tls instead.
       allow_insecure_http: true
+      # Single sign-on instead of passwords: set `method: oidc` above and give
+      # your provider's details here. `scopes` is what is asked for at the
+      # authorization endpoint — the default below suits a provider that
+      # publishes the identity claim under `profile` or `email`; add whatever
+      # scope yours publishes it under. `openid` cannot be dropped: without it
+      # the provider issues no ID token and the sidecar refuses every login.
+      #   oidc:
+      #     issuer: https://idp.example.org
+      #     claim: preferred_username
+      #     scopes: [openid, profile, email]
     # Which tier a user lands on is pinned per entry below. Single sign-on can
     # pick it instead by mapping provider groups onto declared roles — see
     # "Let single sign-on pick the tier" in the multi-user login guide.

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -542,6 +542,10 @@ config:
   ariel.enhancement_modules.semantic_processor.enabled: false
   # Token budget for each of its LLM calls.
   ariel.enhancement_modules.semantic_processor.model.max_tokens: 256
+  # How much of an entry is sent for keywords and summary. Longer entries are
+  # cut here — the cut is logged, naming the entry — so this is what a facility
+  # with long entries and a roomy context window raises.
+  # ariel.enhancement_modules.semantic_processor.max_input_chars: 8000
   # Text embedding for semantic search. Degrades gracefully when Ollama or
   # pgvector is unavailable.
   ariel.enhancement_modules.text_embedding.enabled: true

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -474,6 +474,10 @@ config:
   # opening tab, `osprey ariel search` without `--mode`, and the service API.
   # Naming a module that is off below is refused at startup.
   ariel.default_search_mode: hybrid
+  # Largest file one entry may attach, in MB. Attachments are stored as rows in
+  # the same Postgres the logbook lives in, so this number is a storage
+  # decision in both directions.
+  # ariel.attachments.max_file_mb: 10
   # Facility vocabulary: control-room shorthand ("t/s the bpm offset") mapped
   # to the words the logbook prose contains, so a search typed in shorthand
   # finds the entries about it. Plain dictionary matching, every rewrite

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -311,6 +311,10 @@ config:
   #
   # Channel Access timeout in seconds.
   control_system.connector.epics.timeout: 5.0
+  # How long the pre-write `max_step` check waits for a channel's present
+  # value, in seconds. Running out of budget refuses the write, so raise this
+  # for a slow gateway — it buys room, never a weaker check.
+  # control_system.connector.epics.step_read_timeout_s: 2.0
   # Write posture for the live machine. Stating it pins it: a type with its
   # own posture never falls back to the master switch.
   # control_system.connector.epics.writes_enabled: false

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -264,6 +264,11 @@ config:
   # has no env override.
   artifact_server.host: 127.0.0.1
   artifact_server.auto_launch: true
+  # Largest timeseries data file the gallery will chart or tabulate, in MB.
+  # The handler loads the whole file to build the view, so raising this spends
+  # memory on the machine serving the gallery. Over the cap the browser views
+  # refuse with a 413; the file itself stays downloadable either way.
+  # artifact_server.max_timeseries_file_mb: 200
   # Extra artifact categories on top of the ones the gallery ships, so a badge
   # reads in this facility's own vocabulary. One dotted line per category, each
   # value a `label` and a `#RRGGBB` `color`. An artifact handed in under a

--- a/src/osprey/services/ariel_search/attachments.py
+++ b/src/osprey/services/ariel_search/attachments.py
@@ -11,15 +11,50 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from osprey.utils.logger import get_logger
+
 if TYPE_CHECKING:
     from osprey.services.ariel_search.database.repository import ARIELRepository
     from osprey.services.ariel_search.models import AttachmentInfo
 
-MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024  # 10 MB
+logger = get_logger("ariel")
+
+#: Used when ``ariel.attachments.max_file_mb`` is unset.
+DEFAULT_MAX_ATTACHMENT_MB = 10
 
 
 class AttachmentValidationError(Exception):
     """Raised when an attachment fails validation."""
+
+
+def max_attachment_bytes() -> int:
+    """Largest attachment an entry may carry, in bytes.
+
+    Attachments are stored as ``BYTEA`` in the same Postgres the logbook lives
+    in, so both directions of this number are a site storage decision: a
+    facility that attaches raw scope traces raises it and pays for the space, a
+    facility that wants the database small lowers it.
+
+    Read on every call — never cached at import — so a test and a re-primed
+    process see the value their config declares.
+    """
+    megabytes = DEFAULT_MAX_ATTACHMENT_MB
+    try:
+        from osprey.utils.config import get_config_value
+
+        configured = get_config_value("ariel.attachments.max_file_mb", DEFAULT_MAX_ATTACHMENT_MB)
+    except Exception:
+        logger.debug("No config available for ariel.attachments.max_file_mb", exc_info=True)
+        configured = None
+    if isinstance(configured, int) and not isinstance(configured, bool) and configured > 0:
+        megabytes = configured
+    elif configured is not None and configured != DEFAULT_MAX_ATTACHMENT_MB:
+        logger.warning(
+            "ariel.attachments.max_file_mb must be an integer >= 1 (got %r); using %d MB",
+            configured,
+            DEFAULT_MAX_ATTACHMENT_MB,
+        )
+    return megabytes * 1024 * 1024
 
 
 def validate_file_size(size: int, filename: str) -> None:
@@ -30,10 +65,12 @@ def validate_file_size(size: int, filename: str) -> None:
         filename: Filename for error messages.
 
     Raises:
-        AttachmentValidationError: If file exceeds MAX_ATTACHMENT_SIZE.
+        AttachmentValidationError: If the file exceeds
+            ``ariel.attachments.max_file_mb``.
     """
-    if size > MAX_ATTACHMENT_SIZE:
-        max_mb = MAX_ATTACHMENT_SIZE / (1024 * 1024)
+    limit = max_attachment_bytes()
+    if size > limit:
+        max_mb = limit / (1024 * 1024)
         actual_mb = size / (1024 * 1024)
         raise AttachmentValidationError(
             f"File '{filename}' is {actual_mb:.1f} MB, exceeds {max_mb:.0f} MB limit."

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -1445,7 +1445,13 @@ async def run_reembed(
         if not table_exists:
             if progress:
                 progress(f"Creating embedding table: {table_name}")
-            migration = TextEmbeddingMigration([(model, dimension)])
+            embedding_config = config.enhancement_modules.get("text_embedding")
+            migration = TextEmbeddingMigration(
+                [(model, dimension)],
+                index_lists=(
+                    embedding_config.settings.get("index_lists") if embedding_config else None
+                ),
+            )
             async with service.pool.connection() as conn:
                 await migration.up(conn)
             if progress:

--- a/src/osprey/services/ariel_search/database/migrations.py
+++ b/src/osprey/services/ariel_search/database/migrations.py
@@ -253,7 +253,9 @@ class MigrationRunner:
                     # table per configured model, not just the hardcoded default.
                     if name == "text_embedding":
                         models = self._configured_embedding_models()
-                        migration = migration_class(models) if models else migration_class()
+                        migration = migration_class(
+                            models, index_lists=self._configured_index_lists()
+                        )
                     else:
                         migration = migration_class()
                     migrations.append(migration)
@@ -273,6 +275,17 @@ class MigrationRunner:
         if module_config and module_config.models:
             return [(m.name, m.dimension) for m in module_config.models]
         return None
+
+    def _configured_index_lists(self) -> int | None:
+        """Read ``text_embedding.index_lists``, or None to take the default.
+
+        Cannot be derived here: `osprey ariel migrate` creates the index before
+        any entry is embedded, so there is no row count to size it from.
+        """
+        module_config = self.config.enhancement_modules.get("text_embedding")
+        if module_config is None:
+            return None
+        return module_config.settings.get("index_lists")
 
     def _topological_sort(self, migrations: list[BaseMigration]) -> list[BaseMigration]:
         """Sort migrations by dependencies using topological sort.

--- a/src/osprey/services/ariel_search/enhancement/semantic_processor/processor.py
+++ b/src/osprey/services/ariel_search/enhancement/semantic_processor/processor.py
@@ -33,6 +33,11 @@ class SemanticProcessorResult(BaseModel):
     summary: str = Field(description="Concise summary capturing the main point of the entry")
 
 
+#: How much of an entry is sent for keyword extraction and summarising when
+#: ``ariel.enhancement_modules.semantic_processor.max_input_chars`` is unset.
+#: Roughly two thousand tokens, which every provider OSPREY talks to serves.
+DEFAULT_MAX_INPUT_CHARS = 8000
+
 DEFAULT_PROMPT_TEMPLATE = """Extract keywords and generate a summary from this logbook entry.
 
 Entry text:
@@ -68,6 +73,7 @@ class SemanticProcessorModule(BaseEnhancementModule):
         """Initialize the module."""
         self._model_config: dict[str, Any] = {}
         self._prompt_template: str = DEFAULT_PROMPT_TEMPLATE
+        self._max_input_chars: int = DEFAULT_MAX_INPUT_CHARS
 
     @property
     def name(self) -> str:
@@ -87,11 +93,16 @@ class SemanticProcessorModule(BaseEnhancementModule):
         default — ``ariel.embedding.provider`` names an embedding endpoint and is
         not a stand-in for it.
 
+        ``max_input_chars`` bounds how much of an entry reaches the model. It is
+        a facility's to set: how long a logbook entry runs, and how big a
+        context window the provider serves, are both site properties.
+
         Args:
             config: The enhancement_modules.semantic_processor config dict
 
         Raises:
-            ValueError: If no provider is configured for the module.
+            ValueError: If no provider is configured for the module, or if
+                ``max_input_chars`` is not a positive integer.
         """
         provider = config.get("provider")
         if not provider:
@@ -109,6 +120,18 @@ class SemanticProcessorModule(BaseEnhancementModule):
         self._model_config = model
         if config.get("prompt_template"):
             self._prompt_template = config["prompt_template"]
+
+        max_input_chars = config.get("max_input_chars", DEFAULT_MAX_INPUT_CHARS)
+        if (
+            not isinstance(max_input_chars, int)
+            or isinstance(max_input_chars, bool)
+            or max_input_chars < 1
+        ):
+            raise ValueError(
+                "ariel.enhancement_modules.semantic_processor.max_input_chars must be "
+                f"an integer >= 1 (got {max_input_chars!r})"
+            )
+        self._max_input_chars = max_input_chars
 
     async def enhance(
         self,
@@ -128,7 +151,7 @@ class SemanticProcessorModule(BaseEnhancementModule):
             return
 
         try:
-            result = await self._process_text(raw_text)
+            result = await self._process_text(raw_text, entry_id=entry.get("entry_id"))
 
             if result:
                 await self._store_results(
@@ -147,11 +170,15 @@ class SemanticProcessorModule(BaseEnhancementModule):
         except Exception as e:
             logger.warning(f"Failed to process entry {entry.get('entry_id')}: {e}")
 
-    async def _process_text(self, text: str) -> SemanticProcessorResult | None:
+    async def _process_text(
+        self, text: str, entry_id: Any = None
+    ) -> SemanticProcessorResult | None:
         """Process text using LLM to extract keywords and summary.
 
         Args:
             text: Entry text to process
+            entry_id: The entry this text came from, named in the log line when
+                the text is longer than ``max_input_chars`` and gets cut.
 
         Returns:
             SemanticProcessorResult or None if processing failed
@@ -159,7 +186,20 @@ class SemanticProcessorModule(BaseEnhancementModule):
         try:
             from osprey.models.completion import get_chat_completion
 
-            prompt = self._prompt_template.format(text=text[:8000])
+            if len(text) > self._max_input_chars:
+                # Said out loud, and per entry: the keywords and summary stored
+                # for this entry describe its opening only, and an operator
+                # reading them has no other way to know that.
+                logger.info(
+                    "Entry %s is %d characters; only the first %d were sent for "
+                    "keywords and summary (raise "
+                    "ariel.enhancement_modules.semantic_processor.max_input_chars "
+                    "to send more)",
+                    entry_id,
+                    len(text),
+                    self._max_input_chars,
+                )
+            prompt = self._prompt_template.format(text=text[: self._max_input_chars])
 
             response = get_chat_completion(
                 message=prompt,

--- a/src/osprey/services/ariel_search/enhancement/text_embedding/migration.py
+++ b/src/osprey/services/ariel_search/enhancement/text_embedding/migration.py
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
 
+#: Used when ``ariel.enhancement_modules.text_embedding.index_lists`` is unset.
+#: The IVFFlat rule of thumb is rows/1000 for corpora up to a million entries;
+#: this suits a few hundred thousand entries and is a workable index for far
+#: fewer. It cannot be derived at migration time — ``osprey ariel migrate``
+#: runs against an empty table.
+DEFAULT_INDEX_LISTS = 224
+
+
 class TextEmbeddingMigration(BaseMigration):
     """Text embedding enhancement migration.
 
@@ -25,15 +33,33 @@ class TextEmbeddingMigration(BaseMigration):
     - IVFFlat vector indexes
     """
 
-    def __init__(self, models: list[tuple[str, int]] | None = None) -> None:
+    def __init__(
+        self,
+        models: list[tuple[str, int]] | None = None,
+        index_lists: int | None = None,
+    ) -> None:
         """Initialize the migration.
 
         Args:
             models: List of (model_name, dimension) tuples to create tables for.
                    If None, uses a default for testing.
+            index_lists: IVFFlat ``lists`` for the vector index, from
+                ``ariel.enhancement_modules.text_embedding.index_lists``. None
+                uses :data:`DEFAULT_INDEX_LISTS`.
+
+        Raises:
+            ValueError: If ``index_lists`` is not a positive integer.
         """
         super().__init__()
         self._models = models
+        if index_lists is not None and (
+            not isinstance(index_lists, int) or isinstance(index_lists, bool) or index_lists < 1
+        ):
+            raise ValueError(
+                "ariel.enhancement_modules.text_embedding.index_lists must be an "
+                f"integer >= 1 (got {index_lists!r})"
+            )
+        self._index_lists = DEFAULT_INDEX_LISTS if index_lists is None else index_lists
 
     @property
     def name(self) -> str:
@@ -96,12 +122,14 @@ class TextEmbeddingMigration(BaseMigration):
             )
 
             index_name = f"idx_{table_name}_vector"
+            # `lists` is baked into the index at creation, so changing the key
+            # later needs the index dropped and recreated — it is not re-read.
             await conn.execute(
                 f"""
                 CREATE INDEX IF NOT EXISTS {index_name}
                 ON {table_name}
                 USING ivfflat (embedding vector_cosine_ops)
-                WITH (lists = 224)
+                WITH (lists = {self._index_lists})
                 """  # noqa: S608
             )
 

--- a/src/osprey/services/auth_sidecar/app.py
+++ b/src/osprey/services/auth_sidecar/app.py
@@ -144,6 +144,12 @@ ENV_OIDC_ISSUER = "OSPREY_AUTH_OIDC_ISSUER"
 ENV_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID_ENV"
 ENV_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET_ENV"
 ENV_OIDC_CLAIM = "OSPREY_AUTH_OIDC_CLAIM"
+ENV_OIDC_SCOPES = "OSPREY_AUTH_OIDC_SCOPES"
+"""Space-separated scopes to request at the authorization endpoint.
+
+Set from the rendered ``modules.web_terminals.auth.oidc.scopes``. Absent means
+the sidecar's own :data:`~osprey.services.auth_sidecar.app.DEFAULT_OIDC_SCOPES`
+apply, so the default lives in one place."""
 ENV_OIDC_SUBJECT_PREFIX = "OSPREY_AUTH_OIDC_SUBJECT_"
 """Per-user expected IdP identity: ``OSPREY_AUTH_OIDC_SUBJECT_<SUFFIX>``."""
 
@@ -200,6 +206,25 @@ _ACCESS_VALUE_LOG_LIMIT = 80
 DEFAULT_OIDC_CLIENT_ID_ENV = "OSPREY_AUTH_OIDC_CLIENT_ID"
 DEFAULT_OIDC_CLIENT_SECRET_ENV = "OSPREY_AUTH_OIDC_CLIENT_SECRET"
 DEFAULT_OIDC_CLAIM = "sub"
+
+DEFAULT_OIDC_SCOPES = ("openid", "profile", "email")
+"""Scopes requested at the authorization endpoint when a deployment names none.
+
+``openid`` is what makes this OIDC rather than bare OAuth2 (it is also what
+makes Authlib generate and check a nonce). ``profile`` and ``email`` are asked
+for because the claim a facility maps onto a roster user is commonly
+``preferred_username`` or ``email``, and a claim that was never requested is
+simply absent from the token — which the callback reads as "deny". A facility
+whose IdP publishes the identity claim under some other scope authors the list
+it needs through ``modules.web_terminals.auth.oidc.scopes``."""
+
+REQUIRED_OIDC_SCOPE = "openid"
+"""The one scope a deployment may not drop.
+
+Without it the IdP issues no ID token, so there is nothing for the nonce and
+audience checks to run against and every identity guarantee this sidecar rests
+on is gone. A list that omits it is refused in
+:meth:`AuthSettings.missing_requirements` rather than silently repaired."""
 
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _FALSE_VALUES = frozenset({"0", "false", "no", "off"})
@@ -427,6 +452,7 @@ class AuthSettings:
     oidc_client_id_var: str = DEFAULT_OIDC_CLIENT_ID_ENV
     oidc_client_secret_var: str = DEFAULT_OIDC_CLIENT_SECRET_ENV
     oidc_claim: str = DEFAULT_OIDC_CLAIM
+    oidc_scopes: tuple[str, ...] = DEFAULT_OIDC_SCOPES
     oidc_subjects: Mapping[str, str] = field(default_factory=dict)
     roster_access: Mapping[str, frozenset[str]] = field(default_factory=dict)
     web_theme: str = ""
@@ -457,6 +483,13 @@ class AuthSettings:
             The parsed settings.
         """
         source: Mapping[str, str] = os.environ if env is None else env
+
+        # Scopes cross the wire the way OAuth spells them: one space-separated
+        # string. An entirely blank value is "the deployment named none", which
+        # takes the sidecar's own default; a non-blank list is taken verbatim,
+        # `openid` included or not, so that `missing_requirements` can refuse a
+        # list missing it instead of this parser quietly putting it back.
+        oidc_scopes = tuple((source.get(ENV_OIDC_SCOPES) or "").split()) or DEFAULT_OIDC_SCOPES
 
         users = _roster(source.get(ENV_USERS))
         password_hashes: dict[str, str] = {}
@@ -497,6 +530,7 @@ class AuthSettings:
             oidc_client_id_var=client_id_var,
             oidc_client_secret_var=client_secret_var,
             oidc_claim=(source.get(ENV_OIDC_CLAIM) or "").strip() or DEFAULT_OIDC_CLAIM,
+            oidc_scopes=oidc_scopes,
             oidc_subjects=oidc_subjects,
             roster_access=roster_access,
             web_theme=(source.get(ENV_WEB_THEME) or "").strip(),
@@ -553,6 +587,14 @@ class AuthSettings:
                 missing.add(self.oidc_client_id_var)
             if not self.oidc_client_secret:
                 missing.add(self.oidc_client_secret_var)
+            # A scope list without `openid` is not a narrower login, it is a
+            # different protocol: the IdP issues no ID token, so the nonce and
+            # audience checks this module rests on have nothing to check. It is
+            # reported here — rather than silently re-added — so the operator
+            # who removed it is told, and every login stays refused until they
+            # put it back.
+            if REQUIRED_OIDC_SCOPE not in self.oidc_scopes:
+                missing.add(ENV_OIDC_SCOPES)
         return tuple(sorted(missing))
 
     def roster_collisions(self) -> dict[str, list[str]]:

--- a/src/osprey/services/auth_sidecar/routes/oidc.py
+++ b/src/osprey/services/auth_sidecar/routes/oidc.py
@@ -129,15 +129,6 @@ One entry, not a map: Authlib's Starlette integration drops every previous
 have one handshake it could complete. A second entry here would outlive the
 Authlib data it is paired with and could only ever fail the state check."""
 
-DEFAULT_SCOPE = "openid profile email"
-"""Requested scopes.
-
-``openid`` is what makes this OIDC rather than bare OAuth2 (it is also what
-makes Authlib generate and check a nonce). ``profile`` and ``email`` are asked
-for because the claim a facility maps onto a roster user is commonly
-``preferred_username`` or ``email``, and a claim that was never requested is
-simply absent from the token — which this module reads as "deny"."""
-
 ENV_ROLE_CLAIM = "OSPREY_AUTH_ROLE_CLAIM"
 """Names the ID-token claim carrying group membership, e.g. ``groups``.
 
@@ -738,7 +729,9 @@ def _oauth_client(request: Request) -> Any:
         server_metadata_url=_discovery_url(settings.oidc_issuer or ""),
         client_id=settings.oidc_client_id,
         client_secret=settings.oidc_client_secret,
-        client_kwargs={"scope": DEFAULT_SCOPE},
+        # The scope list the deployment authored (or the sidecar's default when
+        # it authored none). Authlib takes it as one space-separated string.
+        client_kwargs={"scope": " ".join(settings.oidc_scopes)},
     )
     client = registry.create_client(CLIENT_NAME)
     request.app.state.oidc_client = client

--- a/src/osprey/services/bluesky_bridge/app.py
+++ b/src/osprey/services/bluesky_bridge/app.py
@@ -240,8 +240,10 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
       `BLUESKY_DEVICES_FILE`: the posture it guards against is a property of
       the project config, not of whether this deployment wires up any devices
       at all, and a gated guard leaves whole classes of deployment unchecked.
-      Alongside it, `queue.device_page_size()` is parsed once so a malformed
-      `BLUESKY_DEVICE_PAGE_SIZE` fails the boot instead of the first request.
+      Alongside it, `queue.device_page_size()` and the two `live_rows` caps are
+      parsed once so a malformed `BLUESKY_DEVICE_PAGE_SIZE`,
+      `BLUESKY_LIVE_MAX_RUNS` or `BLUESKY_LIVE_MAX_ROWS_PER_RUN` fails the boot
+      instead of the first request.
     - The document plane: the 0MQ proxy the queueserver's Publisher connects
       to, and the dispatcher that turns that stream into live rows.
       Unconfigured is a no-op; see `document_plane.start_from_env`.
@@ -265,6 +267,13 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # read per request downstream, so parsing it once here turns a bad env var
     # into a failed start rather than a surprise 500 on the first caller.
     queue.device_page_size()
+
+    # The live-row buffer caps, for the same reason and one more: the recorder
+    # that reads them handles every document inside a try/except, so a bad
+    # value there would silently drop every run buffer instead of announcing
+    # itself. Parsing both here makes an unusable value fail the start.
+    live_rows.max_runs()
+    live_rows.max_rows_per_run()
 
     # The document plane's 0MQ proxy — the binding element the queueserver's
     # Publisher connects to, and the RemoteDispatcher that turns that stream
@@ -1641,7 +1650,7 @@ def _tiled_run_snapshot(run_id: str) -> dict[str, Any] | None:
     Two situations fall through the live path in `get_run_data` and land here: a
     run with no live buffer at all (a bridge restart drops every buffer, so a
     run that started before it — even one still executing — has nothing in
-    memory), and one whose buffer was evicted past `live_rows._MAX_RUNS`. The
+    memory), and one whose buffer was evicted past `live_rows.max_runs()`. The
     search keys on `osprey_run_id`, the durable stamp the enqueue path threads
     into the item metadata and the worker records onto the start document.
 

--- a/src/osprey/services/bluesky_bridge/devices/connector.py
+++ b/src/osprey/services/bluesky_bridge/devices/connector.py
@@ -34,6 +34,7 @@ import-clean of ophyd.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections.abc import Sequence
 from typing import Any
@@ -44,19 +45,74 @@ from ophyd_async.core import AsyncStatus, StandardReadable
 from ._connect import connect_all
 from .specs import ReadableSpec, SettableSpec
 
-_READBACK_DEADBAND = 1e-9
-"""Max ``abs(readback - demand)`` for ``ConnectorSettable.set()`` to
-consider a move settled. Mirrors ``epics.py``'s deadband: a float-noise
-bound on a setpoint/readback pair the underlying IOC keeps in exact
-software sync, not a physical tolerance."""
+#: Env var carrying how close a readback must come to the demand before
+#: ``ConnectorSettable.set()`` calls a move settled. Authored per facility in
+#: the build profile and rendered into the compose file; the container cannot
+#: read `config.yml`, so the env var is the whole channel.
+SETTLE_TOLERANCE_ENV = "BLUESKY_SETTLE_TOLERANCE"
 
-_READBACK_SETTLE_TIMEOUT_S = 5.0
-"""Bound on how long ``ConnectorSettable.set()`` polls the readback channel
-for settlement after the write verifies, before raising ``TimeoutError``.
-Referenced by name (not bound as a default argument) inside ``set()`` so
-its current module-level value is read at call time — this lets a test
-monkeypatch the module attribute to a tiny value without touching the
-class."""
+#: Used when the variable is unset. A float-noise bound on a setpoint/readback
+#: pair the underlying IOC keeps in exact software sync — the right value for a
+#: device whose readback is the setpoint echoed back, and far too strict for a
+#: device that physically moves, which is exactly why a facility authors it.
+DEFAULT_SETTLE_TOLERANCE = 1e-9
+
+#: Env var bounding how long ``ConnectorSettable.set()`` polls the readback
+#: channel for settlement after the write verifies.
+SETTLE_TIMEOUT_ENV = "BLUESKY_SETTLE_TIMEOUT_S"
+
+#: Used when the variable is unset.
+DEFAULT_SETTLE_TIMEOUT_S = 5.0
+
+
+def settle_tolerance() -> float:
+    """Max ``abs(readback - demand)`` for a move to count as settled.
+
+    How far a readback may sit from its demand before a plan calls the move
+    done is a property of the DEVICES a facility drives, not of OSPREY: an
+    aliased software setpoint settles to float noise, a magnet or a gap does
+    not. Read from `os.environ` on every call — never cached at import — so a
+    test (and a re-exec'd process) sees the value its environment declares.
+
+    Raises:
+        ValueError: if the variable is set to something that is not a number,
+            or to a value below zero. A negative tolerance can never be
+            satisfied, so it would turn every move into a timeout.
+    """
+    return _positive_float(SETTLE_TOLERANCE_ENV, DEFAULT_SETTLE_TOLERANCE, allow_zero=True)
+
+
+def settle_timeout_s() -> float:
+    """How long ``set()`` polls the readback before raising ``TimeoutError``.
+
+    Fail-closed: running out of budget raises out of the ``AsyncStatus`` and
+    aborts the RunEngine. Raising this key gives a slow device more room; it
+    never turns an unsettled move into a successful one.
+
+    Raises:
+        ValueError: if the variable is set to something that is not a number,
+            or to a value at or below zero — a zero budget would abort every
+            move that needs even one poll.
+    """
+    return _positive_float(SETTLE_TIMEOUT_ENV, DEFAULT_SETTLE_TIMEOUT_S, allow_zero=False)
+
+
+def _positive_float(env_var: str, default: float, *, allow_zero: bool) -> float:
+    """Read *env_var* as a float, falling back to *default* when unset."""
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        raise ValueError(
+            f"{env_var}={raw!r} is not a number; set it to a decimal value (default {default})"
+        ) from None
+    if value < 0 or (value == 0 and not allow_zero):
+        bound = ">= 0" if allow_zero else "> 0"
+        raise ValueError(f"{env_var}={raw!r} must be {bound}")
+    return value
+
 
 _READBACK_POLL_INTERVAL_S = 0.05
 """Sleep between readback polls in ``ConnectorSettable.set()``."""
@@ -80,9 +136,9 @@ class ConnectorSettable(StandardReadable):
     setpoint through ``connector.write_channel_checked`` — which raises on
     any refusal, failure, mismatch, or unconfirmed write, aborting the
     RunEngine — then polls the (possibly separate) readback channel through
-    ``connector.read_channel`` until it settles within ``_READBACK_DEADBAND``
-    of the demanded value, or raises ``TimeoutError`` after
-    ``_READBACK_SETTLE_TIMEOUT_S``. ``read()``/``describe()`` are overridden
+    ``connector.read_channel`` until it settles within :func:`settle_tolerance`
+    of the demanded value, or raises ``TimeoutError`` once the
+    :func:`settle_timeout_s` budget runs out. ``read()``/``describe()`` are overridden
     to return the *live* readback via the connector on every call — never a
     cached/soft value — so a plan's ``trigger_and_read`` document always
     reflects the current mediated state.
@@ -148,8 +204,8 @@ class ConnectorSettable(StandardReadable):
                 Channel Access layer.
             TimeoutError: Either propagated unchanged from the connector's
                 write, or raised directly by this method when ``readback``
-                does not settle within ``_READBACK_DEADBAND`` of ``value``
-                within ``_READBACK_SETTLE_TIMEOUT_S`` seconds.
+                does not settle within :func:`settle_tolerance` of ``value``
+                within :func:`settle_timeout_s` seconds.
 
             Every one of these propagates uncaught through the
             ``AsyncStatus`` this method is wrapped in, aborting the
@@ -164,8 +220,8 @@ class ConnectorSettable(StandardReadable):
         if self._readback_pv == self._setpoint_pv and result.outcome == "confirmed":
             # ``confirmed`` means the connector re-read this very channel and
             # found the value sent — that IS the settle, so return on the word,
-            # never on arithmetic over ``observed_value``: _READBACK_DEADBAND is
-            # stricter than the connector's comparison rule
+            # never on arithmetic over ``observed_value``: the settle tolerance
+            # is stricter, by default, than the connector's comparison rule
             # (``isclose(rel_tol=1e-6)``), so re-checking a confirmed write here
             # would poll the setpoint just written for the full settle timeout
             # and then raise on a write that succeeded. (``WriteOutcome`` is a
@@ -173,15 +229,21 @@ class ConnectorSettable(StandardReadable):
             # connector package into this deliberately duck-typed device layer.)
             return
 
-        deadline = time.monotonic() + _READBACK_SETTLE_TIMEOUT_S
+        # Both budgets are read HERE, once per call, rather than bound as
+        # defaults: the facility authors them in its profile and they reach the
+        # container as env vars, so the value in force is whatever the process
+        # environment says at the moment the move starts.
+        tolerance = settle_tolerance()
+        timeout_s = settle_timeout_s()
+        deadline = time.monotonic() + timeout_s
         while True:
             reading = await self._osprey_connector.read_channel(self._readback_pv)
-            if abs(reading.value - value) <= _READBACK_DEADBAND:
+            if abs(reading.value - value) <= tolerance:
                 return
             if time.monotonic() >= deadline:
                 raise TimeoutError(
                     f"Readback '{self._readback_pv}' did not settle to {value} "
-                    f"within {_READBACK_SETTLE_TIMEOUT_S}s (last read: {reading.value})"
+                    f"within {timeout_s}s (last read: {reading.value})"
                 )
             await asyncio.sleep(_READBACK_POLL_INTERVAL_S)
 

--- a/src/osprey/services/bluesky_bridge/figure_cache.py
+++ b/src/osprey/services/bluesky_bridge/figure_cache.py
@@ -47,7 +47,7 @@ from typing import Any
 
 # Settled figures retained at once, oldest-*used* evicted first: a settled run
 # being polled stays hot, and one nobody has asked about since falls out. Sized
-# like `live_rows._MAX_RUNS` — the runs whose rows are still retained are
+# like `live_rows.max_runs()` — the runs whose rows are still retained are
 # roughly the runs whose figures are worth keeping.
 _MAX_ENTRIES = 50
 

--- a/src/osprey/services/bluesky_bridge/live_rows.py
+++ b/src/osprey/services/bluesky_bridge/live_rows.py
@@ -31,17 +31,22 @@ Document handling (bluesky's plain-dict document protocol):
 
 Bounding uses two independent knobs:
 
-- ``_MAX_ROWS_PER_RUN``: a hard cap on stored rows per run, so a runaway plan
-  cannot grow the buffer without limit. ``total_seen`` keeps counting every
-  event past this cap — the ``row_count`` on the run-data route reports this
-  *true* total
+- :func:`max_rows_per_run`: a hard cap on stored rows per run, so a runaway
+  plan cannot grow the buffer without limit. ``total_seen`` keeps counting
+  every event past this cap — the ``row_count`` on the run-data route reports
+  this *true* total
   even when the tail beyond the cap was never stored (a documented trade-off
   for a pathological never-ending run, not the common case).
-- ``_MAX_RUNS``: number of run buffers retained at all, oldest-evicted
+- :func:`max_runs`: number of run buffers retained at all, oldest-evicted
   (insertion-ordered ``OrderedDict``, ``move_to_end`` on every write) once
-  exceeded. This is what lets a completed run's data survive to be read
-  later — unlike BELLA's demo-day ``_MAX_RUNS = 4``, Phase 2 sets this much
-  higher since there is no Tiled fallback yet.
+  exceeded. This is what lets a completed run's data survive to be read later.
+
+Both are authored per facility (``bluesky.live_max_rows_per_run`` and
+``bluesky.live_max_runs`` in the build profile) and reach the bridge as env
+vars, because how many runs are worth keeping in memory, and how long a run
+gets, are properties of the plans a facility runs and of the memory its
+deployment host has. A recorder resolves both at its start document and holds
+them for that run, so a cap never moves under a buffer that is already filling.
 
 The recorder itself never raises: every document is handled inside a
 try/except so a recorder bug can never abort a run (mirrors the runner
@@ -52,19 +57,74 @@ run, not the run itself.
 from __future__ import annotations
 
 import logging
+import os
 from collections import OrderedDict
 from threading import Lock
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Retained run buffers (oldest evicted first). Considerably higher than
-# BELLA's demo-day `_MAX_RUNS = 4` since Phase 2 has no Tiled fallback yet — a
-# completed run must stay readable well past its own completion.
-_MAX_RUNS = 50
-# Hard per-run row storage cap — a safety valve against a runaway/never-ending
-# plan, not a normal-case limit (see `total_seen` above).
-_MAX_ROWS_PER_RUN = 10_000
+#: Env var carrying how many run buffers this bridge retains at once.
+#: Authored per facility in the build profile and rendered into the compose
+#: file; the container cannot read `config.yml`, so the env var is the channel.
+MAX_RUNS_ENV = "BLUESKY_LIVE_MAX_RUNS"
+
+#: Used when the variable is unset — high enough that a completed run stays
+#: readable well past its own completion.
+DEFAULT_MAX_RUNS = 50
+
+#: Env var carrying the hard per-run row storage cap.
+MAX_ROWS_PER_RUN_ENV = "BLUESKY_LIVE_MAX_ROWS_PER_RUN"
+
+#: Used when the variable is unset. A safety valve against a runaway or
+#: never-ending plan, not a normal-case limit (see `total_seen` above).
+DEFAULT_MAX_ROWS_PER_RUN = 10_000
+
+
+def max_runs() -> int:
+    """How many run buffers this bridge retains at once, oldest evicted first.
+
+    Read from `os.environ` on every call — never cached at import — so a test
+    (and a re-exec'd process) sees the value its environment declares.
+
+    Raises:
+        ValueError: if the variable is set to something that is not an integer,
+            or to an integer below 1. Retaining zero runs would evict every
+            buffer the moment it was created, which is a misconfiguration
+            rather than a policy.
+    """
+    return _positive_int(MAX_RUNS_ENV, DEFAULT_MAX_RUNS)
+
+
+def max_rows_per_run() -> int:
+    """How many rows one run buffer stores before it stops growing.
+
+    Rows past this cap are counted in ``total_seen`` and not stored, so the
+    run-data route keeps reporting the true total over a truncated buffer.
+
+    Raises:
+        ValueError: if the variable is set to something that is not an integer,
+            or to an integer below 1.
+    """
+    return _positive_int(MAX_ROWS_PER_RUN_ENV, DEFAULT_MAX_ROWS_PER_RUN)
+
+
+def _positive_int(env_var: str, default: int) -> int:
+    """Read *env_var* as an integer >= 1, falling back to *default* when unset."""
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"{env_var}={raw!r} is not an integer; set it to a whole "
+            f"number >= 1 (default {default})"
+        ) from None
+    if value < 1:
+        raise ValueError(f"{env_var}={raw!r} must be >= 1")
+    return value
+
 
 _lock = Lock()
 # run_uid -> {"columns": [...], "rows": [[...], ...], "partial": bool,
@@ -128,6 +188,7 @@ class LiveRowRecorder:
         self._key = key
         self._plan = plan
         self._uid: str | None = None
+        self._max_rows: int = DEFAULT_MAX_ROWS_PER_RUN
 
     def __call__(self, name: str, doc: dict[str, Any]) -> None:
         try:
@@ -146,6 +207,12 @@ class LiveRowRecorder:
         if not uid:
             return
         self._uid = uid
+        # Both caps are resolved once, here, and not again for the rest of the
+        # run: `_on_event` runs per event document on the RunEngine's thread,
+        # and a cap that changes mid-run would move the boundary of a buffer
+        # that is already half-filled under it.
+        self._max_rows = max_rows_per_run()
+        retained_runs = max_runs()
         with _lock:
             _buffers[uid] = {
                 "columns": [],
@@ -155,7 +222,7 @@ class LiveRowRecorder:
                 "plan": self._plan,
             }
             _buffers.move_to_end(uid)
-            while len(_buffers) > _MAX_RUNS:
+            while len(_buffers) > retained_runs:
                 _buffers.popitem(last=False)
 
     def _on_event(self, doc: dict[str, Any]) -> None:
@@ -172,7 +239,7 @@ class LiveRowRecorder:
                 for row in buf["rows"]:
                     row.extend([None] * len(new_columns))
             buf["total_seen"] += 1
-            if len(buf["rows"]) < _MAX_ROWS_PER_RUN:
+            if len(buf["rows"]) < self._max_rows:
                 buf["rows"].append([data.get(col) for col in buf["columns"]])
             _buffers.move_to_end(self._uid)
 

--- a/src/osprey/services/bluesky_bridge/qserver_startup.py
+++ b/src/osprey/services/bluesky_bridge/qserver_startup.py
@@ -266,10 +266,10 @@ async def build_devices(
     names a file this process can read — file presence is the switch, so there
     is no second flag that can disagree with it.
 
-    Returns an empty mapping — never raises — when the substrate is disabled
-    (browse-only) or when the device file names no devices at all. A caller
-    treats an empty result as "this worker cannot execute plans", which is
-    exactly what :func:`build_namespace` does with it.
+    Returns an empty mapping when the substrate is disabled (browse-only) or
+    when the device file names no devices at all. A caller treats an empty
+    result as "this worker cannot execute plans", which is exactly what
+    :func:`build_namespace` does with it.
 
     Args:
         env: Environment mapping to read; defaults to ``os.environ``.
@@ -279,6 +279,12 @@ async def build_devices(
 
     Returns:
         Mapping of device name to connected device.
+
+    Raises:
+        ValueError: ``BLUESKY_SETTLE_TIMEOUT_S`` or ``BLUESKY_SETTLE_TOLERANCE``
+            is set to a value the settle loop cannot use. A worker that came up
+            anyway would carry the fault to the first write of the first plan
+            and abort it there, so an unusable budget fails the boot instead.
     """
     env = os.environ if env is None else env
     devices_file = (env.get(DEVICES_FILE_ENV) or "").strip()
@@ -304,6 +310,12 @@ async def build_devices(
     # resolve and takes the whole worker environment down with it.
     from osprey.services.bluesky_bridge.devices import connector as connector_devices
     from osprey.services.bluesky_bridge.devices._specs_from_file import specs_from_file
+
+    # The settle budgets every ConnectorSettable.set() reads per move, parsed
+    # once here: they are read inside the RunEngine, where a ValueError aborts
+    # a plan an operator is waiting on.
+    connector_devices.settle_timeout_s()
+    connector_devices.settle_tolerance()
 
     setpoints, readbacks = specs_from_file(path)
     if not setpoints and not readbacks:

--- a/src/osprey/services/channel_finder/benchmarks/runner.py
+++ b/src/osprey/services/channel_finder/benchmarks/runner.py
@@ -276,7 +276,10 @@ class BenchmarkRunner:
             services.get("graphdb"), base=resolve_port_base(config)
         )
         with graph_seeder.open_session(
-            connection.uri, connection.username, connection.password
+            connection.uri,
+            connection.username,
+            connection.password,
+            database=connection.database,
         ) as session:
             record = session.run(GRAPH_CHANNEL_COUNT_CYPHER).single()
         if record is None:

--- a/src/osprey/services/facility_knowledge/seeder/__init__.py
+++ b/src/osprey/services/facility_knowledge/seeder/__init__.py
@@ -19,7 +19,9 @@ Example::
 
     stubs = seed_from_ttl(Path("/path/to/corpus.ttl"))
 
-    with open_session(conn.uri, conn.username, conn.password) as session:
+    with open_session(
+        conn.uri, conn.username, conn.password, database=conn.database
+    ) as session:
         bootstrap(session)
 """
 

--- a/src/osprey/services/facility_knowledge/seeder/graph_seeder.py
+++ b/src/osprey/services/facility_knowledge/seeder/graph_seeder.py
@@ -102,10 +102,6 @@ COMMIT_SIZE = 10_000
 #: ``terminationStatus`` value n10s reports for a fully successful import.
 TERMINATION_OK = "OK"
 
-#: Default Neo4j database.  Named explicitly so the driver skips the home-database
-#: lookup round-trip on every session.
-DEFAULT_DATABASE = "neo4j"
-
 #: Label of the singleton node carrying the seeded TTL's sha256.
 SEED_MARKER_LABEL = "_OspreySeed"
 
@@ -275,21 +271,24 @@ def open_session(
     username: str,
     password: str,
     *,
-    database: str = DEFAULT_DATABASE,
+    database: str,
 ) -> Iterator[Session]:
     """Open a driver session against the graph store, closing both on exit.
 
-    Takes the three fields of
+    Takes the four fields of
     :class:`~osprey.deployment.graphdb_service.GraphdbConnection` explicitly
     rather than the dataclass itself, so this module stays free of any
     deployment/config import and can be driven from a test or a script with
-    three literals.
+    four literals.
 
     Args:
         uri: Bolt address to dial, e.g. ``bolt://localhost:7687``.
         username: Account to authenticate as.
         password: That account's password.
-        database: Database to open the session against.
+        database: Database to open the session against, named explicitly so the
+            driver skips the home-database lookup round-trip. Required rather
+            than defaulted: the one place that name is decided is the resolved
+            ``GraphdbConnection``, never a literal restated here.
 
     Yields:
         An open :class:`neo4j.Session`.

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -87,6 +87,7 @@ class ExecutionWrapper:
         protected_roots: Iterable[str | Path] = (),
         permitted_roots: Iterable[str | Path] = (),
         perimeter_denied_ports: Iterable[int] = (),
+        step_read_timeout_s: float | None = None,
     ):
         """
         Initialize the wrapper.
@@ -131,12 +132,30 @@ class ExecutionWrapper:
                 (:meth:`_get_net_guard`); a non-empty set puts the guard in
                 front of user code in **every** execution mode, because the
                 perimeter is orthogonal to the write posture.
+            step_read_timeout_s: Ceiling on the fresh read a ``max_step`` check
+                makes, in seconds. Resolved by the parent
+                (:func:`osprey.mcp_server.python_executor.executor._step_read_timeout_seconds`)
+                from the block of the connector the run's control target
+                selects, and passed as a literal for the same reason the guard
+                roots are: the sandbox holds no config, and a child deriving
+                the budget for itself would read the deployment's baseline
+                block rather than the one its own connector reads. ``None`` —
+                what a caller that knows no deployment gets — takes the
+                connectors package's own default, which fails closed just as
+                quickly.
         """
         self.limits_validator = limits_validator
         self.execution_mode = execution_mode
         self.protected_roots = tuple(str(root) for root in protected_roots)
         self.permitted_roots = tuple(str(root) for root in permitted_roots)
         self.perimeter_denied_ports = tuple(perimeter_denied_ports)
+        if step_read_timeout_s is None:
+            from osprey_connectors.control_system.limits_validator import (
+                DEFAULT_STEP_READ_TIMEOUT_SECONDS,
+            )
+
+            step_read_timeout_s = DEFAULT_STEP_READ_TIMEOUT_SECONDS
+        self.step_read_timeout_s = float(step_read_timeout_s)
 
     def create_wrapper(self, user_code: str, execution_folder: Path | None = None) -> str:
         """
@@ -306,6 +325,13 @@ if not _execution_dir.exists():
 
         db_json = json.dumps(limits_db_serialized)
         policy_json = json.dumps(self.limits_validator.policy)
+        # Embedded as a literal for the same reason the database and the policy
+        # are: the sandbox holds no config, so every number the guard applies
+        # has to travel in the generated source. The parent resolved it from
+        # the connector block this run's control target selects
+        # (`control_system.connector.<type>.step_read_timeout_s`), so a
+        # script's step check and that connector's own read use one budget.
+        step_read_timeout = self.step_read_timeout_s
 
         return textwrap.dedent(
             f"""
@@ -313,9 +339,13 @@ if not _execution_dir.exists():
             try:
                 import json
                 from osprey.connectors.control_system.limits_validator import (
-                    LimitsValidator, ChannelLimitsConfig, STEP_READ_TIMEOUT_SECONDS
+                    LimitsValidator, ChannelLimitsConfig
                 )
+
                 from osprey.errors import ChannelLimitsViolationError
+
+                # This deployment's `max_step` fresh-read budget, in seconds.
+                _step_read_timeout = {step_read_timeout}
 
                 # Deserialize embedded config
                 _limits_db_raw = json.loads('''{db_json}''')
@@ -373,7 +403,7 @@ if not _execution_dir.exists():
                         check closed.
                         '''
                         try:
-                            return _original_ca_get(_chid, timeout=STEP_READ_TIMEOUT_SECONDS)
+                            return _original_ca_get(_chid, timeout=_step_read_timeout)
                         except Exception:
                             return None
 
@@ -446,7 +476,7 @@ if not _execution_dir.exists():
                         if _cfg and _cfg['max_step'] is not None:
                             try:
                                 _current = await _orig_aioca_caget(
-                                    pv, timeout=STEP_READ_TIMEOUT_SECONDS
+                                    pv, timeout=_step_read_timeout
                                 )
                             except Exception:
                                 _current = None
@@ -1305,7 +1335,7 @@ if not _execution_dir.exists():
                         holding the write open.
                         '''
                         return _caproto_scalar(
-                            _caproto_sync.read(_address, timeout=STEP_READ_TIMEOUT_SECONDS)
+                            _caproto_sync.read(_address, timeout=_step_read_timeout)
                         )
 
                     _caproto_sync_reader = (
@@ -1387,7 +1417,7 @@ if not _execution_dir.exists():
 
                         def _read(_address):
                             return _caproto_scalar(
-                                _pv.read(timeout=STEP_READ_TIMEOUT_SECONDS)
+                                _pv.read(timeout=_step_read_timeout)
                             )
 
                         return _read
@@ -1480,7 +1510,7 @@ if not _execution_dir.exists():
                             if _cfg and _cfg['max_step'] is not None:
                                 try:
                                     _current = _caproto_scalar(
-                                        await self.read(timeout=STEP_READ_TIMEOUT_SECONDS)
+                                        await self.read(timeout=_step_read_timeout)
                                     )
                                 except Exception:
                                     _current = None

--- a/src/osprey/services/virtual_accelerator/entrypoint.py
+++ b/src/osprey/services/virtual_accelerator/entrypoint.py
@@ -77,7 +77,11 @@ from collections.abc import Container
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from osprey.services.virtual_accelerator.ioc.engine_source import EngineSource
+from osprey.services.virtual_accelerator.ioc.engine_source import (
+    DEFAULT_NOISE_LEVEL,
+    DEFAULT_POLL_INTERVAL_S,
+    EngineSource,
+)
 from osprey.services.virtual_accelerator.manifest import (
     PARTITION_SP_ECHO,
     READBACK_SUBFIELD,
@@ -96,7 +100,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from lume.model import LUMEModel
 
 DEFAULT_DATA_DIR = "/data/simulation"
-ENGINE_POLL_INTERVAL_S = 1.0
 
 # The line this process prints once it is serving, and the marker everything
 # that waits on that boot greps for: the image boot check
@@ -213,6 +216,52 @@ def _parse_bpm_errors(env_var: str = "VA_BPM_ERRORS") -> dict[str, dict[str, flo
             fields[field] = value
         result[device] = fields
     return result
+
+
+def _positive_float_env(env_var: str, default: float) -> float:
+    """Read *env_var* as a float greater than zero, or fall back to *default*.
+
+    Args:
+        env_var: Name of the variable to read.
+        default: Value used when the variable is unset or empty.
+
+    Returns:
+        The configured value, or *default*.
+
+    Raises:
+        SystemExit: If the variable is set to something that is not a number,
+            or to a value at or below zero — a poll interval of zero is a busy
+            loop, and a negative one is not a duration at all. Refused at boot
+            rather than clamped, so a typo is visible in ``docker logs``.
+    """
+    return _float_env(env_var, default, minimum=0.0, inclusive=False)
+
+
+def _non_negative_float_env(env_var: str, default: float) -> float:
+    """Read *env_var* as a float of zero or more, or fall back to *default*.
+
+    Zero is meaningful here — it asks for no noise at all — so it is accepted
+    where :func:`_positive_float_env` refuses it.
+    """
+    return _float_env(env_var, default, minimum=0.0, inclusive=True)
+
+
+def _float_env(env_var: str, default: float, *, minimum: float, inclusive: bool) -> float:
+    """Shared reader behind the two float-env helpers above."""
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        raise SystemExit(
+            f"FATAL: {env_var}={raw!r} is not a number. Set it to a decimal "
+            f"value, or unset it for the default of {default}."
+        ) from None
+    if value < minimum or (value == minimum and not inclusive):
+        bound = f">= {minimum}" if inclusive else f"> {minimum}"
+        raise SystemExit(f"FATAL: {env_var}={raw!r} must be {bound}.")
+    return value
 
 
 def _resolve_channels_file(data_dir: Path) -> Path:
@@ -398,6 +447,12 @@ def main() -> None:
     configure_logging()
 
     data_dir = Path(os.environ.get("VA_DATA_DIR", DEFAULT_DATA_DIR))
+    # Two facility-network facts, read here rather than fixed in the image: how
+    # often the telemetry thread republishes engine values, and how much noise
+    # the synthesised channels carry. Both default to the `engine_source`
+    # constants, which are the one place either number is written down.
+    poll_interval_s = _positive_float_env("VA_POLL_INTERVAL_S", DEFAULT_POLL_INTERVAL_S)
+    noise_level = _non_negative_float_env("VA_NOISE_LEVEL", DEFAULT_NOISE_LEVEL)
     state_dir = Path(os.environ.get("VA_STATE_DIR", "").strip() or data_dir)
     machine_path = data_dir / "machine.json"
     if not machine_path.is_file():
@@ -536,6 +591,7 @@ def main() -> None:
         records.static_noisy,
         data_dir,
         state_dir=state_dir,
+        noise_level=noise_level,
         setpoint_echo_records=setpoint_echoes,
     )
 
@@ -559,7 +615,7 @@ def main() -> None:
     # Telemetry starts only once the driver is attached, so its first tick
     # posts monitor events to the server rather than editing boot specs
     # behind it.
-    _start_engine_source(engine_source, ENGINE_POLL_INTERVAL_S)
+    _start_engine_source(engine_source, poll_interval_s)
 
     _install_shutdown_signals()
     print(_ready_line(len(records.all)), flush=True)

--- a/src/osprey/services/virtual_accelerator/ioc/engine_source.py
+++ b/src/osprey/services/virtual_accelerator/ioc/engine_source.py
@@ -15,8 +15,11 @@ Not every partition-(c) address is necessarily defined in the bind-mounted
 ``machine.json`` (only a scenario-relevant subset is -- see
 ``machine-json-lattice-augment``); addresses the engine doesn't serve fall
 back to the same generic channel-taxonomy synthesis the mock connector itself uses
-for unknown channels (``osprey.connectors.channel_taxonomy.classify_channel``), so mock
-and VA present identical values for anything neither one has real data for.
+for unknown channels (``osprey.connectors.channel_taxonomy.classify_channel``): mock
+and VA run the same synthesis path for anything neither one has real data for.
+What each one puts on top of it -- the noise level in particular -- is
+configured separately, so the two agree on the method and not necessarily on
+the number.
 
 Scenario-switch detection deliberately does its own (mtime, content-hash)
 comparison of ``active_scenarios`` in addition to the engine's own internal
@@ -41,7 +44,14 @@ from osprey.services.virtual_accelerator.manifest import PARTITION_STATIC_NOISY,
 from osprey.simulation.engine import SimulationEngine, engine_serves
 
 ACTIVE_SCENARIOS_FILENAME = "active_scenarios"
+#: Seconds between telemetry ticks when ``VA_POLL_INTERVAL_S`` is unset. The
+#: one place this number is written down: the entrypoint reads the env var and
+#: falls back here rather than keeping a copy of its own.
 DEFAULT_POLL_INTERVAL_S = 1.0
+
+#: Fractional noise applied to synthesised channel values when ``VA_NOISE_LEVEL``
+#: is unset. How lively a stand-in machine's readings should look is a facility's
+#: call, so the entrypoint forwards the env var into :class:`EngineSource`.
 DEFAULT_NOISE_LEVEL = 0.01
 
 _Signature = tuple[int, str]

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -745,6 +745,12 @@ services:
          one place instead of being restated by the renderer. #}
       - OSPREY_AUTH_OIDC_CLAIM={{ auth_oidc_claim }}
 {%- endif %}
+{%- if auth_oidc_scopes %}
+      {#- Only when the facility names them: with no line here the sidecar
+         applies its own documented default (`openid profile email`). A list
+         that drops `openid` is refused by the sidecar, not repaired. #}
+      - OSPREY_AUTH_OIDC_SCOPES={{ auth_oidc_scopes }}
+{%- endif %}
 {%- set role_claim = authorization_claim | default("") %}
 {%- set role_map = authorization_claim_map | default({}) %}
 {%- if role_claim and role_map %}

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -359,6 +359,19 @@ services:
       # the default, so a default-valued deploy never renders this key at all.
       BLUESKY_DEVICE_PAGE_SIZE: "{{ svc.device_page_size }}"
 {% endif %}
+{%- if svc.live_max_runs %}
+      # Live-run buffer retention: how many run buffers the bridge holds in
+      # memory, oldest evicted first. The bridge is where the buffers live, so
+      # this and the row cap below stop here. Written by _inject_bluesky
+      # (build_injectors.py) only when the profile departs from the default.
+      BLUESKY_LIVE_MAX_RUNS: "{{ svc.live_max_runs }}"
+{% endif %}
+{%- if svc.live_max_rows_per_run %}
+      # Per-run row storage cap. Rows past it are still counted, so the
+      # run-data route reports the true total over a truncated buffer. Same
+      # omit-when-default contract as the retention count above.
+      BLUESKY_LIVE_MAX_ROWS_PER_RUN: "{{ svc.live_max_rows_per_run }}"
+{% endif %}
 {% if svc.target == 'standin' %}
       # This lane serves the STAND-IN target: the `live-standin` soft IOC this
       # deployment runs for itself, so a session can rehearse against the live

--- a/src/osprey/templates/services/bluesky/docker-compose.yml.j2
+++ b/src/osprey/templates/services/bluesky/docker-compose.yml.j2
@@ -701,6 +701,24 @@ services:
       # not be reachable by name through a hand-built queue item.
       BLUESKY_EXCLUDED_PLANS: "{{ svc.excluded_plans }}"
 {% endif %}
+{%- if svc.settle_timeout_s %}
+      # Plan-write settle budget: the worker is where devices are built, so
+      # this is the only container that reads it. `ConnectorSettable.set()`
+      # polls the readback until it reaches the demand and raises once this
+      # many seconds pass. Written by _inject_bluesky (build_injectors.py) only
+      # when the profile departs from the default, so a default-valued deploy
+      # renders nothing here at all.
+      BLUESKY_SETTLE_TIMEOUT_S: "{{ svc.settle_timeout_s }}"
+{% endif %}
+{%- if svc.settle_tolerance is defined %}
+      # Plan-write settle tolerance: the absolute `abs(readback - demand)` a
+      # move must reach to count as settled. Same worker-only reach and the
+      # same omit-when-default contract as the budget above. Tested for
+      # DEFINEDNESS rather than truth: zero is a tolerance the profile parser
+      # and the device's reader both accept — an exact-match demand — and a
+      # truth test would drop it and leave the device on its own default.
+      BLUESKY_SETTLE_TOLERANCE: "{{ svc.settle_tolerance }}"
+{% endif %}
 {% if svc.target == 'standin' %}
       # The co-deployed stand-in IOC, the same container address as the bridge's
       # copy — the worker is where the devices are actually built, so the two

--- a/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
+++ b/src/osprey/templates/services/dispatch_worker/docker-compose.yml.j2
@@ -125,6 +125,9 @@ services:
 {%- endif %}
       DISPATCH_TIMEOUT_SEC: "{{ services.dispatch_worker.timeout_sec | default(300) }}"
       DISPATCH_INACTIVITY_SEC: "{{ services.dispatch_worker.inactivity_sec | default(120) }}"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "{{ services.dispatch_worker.max_turns | default(25) }}"
       OSPREY_PROJECT_DIR: /app/{{ osprey_labels.project_name }}
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/src/osprey/templates/services/qmd/docker-compose.yml.j2
+++ b/src/osprey/templates/services/qmd/docker-compose.yml.j2
@@ -174,12 +174,13 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      # Long by design, not by accident. The entrypoint refuses to open the port
-      # until the index is built and provably non-empty, and a first-boot full
-      # build measured 41 minutes at ALS scale (~135,000 documents). A shorter
-      # grace period would report a container that is working correctly as
-      # unhealthy for most of its first hour.
-      start_period: 3600s
+      # Long by design, not by accident. The entrypoint refuses to open the
+      # port until the index is built and provably non-empty, so a first boot
+      # is unhealthy for as long as the full build takes — which scales with
+      # the corpus. A grace period shorter than that build reports a container
+      # that is working correctly as unhealthy. `services.qmd.first_index_grace`
+      # is this number, in seconds, for a corpus the default does not fit.
+      start_period: {{ osprey_qmd.first_index_grace_seconds }}s
 
 volumes:
   qmd_index:

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -188,6 +188,12 @@ services:
       VA_BPM_ERRORS: "${VA_STANDIN_BPM_ERRORS-{{ standin_bpm_errors_default | default('') }}}"
 {%- endif %}
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # How often the telemetry thread republishes engine values, and how much
+      # noise the synthesised channels carry. Empty means the entrypoint's own
+      # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
+      # than clamped, so a typo shows up in `docker logs`.
+      VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/_graphdb_container.py
+++ b/tests/_graphdb_container.py
@@ -87,6 +87,10 @@ GRAPHDB_TEST_PASSWORD = "ospreytest1234"
 
 GRAPHDB_TEST_USERNAME = "neo4j"
 
+#: Database the throwaway store serves. The Community image serves exactly one,
+#: and this is its name.
+GRAPHDB_TEST_DATABASE = "neo4j"
+
 
 # ---------------------------------------------------------------------------
 # Plugins

--- a/tests/agent_runner/test_primitives.py
+++ b/tests/agent_runner/test_primitives.py
@@ -14,11 +14,12 @@ silently broke proxy-provider auth for the in_context backend.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
-from osprey.agent_runner import sdk_env
+from osprey.agent_runner import primitives, sdk_env
 from osprey.agent_runner.primitives import provider_env_for_project
 
 
@@ -382,3 +383,42 @@ class TestTelemetryCredentialNotIssuedYet:
 
         assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
         assert "Authorization=Basic " in env["OTEL_EXPORTER_OTLP_HEADERS"]
+
+
+class TestTheMcpReadinessBudgetIsNamedForWhatItGates:
+    """``OSPREY_MCP_READY_TIMEOUT``: the readiness barrier's ceiling.
+
+    It gates production ``osprey query`` (exit 1 when a declared server never
+    registers), the interactive session, and the dispatch worker — not only
+    E2E, which is what the old ``OSPREY_E2E_`` spelling implied.
+
+    The reader takes the environment as an argument, so these cases hand it a
+    dict rather than reloading the module: a reload would rebind the module's
+    classes while every importer keeps the originals.
+    """
+
+    def test_the_default_applies_with_neither_name_set(self) -> None:
+        assert primitives._mcp_ready_timeout_from_env({}) == 90.0
+
+    def test_the_new_name_is_read(self) -> None:
+        assert primitives._mcp_ready_timeout_from_env({"OSPREY_MCP_READY_TIMEOUT": "12"}) == 12.0
+
+    def test_the_old_name_still_works_for_one_release(self) -> None:
+        """A host that already sets the E2E spelling keeps its value."""
+        assert primitives._mcp_ready_timeout_from_env({"OSPREY_E2E_MCP_READY_TIMEOUT": "7"}) == 7.0
+
+    def test_the_new_name_wins_when_both_are_set(self) -> None:
+        assert (
+            primitives._mcp_ready_timeout_from_env(
+                {
+                    "OSPREY_MCP_READY_TIMEOUT": "12",
+                    "OSPREY_E2E_MCP_READY_TIMEOUT": "7",
+                }
+            )
+            == 12.0
+        )
+
+    def test_the_module_constant_comes_from_this_process_environment(self) -> None:
+        """The barrier's own default is what the reader answers for this host."""
+        assert primitives.MCP_READY_TIMEOUT_S == primitives._mcp_ready_timeout_from_env(os.environ)
+        assert primitives._MCP_READY_TIMEOUT_S == primitives.MCP_READY_TIMEOUT_S

--- a/tests/cli/test_bluesky_profile_keys.py
+++ b/tests/cli/test_bluesky_profile_keys.py
@@ -97,6 +97,8 @@ def test_every_valid_key_is_accepted_and_read() -> None:
             "excluded_plans": ["orm"],
             "devices_file": "data/facility_devices.yml",
             "device_page_size": 250,
+            "settle_timeout_s": 30.0,
+            "settle_tolerance": 0.001,
         },
     }
 
@@ -111,6 +113,8 @@ def test_every_valid_key_is_accepted_and_read() -> None:
         excluded_plans=["orm"],
         devices_file="data/facility_devices.yml",
         device_page_size=250,
+        settle_timeout_s=30.0,
+        settle_tolerance=0.001,
     )
 
 
@@ -146,6 +150,49 @@ def test_device_page_size_accepts_one() -> None:
 
     assert profile.bluesky is not None
     assert profile.bluesky.device_page_size == 1
+
+
+def test_settle_keys_default_when_unstated() -> None:
+    """Unstated settle keys take the dataclass defaults the bridge falls back to."""
+    profile = _parse_profile({"name": "x", "data": "data", "bluesky": {}})
+
+    assert profile.bluesky is not None
+    assert profile.bluesky.settle_timeout_s == BlueskyConfig.settle_timeout_s
+    assert profile.bluesky.settle_tolerance == BlueskyConfig.settle_tolerance
+
+
+@pytest.mark.parametrize("value", [0, -1.0, True, "abc"])
+def test_settle_timeout_rejects_a_value_that_is_not_a_positive_number(value: Any) -> None:
+    """A zero or negative budget would abort every move that needs one poll."""
+    with pytest.raises(BuildProfileError) as excinfo:
+        _parse_profile({"name": "x", "data": "data", "bluesky": {"settle_timeout_s": value}})
+
+    message = str(excinfo.value)
+    assert "bluesky.settle_timeout_s" in message
+    assert repr(value) in message
+
+
+@pytest.mark.parametrize("value", [-1e-9, True, "abc"])
+def test_settle_tolerance_rejects_a_value_that_is_not_a_non_negative_number(value: Any) -> None:
+    """A negative tolerance can never be met, so it turns every move into a timeout."""
+    with pytest.raises(BuildProfileError) as excinfo:
+        _parse_profile({"name": "x", "data": "data", "bluesky": {"settle_tolerance": value}})
+
+    message = str(excinfo.value)
+    assert "bluesky.settle_tolerance" in message
+    assert repr(value) in message
+
+
+def test_settle_keys_read_an_authored_integer_as_a_float() -> None:
+    """`settle_timeout_s: 30` is a number, and reaches the config typed as one."""
+    profile = _parse_profile(
+        {"name": "x", "data": "data", "bluesky": {"settle_timeout_s": 30, "settle_tolerance": 0}}
+    )
+
+    assert profile.bluesky is not None
+    assert profile.bluesky.settle_timeout_s == 30.0
+    assert isinstance(profile.bluesky.settle_timeout_s, float)
+    assert profile.bluesky.settle_tolerance == 0.0
 
 
 # ── unknown keys are rejected ────────────────────────────────────────────────

--- a/tests/cli/test_bluesky_profile_keys.py
+++ b/tests/cli/test_bluesky_profile_keys.py
@@ -99,6 +99,8 @@ def test_every_valid_key_is_accepted_and_read() -> None:
             "device_page_size": 250,
             "settle_timeout_s": 30.0,
             "settle_tolerance": 0.001,
+            "live_max_runs": 4,
+            "live_max_rows_per_run": 200,
         },
     }
 
@@ -115,6 +117,8 @@ def test_every_valid_key_is_accepted_and_read() -> None:
         device_page_size=250,
         settle_timeout_s=30.0,
         settle_tolerance=0.001,
+        live_max_runs=4,
+        live_max_rows_per_run=200,
     )
 
 
@@ -181,6 +185,27 @@ def test_settle_tolerance_rejects_a_value_that_is_not_a_non_negative_number(valu
     message = str(excinfo.value)
     assert "bluesky.settle_tolerance" in message
     assert repr(value) in message
+
+
+@pytest.mark.parametrize("key", ["live_max_runs", "live_max_rows_per_run"])
+@pytest.mark.parametrize("value", [0, -5, True, "abc"])
+def test_live_buffer_caps_reject_a_value_that_is_not_a_positive_int(key: str, value: Any) -> None:
+    """Retaining zero runs or zero rows evicts everything the moment it lands."""
+    with pytest.raises(BuildProfileError) as excinfo:
+        _parse_profile({"name": "x", "data": "data", "bluesky": {key: value}})
+
+    message = str(excinfo.value)
+    assert f"bluesky.{key}" in message
+    assert repr(value) in message
+
+
+def test_live_buffer_caps_default_when_unstated() -> None:
+    """Unstated caps take the dataclass defaults the bridge falls back to."""
+    profile = _parse_profile({"name": "x", "data": "data", "bluesky": {}})
+
+    assert profile.bluesky is not None
+    assert profile.bluesky.live_max_runs == BlueskyConfig.live_max_runs
+    assert profile.bluesky.live_max_rows_per_run == BlueskyConfig.live_max_rows_per_run
 
 
 def test_settle_keys_read_an_authored_integer_as_a_float() -> None:

--- a/tests/cli/test_bluesky_service_registration.py
+++ b/tests/cli/test_bluesky_service_registration.py
@@ -712,3 +712,42 @@ def test_settle_keys_stop_at_the_worker(tmp_path: Path) -> None:
     bridge = rendered["services"]["bluesky-bridge"]["environment"] or {}
     assert "BLUESKY_SETTLE_TIMEOUT_S" not in bridge
     assert "BLUESKY_SETTLE_TOLERANCE" not in bridge
+
+
+# ---------------------------------------------------------------------------
+# Live-run buffer caps through the rendered compose file.
+#
+# The buffers live in the bridge process, so these two land where the page
+# size does and never reach the worker.
+# ---------------------------------------------------------------------------
+
+
+def test_live_buffer_caps_round_trip_through_compose(tmp_path: Path) -> None:
+    """Authored caps reach the bridge under the names `live_rows` reads."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(live_max_runs=4, live_max_rows_per_run=200), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]
+    assert bridge["environment"]["BLUESKY_LIVE_MAX_RUNS"] == "4"
+    assert bridge["environment"]["BLUESKY_LIVE_MAX_ROWS_PER_RUN"] == "200"
+
+
+def test_default_live_buffer_caps_omit_the_env(tmp_path: Path) -> None:
+    """An unauthored cap renders neither key anywhere at all."""
+    import yaml as pyyaml
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    config = _read_config(project_path)
+    text = pyyaml.safe_dump(_render_copied_compose(project_path, config))
+
+    assert "BLUESKY_LIVE_MAX_RUNS" not in text
+    assert "BLUESKY_LIVE_MAX_ROWS_PER_RUN" not in text

--- a/tests/cli/test_bluesky_service_registration.py
+++ b/tests/cli/test_bluesky_service_registration.py
@@ -637,3 +637,78 @@ def test_device_page_size_stops_at_the_bridge(tmp_path: Path) -> None:
 
     queueserver = rendered["services"]["queueserver"]
     assert "BLUESKY_DEVICE_PAGE_SIZE" not in (queueserver["environment"] or {})
+
+
+# ---------------------------------------------------------------------------
+# Settle budget and tolerance through the rendered compose file.
+#
+# Same omit-when-EQUALS-DEFAULT contract as the page size, and the mirror
+# image of where it lands: `ConnectorSettable` is built by the RE Manager's
+# worker, so these two reach the queueserver and stop there.
+# ---------------------------------------------------------------------------
+
+
+def test_settle_keys_round_trip_through_compose(tmp_path: Path) -> None:
+    """Authored settle keys reach the worker under the names the device reads."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(settle_timeout_s=30.0, settle_tolerance=0.001), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    queueserver = rendered["services"]["queueserver"]
+    assert queueserver["environment"]["BLUESKY_SETTLE_TIMEOUT_S"] == "30.0"
+    assert queueserver["environment"]["BLUESKY_SETTLE_TOLERANCE"] == "0.001"
+
+
+def test_default_settle_keys_omit_the_env(tmp_path: Path) -> None:
+    """An unauthored budget or tolerance renders neither key anywhere at all."""
+    import yaml as pyyaml
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(), project_path)
+    config = _read_config(project_path)
+    text = pyyaml.safe_dump(_render_copied_compose(project_path, config))
+
+    assert "BLUESKY_SETTLE_TIMEOUT_S" not in text
+    assert "BLUESKY_SETTLE_TOLERANCE" not in text
+
+
+def test_zero_settle_tolerance_reaches_the_worker(tmp_path: Path) -> None:
+    """Zero is an authored tolerance, not an absent one, and must be rendered.
+
+    A demand that has to match its readback exactly is spelled ``0``; the
+    profile parser accepts it and the device's reader accepts it, so the render
+    has to carry it. A falsy guard in the template would drop the line and
+    leave the worker on its own default instead.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(settle_tolerance=0.0), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    queueserver = rendered["services"]["queueserver"]
+    assert queueserver["environment"]["BLUESKY_SETTLE_TOLERANCE"] == "0.0"
+
+
+def test_settle_keys_stop_at_the_worker(tmp_path: Path) -> None:
+    """The bridge never drives a device, so it is handed neither key."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    _write_config(project_path)
+
+    _inject_bluesky(BlueskyConfig(settle_timeout_s=30.0, settle_tolerance=0.001), project_path)
+    config = _read_config(project_path)
+    rendered = _render_copied_compose(project_path, config)
+
+    bridge = rendered["services"]["bluesky-bridge"]["environment"] or {}
+    assert "BLUESKY_SETTLE_TIMEOUT_S" not in bridge
+    assert "BLUESKY_SETTLE_TOLERANCE" not in bridge

--- a/tests/cli/test_dispatch_network_injection.py
+++ b/tests/cli/test_dispatch_network_injection.py
@@ -32,6 +32,10 @@ from osprey.cli.build_profile import DispatchConfig
 # writer, whose style indents block sequences under their key. Any byte of
 # drift in the default (bridge) render is a regression, not a refresh: the
 # axis is opt-in and unset means unchanged.
+#
+# ``max_turns`` sits in the worker's block beside the two clock budgets and is
+# written on every deploy exactly as they are, so it belongs in the pinned
+# bytes rather than in an exception beside them.
 PRE_AXIS_CONFIG_YML = """\
 deployed_services:
   - postgresql
@@ -54,6 +58,7 @@ services:
     workspace_mode: isolated
     timeout_sec: 300
     inactivity_sec: 120
+    max_turns: 25
 web:
   panels:
     events:

--- a/tests/cli/test_dispatch_profile_keys.py
+++ b/tests/cli/test_dispatch_profile_keys.py
@@ -60,6 +60,7 @@ def test_every_valid_key_is_accepted_and_read() -> None:
         worker_port_base=9200,
         timeout_sec=600,
         inactivity_sec=240,
+        max_turns=40,
         facility_name="ALS",
         pv_strip_prefix="SR:",
         network="host",
@@ -76,6 +77,38 @@ def test_empty_block_still_takes_the_defaults() -> None:
     profile = _parse_profile({"name": "x", "dispatch": {}})
 
     assert profile.dispatch == DispatchConfig(triggers="")
+
+
+def test_max_turns_defaults_when_unstated() -> None:
+    """An unstated turn ceiling takes the dataclass default the worker falls back to."""
+    profile = _parse_profile({"name": "x", "dispatch": {}})
+
+    assert profile.dispatch is not None
+    assert profile.dispatch.max_turns == DispatchConfig.max_turns
+
+
+def test_max_turns_is_read_from_the_block() -> None:
+    """An authored ceiling survives parsing."""
+    profile = _parse_profile({"name": "x", "dispatch": {"max_turns": 60}})
+
+    assert profile.dispatch is not None
+    assert profile.dispatch.max_turns == 60
+
+
+@pytest.mark.parametrize("value", [0, -5, True, "abc", 2.5])
+def test_max_turns_rejects_a_value_that_is_not_a_positive_int(value: Any) -> None:
+    """The number is rendered into the worker's env, which calls ``int()`` on it.
+
+    A ceiling of zero would end every run before its first turn, and a
+    non-integer only surfaces when the worker container fails at import — long
+    after the build that accepted it.
+    """
+    with pytest.raises(BuildProfileError) as excinfo:
+        _parse_profile({"name": "x", "dispatch": {"max_turns": value}})
+
+    message = str(excinfo.value)
+    assert "dispatch.max_turns" in message
+    assert repr(value) in message
 
 
 # ── unknown keys are rejected ────────────────────────────────────────────────

--- a/tests/cli/test_explicit_config_equivalence.py
+++ b/tests/cli/test_explicit_config_equivalence.py
@@ -397,6 +397,38 @@ def _retired_upstream_link_deltas(*documents: str) -> tuple[Delta, ...]:
     )
 
 
+def _query_max_rows_deltas(*documents: str) -> tuple[Delta, ...]:
+    """The middle-layer SQL row cap the presets now state.
+
+    ``run_sql`` capped its answer at a number fixed in the tool, so a facility
+    could not decide how much of its channel table was worth a turn of the
+    agent's context. The cap is now ``channel_finder.query_max_rows``, stated at
+    its previous value in the two presets that carry a ``channel_finder`` block,
+    so every document they render gains the leaf. The fixtures were frozen
+    before the key existed, which is why it reads as a difference here rather
+    than as a render that changed.
+
+    ``hello-world`` and ``ariel-standalone`` name no ``channel_finder`` block
+    and gain nothing, so their cells are absent below.
+
+    Args:
+        documents: The rendered documents the cell emits, ``root`` plus one per
+            persona.
+
+    Returns:
+        One delta per document.
+    """
+    return tuple(
+        Delta(
+            document=document,
+            path="channel_finder.query_max_rows",
+            fixture=ABSENT,
+            live=500,
+        )
+        for document in documents
+    )
+
+
 def _dispatch_max_turns_deltas() -> tuple[Delta, ...]:
     """The dispatch worker's turn ceiling, now written into its service block.
 
@@ -450,31 +482,38 @@ CELL_DELTAS: dict[str, tuple[Delta, ...]] = {
     + _rail_tool_deltas("root")
     + _retired_upstream_link_deltas("root"),
     "channel-finder-standalone/in_context": _standalone_catalog_delta()
-    + _retired_upstream_link_deltas("root"),
+    + _retired_upstream_link_deltas("root")
+    + _query_max_rows_deltas("root"),
     "channel-finder-standalone/hierarchical": _standalone_catalog_delta()
-    + _retired_upstream_link_deltas("root"),
+    + _retired_upstream_link_deltas("root")
+    + _query_max_rows_deltas("root"),
     "channel-finder-standalone/middle_layer": _standalone_catalog_delta()
-    + _retired_upstream_link_deltas("root"),
+    + _retired_upstream_link_deltas("root")
+    + _query_max_rows_deltas("root"),
     "control-assistant/in_context": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _dispatch_max_turns_deltas(),
+    + _dispatch_max_turns_deltas()
+    + _query_max_rows_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/hierarchical": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _dispatch_max_turns_deltas(),
+    + _dispatch_max_turns_deltas()
+    + _query_max_rows_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/middle_layer": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _dispatch_max_turns_deltas(),
+    + _dispatch_max_turns_deltas()
+    + _query_max_rows_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/graph": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _dispatch_max_turns_deltas(),
+    + _dispatch_max_turns_deltas()
+    + _query_max_rows_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
 }
 
 

--- a/tests/cli/test_explicit_config_equivalence.py
+++ b/tests/cli/test_explicit_config_equivalence.py
@@ -397,6 +397,33 @@ def _retired_upstream_link_deltas(*documents: str) -> tuple[Delta, ...]:
     )
 
 
+def _dispatch_max_turns_deltas() -> tuple[Delta, ...]:
+    """The dispatch worker's turn ceiling, now written into its service block.
+
+    How many agentic turns one dispatched run may take was a literal in the
+    worker's request model, so a facility could set the two clock budgets and
+    not this one. ``dispatch.max_turns`` is the third budget, and the build
+    writes it into ``services.dispatch_worker`` beside ``timeout_sec`` and
+    ``inactivity_sec`` on every deploy. The fixtures were frozen before the key
+    existed, and only the root document carries a service block, so this is one
+    delta rather than one per persona.
+
+    Only ``control-assistant`` deploys a dispatch worker; the other presets gain
+    nothing and are absent below.
+
+    Returns:
+        The single root-document delta.
+    """
+    return (
+        Delta(
+            document="root",
+            path="services.dispatch_worker.max_turns",
+            fixture=ABSENT,
+            live=25,
+        ),
+    )
+
+
 #: The documents a control-assistant cell renders: the root config plus one per
 #: persona in the preset's roster.
 _CONTROL_ASSISTANT_DOCUMENTS = (
@@ -431,19 +458,23 @@ CELL_DELTAS: dict[str, tuple[Delta, ...]] = {
     "control-assistant/in_context": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _dispatch_max_turns_deltas(),
     "control-assistant/hierarchical": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _dispatch_max_turns_deltas(),
     "control-assistant/middle_layer": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _dispatch_max_turns_deltas(),
     "control-assistant/graph": _control_assistant_persona_deltas()
     + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
     + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
-    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _retired_upstream_link_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _dispatch_max_turns_deltas(),
 }
 
 

--- a/tests/cli/test_explicit_config_partition.py
+++ b/tests/cli/test_explicit_config_partition.py
@@ -265,10 +265,12 @@ def test_root_render_is_partitioned_between_its_sources(
     # fixtures were frozen before: hello-world gains `hooks.debug: false`,
     # which the old template shipped commented out; every preset that spells an
     # ARIEL approval policy gains `approval.tools.entry_publish`, the logbook
-    # write-through that was gated nowhere when the freeze ran; and every
-    # preset that names its approval policy tool by tool gains the three
-    # panel-rail verbs, which decide what an operator can launch at all and
-    # were likewise gated nowhere then.
+    # write-through that was gated nowhere when the freeze ran; every preset
+    # that names its approval policy tool by tool gains the three panel-rail
+    # verbs, which decide what an operator can launch at all and were likewise
+    # gated nowhere then; and every preset that carries a `channel_finder`
+    # block gains `channel_finder.query_max_rows`, the middle-layer SQL row
+    # cap, which was a number fixed in the tool.
     missing = set(config) - set(render)
     expected_gain = {"hooks.debug"} if preset == "hello-world" else set()
     if "approval.tools.entry_publish" in config:
@@ -276,6 +278,8 @@ def test_root_render_is_partitioned_between_its_sources(
     for tool in ("add_panel_to_rail", "remove_panel_from_rail", "register_panel"):
         if f"approval.tools.{tool}" in config:
             expected_gain = expected_gain | {f"approval.tools.{tool}"}
+    if "channel_finder.query_max_rows" in config:
+        expected_gain = expected_gain | {"channel_finder.query_max_rows"}
     assert missing == expected_gain, (
         f"{directory}: preset keys absent from the render: {sorted(missing)}"
     )

--- a/tests/cli/test_http_axis_schema.py
+++ b/tests/cli/test_http_axis_schema.py
@@ -1,0 +1,137 @@
+"""Tests for the ``http:`` axis on the build-profile surface.
+
+A deployment's own service is one the framework has never heard of, so nothing
+in it can say whether the port that service publishes answers HTTP.
+``services.<name>.config.http`` is the service saying so, and the only thing it
+changes is whether the deploy summary prints an address an operator can click.
+
+Both authoring surfaces are exercised, as for the ``network:`` axis: the
+``services:`` block and the dotted ``config:`` overrides reach the same key in
+the rendered ``config.yml``, so a rule catching only one would be trivially
+bypassable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from osprey.cli.build_profile import BuildProfile, ServiceDef, _parse_profile
+from osprey.cli.build_profile_schema import DEFAULT_SPEAKS_HTTP, http_errors
+from osprey.errors import BuildProfileError
+
+
+@pytest.fixture(autouse=True)
+def _facility_data_tree(tmp_path: Path) -> None:
+    """The tree every profile's ``data:`` key names, beside the profile."""
+    (tmp_path / "data").mkdir(exist_ok=True)
+
+
+def _errors(profile: BuildProfile, profile_dir: Path) -> list[str]:
+    """Validate ``profile`` and return the individual accumulated failures."""
+    with pytest.raises(BuildProfileError) as exc:
+        profile.validate(profile_dir)
+    header, _, body = str(exc.value).partition(":\n  - ")
+    assert header == "Build profile validation failed"
+    return body.split("\n  - ")
+
+
+def _http_errors(profile: BuildProfile, profile_dir: Path) -> list[str]:
+    """Return only the failures that mention an ``http`` key."""
+    return [e for e in _errors(profile, profile_dir) if ".http" in e]
+
+
+def _profile(**raw: Any) -> BuildProfile:
+    """Parse a profile from the YAML surface, filling in the required name."""
+    return _parse_profile({"name": "httpaxis", "data": "data", **raw})
+
+
+# --- the accessor ---------------------------------------------------------
+
+
+def test_the_default_is_off() -> None:
+    """A binary-protocol service shown as a link is worse than no link."""
+    assert DEFAULT_SPEAKS_HTTP is False
+    assert ServiceDef(template="services/facility-mcp").speaks_http() is False
+    assert ServiceDef(template="services/facility-mcp", config={}).speaks_http() is False
+
+
+def test_a_declared_service_says_so() -> None:
+    """``speaks_http()`` is the single place the axis default is applied."""
+    service = ServiceDef(template="services/facility-mcp", config={"http": True})
+
+    assert service.speaks_http() is True
+
+
+def test_an_explicit_false_reads_as_the_default() -> None:
+    assert (
+        ServiceDef(template="services/facility-mcp", config={"http": False}).speaks_http() is False
+    )
+
+
+def test_a_non_boolean_reads_as_the_default_rather_than_being_coerced() -> None:
+    """A profile that never validated must not produce a link that cannot open."""
+    assert (
+        ServiceDef(template="services/facility-mcp", config={"http": "yes"}).speaks_http() is False
+    )
+
+
+# --- the shared checker ---------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_both_booleans_pass_the_shared_checker(value: bool) -> None:
+    assert http_errors(value, "services.facility-mcp.http") == []
+
+
+def test_the_checker_names_the_key_and_what_the_value_means() -> None:
+    (message,) = http_errors("yes", "services.facility-mcp.http")
+
+    assert "services.facility-mcp.http" in message
+    assert "'yes'" in message
+    assert "true or false" in message
+
+
+# --- validation, both authoring surfaces ----------------------------------
+
+
+def test_a_non_boolean_in_the_services_block_is_refused(tmp_path: Path) -> None:
+    profile = _profile(
+        services={"facility-mcp": {"template": "services/facility-mcp", "config": {"http": "yes"}}}
+    )
+
+    assert _http_errors(profile, tmp_path) == [
+        "services.facility-mcp.http must be true or false — whether this service "
+        "answers HTTP on the port it publishes (got 'yes')"
+    ]
+
+
+def test_a_non_boolean_in_a_dotted_override_is_refused(tmp_path: Path) -> None:
+    profile = _profile(
+        services={"facility-mcp": {"template": "services/facility-mcp"}},
+        config={"services.facility-mcp.http": 1},
+    )
+
+    assert _http_errors(profile, tmp_path) == [
+        "services.facility-mcp.http must be true or false — whether this service "
+        "answers HTTP on the port it publishes (got 1)"
+    ]
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_a_boolean_validates_on_either_surface(tmp_path: Path, value: bool) -> None:
+    """A valid axis contributes no failure, on either surface."""
+    (tmp_path / "services" / "facility-mcp").mkdir(parents=True)
+    (tmp_path / "services" / "facility-mcp" / "docker-compose.yml.j2").write_text(
+        "services: {}\n", encoding="utf-8"
+    )
+    profile = _profile(
+        services={
+            "facility-mcp": {"template": "services/facility-mcp", "config": {"http": value}},
+        },
+        config={"services.facility-gateway.http": value},
+    )
+
+    profile.validate(tmp_path)

--- a/tests/cli/test_inject_dispatch.py
+++ b/tests/cli/test_inject_dispatch.py
@@ -157,6 +157,25 @@ def test_inject_dispatch_propagates_inactivity_sec(tmp_path: Path) -> None:
     assert dw["inactivity_sec"] == 45
 
 
+def test_inject_dispatch_propagates_max_turns(tmp_path: Path) -> None:
+    """A dispatch.max_turns lands in services.dispatch_worker so the compose
+    template can render DISPATCH_MAX_TURNS beside the two clock budgets."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    profile_dir = tmp_path / "profile"  # empty — forces bundled resolution
+    profile_dir.mkdir()
+    _write_config(project_path)
+
+    _inject_dispatch(
+        _dispatch(max_turns=60),
+        profile_dir=profile_dir,
+        project_path=project_path,
+    )
+
+    dw = _read_config(project_path)["services"]["dispatch_worker"]
+    assert dw["max_turns"] == 60
+
+
 def test_inject_dispatch_propagates_pool_limits(tmp_path: Path) -> None:
     """A non-default dispatch.max_concurrent_runs/max_queue_depth lands in triggers.yml.
 

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -76,30 +76,41 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # defaults are unchanged, and the mail default already ships blank — so a
     # rebuilt project behaves exactly as before; the advisory firing is the
     # correct signal that its rendered config really is three leaves shorter.
+    # The eighth move, and the narrowest yet: the two presets that carry a
+    # `channel_finder` block — control-assistant and channel-finder-standalone —
+    # gained `channel_finder.query_max_rows: 500`, the cap on what the
+    # middle-layer `run_sql` tool hands back. It was a number fixed in the tool,
+    # so a facility could not decide how much of its channel table was worth a
+    # turn of the agent's context. The value is the one the tool already
+    # applied, so a rebuilt project behaves identically — the digest moves
+    # because the preset now STATES it. control-assistant's six `extends`
+    # children inherit the root preset and move with it; ariel-standalone and
+    # hello-world carry no channel finder and stand still. Every other key this
+    # change added is shipped commented, and a comment is not resolved content.
     "ariel-standalone": ("sha256:389fad6bd826efc4b53ea263800110585867aab31c92d9931206897c75548643"),
     "channel-finder-standalone": (
-        "sha256:6c42cc563c637073dd76803ebfb0a371f29437747ee3b6ea701662de44bc4ca9"
+        "sha256:2dfc06f64433fcb1d8393931dccf76550e75ac76dc12f5011029010e02aa9448"
     ),
     "control-assistant": (
-        "sha256:54780712d416102f266fa303bc96fccc06db262bd70d18c9e2ef511468e8c252"
+        "sha256:ab96027bc359a067f44aa04028ebbac34358e675fca503a1d1cc4bcd790c18aa"
     ),
     "control-assistant-admin": (
-        "sha256:d5bcb632db87fbd7be5339a56be6cdca4e6c5d121a148b73b8b9d369543d2de2"
+        "sha256:cef4c0b2de1d152ef4b88d8b8cd1e31f900f4719d99c171ebecc08de3347d769"
     ),
     "control-assistant-knowledge": (
-        "sha256:11248666b3009d9d8fd3f81460dad2cfeb62e555f19fe2482dbe4876de9ef599"
+        "sha256:98cdd6a4930cf92ceaa9bc6c3e741ac51e90ca56cf86d40551e84c00e9179c20"
     ),
     "control-assistant-logbook": (
-        "sha256:67d66dbb1d476115efb91b3f444fa7b0f512e446363c4179213d1bf2fb4bf350"
+        "sha256:38483b2115bc153440dfce862c6d337b5ad6beb2addf3c1e4dc6c57f1efdf2ce"
     ),
     "control-assistant-readonly": (
-        "sha256:4b9b2fa8c40c1fa9e0eed6eb27f9e6ef181cd0b03c15b93cb99c0db895e5d6ec"
+        "sha256:c89b22d754632805e7cdb8b3026bdaf7f7d4401628904083480f4681b4a71a0f"
     ),
     "control-assistant-readwrite": (
-        "sha256:70111bf6029217c2999f7c1e98c7c43a23cd071a357962bff3530412767a2243"
+        "sha256:a4a695bbc044975ba2258a9cd58c46e283b832e2d4b9efd1720b9e1860502ba8"
     ),
     "control-assistant-va-readwrite": (
-        "sha256:b2a14f6358a6c896c84fa465bec0c472b0c0538b6f207bc06dea83c4ed7ce679"
+        "sha256:862dd6a5c5df3843c066ebdc26806c9283f75c9a658145fba1856b47d6e14ce1"
     ),
     "hello-world": ("sha256:10ce4bc73c7a244debbf355189dfbcd13feb7d31007c79e83c93aec978831b65"),
 }

--- a/tests/connectors/test_max_step_reader.py
+++ b/tests/connectors/test_max_step_reader.py
@@ -21,8 +21,10 @@ import pytest
 from osprey.connectors.control_system.base import WriteOutcome
 from osprey.connectors.control_system.epics_connector import EPICSConnector
 from osprey.connectors.control_system.limits_validator import (
+    DEFAULT_STEP_READ_TIMEOUT_SECONDS,
     ChannelLimitsConfig,
     LimitsValidator,
+    step_read_timeout_seconds,
 )
 from osprey.connectors.control_system.mock_connector import MockConnector
 from osprey.errors import ChannelLimitsViolationError
@@ -181,3 +183,70 @@ async def test_max_step_lets_a_small_step_through_on_the_simulator(monkeypatch):
     assert connector._state["SIM:CHANNEL:SP"] == 12.0
 
     await connector.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# The fresh-read budget is a connector key, not a framework constant
+#
+# How long that read takes is a property of the facility's control network —
+# a gateway two hops away answers slower than a soft IOC on this host — so it
+# is authored beside the connector's own `timeout`. Running out of budget
+# answers None, which refuses the write, so raising it buys a slow channel
+# room and never a weaker check.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "block",
+    [None, {}, {"timeout": 5.0}, {"step_read_timeout_s": 0}, {"step_read_timeout_s": "2"}],
+    ids=["absent-block", "empty", "other-keys", "zero", "string"],
+)
+def test_an_unstated_or_unusable_budget_takes_the_default(block) -> None:
+    """A typo in a tuning key must not be what takes writes down."""
+    assert step_read_timeout_seconds(block) == DEFAULT_STEP_READ_TIMEOUT_SECONDS
+
+
+def test_an_unusable_budget_is_warned_about_by_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A silent fallback leaves an operator with a key that reads as accepted."""
+    with caplog.at_level("WARNING"):
+        assert (
+            step_read_timeout_seconds({"step_read_timeout_s": -1}, "epics")
+            == DEFAULT_STEP_READ_TIMEOUT_SECONDS
+        )
+
+    assert "control_system.connector.epics.step_read_timeout_s" in caplog.text
+    assert "-1" in caplog.text
+
+
+def test_a_block_declaring_nothing_warns_about_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unset is the shipped posture, not a misconfiguration."""
+    with caplog.at_level("WARNING"):
+        step_read_timeout_seconds({"timeout": 5.0}, "epics")
+
+    assert caplog.text == ""
+
+
+def test_a_declared_budget_is_read() -> None:
+    assert step_read_timeout_seconds({"step_read_timeout_s": 0.5}) == 0.5
+    assert step_read_timeout_seconds({"step_read_timeout_s": 10}) == 10.0
+
+
+async def test_the_epics_connector_reads_with_the_budget_its_block_declares() -> None:
+    """The connector's own block is where the budget comes from."""
+    connector = EPICSConnector()
+    connector._epics = MagicMock()
+    connector._epics.caget.return_value = CURRENT
+    connector._step_read_timeout = step_read_timeout_seconds({"step_read_timeout_s": 0.5})
+
+    connector._current_value_reader()("SR:CH")
+
+    assert connector._epics.caget.call_args.kwargs["timeout"] == 0.5
+
+
+def test_an_unconnected_connector_still_has_a_budget() -> None:
+    """The reader is usable before connect, and fails closed just as quickly."""
+    assert EPICSConnector()._step_read_timeout == DEFAULT_STEP_READ_TIMEOUT_SECONDS

--- a/tests/deployment/goldens/va_single_instance/minimal.yml
+++ b/tests/deployment/goldens/va_single_instance/minimal.yml
@@ -81,6 +81,12 @@ services:
       # Passthrough from the project .env; unset -> no fault.
       VA_BPM_ERRORS: "${VA_BPM_ERRORS:-}"
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # How often the telemetry thread republishes engine values, and how much
+      # noise the synthesised channels carry. Empty means the entrypoint's own
+      # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
+      # than clamped, so a typo shows up in `docker logs`.
+      VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/deployment/goldens/va_single_instance/overridden.yml
+++ b/tests/deployment/goldens/va_single_instance/overridden.yml
@@ -83,6 +83,12 @@ services:
       # Passthrough from the project .env; unset -> no fault.
       VA_BPM_ERRORS: "${VA_BPM_ERRORS:-}"
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # How often the telemetry thread republishes engine values, and how much
+      # noise the synthesised channels carry. Empty means the entrypoint's own
+      # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
+      # than clamped, so a typo shows up in `docker logs`.
+      VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -983,6 +983,22 @@ def test_worker_template_inactivity_reflects_injected_value() -> None:
     assert 'DISPATCH_INACTIVITY_SEC: "600"' in rendered
 
 
+def test_worker_template_max_turns_defaults_to_25() -> None:
+    """With no max_turns configured the worker env pins the built-in default, so a
+    project built before the key existed still renders a number the worker reads."""
+    rendered = _render_worker_template(env_present=True)
+    assert 'DISPATCH_MAX_TURNS: "25"' in rendered
+
+
+def test_worker_template_max_turns_reflects_injected_value() -> None:
+    """A configured services.dispatch_worker.max_turns flows to DISPATCH_MAX_TURNS,
+    which is what a trigger naming no ceiling of its own is given."""
+    rendered = _render_worker_template(
+        env_present=False, project_name="p", dispatch_worker={"max_turns": 60}
+    )
+    assert 'DISPATCH_MAX_TURNS: "60"' in rendered
+
+
 def test_worker_command_unchanged() -> None:
     """The worker overrides only ``command:`` — it must still launch the
     dispatch-worker MCP server, unchanged by the image/layout repoint."""

--- a/tests/deployment/test_container_lifecycle.py
+++ b/tests/deployment/test_container_lifecycle.py
@@ -3387,6 +3387,40 @@ def test_compression_comes_from_the_service_block_not_the_knobs(
     assert staged_archiver["seeded"][0]["kwargs"]["compression"] == expected
 
 
+def test_the_graph_store_wait_outlasts_its_own_healthcheck_start_period():
+    """The deploy's bolt wait must cover the first start the template budgets for.
+
+    The template's ``start_period`` is the container's own estimate of how long
+    a first start takes — fetch the n10s jar, initialize a fresh store, wait out
+    the JVM. The host-side wait was shorter than that, so on a first deploy it
+    gave up while the store was doing exactly what the template says it does,
+    and the corpus seed was skipped. Nothing failed: the deployment came up with
+    an empty graph, which reads as a store nobody seeded rather than a wait that
+    was too short. Pinned as a pair, because either number alone looks fine.
+    """
+    import re
+
+    import osprey
+
+    template = (
+        Path(osprey.__file__).parent
+        / "templates"
+        / "services"
+        / "graphdb"
+        / "docker-compose.yml.j2"
+    ).read_text(encoding="utf-8")
+
+    match = re.search(r"start_period:\s*(\d+)s", template)
+    assert match, "no healthcheck start_period found in the graphdb template"
+    start_period_s = float(match.group(1))
+
+    assert start_period_s < container_lifecycle._GRAPHDB_HEALTH_TIMEOUT_S, (
+        f"the bolt wait ({container_lifecycle._GRAPHDB_HEALTH_TIMEOUT_S}s) must outlast the "
+        f"store's own healthcheck start_period ({start_period_s}s), or a first deploy "
+        f"gives up on a container that is still coming up and skips the corpus seed"
+    )
+
+
 def test_the_auth_grace_sits_between_the_healthcheck_and_the_reachability_budget():
     """The 15/45/180 ordering documented at ``_ARCHIVER_AUTH_GRACE_S`` IS the design.
 

--- a/tests/deployment/test_deploy_summary.py
+++ b/tests/deployment/test_deploy_summary.py
@@ -1476,3 +1476,141 @@ def test_shared_cards_are_reported_only_while_a_wall_stands():
     URL, shared or not — so naming it would be noise."""
     assert deploy_summary._shared_cards(_walled_roster_config("token")) == []
     assert deploy_summary._shared_cards(_walled_roster_config("oidc")) == ["ops"]
+
+
+# ---------------------------------------------------------------------------
+# A facility's own service saying it answers HTTP
+#
+# The framework recognises its own services by name, which is exactly what it
+# cannot do for a service a deployment brought with it. `services.<name>.http`
+# is that service saying so, and the only thing it changes is whether the
+# summary prints an address an operator can click.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def facility_service_compose(tmp_path):
+    """A compose file publishing one service the framework has never heard of."""
+    path = tmp_path / "facility-compose.yml"
+    path.write_text(
+        """
+services:
+  facility-mcp:
+    ports:
+      - "127.0.0.1:10900:10900"
+  facility-gateway:
+    ports:
+      - "127.0.0.1:10901:10901"
+""",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def test_a_declared_facility_service_renders_as_a_link(facility_service_compose):
+    """`http: true` is what turns a bare address into one a browser can open."""
+    config = {
+        "project_name": "demo",
+        "services": {"facility-mcp": {"http": True}},
+    }
+
+    text = deploy_summary.format_endpoint_summary(config, [facility_service_compose])
+
+    assert "http://127.0.0.1:10900" in text
+
+
+def test_an_undeclared_facility_service_stays_a_bare_address(facility_service_compose):
+    """Default off: a binary-protocol service must never be shown as a link."""
+    config = {"project_name": "demo", "services": {"facility-gateway": {}}}
+
+    text = deploy_summary.format_endpoint_summary(config, [facility_service_compose])
+
+    assert "127.0.0.1:10901" in text
+    assert "http://127.0.0.1:10901" not in text
+
+
+def test_http_false_is_honoured_like_an_absent_key(facility_service_compose):
+    """An explicit `false` says the same thing as saying nothing."""
+    config = {"project_name": "demo", "services": {"facility-mcp": {"http": False}}}
+
+    text = deploy_summary.format_endpoint_summary(config, [facility_service_compose])
+
+    assert "http://127.0.0.1:10900" not in text
+
+
+def test_a_non_boolean_declaration_does_not_produce_a_link(facility_service_compose):
+    """A profile that never validated must not hand out a dead link."""
+    config = {"project_name": "demo", "services": {"facility-mcp": {"http": "yes"}}}
+
+    text = deploy_summary.format_endpoint_summary(config, [facility_service_compose])
+
+    assert "http://127.0.0.1:10900" not in text
+
+
+def test_a_declaration_cannot_relabel_a_multi_port_services_binary_port(tmp_path):
+    """Per-port roles win: bolt stays bolt however the config is written.
+
+    The graph store's two ports are described by role, and prefixing bolt with
+    `http://` would hand the operator a link that cannot open — which is the
+    whole reason the roles table exists.
+    """
+    path = tmp_path / "graphdb-compose.yml"
+    path.write_text(
+        """
+services:
+  graphdb:
+    ports:
+      - "127.0.0.1:10802:7687"
+      - "127.0.0.1:10803:7474"
+""",
+        encoding="utf-8",
+    )
+    config = {"project_name": "demo", "services": {"graphdb": {"http": True}}}
+
+    text = deploy_summary.format_endpoint_summary(config, [str(path)])
+
+    assert "bolt 127.0.0.1:10802" in text
+    assert "http://127.0.0.1:10802" not in text
+    assert "browser http://127.0.0.1:10803" in text
+
+
+def test_a_declared_service_survives_the_card_filter(facility_service_compose):
+    """The rows the deploy card carries are the ones the summary built.
+
+    ``as_built_endpoint_entries`` is ``endpoint_entries`` plus the file lookup,
+    and the card reads its ``(tier, service, address)`` triples straight
+    through — so what has to hold is that the declaration reaches the address in
+    the row, not only the printed text.
+    """
+    config = {"project_name": "demo", "services": {"facility-mcp": {"http": True}}}
+
+    entries = deploy_summary.endpoint_entries(config, [facility_service_compose])
+
+    addresses = {service: address for _tier, service, address in entries}
+    assert addresses["facility-mcp"] == "http://127.0.0.1:10900"
+    assert addresses["facility-gateway"] == "127.0.0.1:10901"
+
+
+def test_the_declared_set_is_the_schema_accessor_applied_per_block():
+    """One spelling of the axis default: the summary asks the schema, not the key.
+
+    ``ServiceDef.speaks_http()`` is where the ``http:`` default lives. A second
+    reading of the key here would be a second place it lives, and the two would
+    drift the first time the axis grew a shape one of them did not know about.
+    """
+    from osprey.cli.build_profile_schema import ServiceDef
+
+    blocks = {
+        "declared": {"http": True},
+        "refused": {"http": False},
+        "silent": {},
+        "malformed": {"http": "yes"},
+    }
+
+    declared = deploy_summary._declared_http_services({"services": blocks})
+
+    assert declared == {
+        name
+        for name, block in blocks.items()
+        if ServiceDef(template="", config=block).speaks_http()
+    }

--- a/tests/deployment/test_graphdb_service_config.py
+++ b/tests/deployment/test_graphdb_service_config.py
@@ -10,6 +10,7 @@ from osprey.deployment.graphdb_service import (
     CONTAINER_BOLT_PORT,
     CONTAINER_HTTP_PORT,
     DEFAULT_BIND_ADDRESS,
+    DEFAULT_DATABASE,
     DEFAULT_HEAP_INITIAL_SIZE,
     DEFAULT_HEAP_MAX_SIZE,
     DEFAULT_HTTP_PORT,
@@ -497,6 +498,31 @@ class TestConnectionPrecedence:
     def test_connection_blank_username_raises(self, bad: object) -> None:
         with pytest.raises(ValueError, match=r"services\.graphdb\.username"):
             resolve_graphdb_connection({"uri": "bolt://graph.example.org:7687", "username": bad})
+
+    def test_connection_database_defaults_to_the_one_the_shipped_image_serves(self) -> None:
+        """No key, and every session opens against the database OSPREY's own store has."""
+        assert resolve_graphdb_connection({}).database == DEFAULT_DATABASE
+        assert (
+            resolve_graphdb_connection({"uri": "bolt://graph.example.org:7687"}).database
+            == DEFAULT_DATABASE
+        )
+
+    def test_connection_database_is_read_from_the_block(self) -> None:
+        """A facility whose cluster keeps the corpus elsewhere names it once."""
+        resolved = resolve_graphdb_connection(
+            {"uri": "bolt://graph.example.org:7687", "database": "facility"}
+        )
+        assert resolved.database == "facility"
+
+    def test_connection_database_reaches_a_derived_address_too(self) -> None:
+        """The key is about the store, not about how its address was arrived at."""
+        assert resolve_graphdb_connection({"database": "facility"}).database == "facility"
+
+    @pytest.mark.parametrize("bad", ["", "   ", 4, True])
+    def test_connection_blank_database_raises(self, bad: object) -> None:
+        """A half-finished edit refuses rather than silently opening ``neo4j``."""
+        with pytest.raises(ValueError, match=r"services\.graphdb\.database"):
+            resolve_graphdb_connection({"database": bad})
 
     @pytest.mark.parametrize(
         "section",

--- a/tests/deployment/test_qmd_compose_fragment.py
+++ b/tests/deployment/test_qmd_compose_fragment.py
@@ -463,6 +463,22 @@ def test_sweep_interval_default_tracks_the_schema_module():
     )
 
 
+def test_first_index_grace_renders_as_the_healthcheck_start_period():
+    """The grace period is the healthcheck's `start_period`, in seconds."""
+    service = compose_service(qmd={"first_index_grace": 14400})
+
+    assert service["healthcheck"]["start_period"] == "14400s"
+
+
+def test_first_index_grace_default_tracks_the_schema_module():
+    """Unstated, the template renders the module's own default rather than a literal."""
+    from osprey.deployment.qmd_service import DEFAULT_FIRST_INDEX_GRACE_SECONDS
+
+    assert compose_service()["healthcheck"]["start_period"] == (
+        f"{DEFAULT_FIRST_INDEX_GRACE_SECONDS}s"
+    )
+
+
 def test_container_name_is_namespaced_per_project():
     """``container_name`` is a host-global docker identifier: two projects
     deploying a sidecar on one host must not collide on one name."""

--- a/tests/deployment/test_qmd_service_config.py
+++ b/tests/deployment/test_qmd_service_config.py
@@ -8,6 +8,7 @@ from osprey.deployment.errors import DeploymentPreconditionError
 from osprey.deployment.host_ports import _SERVICE_REMEDY_KEYS
 from osprey.deployment.qmd_service import (
     DEFAULT_BIND_ADDRESS,
+    DEFAULT_FIRST_INDEX_GRACE_SECONDS,
     DEFAULT_INTERVAL_SECONDS,
     DEFAULT_PORT,
     MODEL_FILENAMES,
@@ -65,6 +66,18 @@ class TestDefaults:
         assert (resolved.port, resolved.interval_seconds) == (9999, 300)
         assert resolved.bind_address == "0.0.0.0"
 
+    def test_first_index_grace_defaults(self) -> None:
+        """An unstated grace period keeps the number the template has always used."""
+        resolved = resolve_qmd_service_config({"services": {"qmd": {}}})
+        assert resolved is not None
+        assert resolved.first_index_grace_seconds == DEFAULT_FIRST_INDEX_GRACE_SECONDS
+
+    def test_first_index_grace_is_read(self) -> None:
+        """A facility whose corpus takes longer than an hour to index says so."""
+        resolved = resolve_qmd_service_config({"services": {"qmd": {"first_index_grace": 14400}}})
+        assert resolved is not None
+        assert resolved.first_index_grace_seconds == 14400
+
 
 class TestBindAddress:
     """``bind_address`` is project-wide, never a per-service key."""
@@ -113,6 +126,12 @@ class TestValidation:
     def test_bad_interval_raises(self, bad: object) -> None:
         with pytest.raises(ValueError, match=r"services\.qmd\.interval"):
             resolve_qmd_service_config({"services": {"qmd": {"interval": bad}}})
+
+    @pytest.mark.parametrize("bad", [0, -30, "3600", 3600.0, True])
+    def test_bad_first_index_grace_raises(self, bad: object) -> None:
+        """A zero or malformed grace period would fail the container on first boot."""
+        with pytest.raises(ValueError, match=r"services\.qmd\.first_index_grace"):
+            resolve_qmd_service_config({"services": {"qmd": {"first_index_grace": bad}}})
 
 
 class TestBaseUrl:

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -2636,6 +2636,7 @@ _AUTH_CODES = frozenset(
         "web_terminals.auth_insecure_http",
         "web_terminals.auth_oidc_missing_issuer",
         "web_terminals.auth_oidc_invalid_client_env",
+        "web_terminals.auth_oidc_invalid_scopes",
         "web_terminals.auth_oidc_unresolvable_origin",
         "web_terminals.auth_oidc_subject_unsafe",
         "web_terminals.auth_credential_collision",
@@ -3228,6 +3229,58 @@ def test_lint_auth_oidc_non_string_client_secret_env_is_an_error() -> None:
     errors = _errors(findings)
     assert any(f.code == "web_terminals.auth_oidc_invalid_client_env" for f in errors)
     assert any("client_secret_env" in f.message for f in errors)
+
+
+def test_lint_auth_oidc_omitted_scopes_report_no_error() -> None:
+    """The sidecar ships `openid profile email`, so omitting the key is valid."""
+    # Arrange
+    config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_oidc_invalid_scopes" for f in _errors(findings))
+
+
+@pytest.mark.parametrize(
+    "scopes",
+    [["openid", 3], {"openid": True}, [], "   ", 7],
+    ids=["list-with-a-non-string", "mapping", "empty-list", "blank-string", "number"],
+)
+def test_lint_auth_oidc_unreadable_scopes_are_an_error(scopes: object) -> None:
+    """Render emits no scopes line for these, so what was authored never ships."""
+    # Arrange
+    config = _auth_config(
+        {"method": "oidc", "oidc": {"issuer": "https://idp.example.org", "scopes": scopes}}
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _errors(findings)
+    assert any(f.code == "web_terminals.auth_oidc_invalid_scopes" for f in errors)
+    assert any("auth.oidc.scopes" in f.message for f in errors)
+
+
+@pytest.mark.parametrize(
+    "scopes",
+    [["openid", "profile"], "openid profile", ["openid"]],
+    ids=["list", "joined-string", "one-scope"],
+)
+def test_lint_auth_oidc_readable_scopes_report_no_error(scopes: object) -> None:
+    """Both authored shapes reach the sidecar, so neither is a finding."""
+    # Arrange
+    config = _auth_config(
+        {"method": "oidc", "oidc": {"issuer": "https://idp.example.org", "scopes": scopes}}
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    assert not any(f.code == "web_terminals.auth_oidc_invalid_scopes" for f in _errors(findings))
 
 
 def test_lint_auth_oidc_without_deploy_fqdn_is_an_error() -> None:

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import re
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -3636,6 +3637,59 @@ def test_auth_context_reads_the_oidc_claim_and_leaves_it_none_when_unusable() ->
         ]
         is None
     )
+
+
+def test_auth_context_reads_the_oidc_scopes_and_leaves_them_none_when_unusable() -> None:
+    """A list, or a pre-joined string, becomes the space-separated OAuth spelling.
+
+    Anything unusable — absent, empty, wrong-typed — resolves to None, which is
+    what makes the sidecar's own default list apply instead of this renderer
+    restating it.
+    """
+
+    # Arrange
+    def _with(oidc: dict[str, Any]) -> dict[str, Any]:
+        web_terminals = copy.deepcopy(_MULTI_USER_CONFIG)["modules"]["web_terminals"]
+        web_terminals["auth"] = {"method": "oidc", "oidc": oidc}
+        return web_terminals
+
+    # Act / Assert
+    assert (
+        _auth_tls_context(_with({"scopes": ["openid", "profile", "groups"]}))["auth_oidc_scopes"]
+        == "openid profile groups"
+    )
+    assert (
+        _auth_tls_context(_with({"scopes": "openid  groups"}))["auth_oidc_scopes"]
+        == "openid groups"
+    )
+    assert _auth_tls_context(_with({"scopes": []}))["auth_oidc_scopes"] is None
+    assert _auth_tls_context(_with({"scopes": {"openid": True}}))["auth_oidc_scopes"] is None
+    assert _auth_tls_context(_with({}))["auth_oidc_scopes"] is None
+
+
+def test_authored_oidc_scopes_reach_the_sidecar_service() -> None:
+    """The authored list renders as one env line the sidecar reads."""
+    # Act
+    auth_env = _compose(
+        _auth_config(
+            method="oidc",
+            oidc={"issuer": "https://sso.example.org", "scopes": ["openid", "profile", "groups"]},
+        )
+    )["services"]["auth"]["environment"]
+
+    # Assert
+    assert "OSPREY_AUTH_OIDC_SCOPES=openid profile groups" in auth_env
+
+
+def test_unauthored_oidc_scopes_render_no_env_line() -> None:
+    """With no list authored the sidecar's own default is the only default."""
+    # Act
+    auth_env = _compose(_auth_config(method="oidc", oidc={"issuer": "https://sso.example.org"}))[
+        "services"
+    ]["auth"]["environment"]
+
+    # Assert
+    assert not any(str(entry).startswith("OSPREY_AUTH_OIDC_SCOPES=") for entry in auth_env)
 
 
 def test_auth_sidecar_service_healthcheck_probes_its_own_health_route() -> None:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -873,6 +873,9 @@ config:
   # GRAPHDB_PASSWORD in this repo's .env yourself.
   # services.graphdb.uri: bolt://graph.example.org:7687
   # services.graphdb.username: neo4j
+  # Which database on that store holds the corpus. The store this deployment
+  # runs serves exactly one, called `neo4j`; a cluster of your own may not.
+  # services.graphdb.database: neo4j
   # Which declared services `osprey up` launches. qmd and graphdb each go
   # together with their `services.<name>.*` keys above: remove both or neither.
   deployed_services:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -902,6 +902,11 @@ config:
   # thing that stops it. `host` has no env override.
   artifact_server.host: 127.0.0.1
   artifact_server.auto_launch: true
+  # Largest timeseries data file the gallery will chart or tabulate, in MB.
+  # The handler loads the whole file to build the view, so raising this spends
+  # memory on the machine serving the gallery. Over the cap the browser views
+  # refuse with a 413; the file itself stays downloadable either way.
+  # artifact_server.max_timeseries_file_mb: 200
   # Extra artifact categories on top of the ones the gallery ships, so a badge
   # reads in this facility's own vocabulary. One dotted line per category, each
   # value a `label` and a `#RRGGBB` `color`. An artifact handed in under a

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -537,6 +537,10 @@ config:
   # build; `osprey channel-finder benchmark` runs it (`--queries-path FILE`
   # for another).
   channel_finder.benchmark.dataset_path: data/benchmarks/queries.json
+  # Rows one `run_sql` answer carries before it is cut. The cap is on the
+  # AGENT's context, not on DuckDB: a truncated answer says so and names this
+  # key, so the agent narrows the query rather than presenting a partial list.
+  channel_finder.query_max_rows: 500
   # osprey:panel-port channel_finder
   # The CHANNELS tab's own web server. It launches when `channel-finder` is in
   # `web_panels:` above, on this deployment's channel-finder slot;

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -843,6 +843,11 @@ config:
   # is the primary re-index trigger, so this is the ceiling on staleness.
   # Raise it on a large corpus, where a no-op sweep is not free.
   services.qmd.interval: 30
+  # How long the container's healthcheck holds off, in seconds, while the first
+  # full index is built — the sidecar does not open its port until the index
+  # exists and is non-empty, so until then it is legitimately unhealthy. Scale
+  # it with the corpus: too short reports a working container as failed.
+  # services.qmd.first_index_grace: 3600
   # Neo4j graph store holding a DISPOSABLE mirror of an RDF/Turtle corpus. The
   # TTL on disk stays the source of truth and `osprey knowledge seed-graph`
   # rebuilds the graph from it. It answers the multi-hop questions keyword and

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -682,6 +682,10 @@ config:
   ariel.enhancement_modules.semantic_processor.enabled: false
   # Token budget for each of its LLM calls.
   ariel.enhancement_modules.semantic_processor.model.max_tokens: 256
+  # How much of an entry is sent for keywords and summary. Longer entries are
+  # cut here — the cut is logged, naming the entry — so this is what a facility
+  # with long entries and a roomy context window raises.
+  # ariel.enhancement_modules.semantic_processor.max_input_chars: 8000
   # Text embedding for semantic search. Degrades gracefully when Ollama or
   # pgvector is unavailable.
   ariel.enhancement_modules.text_embedding.enabled: true

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -451,6 +451,10 @@ config:
   #
   # Channel Access timeout in seconds.
   control_system.connector.epics.timeout: 5.0
+  # How long the pre-write `max_step` check waits for a channel's present
+  # value, in seconds. Running out of budget refuses the write, so raise this
+  # for a slow gateway — it buys room, never a weaker check.
+  # control_system.connector.epics.step_read_timeout_s: 2.0
   # Write posture for the live machine. Stating it pins it: a type with its
   # own posture never falls back to the master switch.
   # control_system.connector.epics.writes_enabled: false

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -1063,6 +1063,16 @@ config:
       # Accepts login over plain HTTP, which fits 127.0.0.1 and nothing else.
       # For any reachable host, delete this line and configure tls instead.
       allow_insecure_http: true
+      # Single sign-on instead of passwords: set `method: oidc` above and give
+      # your provider's details here. `scopes` is what is asked for at the
+      # authorization endpoint — the default below suits a provider that
+      # publishes the identity claim under `profile` or `email`; add whatever
+      # scope yours publishes it under. `openid` cannot be dropped: without it
+      # the provider issues no ID token and the sidecar refuses every login.
+      #   oidc:
+      #     issuer: https://idp.example.org
+      #     claim: preferred_username
+      #     scopes: [openid, profile, email]
     # Which tier a user lands on is pinned per entry below. Single sign-on can
     # pick it instead by mapping provider groups onto declared roles — see
     # "Let single sign-on pick the tier" in the multi-user login guide.

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -698,6 +698,11 @@ config:
   ariel.enhancement_modules.text_embedding.models:
     - name: nomic-embed-text
       dimension: 768
+  # IVFFlat `lists` for the vector index, chosen when the index is created.
+  # Rule of thumb: rows/1000 for corpora up to a million entries. It cannot be
+  # derived — `osprey ariel migrate` runs against an empty table — and changing
+  # it later needs the index dropped and recreated.
+  # ariel.enhancement_modules.text_embedding.index_lists: 224
   # qmd export: one markdown file per entry into the mirror tree the sidecar
   # indexes. On for the same reason `hybrid` above is; an enabled export with
   # no mirror_path is refused at startup.

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -614,6 +614,10 @@ config:
   # opening tab, `osprey ariel search` without `--mode`, and the service API.
   # Naming a module that is off below is refused at startup.
   ariel.default_search_mode: hybrid
+  # Largest file one entry may attach, in MB. Attachments are stored as rows in
+  # the same Postgres the logbook lives in, so this number is a storage
+  # decision in both directions.
+  # ariel.attachments.max_file_mb: 10
   # Facility vocabulary: control-room shorthand ("t/s the bpm offset") mapped
   # to the words the logbook prose contains, so a search typed in shorthand
   # finds the entries about it. Plain dictionary matching, every rewrite

--- a/tests/integration/test_graph_index_parity_ties.py
+++ b/tests/integration/test_graph_index_parity_ties.py
@@ -39,6 +39,7 @@ import pytest
 
 from osprey.services.channel_finder.graph_queries import GRAPH_CHANNEL_COUNT_CYPHER
 from tests._graphdb_container import (
+    GRAPHDB_TEST_DATABASE,
     GRAPHDB_TEST_PASSWORD,
     GRAPHDB_TEST_USERNAME,
     graphdb_store,
@@ -147,7 +148,9 @@ def _session(uri: str) -> Iterator[Any]:
     """A driver session on *uri*, closed with the block."""
     from osprey.services.facility_knowledge.seeder import graph_seeder
 
-    with graph_seeder.open_session(uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD) as session:
+    with graph_seeder.open_session(
+        uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD, database=GRAPHDB_TEST_DATABASE
+    ) as session:
         yield session
 
 

--- a/tests/integration/test_graph_mcp.py
+++ b/tests/integration/test_graph_mcp.py
@@ -52,6 +52,7 @@ from osprey.services.channel_finder.graph_queries import (
 )
 from tests._container_support import start_or_skip, stop_quietly
 from tests._graphdb_container import (
+    GRAPHDB_TEST_DATABASE,
     GRAPHDB_TEST_PASSWORD,
     GRAPHDB_TEST_USERNAME,
     NEO4J_IMAGE,
@@ -157,7 +158,10 @@ def _seeded_store(plugin_dir: Path, ttl_text: str, label: str) -> Iterator[str]:
         from osprey.services.facility_knowledge.seeder import graph_seeder
 
         with graph_seeder.open_session(
-            uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD
+            uri,
+            GRAPHDB_TEST_USERNAME,
+            GRAPHDB_TEST_PASSWORD,
+            database=GRAPHDB_TEST_DATABASE,
         ) as session:
             bootstrap = graph_seeder.bootstrap(session)
             assert bootstrap.ok, bootstrap.message
@@ -342,7 +346,9 @@ def _store_state(uri: str) -> tuple[int, str | None]:
     """Read the store's corpus size and seed marker straight off the driver."""
     from osprey.services.facility_knowledge.seeder import graph_seeder
 
-    with graph_seeder.open_session(uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD) as session:
+    with graph_seeder.open_session(
+        uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD, database=GRAPHDB_TEST_DATABASE
+    ) as session:
         return graph_seeder.resource_count(session), graph_seeder.read_marker(session)
 
 

--- a/tests/integration/test_graphdb_store.py
+++ b/tests/integration/test_graphdb_store.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import pytest
 
 from tests._graphdb_container import (
+    GRAPHDB_TEST_DATABASE,
     GRAPHDB_TEST_PASSWORD,
     GRAPHDB_TEST_USERNAME,
     graphdb_store,
@@ -176,7 +177,10 @@ def test_bootstrap_seed_and_force_reseed(graphdb_uri: str, demo_ttl: str) -> Non
     expected_sha = graph_seeder.ttl_sha256(demo_ttl)
 
     with graph_seeder.open_session(
-        graphdb_uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD
+        graphdb_uri,
+        GRAPHDB_TEST_USERNAME,
+        GRAPHDB_TEST_PASSWORD,
+        database=GRAPHDB_TEST_DATABASE,
     ) as session:
         # --- 1. Bootstrap a fresh store -------------------------------------
         first = graph_seeder.bootstrap(session)

--- a/tests/interfaces/artifacts/test_timeseries_api.py
+++ b/tests/interfaces/artifacts/test_timeseries_api.py
@@ -11,6 +11,8 @@ import math
 
 import pytest
 
+from osprey.interfaces.artifacts import app as artifacts_app
+
 
 def _write_artifact(store, workspace_root, payload, filename, title):
     """Write ``payload`` as an artifact's data file and register the entry."""
@@ -526,7 +528,9 @@ class TestDataFileResolution:
     def test_oversized_data_file_returns_413(self, app_client, monkeypatch):
         """A data file over the size cap is refused with 413 rather than
         parsed; the cap protects the gallery process, not the client."""
-        monkeypatch.setattr("osprey.interfaces.artifacts.app.MAX_TIMESERIES_FILE_BYTES", 64)
+        monkeypatch.setattr(
+            "osprey.interfaces.artifacts.app._max_timeseries_file_bytes", lambda: 64
+        )
         client, workspace = app_client
         store = client.app.state.artifact_store
         entry, _ = _make_timeseries_artifact(store, workspace, n_rows=50)
@@ -539,6 +543,46 @@ class TestDataFileResolution:
         # (no format param) still streams the file bytes.
         raw = client.get(f"/api/artifacts/{entry.id}/data")
         assert raw.status_code == 200
+
+
+class TestTheTimeseriesSizeCapIsAConfigKey:
+    """``artifact_server.max_timeseries_file_mb``: default, override, refusal.
+
+    The handler loads the whole file to build a chart or a table, so this bound
+    is about the gallery host's memory. It is a facility's to set, and the
+    reader is what decides how far a value gets.
+    """
+
+    @pytest.mark.unit
+    def test_default_when_no_config_is_primed(self, monkeypatch):
+        """A standalone gallery reads no config and still has a bound."""
+        monkeypatch.setattr(
+            "osprey.utils.config.get_config_value",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no config")),
+        )
+
+        assert (
+            artifacts_app._max_timeseries_file_bytes()
+            == artifacts_app.DEFAULT_MAX_TIMESERIES_FILE_MB * 1024 * 1024
+        )
+
+    @pytest.mark.unit
+    def test_configured_value_is_read_in_megabytes(self, monkeypatch):
+        """The key is authored in MB; the handler compares bytes."""
+        monkeypatch.setattr("osprey.utils.config.get_config_value", lambda *a, **k: 500)
+
+        assert artifacts_app._max_timeseries_file_bytes() == 500 * 1024 * 1024
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", [0, -1, True, "500", None])
+    def test_an_unusable_value_falls_back_to_the_default(self, monkeypatch, bad):
+        """A nonsense cap keeps the documented bound rather than removing it."""
+        monkeypatch.setattr("osprey.utils.config.get_config_value", lambda *a, **k: bad)
+
+        assert (
+            artifacts_app._max_timeseries_file_bytes()
+            == artifacts_app.DEFAULT_MAX_TIMESERIES_FILE_MB * 1024 * 1024
+        )
 
 
 class TestArtifactTablePivotRobustness:

--- a/tests/mcp_server/channel_finder_graph/test_examples_live.py
+++ b/tests/mcp_server/channel_finder_graph/test_examples_live.py
@@ -61,6 +61,7 @@ import pytest
 
 from osprey.mcp_server.channel_finder_graph.tools.examples_data import EXAMPLE_QUERIES
 from tests._graphdb_container import (
+    GRAPHDB_TEST_DATABASE,
     GRAPHDB_TEST_PASSWORD,
     GRAPHDB_TEST_USERNAME,
     graphdb_store,
@@ -136,7 +137,9 @@ def _seed(uri: str, ttl: str, label: str) -> None:
     """
     from osprey.services.facility_knowledge.seeder import graph_seeder
 
-    with graph_seeder.open_session(uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD) as session:
+    with graph_seeder.open_session(
+        uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD, database=GRAPHDB_TEST_DATABASE
+    ) as session:
         graph_seeder.wipe(session)
 
         result = graph_seeder.bootstrap(session)

--- a/tests/mcp_server/channel_finder_middle_layer/test_run_sql.py
+++ b/tests/mcp_server/channel_finder_middle_layer/test_run_sql.py
@@ -14,6 +14,10 @@ from unittest.mock import MagicMock, patch
 import duckdb
 import pytest
 
+from osprey.mcp_server.channel_finder_middle_layer.server_context import (
+    DEFAULT_QUERY_MAX_ROWS,
+    QUERY_MAX_ROWS_CONFIG_KEY,
+)
 from tests.mcp_server.channel_finder_middle_layer.conftest import get_tool_fn
 from tests.mcp_server.conftest import assert_raises_error
 
@@ -28,12 +32,18 @@ def _make_duckdb(path, rows):
     con.close()
 
 
-def _run(sql: str, duckdb_path):
-    """Invoke the tool fn with get_cf_ml_context patched to expose duckdb_path."""
+def _run(sql: str, duckdb_path, query_max_rows: int = DEFAULT_QUERY_MAX_ROWS):
+    """Invoke the tool fn with get_cf_ml_context patched to expose duckdb_path.
+
+    ``query_max_rows`` is what the deployment's `channel_finder.query_max_rows`
+    resolved to; the default here is the context's own fallback, so a test that
+    does not care about the cap exercises the shipped one.
+    """
     from osprey.mcp_server.channel_finder_middle_layer.tools.run_sql import run_sql
 
     ctx = MagicMock()
     ctx.duckdb_path = duckdb_path
+    ctx.query_max_rows = query_max_rows
     with patch(f"{_TOOL_MODULE}.get_cf_ml_context", return_value=ctx):
         return get_tool_fn(run_sql)(sql=sql)
 
@@ -55,16 +65,56 @@ def test_query_returns_columns_rows_and_count(tmp_path):
 
 @pytest.mark.unit
 def test_query_caps_and_flags_truncation(tmp_path):
-    """More than 500 matching rows are capped at 500 and flagged truncated."""
+    """More rows than the cap are capped at it and flagged truncated.
+
+    The number comes from the deployment's `channel_finder.query_max_rows`, so
+    this reads the default rather than pinning a literal a facility may raise.
+    """
     db = tmp_path / "chan.duckdb"
-    _make_duckdb(db, [(f"PV:{i}", f"desc {i}") for i in range(600)])
+    _make_duckdb(db, [(f"PV:{i}", f"desc {i}") for i in range(DEFAULT_QUERY_MAX_ROWS + 100)])
 
     result = _run("SELECT channel_name FROM channels", str(db))
     data = json.loads(result)
 
-    assert data["row_count"] == 500
-    assert len(data["rows"]) == 500
+    assert data["row_count"] == DEFAULT_QUERY_MAX_ROWS
+    assert len(data["rows"]) == DEFAULT_QUERY_MAX_ROWS
     assert data["truncated"] is True
+
+
+@pytest.mark.unit
+def test_the_cap_is_the_configured_one(tmp_path):
+    """A facility that lowers the key gets fewer rows, not the shipped default."""
+    db = tmp_path / "chan.duckdb"
+    _make_duckdb(db, [(f"PV:{i}", f"desc {i}") for i in range(20)])
+
+    data = json.loads(_run("SELECT channel_name FROM channels", str(db), query_max_rows=5))
+
+    assert data["row_count"] == 5
+    assert data["truncated"] is True
+
+
+@pytest.mark.unit
+def test_a_truncated_answer_names_the_key_and_the_number(tmp_path):
+    """The agent is told what cut the list, so it narrows instead of guessing."""
+    db = tmp_path / "chan.duckdb"
+    _make_duckdb(db, [(f"PV:{i}", f"desc {i}") for i in range(20)])
+
+    data = json.loads(_run("SELECT channel_name FROM channels", str(db), query_max_rows=5))
+
+    guidance = " ".join(data["guidance"])
+    assert QUERY_MAX_ROWS_CONFIG_KEY in guidance
+    assert "5" in guidance
+
+
+@pytest.mark.unit
+def test_an_untruncated_answer_carries_no_guidance(tmp_path):
+    """Nothing to say when the whole result fits."""
+    db = tmp_path / "chan.duckdb"
+    _make_duckdb(db, [("PV:1", "x")])
+
+    data = json.loads(_run("SELECT channel_name FROM channels", str(db)))
+
+    assert "guidance" not in data
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/channel_finder_middle_layer/test_server_context.py
+++ b/tests/mcp_server/channel_finder_middle_layer/test_server_context.py
@@ -3,8 +3,11 @@
 import json
 
 import pytest
+import yaml
 
 from osprey.mcp_server.channel_finder_middle_layer.server_context import (
+    DEFAULT_QUERY_MAX_ROWS,
+    QUERY_MAX_ROWS_CONFIG_KEY,
     get_cf_ml_context,
     initialize_cf_ml_context,
 )
@@ -58,3 +61,39 @@ def test_registry_loads_database(tmp_path, monkeypatch):
     initialize_cf_ml_context()
     reg = get_cf_ml_context()
     assert reg.database is not None
+
+
+@pytest.mark.unit
+def test_query_max_rows_defaults_when_unset(tmp_path, monkeypatch):
+    """A config naming no cap gets the shipped one."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("{}")
+    initialize_cf_ml_context()
+
+    assert get_cf_ml_context().query_max_rows == DEFAULT_QUERY_MAX_ROWS
+
+
+@pytest.mark.unit
+def test_query_max_rows_is_read_from_the_top_level_block(tmp_path, monkeypatch):
+    """The key sits on `channel_finder`, outside the derived `pipelines` prefix."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text("channel_finder:\n  query_max_rows: 50")
+    initialize_cf_ml_context()
+
+    assert get_cf_ml_context().query_max_rows == 50
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", ["50", 0, -1, True, 1.5])
+def test_an_unusable_cap_warns_and_keeps_the_default(tmp_path, monkeypatch, caplog, bad):
+    """A typo must not leave the agent with no channel tools, so it warns."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.yml").write_text(
+        yaml.safe_dump({"channel_finder": {"query_max_rows": bad}})
+    )
+
+    with caplog.at_level("WARNING"):
+        initialize_cf_ml_context()
+
+    assert get_cf_ml_context().query_max_rows == DEFAULT_QUERY_MAX_ROWS
+    assert any(QUERY_MAX_ROWS_CONFIG_KEY in record.getMessage() for record in caplog.records)

--- a/tests/mcp_server/python_executor/test_executor_limits_target.py
+++ b/tests/mcp_server/python_executor/test_executor_limits_target.py
@@ -22,6 +22,7 @@ import pytest
 
 from osprey.mcp_server.python_executor import executor as host_executor
 from osprey_connectors import control_context
+from osprey_connectors.control_system import limits_validator
 from osprey_connectors.control_system.limits_validator import LimitsValidator
 
 pytestmark = pytest.mark.unit
@@ -170,3 +171,97 @@ class TestLoadLimitsValidator:
         monkeypatch.setattr(LimitsValidator, "from_config", boom)
 
         assert host_executor._load_limits_validator(target=None) is None
+
+
+class TestStepReadTimeout:
+    """The ``max_step`` fresh-read budget follows the same target as the policy.
+
+    The budget bounds a read the embedded policy makes before a write. It is
+    authored per connector block, beside that connector's own ``timeout``, so
+    resolving it from the deployment's baseline type would hand a run that
+    switched targets one connector's budget while its connector reads with
+    another's — the disagreement between the script's check and the connector's
+    that the key exists to prevent.
+    """
+
+    @staticmethod
+    def _config(section):
+        """Patch ``get_config_value`` to serve one ``control_system`` section."""
+
+        def get_config_value(key, default=None):
+            return section if key == "control_system" else default
+
+        return get_config_value
+
+    #: A deployment baselined on its simulator that also describes a real
+    #: machine — the shape a target switch exists for, and the one where a
+    #: baseline read and a target read disagree.
+    SWITCHABLE = {
+        "type": "virtual_accelerator",
+        "connector": {
+            "virtual_accelerator": {"step_read_timeout_s": 9.0},
+            "epics": {"step_read_timeout_s": 0.5},
+        },
+    }
+
+    def test_the_budget_comes_from_the_stamped_targets_block(self, monkeypatch):
+        """A run switched onto the live machine reads with the live block's value."""
+        monkeypatch.setattr(
+            "osprey_connectors.config.get_config_value", self._config(self.SWITCHABLE)
+        )
+
+        assert host_executor._step_read_timeout_seconds("live") == 0.5
+        assert host_executor._step_read_timeout_seconds("va") == 9.0
+
+    def test_the_baseline_reads_the_deployments_own_block(self, monkeypatch):
+        """A target that names no machine here gets the deployment-wide reading."""
+        monkeypatch.setattr(
+            "osprey_connectors.config.get_config_value", self._config(self.SWITCHABLE)
+        )
+
+        assert (
+            host_executor._step_read_timeout_seconds(host_executor.CONTROL_TARGET_BASELINE) == 9.0
+        )
+
+    def test_a_block_declaring_none_takes_the_packages_default(self, monkeypatch):
+        """A deployment that never authored the key still bounds the read."""
+        monkeypatch.setattr(
+            "osprey_connectors.config.get_config_value",
+            self._config({"type": "epics", "connector": {"epics": {}}}),
+        )
+
+        assert host_executor._step_read_timeout_seconds("live") == (
+            limits_validator.DEFAULT_STEP_READ_TIMEOUT_SECONDS
+        )
+
+    def test_a_config_that_cannot_be_read_still_bounds_the_read(self, monkeypatch):
+        """Config that will not load must not be what takes the bound off the read."""
+
+        def explode(key, default=None):
+            raise RuntimeError("no config here")
+
+        monkeypatch.setattr("osprey_connectors.config.get_config_value", explode)
+
+        assert host_executor._step_read_timeout_seconds("live") == (
+            limits_validator.DEFAULT_STEP_READ_TIMEOUT_SECONDS
+        )
+
+    def test_the_stamped_target_is_what_the_sandbox_is_built_with(self, tmp_path, monkeypatch):
+        """The run resolves the budget once, for the target it stamped.
+
+        The wiring, not the resolution: the generated source carries the number
+        the helper answered for the stamped target, so a sandbox cannot end up
+        holding a budget resolved for a machine it was not pointed at.
+        """
+        asked: list[str] = []
+
+        def fake_budget(target: str) -> float:
+            asked.append(target)
+            return 0.125
+
+        monkeypatch.setattr(host_executor, "_step_read_timeout_seconds", fake_budget)
+
+        run = _run_local(tmp_path, monkeypatch)
+
+        assert asked == ["va"]
+        assert "_step_read_timeout = 0.125" in run.script

--- a/tests/services/ariel_search/test_attachments.py
+++ b/tests/services/ariel_search/test_attachments.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from osprey.services.ariel_search import attachments as attachments_module
 from osprey.services.ariel_search.attachments import (
-    MAX_ATTACHMENT_SIZE,
+    DEFAULT_MAX_ATTACHMENT_MB,
     AttachmentValidationError,
     generate_attachment_id,
     guess_mime_type,
@@ -13,6 +14,8 @@ from osprey.services.ariel_search.attachments import (
     read_local_file,
     validate_file_size,
 )
+
+_DEFAULT_MAX_BYTES = DEFAULT_MAX_ATTACHMENT_MB * 1024 * 1024
 
 
 class TestValidateFileSize:
@@ -26,13 +29,13 @@ class TestValidateFileSize:
     @pytest.mark.unit
     def test_exact_limit(self):
         """Files at exactly the limit pass validation."""
-        validate_file_size(MAX_ATTACHMENT_SIZE, "exact.bin")
+        validate_file_size(_DEFAULT_MAX_BYTES, "exact.bin")
 
     @pytest.mark.unit
     def test_exceeds_limit(self):
         """Files over the limit raise AttachmentValidationError."""
         with pytest.raises(AttachmentValidationError, match="exceeds"):
-            validate_file_size(MAX_ATTACHMENT_SIZE + 1, "big.bin")
+            validate_file_size(_DEFAULT_MAX_BYTES + 1, "big.bin")
 
 
 class TestGuessMimeType:
@@ -107,7 +110,7 @@ class TestReadLocalFile:
     def test_oversized_file(self, tmp_path):
         """Files exceeding the size limit are rejected."""
         f = tmp_path / "huge.bin"
-        f.write_bytes(b"\x00" * (MAX_ATTACHMENT_SIZE + 1))
+        f.write_bytes(b"\x00" * (_DEFAULT_MAX_BYTES + 1))
 
         with pytest.raises(AttachmentValidationError, match="exceeds"):
             read_local_file(str(f))
@@ -161,3 +164,47 @@ class TestProcessAttachmentsForEntry:
 
         # No store calls should have been made
         mock_repo.store_attachment.assert_not_called()
+
+
+class TestTheAttachmentCapIsAConfigKey:
+    """``ariel.attachments.max_file_mb``: default, override, refusal.
+
+    Attachments are BYTEA rows in the same Postgres the logbook lives in, so
+    both directions of this number are a site storage decision.
+    """
+
+    @pytest.mark.unit
+    def test_default_when_no_config_is_primed(self, monkeypatch):
+        """A standalone ARIEL reads no config and still has a bound."""
+        monkeypatch.setattr(
+            "osprey.utils.config.get_config_value",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no config")),
+        )
+
+        assert attachments_module.max_attachment_bytes() == _DEFAULT_MAX_BYTES
+
+    @pytest.mark.unit
+    def test_configured_value_is_read_in_megabytes(self, monkeypatch):
+        """The key is authored in MB; validation compares bytes."""
+        monkeypatch.setattr("osprey.utils.config.get_config_value", lambda *a, **k: 50)
+
+        assert attachments_module.max_attachment_bytes() == 50 * 1024 * 1024
+        validate_file_size(40 * 1024 * 1024, "trace.bin")
+        with pytest.raises(AttachmentValidationError, match="exceeds"):
+            validate_file_size(50 * 1024 * 1024 + 1, "trace.bin")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad", [0, -1, True, "10", None])
+    def test_an_unusable_cap_falls_back_to_the_default(self, monkeypatch, bad):
+        """A nonsense cap keeps the documented bound rather than removing it."""
+        monkeypatch.setattr("osprey.utils.config.get_config_value", lambda *a, **k: bad)
+
+        assert attachments_module.max_attachment_bytes() == _DEFAULT_MAX_BYTES
+
+    @pytest.mark.unit
+    def test_the_refusal_names_the_configured_limit(self, monkeypatch):
+        """The operator is told the number in force, not a framework literal."""
+        monkeypatch.setattr("osprey.utils.config.get_config_value", lambda *a, **k: 50)
+
+        with pytest.raises(AttachmentValidationError, match="50 MB limit"):
+            validate_file_size(60 * 1024 * 1024, "trace.bin")

--- a/tests/services/ariel_search/test_database.py
+++ b/tests/services/ariel_search/test_database.py
@@ -193,6 +193,24 @@ class TestBaseMigration:
         migration = TextEmbeddingMigration(models=models)
         assert migration._get_models() == models
 
+    def test_text_embedding_index_lists_defaults(self) -> None:
+        """With no key the migration keeps the number it has always written."""
+        from osprey.services.ariel_search.enhancement.text_embedding.migration import (
+            DEFAULT_INDEX_LISTS,
+        )
+
+        assert TextEmbeddingMigration()._index_lists == DEFAULT_INDEX_LISTS
+
+    def test_text_embedding_index_lists_is_read(self) -> None:
+        """A facility sizes the IVFFlat index for the corpus it expects."""
+        assert TextEmbeddingMigration(index_lists=40)._index_lists == 40
+
+    @pytest.mark.parametrize("bad", [0, -1, True, "224", 2.5])
+    def test_text_embedding_index_lists_refuses_a_non_positive_int(self, bad) -> None:
+        """Refused where the operator can still see the line, naming the key."""
+        with pytest.raises(ValueError, match="index_lists"):
+            TextEmbeddingMigration(index_lists=bad)
+
 
 class TestMigrationTopologicalSort:
     """Tests for migration topological sorting (no database required)."""
@@ -512,6 +530,41 @@ class TestMigrationRunnerLogic:
 
         text_emb = next(m for m in migrations if m.name == "text_embedding")
         assert text_emb._get_models() == [("mxbai-embed-large", 1024)]
+
+    def test_get_enabled_migrations_defaults_the_index_lists(self) -> None:
+        """An unstated `index_lists` leaves the migration's own default in force."""
+        from osprey.services.ariel_search.database.migrations import MigrationRunner
+        from osprey.services.ariel_search.enhancement.text_embedding.migration import (
+            DEFAULT_INDEX_LISTS,
+        )
+
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "enhancement_modules": {"text_embedding": {"enabled": True}},
+            }
+        )
+
+        runner = MigrationRunner(pool=None, config=config)  # type: ignore[arg-type]
+        text_emb = next(m for m in runner._get_enabled_migrations() if m.name == "text_embedding")
+
+        assert text_emb._index_lists == DEFAULT_INDEX_LISTS
+
+    def test_get_enabled_migrations_passes_the_configured_index_lists(self) -> None:
+        """A facility sizing the index for its own corpus reaches the CREATE INDEX."""
+        from osprey.services.ariel_search.database.migrations import MigrationRunner
+
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "enhancement_modules": {"text_embedding": {"enabled": True, "index_lists": 40}},
+            }
+        )
+
+        runner = MigrationRunner(pool=None, config=config)  # type: ignore[arg-type]
+        text_emb = next(m for m in runner._get_enabled_migrations() if m.name == "text_embedding")
+
+        assert text_emb._index_lists == 40
 
 
 class TestRepositoryInitialization:

--- a/tests/services/ariel_search/test_semantic_processor_provider.py
+++ b/tests/services/ariel_search/test_semantic_processor_provider.py
@@ -18,6 +18,9 @@ from typing import Any
 import pytest
 
 from osprey.services.ariel_search.config import ARIELConfig
+from osprey.services.ariel_search.enhancement.semantic_processor import (
+    processor as processor_module,
+)
 from osprey.services.ariel_search.enhancement.semantic_processor.processor import (
     SemanticProcessorModule,
 )
@@ -231,3 +234,93 @@ class TestEndToEndThroughConfig:
 
         with pytest.raises(ValueError, match="semantic_processor.provider"):
             SemanticProcessorModule().configure(module_config)
+
+
+class TestTheInputBudgetIsAConfigKey:
+    """``max_input_chars``: how much of an entry reaches the model.
+
+    Long entries are common at some facilities and rare at others, and the
+    context window a provider serves is a site property too — so the slice is
+    authored rather than fixed, and a slice that happens is said out loud.
+    """
+
+    def test_default_when_the_key_is_unstated(self, provider_models) -> None:
+        module = SemanticProcessorModule()
+        module.configure(_config())
+
+        assert module._max_input_chars == processor_module.DEFAULT_MAX_INPUT_CHARS
+
+    def test_configured_value_is_read(self, provider_models) -> None:
+        module = SemanticProcessorModule()
+        module.configure(_config(max_input_chars=32000))
+
+        assert module._max_input_chars == 32000
+
+    @pytest.mark.parametrize("bad", [0, -1, True, "8000", 1.5])
+    def test_an_unusable_budget_is_refused_naming_the_key(self, provider_models, bad) -> None:
+        """Refused at configure time, where the operator can still see the line."""
+        module = SemanticProcessorModule()
+
+        with pytest.raises(ValueError, match="max_input_chars"):
+            module.configure(_config(max_input_chars=bad))
+
+    @pytest.mark.asyncio
+    async def test_the_prompt_carries_only_the_budget(self, provider_models, monkeypatch) -> None:
+        """The slice is the configured one, not a fixed 8000."""
+        module = SemanticProcessorModule()
+        module.configure(_config(max_input_chars=10))
+
+        captured: dict[str, Any] = {}
+
+        def fake_completion(message: str, model_config: Any = None) -> str:
+            captured["message"] = message
+            return '{"keywords": [], "summary": ""}'
+
+        import osprey.models.completion as completion_module
+
+        monkeypatch.setattr(completion_module, "get_chat_completion", fake_completion)
+
+        await module._process_text("x" * 50, entry_id="e-1")
+
+        assert "x" * 10 in captured["message"]
+        assert "x" * 11 not in captured["message"]
+
+    @pytest.mark.asyncio
+    async def test_a_cut_entry_is_logged_by_id(self, provider_models, monkeypatch, caplog) -> None:
+        """An operator reading the summary can tell it describes an opening."""
+        module = SemanticProcessorModule()
+        module.configure(_config(max_input_chars=10))
+
+        import osprey.models.completion as completion_module
+
+        monkeypatch.setattr(
+            completion_module,
+            "get_chat_completion",
+            lambda message, model_config=None: '{"keywords": [], "summary": ""}',
+        )
+
+        with caplog.at_level("INFO", logger="ariel"):
+            await module._process_text("x" * 50, entry_id="entry-42")
+
+        assert any("entry-42" in record.getMessage() for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_an_entry_within_the_budget_is_not_logged(
+        self, provider_models, monkeypatch, caplog
+    ) -> None:
+        """No line for the normal case, which is every entry at most sites."""
+        module = SemanticProcessorModule()
+        module.configure(_config(max_input_chars=100))
+
+        import osprey.models.completion as completion_module
+
+        monkeypatch.setattr(
+            completion_module,
+            "get_chat_completion",
+            lambda message, model_config=None: '{"keywords": [], "summary": ""}',
+        )
+
+        with caplog.at_level("INFO", logger="ariel"):
+            await module._process_text("x" * 50, entry_id="entry-42")
+
+        assert not any("entry-42" in record.getMessage() for record in caplog.records)

--- a/tests/services/auth_sidecar/test_app.py
+++ b/tests/services/auth_sidecar/test_app.py
@@ -29,7 +29,9 @@ from osprey.services.auth_sidecar import app as app_mod
 from osprey.services.auth_sidecar.app import (
     DEFAULT_OIDC_CLIENT_ID_ENV,
     DEFAULT_OIDC_CLIENT_SECRET_ENV,
+    DEFAULT_OIDC_SCOPES,
     DEFAULT_SESSION_LIFETIME,
+    ENV_OIDC_SCOPES,
     HEALTH_PATH,
     OWNER_ONLY,
     STATE_COOKIE_MAX_AGE,
@@ -1205,3 +1207,51 @@ class TestRouteExtensionPoint:
         monkeypatch.setattr(app_mod, "import_module", _raise)
         with pytest.raises(ModuleNotFoundError, match="joserfc"):
             create_app(PASSWORD_ENV)
+
+
+# ---------------------------------------------------------------------------
+# OIDC scopes: authored per deployment, with one scope that may not be dropped.
+# ---------------------------------------------------------------------------
+
+
+def test_oidc_scopes_default_when_the_env_names_none() -> None:
+    """No env line means the sidecar's own list, which is the only default."""
+    settings = AuthSettings.from_env(OIDC_ENV)
+
+    assert settings.oidc_scopes == DEFAULT_OIDC_SCOPES
+
+
+def test_oidc_scopes_are_read_as_the_space_separated_list_oauth_spells() -> None:
+    """The env carries one string; the settings carry the scopes it names."""
+    settings = AuthSettings.from_env(
+        dict(OIDC_ENV, OSPREY_AUTH_OIDC_SCOPES="openid  profile groups")
+    )
+
+    assert settings.oidc_scopes == ("openid", "profile", "groups")
+
+
+def test_a_scope_list_without_openid_takes_the_sidecar_down() -> None:
+    """Refused, not repaired: without `openid` there is no ID token to check.
+
+    Reported under the env var's own name, so the operator is sent to the line
+    they have to fix rather than to a generic misconfiguration.
+    """
+    settings = AuthSettings.from_env(dict(OIDC_ENV, OSPREY_AUTH_OIDC_SCOPES="profile email"))
+
+    assert ENV_OIDC_SCOPES in settings.missing_requirements()
+    assert not settings.configured
+
+
+def test_a_scope_list_keeping_openid_serves() -> None:
+    """The same deployment with `openid` back in the list is servable."""
+    settings = AuthSettings.from_env(dict(OIDC_ENV, OSPREY_AUTH_OIDC_SCOPES="openid groups"))
+
+    assert settings.missing_requirements() == ()
+    assert settings.oidc_scopes == ("openid", "groups")
+
+
+def test_a_password_deployment_is_never_refused_over_scopes() -> None:
+    """The scope rule belongs to the OIDC method and to no other."""
+    settings = AuthSettings.from_env(dict(PASSWORD_ENV, OSPREY_AUTH_OIDC_SCOPES="profile"))
+
+    assert ENV_OIDC_SCOPES not in settings.missing_requirements()

--- a/tests/services/auth_sidecar/test_oidc_flow.py
+++ b/tests/services/auth_sidecar/test_oidc_flow.py
@@ -39,12 +39,15 @@ from fastapi.testclient import TestClient
 from osprey.deployment.web_terminals.personas import access_wire_value, env_var_suffix
 from osprey.interfaces._serving import run_app_server
 from osprey.services.auth_sidecar import audit
-from osprey.services.auth_sidecar.app import STATE_COOKIE_NAME, create_app
+from osprey.services.auth_sidecar.app import (
+    DEFAULT_OIDC_SCOPES,
+    STATE_COOKIE_NAME,
+    create_app,
+)
 from osprey.services.auth_sidecar.identity_headers import ACCOUNT_HEADER, SUBJECT_HEADER
 from osprey.services.auth_sidecar.routes.oidc import (
     CALLBACK_PATH,
     CLIENT_NAME,
-    DEFAULT_SCOPE,
     LOGIN_PATH,
     PENDING_FLOW_SESSION_KEY,
 )
@@ -280,7 +283,7 @@ def test_a_real_handshake_unlocks_the_clicked_user(idp: MockIdP) -> None:
     authorize = idp.authorize_requests[-1]
     assert authorize["client_id"] == idp.client_id
     assert authorize["response_type"] == "code"
-    assert authorize["scope"] == DEFAULT_SCOPE
+    assert authorize["scope"] == " ".join(DEFAULT_OIDC_SCOPES)
     # `openid` in the scope is what makes Authlib generate and later check a nonce.
     assert authorize["nonce"]
 

--- a/tests/services/bluesky_bridge/test_connector_devices.py
+++ b/tests/services/bluesky_bridge/test_connector_devices.py
@@ -147,9 +147,87 @@ async def test_set_aborts_when_the_write_was_not_confirmed(reason: str) -> None:
     assert fake.read_calls == [], "a raised write must never fall through to the poll loop"
 
 
+def test_settle_budgets_default_when_the_env_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With nothing in the environment the module's own defaults are in force."""
+    monkeypatch.delenv(connector_module.SETTLE_TIMEOUT_ENV, raising=False)
+    monkeypatch.delenv(connector_module.SETTLE_TOLERANCE_ENV, raising=False)
+
+    assert connector_module.settle_timeout_s() == connector_module.DEFAULT_SETTLE_TIMEOUT_S
+    assert connector_module.settle_tolerance() == connector_module.DEFAULT_SETTLE_TOLERANCE
+
+
+def test_settle_budgets_read_the_env_on_every_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The value in force is whatever the environment says now, never at import."""
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "30")
+    monkeypatch.setenv(connector_module.SETTLE_TOLERANCE_ENV, "1e-3")
+
+    assert connector_module.settle_timeout_s() == 30.0
+    assert connector_module.settle_tolerance() == 1e-3
+
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "45")
+    assert connector_module.settle_timeout_s() == 45.0
+
+
+@pytest.mark.parametrize("raw", ["", "abc", "-1", "0"])
+def test_settle_timeout_refuses_a_budget_that_is_not_positive(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """A zero or unreadable budget is a misconfiguration, not a policy."""
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, raw)
+
+    with pytest.raises(ValueError, match=connector_module.SETTLE_TIMEOUT_ENV):
+        connector_module.settle_timeout_s()
+
+
+@pytest.mark.parametrize("raw", ["", "abc", "-1e-9"])
+def test_settle_tolerance_refuses_a_value_below_zero(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """A negative tolerance can never be met, so every move would time out."""
+    monkeypatch.setenv(connector_module.SETTLE_TOLERANCE_ENV, raw)
+
+    with pytest.raises(ValueError, match=connector_module.SETTLE_TOLERANCE_ENV):
+        connector_module.settle_tolerance()
+
+
+def test_settle_tolerance_accepts_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exact equality is a legitimate demand for a readback the IOC echoes."""
+    monkeypatch.setenv(connector_module.SETTLE_TOLERANCE_ENV, "0")
+
+    assert connector_module.settle_tolerance() == 0.0
+
+
+async def test_set_settles_within_an_authored_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A readback that lands near the demand settles once the facility says so.
+
+    At the default tolerance this same move polls until the budget runs out and
+    raises — which is what a facility driving a device that physically moves is
+    raising the key to avoid.
+    """
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "0.3")
+    monkeypatch.setenv(connector_module.SETTLE_TOLERANCE_ENV, "0.01")
+
+    fake = FakeConnector(readbacks={"SP": 0.0, "RB": 0.0})
+    fake.echo_target["SP"] = "RB"
+    fake.write_outcome = "unrequested"
+
+    async def read_near_miss(channel_address: str, timeout: float | None = None):
+        fake.read_calls.append(channel_address)
+        return _FakeChannelValue(value=5.0 - 0.005)
+
+    monkeypatch.setattr(fake, "read_channel", read_near_miss)
+    device = ConnectorSettable(fake, "SP", readback_pv="RB", name="motor")
+
+    await device.set(5.0)  # must not raise
+
+    assert fake.read_calls == ["RB"]
+
+
 async def test_set_times_out_when_readback_never_settles(monkeypatch: pytest.MonkeyPatch) -> None:
     """If the readback never echoes the demand, ``set()`` must raise, never hang."""
-    monkeypatch.setattr(connector_module, "_READBACK_SETTLE_TIMEOUT_S", 0.1)
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "0.1")
 
     fake = FakeConnector(readbacks={"SP": 0.0})
     fake.echo_readback = False  # write succeeds, but readback never moves
@@ -192,7 +270,7 @@ async def test_set_returns_on_a_confirmed_write_to_the_readback_channel() -> Non
     """A confirmed write to the readback channel itself needs no settle poll at all.
 
     The connector already re-read that exact channel and found the value sent, so
-    polling it again could only disagree — ``_READBACK_DEADBAND`` is stricter than
+    polling it again could only disagree — the settle tolerance is stricter than
     the connector's comparison rule, so a confirmed write would time out here.
     """
     fake = FakeConnector(readbacks={"SP": 0.0})
@@ -212,7 +290,7 @@ async def test_set_returns_on_a_confirmed_write_the_deadband_would_reject(
     value against the 1e-9 absolute deadband would poll the setpoint just written
     for the full settle timeout and then raise on a write that in fact succeeded.
     """
-    monkeypatch.setattr(connector_module, "_READBACK_SETTLE_TIMEOUT_S", 0.1)
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "0.1")
     fake = FakeConnector(readbacks={"SP": 0.0})
     fake.echo_readback = False
     fake.readbacks["SP"] = 3.5 + 1e-7  # confirmed by the connector, outside the deadband
@@ -238,7 +316,7 @@ async def test_set_polls_an_unrequested_write_until_the_readback_settles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unchecked write settles on the poll loop, not on the result it returned."""
-    monkeypatch.setattr(connector_module, "_READBACK_SETTLE_TIMEOUT_S", 0.5)
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "0.5")
     fake = FakeConnector(readbacks={"SP": 0.0})
     fake.write_outcome = "unrequested"
     fake.echo_readback = False  # the readback moves only under the poll loop
@@ -260,7 +338,7 @@ async def test_set_never_takes_a_confirmed_setpoint_for_a_separate_readback_pv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A confirmed setpoint write says nothing about a separate readback channel."""
-    monkeypatch.setattr(connector_module, "_READBACK_SETTLE_TIMEOUT_S", 0.1)
+    monkeypatch.setenv(connector_module.SETTLE_TIMEOUT_ENV, "0.1")
     fake = FakeConnector(readbacks={"SP": 0.0, "RB": 0.0})
     # The setpoint echoes (so the write confirms) but the readback never moves.
     device = ConnectorSettable(fake, "SP", readback_pv="RB", name="motor")

--- a/tests/services/bluesky_bridge/test_data_route.py
+++ b/tests/services/bluesky_bridge/test_data_route.py
@@ -2,7 +2,7 @@
 `_tiled_run_snapshot` it windows.
 
 `get_run_data` falls back to Tiled once a run's live buffer is gone
-(post-restart, or evicted past `live_rows._MAX_RUNS`). This environment has
+(post-restart, or evicted past `live_rows.max_runs()`). This environment has
 `tiled[client]` but not `tiled[server]` (no `sqlalchemy`), so there is no
 in-process Tiled server to run against — these tests fake the client boundary
 (`tiled.client.from_uri`) instead, which is exactly the seam the read path is

--- a/tests/services/bluesky_bridge/test_dual_source_read.py
+++ b/tests/services/bluesky_bridge/test_dual_source_read.py
@@ -21,7 +21,7 @@ Exercised here:
   never called. The fallback trigger is `buf is None`, never falsy rows — a
   present-but-empty in-flight buffer must NOT be diverted to Tiled.
 - Both buffer keyings resolve through the same lookup.
-- Live buffer evicted (`live_rows._MAX_RUNS` exceeded), and never created at
+- Live buffer evicted (`live_rows.max_runs()` exceeded), and never created at
   all: both fall back to `_from_tiled(run_id, ...)`.
 - Neither source has the run: 404, not a 200-empty (the MCP tool maps 404 to
   `unknown_run`; a 200-empty would make a nonexistent run look like a valid
@@ -185,11 +185,11 @@ def test_the_live_path_reports_run_uid_as_none_rather_than_inventing_one(
 def test_evicted_live_buffer_falls_back_to_tiled(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """`live_rows._MAX_RUNS` eviction retires a buffer for a run whose data is
+    """`live_rows.max_runs()` eviction retires a buffer for a run whose data is
     still durable in Tiled."""
-    monkeypatch.setattr(live_rows, "_MAX_RUNS", 1)
+    monkeypatch.setenv(live_rows.MAX_RUNS_ENV, "1")
     _feed("run-evicted-a", [{"x": 1.0}], stop=True)
-    # A second run's start doc evicts run A's buffer (_MAX_RUNS=1).
+    # A second run's start doc evicts run A's buffer (max_runs()==1).
     _feed("run-evicted-b", [{"x": 9.0}], stop=True)
     assert live_rows.get("run-evicted-a") is None  # sanity: eviction happened
 

--- a/tests/services/bluesky_bridge/test_live_rows.py
+++ b/tests/services/bluesky_bridge/test_live_rows.py
@@ -126,7 +126,7 @@ def test_event_missing_an_already_known_column_records_none() -> None:
 def test_row_storage_cap_stops_appending_but_total_seen_keeps_counting(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(live_rows, "_MAX_ROWS_PER_RUN", 3)
+    monkeypatch.setenv(live_rows.MAX_ROWS_PER_RUN_ENV, "3")
 
     recorder = LiveRowRecorder()
     recorder("start", _start_doc("run-1"))
@@ -138,15 +138,34 @@ def test_row_storage_cap_stops_appending_but_total_seen_keeps_counting(
     assert buf["total_seen"] == 5
 
 
+def test_the_row_cap_is_resolved_at_the_start_document_not_per_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One run keeps the cap it began under, whatever the env says later."""
+    monkeypatch.setenv(live_rows.MAX_ROWS_PER_RUN_ENV, "3")
+
+    recorder = LiveRowRecorder()
+    recorder("start", _start_doc("run-1"))
+    recorder("event", _event_doc({"x": 0.0}))
+
+    monkeypatch.setenv(live_rows.MAX_ROWS_PER_RUN_ENV, "10")
+    for i in range(1, 6):
+        recorder("event", _event_doc({"x": float(i)}))
+
+    buf = live_rows.get("run-1")
+    assert len(buf["rows"]) == 3
+    assert buf["total_seen"] == 6
+
+
 # =========================================================================
-# Run buffer retention: LRU eviction past _MAX_RUNS
+# Run buffer retention: LRU eviction past max_runs()
 # =========================================================================
 
 
 def test_oldest_run_buffer_evicted_once_max_runs_exceeded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(live_rows, "_MAX_RUNS", 2)
+    monkeypatch.setenv(live_rows.MAX_RUNS_ENV, "2")
 
     for uid in ("run-1", "run-2", "run-3"):
         recorder = LiveRowRecorder()
@@ -160,7 +179,7 @@ def test_oldest_run_buffer_evicted_once_max_runs_exceeded(
 def test_writing_to_a_run_moves_it_to_the_front_of_the_eviction_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(live_rows, "_MAX_RUNS", 2)
+    monkeypatch.setenv(live_rows.MAX_RUNS_ENV, "2")
 
     first = LiveRowRecorder()
     first("start", _start_doc("run-1"))
@@ -233,3 +252,43 @@ def test_get_returns_a_copy_not_a_live_reference() -> None:
     buf = live_rows.get("run-1")
     assert buf["rows"] == [[1.0]]
     assert buf["columns"] == ["x"]
+
+
+# =========================================================================
+# The two caps are read from the environment, not fixed in the module
+# =========================================================================
+
+
+def test_caps_default_when_the_env_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With nothing in the environment the module's own defaults are in force."""
+    monkeypatch.delenv(live_rows.MAX_RUNS_ENV, raising=False)
+    monkeypatch.delenv(live_rows.MAX_ROWS_PER_RUN_ENV, raising=False)
+
+    assert live_rows.max_runs() == live_rows.DEFAULT_MAX_RUNS
+    assert live_rows.max_rows_per_run() == live_rows.DEFAULT_MAX_ROWS_PER_RUN
+
+
+def test_caps_read_the_env_on_every_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The value in force is whatever the environment says now, never at import."""
+    monkeypatch.setenv(live_rows.MAX_RUNS_ENV, "4")
+    monkeypatch.setenv(live_rows.MAX_ROWS_PER_RUN_ENV, "200")
+
+    assert live_rows.max_runs() == 4
+    assert live_rows.max_rows_per_run() == 200
+
+    monkeypatch.setenv(live_rows.MAX_RUNS_ENV, "7")
+    assert live_rows.max_runs() == 7
+
+
+@pytest.mark.parametrize("raw", ["", "abc", "0", "-1"])
+@pytest.mark.parametrize("env_var", ["MAX_RUNS_ENV", "MAX_ROWS_PER_RUN_ENV"])
+def test_caps_refuse_a_value_below_one(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, raw: str
+) -> None:
+    """A cap of zero would evict every buffer the moment it was created."""
+    name = getattr(live_rows, env_var)
+    monkeypatch.setenv(name, raw)
+    reader = live_rows.max_runs if env_var == "MAX_RUNS_ENV" else live_rows.max_rows_per_run
+
+    with pytest.raises(ValueError, match=name):
+        reader()

--- a/tests/services/bluesky_bridge/test_qserver_startup.py
+++ b/tests/services/bluesky_bridge/test_qserver_startup.py
@@ -313,6 +313,30 @@ def test_devices_file_with_no_entries_warns_and_builds_no_devices(
     assert "this worker will expose no plans" in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("env_var", "value"),
+    [
+        ("BLUESKY_SETTLE_TIMEOUT_S", "soon"),
+        ("BLUESKY_SETTLE_TOLERANCE", "-1"),
+    ],
+    ids=["timeout-not-a-number", "negative-tolerance"],
+)
+def test_an_unusable_settle_budget_fails_the_worker_boot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, env_var: str, value: str
+) -> None:
+    """A settle budget the move loop cannot use must not reach a plan.
+
+    Both are read inside the RunEngine, once per move, so a worker that came up
+    on a bad value would abort the first write of the first plan an operator
+    ran instead of refusing to start.
+    """
+    monkeypatch.setenv(env_var, value)
+    env = _stock_devices_env(tmp_path)
+
+    with pytest.raises(ValueError, match=env_var):
+        asyncio.run(qserver_startup.build_devices(env=env, connector=FakeConnector()))
+
+
 def test_build_devices_builds_connector_mediated_devices_from_the_device_file(
     tmp_path: Path,
 ) -> None:

--- a/tests/services/bluesky_bridge/test_read_bounded.py
+++ b/tests/services/bluesky_bridge/test_read_bounded.py
@@ -174,7 +174,7 @@ def test_read_data_after_stop_omits_partial(client: TestClient) -> None:
 def test_read_data_row_count_is_true_total_even_past_storage_cap(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(live_rows, "_MAX_ROWS_PER_RUN", 3)
+    monkeypatch.setenv(live_rows.MAX_ROWS_PER_RUN_ENV, "3")
     _feed("run-10", [{"x": float(i)} for i in range(5)], stop=True)
     body = client.get("/runs/run-10/data").json()
     assert len(body["rows"]) == 3

--- a/tests/services/bluesky_bridge/test_specs_from_file.py
+++ b/tests/services/bluesky_bridge/test_specs_from_file.py
@@ -348,7 +348,7 @@ class _FakeConnector:
     Records the channel addresses the built devices actually hand to the
     control system, which is what the comma test asserts on. Reads answer
     ``0.0`` so a ``set(0.0)`` settles on its first readback poll instead of
-    spinning until ``_READBACK_SETTLE_TIMEOUT_S``.
+    spinning until the settle timeout.
     """
 
     def __init__(self) -> None:

--- a/tests/services/bluesky_bridge/test_startup_assertion.py
+++ b/tests/services/bluesky_bridge/test_startup_assertion.py
@@ -34,9 +34,9 @@ Exercised here:
   the same config starts; a read-only run needs no database at all.
 - The refusal message names the resolved per-type posture key and the lane it
   refused for, but never leaks the database file's contents.
-- The other boot-time refusal in the same hook: a `BLUESKY_DEVICE_PAGE_SIZE`
-  that is not a whole number >= 1 fails the start rather than the first
-  request.
+- The other boot-time refusals in the same hook: a `BLUESKY_DEVICE_PAGE_SIZE`,
+  `BLUESKY_LIVE_MAX_RUNS` or `BLUESKY_LIVE_MAX_ROWS_PER_RUN` that is not a
+  whole number >= 1 fails the start rather than the first request.
 """
 
 from __future__ import annotations
@@ -58,6 +58,8 @@ _TILED_API_KEY_ENV = "BLUESKY_TILED_API_KEY"
 _LANE_ENV = "OSPREY_BLUESKY_LANE"
 _EXECUTION_MODE_ENV = "OSPREY_EXECUTION_MODE"
 _DEVICE_PAGE_SIZE_ENV = "BLUESKY_DEVICE_PAGE_SIZE"
+_LIVE_MAX_RUNS_ENV = "BLUESKY_LIVE_MAX_RUNS"
+_LIVE_MAX_ROWS_ENV = "BLUESKY_LIVE_MAX_ROWS_PER_RUN"
 
 
 class _InertBackend:
@@ -88,6 +90,8 @@ def _isolated_state(monkeypatch: pytest.MonkeyPatch):
         _LANE_ENV,
         _EXECUTION_MODE_ENV,
         _DEVICE_PAGE_SIZE_ENV,
+        _LIVE_MAX_RUNS_ENV,
+        _LIVE_MAX_ROWS_ENV,
     ):
         monkeypatch.delenv(var, raising=False)
     set_queue_backend(_InertBackend())
@@ -507,3 +511,35 @@ def test_device_page_size_reads_the_environment(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv(_DEVICE_PAGE_SIZE_ENV, "200")
 
     assert queue.device_page_size() == 200
+
+
+# =========================================================================
+# The live-row buffer caps are parsed at boot too
+# =========================================================================
+
+
+@pytest.mark.parametrize("env_var", [_LIVE_MAX_RUNS_ENV, _LIVE_MAX_ROWS_ENV])
+@pytest.mark.parametrize("bad_value", ["abc", "0", "-1"])
+def test_malformed_live_row_cap_refuses_startup(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, bad_value: str
+) -> None:
+    """A live-row cap that is not a whole number >= 1 fails the boot.
+
+    The recorder that reads these caps handles every document inside a
+    try/except, so a value it cannot parse would drop run buffers silently for
+    the life of the container. Parsing at boot is what turns that into a
+    refusal an operator can see.
+    """
+    # Arrange
+    _patch_config(monkeypatch, writes_enabled=False)
+    monkeypatch.setenv(env_var, bad_value)
+
+    # Act
+    with pytest.raises(ValueError) as excinfo:
+        with TestClient(app):
+            pass
+
+    # Assert
+    message = str(excinfo.value)
+    assert env_var in message
+    assert bad_value in message

--- a/tests/services/facility_knowledge/test_graph_enrichment_live.py
+++ b/tests/services/facility_knowledge/test_graph_enrichment_live.py
@@ -49,6 +49,7 @@ from typing import Any
 import pytest
 
 from tests._graphdb_container import (
+    GRAPHDB_TEST_DATABASE,
     GRAPHDB_TEST_PASSWORD,
     GRAPHDB_TEST_USERNAME,
     graphdb_store,
@@ -228,7 +229,10 @@ def clean_store(enrichment_store_uri: str) -> Iterator[Any]:
     from osprey.services.facility_knowledge.seeder import graph_seeder
 
     with graph_seeder.open_session(
-        enrichment_store_uri, GRAPHDB_TEST_USERNAME, GRAPHDB_TEST_PASSWORD
+        enrichment_store_uri,
+        GRAPHDB_TEST_USERNAME,
+        GRAPHDB_TEST_PASSWORD,
+        database=GRAPHDB_TEST_DATABASE,
     ) as session:
         graph_seeder.wipe(session)
         yield session

--- a/tests/services/facility_knowledge/test_graph_seeder.py
+++ b/tests/services/facility_knowledge/test_graph_seeder.py
@@ -755,7 +755,9 @@ class TestLazyNeo4jImport:
     def test_missing_driver_error_names_the_dependency(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "neo4j", None)
         with pytest.raises(ImportError) as excinfo:
-            with graph_seeder.open_session("bolt://localhost:7687", "neo4j", "pw"):
+            with graph_seeder.open_session(
+                "bolt://localhost:7687", "neo4j", "pw", database="neo4j"
+            ):
                 pass  # pragma: no cover
         message = str(excinfo.value)
         assert "neo4j" in message

--- a/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
+++ b/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
@@ -27,7 +27,7 @@ from types import ModuleType
 import pytest
 
 from osprey.connectors.control_system.limits_validator import (
-    STEP_READ_TIMEOUT_SECONDS,
+    DEFAULT_STEP_READ_TIMEOUT_SECONDS,
     ChannelLimitsConfig,
     LimitsValidator,
 )
@@ -2219,7 +2219,7 @@ def test_caproto_pre_reads_carry_the_step_read_ceiling(monkeypatch):
     asyncio.run(asyncio_client.PV("TEST:MAG:STEP").write(2.0))
 
     assert reads == ["TEST:MAG:STEP"] * 4
-    assert read_kwargs == [{"timeout": STEP_READ_TIMEOUT_SECONDS}] * 4
+    assert read_kwargs == [{"timeout": DEFAULT_STEP_READ_TIMEOUT_SECONDS}] * 4
     assert writes == [("TEST:MAG:STEP", 2.0)] * 4
 
 

--- a/tests/services/python_executor/execution/test_sandbox_step_reader.py
+++ b/tests/services/python_executor/execution/test_sandbox_step_reader.py
@@ -25,6 +25,7 @@ from types import ModuleType
 import pytest
 
 from osprey.connectors.control_system.limits_validator import (
+    DEFAULT_STEP_READ_TIMEOUT_SECONDS,
     ChannelLimitsConfig,
     LimitsValidator,
 )
@@ -65,10 +66,14 @@ def _install_fake_epics(monkeypatch, reads, writes, read=None):
     written against ``caput`` an honest exercise of the wrapper.
 
     ``read`` replaces what ``ca.get`` answers, and may raise: a client that
-    cannot read is the case a step check has to fail closed on.
+    cannot read is the case a step check has to fail closed on. Each read's
+    ``timeout=`` is recorded on ``read_timeouts``, so a test can assert the
+    budget the guard reads with.
     """
     mod = ModuleType("epics")
     ca = ModuleType("epics.ca")
+    #: The ``timeout=`` each guard read was given, in order.
+    mod.read_timeouts = []
 
     class _Chid:
         """What ``epics.ca`` addresses a channel by: an opaque id, not a name."""
@@ -84,6 +89,7 @@ def _install_fake_epics(monkeypatch, reads, writes, read=None):
 
     def get(chid, timeout=None, **kwargs):
         reads.append(name(chid))
+        mod.read_timeouts.append(timeout)
         if read is not None:
             return read(name(chid))
         return CURRENT
@@ -178,12 +184,14 @@ def _install_fake_p4p(monkeypatch, asyncio_flavor=False):
     return asyncio_cls
 
 
-def _run_monkeypatch(monkeypatch, channel=CHANNEL):
+def _run_monkeypatch(monkeypatch, channel=CHANNEL, step_read_timeout_s=None):
     import osprey.runtime as runtime_module
 
     monkeypatch.setattr(runtime_module, "_limits_validator", None, raising=False)
 
-    wrapper = ExecutionWrapper(limits_validator=_step_validator(channel))
+    wrapper = ExecutionWrapper(
+        limits_validator=_step_validator(channel), step_read_timeout_s=step_read_timeout_s
+    )
     source = wrapper._get_limits_checking_monkeypatch()
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -568,3 +576,39 @@ def test_caproto_pv_write_measures_the_step_with_the_writing_pv(monkeypatch):
 
     assert reads == [CHANNEL]
     assert writes == [(CHANNEL, CURRENT + 1.0)]
+
+
+# ---------------------------------------------------------------------------
+# The budget the guard reads with
+#
+# Which connector block the number came out of is the executor's question, and
+# is pinned where it is answered (tests/mcp_server/python_executor/
+# test_executor_limits_target.py). What has to hold here is that the resolved
+# number travels into the generated source and is what every read is bounded
+# by — the sandbox holds no config and can look nothing up for itself.
+# ---------------------------------------------------------------------------
+
+
+def test_the_resolved_budget_bounds_the_guards_read(monkeypatch):
+    """The sandbox holds no config, so the budget travels in its source."""
+    reads: list = []
+    writes: list = []
+    epics = _install_fake_epics(monkeypatch, reads, writes)
+    _run_monkeypatch(monkeypatch, step_read_timeout_s=0.25)
+
+    epics.caput(CHANNEL, CURRENT + 1.0)
+
+    assert epics.read_timeouts == [0.25]
+    assert writes == [(CHANNEL, CURRENT + 1.0)]
+
+
+def test_a_wrapper_handed_no_budget_still_bounds_the_read(monkeypatch):
+    """A caller that knows no deployment gets the connectors package's default."""
+    reads: list = []
+    writes: list = []
+    epics = _install_fake_epics(monkeypatch, reads, writes)
+    _run_monkeypatch(monkeypatch)
+
+    epics.caput(CHANNEL, CURRENT + 1.0)
+
+    assert epics.read_timeouts == [DEFAULT_STEP_READ_TIMEOUT_SECONDS]

--- a/tests/templates/render_axis_shapes/dispatch-env-passthrough/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/dispatch-env-passthrough/dispatch_worker.yml
@@ -82,6 +82,9 @@ services:
       DISPATCH_WORKER_PORT: "10011"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/env-shared-chain/dispatch_worker.yml
@@ -83,6 +83,9 @@ services:
       DISPATCH_WORKER_PORT: "10011"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/tests/templates/render_axis_shapes/images-on-a-registry/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/dispatch_worker.yml
@@ -82,6 +82,9 @@ services:
       DISPATCH_WORKER_PORT: "10011"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/tests/templates/render_axis_shapes/images-on-a-registry/qmd.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/qmd.yml
@@ -97,11 +97,12 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      # Long by design, not by accident. The entrypoint refuses to open the port
-      # until the index is built and provably non-empty, and a first-boot full
-      # build measured 41 minutes at ALS scale (~135,000 documents). A shorter
-      # grace period would report a container that is working correctly as
-      # unhealthy for most of its first hour.
+      # Long by design, not by accident. The entrypoint refuses to open the
+      # port until the index is built and provably non-empty, so a first boot
+      # is unhealthy for as long as the full build takes — which scales with
+      # the corpus. A grace period shorter than that build reports a container
+      # that is working correctly as unhealthy. `services.qmd.first_index_grace`
+      # is this number, in seconds, for a corpus the default does not fit.
       start_period: 3600s
 
 volumes:

--- a/tests/templates/render_axis_shapes/images-on-a-registry/virtual_accelerator.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/virtual_accelerator.yml
@@ -81,6 +81,12 @@ services:
       # Passthrough from the project .env; unset -> no fault.
       VA_BPM_ERRORS: "${VA_BPM_ERRORS:-}"
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # How often the telemetry thread republishes engine values, and how much
+      # noise the synthesised channels carry. Empty means the entrypoint's own
+      # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
+      # than clamped, so a typo shows up in `docker logs`.
+      VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/pair-on-host/dispatch_worker.yml
@@ -89,6 +89,9 @@ services:
       DISPATCH_WORKER_BIND: "127.0.0.1"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/tests/templates/render_axis_shapes/service-env-passthrough/virtual_accelerator.yml
+++ b/tests/templates/render_axis_shapes/service-env-passthrough/virtual_accelerator.yml
@@ -81,6 +81,12 @@ services:
       # Passthrough from the project .env; unset -> no fault.
       VA_BPM_ERRORS: "${VA_BPM_ERRORS:-}"
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # How often the telemetry thread republishes engine values, and how much
+      # noise the synthesised channels carry. Empty means the entrypoint's own
+      # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
+      # than clamped, so a typo shows up in `docker logs`.
+      VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
+++ b/tests/templates/render_axis_shapes/two-workers-on-host/dispatch_worker.yml
@@ -89,6 +89,9 @@ services:
       DISPATCH_WORKER_BIND: "127.0.0.1"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container
@@ -264,6 +267,9 @@ services:
       DISPATCH_WORKER_BIND: "127.0.0.1"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/tests/templates/render_defaults/dispatch_worker.yml
+++ b/tests/templates/render_defaults/dispatch_worker.yml
@@ -82,6 +82,9 @@ services:
       DISPATCH_WORKER_PORT: "10011"
       DISPATCH_TIMEOUT_SEC: "300"
       DISPATCH_INACTIVITY_SEC: "120"
+      # The third budget: how many agentic turns one dispatched run may take
+      # when the trigger names no ceiling of its own.
+      DISPATCH_MAX_TURNS: "25"
       OSPREY_PROJECT_DIR: /app/golden-project
       # WHO this worker's audit records are written as, and WHERE. The audit
       # mount follows the MIDDLEWARE, not the interface app: this container

--- a/tests/templates/render_defaults/qmd.yml
+++ b/tests/templates/render_defaults/qmd.yml
@@ -97,11 +97,12 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      # Long by design, not by accident. The entrypoint refuses to open the port
-      # until the index is built and provably non-empty, and a first-boot full
-      # build measured 41 minutes at ALS scale (~135,000 documents). A shorter
-      # grace period would report a container that is working correctly as
-      # unhealthy for most of its first hour.
+      # Long by design, not by accident. The entrypoint refuses to open the
+      # port until the index is built and provably non-empty, so a first boot
+      # is unhealthy for as long as the full build takes — which scales with
+      # the corpus. A grace period shorter than that build reports a container
+      # that is working correctly as unhealthy. `services.qmd.first_index_grace`
+      # is this number, in seconds, for a corpus the default does not fit.
       start_period: 3600s
 
 volumes:

--- a/tests/templates/render_defaults/virtual_accelerator.yml
+++ b/tests/templates/render_defaults/virtual_accelerator.yml
@@ -81,6 +81,12 @@ services:
       # Passthrough from the project .env; unset -> no fault.
       VA_BPM_ERRORS: "${VA_BPM_ERRORS:-}"
       VA_CORR_GAIN: "${VA_CORR_GAIN:-}"
+      # How often the telemetry thread republishes engine values, and how much
+      # noise the synthesised channels carry. Empty means the entrypoint's own
+      # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
+      # than clamped, so a typo shows up in `docker logs`.
+      VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/unit/dispatch/test_server_error_code.py
+++ b/tests/unit/dispatch/test_server_error_code.py
@@ -63,6 +63,43 @@ async def test_dispatch_passthrough_pops_input_files_before_fold_and_record():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_forwards_the_triggers_parsed_turn_ceiling():
+    """The ceiling the worker receives is the typed field, not a raw lookup."""
+    registry = AsyncMock()
+    captured: dict[str, Any] = {}
+
+    async def _fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"run_id": "r1", "status": "accepted"}
+
+    trigger = TriggerConfig(
+        name="deploy",
+        source="webhook",
+        action={"prompt": "do it", "allowed_tools": []},
+        max_turns=7,
+    )
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        await server._dispatch_with_policy(trigger, {}, registry, "http://worker", "tok")
+
+    assert captured["max_turns"] == 7
+
+
+@pytest.mark.asyncio
+async def test_dispatch_omits_a_turn_ceiling_no_trigger_states():
+    registry = AsyncMock()
+    captured: dict[str, Any] = {}
+
+    async def _fake_dispatch(**kwargs):
+        captured.update(kwargs)
+        return {"run_id": "r1", "status": "accepted"}
+
+    with patch.object(server, "dispatch_to_worker", _fake_dispatch):
+        await server._dispatch_with_policy(_trigger(), {}, registry, "http://worker", "tok")
+
+    assert captured["max_turns"] is None
+
+
+@pytest.mark.asyncio
 async def test_dispatch_passthrough_no_input_files_forwards_none():
     registry = AsyncMock()
     captured: dict[str, Any] = {}

--- a/tests/unit/dispatch/test_trigger_config.py
+++ b/tests/unit/dispatch/test_trigger_config.py
@@ -402,3 +402,59 @@ def test_only_surface_prompt_present_is_fine(tmp_path):
 
     assert triggers[0].surface is None
     assert triggers[0].surface_prompt == "Extra guidance."
+
+
+# ---------------------------------------------------------------------------
+# Test 14: `action.max_turns` is a typed field, refused at load time
+# ---------------------------------------------------------------------------
+
+
+def test_max_turns_is_parsed_when_present(tmp_path):
+    yaml_content = """\
+        dispatcher:
+          dispatch_target: http://localhost:8010/dispatch
+
+        triggers:
+          - name: with-ceiling
+            source: webhook
+            action:
+              prompt: "Handle event"
+              allowed_tools: []
+              max_turns: 5
+    """
+    path = write_yaml(tmp_path, yaml_content)
+    _, triggers = load_triggers(path)
+
+    assert triggers[0].max_turns == 5
+
+
+def test_max_turns_defaults_to_none_when_absent(tmp_path):
+    path = write_yaml(tmp_path, VALID_WEBHOOK_YAML)
+    _, triggers = load_triggers(path)
+
+    assert triggers[0].max_turns is None
+
+
+@pytest.mark.parametrize("bad_value", ["five", 0, -1, 2.5, True, ["3"]])
+def test_an_unusable_max_turns_is_refused_when_the_file_is_loaded(tmp_path, bad_value):
+    """A turn ceiling the worker would reject is a typo the author must see.
+
+    The worker refuses it with a 422 at dispatch time — which is the moment an
+    event fires, long after the file was written — so the file is where it is
+    caught.
+    """
+    yaml_content = f"""\
+        dispatcher:
+          dispatch_target: http://localhost:8010/dispatch
+
+        triggers:
+          - name: bad-ceiling
+            source: webhook
+            action:
+              prompt: "Handle event"
+              allowed_tools: []
+              max_turns: {bad_value!r}
+    """
+    path = write_yaml(tmp_path, yaml_content)
+    with pytest.raises(ValueError, match="max_turns"):
+        load_triggers(path)

--- a/tests/unit/dispatch/test_worker_client_passthrough.py
+++ b/tests/unit/dispatch/test_worker_client_passthrough.py
@@ -194,3 +194,32 @@ async def test_dispatch_500_still_retryable():
             )
     assert exc_info.value.retryable is True
     assert "HTTP 500" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_forwards_a_trigger_turn_ceiling():
+    """A trigger's own ``max_turns`` reaches the worker as a request field."""
+    captured: dict[str, Any] = {}
+    transport = _capturing_transport(captured)
+    with _patch_asyncclient(transport):
+        await dispatch_to_worker(
+            url="http://worker:9190",
+            prompt="hi",
+            allowed_tools=[],
+            token="tok",
+            max_turns=60,
+        )
+    assert captured["json"]["max_turns"] == 60
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passthrough_omits_max_turns_when_absent():
+    """No trigger ceiling -> the key is absent, so the worker applies the
+    deployment's own ``dispatch.max_turns`` rather than a caller's restatement."""
+    captured: dict[str, Any] = {}
+    transport = _capturing_transport(captured)
+    with _patch_asyncclient(transport):
+        await dispatch_to_worker(
+            url="http://worker:9190", prompt="hi", allowed_tools=[], token="tok"
+        )
+    assert "max_turns" not in captured["json"]

--- a/tests/unit/dispatch_worker/test_dispatch_api.py
+++ b/tests/unit/dispatch_worker/test_dispatch_api.py
@@ -741,3 +741,22 @@ def test_persisted_runs_follow_a_relocated_agent_data_root(tmp_path, monkeypatch
     dispatch_api._persist_run("run-8", {"status": "completed"})
 
     assert (tmp_path / "state" / "data" / "dispatch" / "run-8.json").is_file()
+
+
+def test_dispatch_request_max_turns_defaults_to_the_deployments_ceiling() -> None:
+    """A request naming no ceiling takes DISPATCH_MAX_TURNS, this deployment's own.
+
+    The env is read at import, so the assertion is against the module attribute
+    rather than a literal — what matters is that the request model and the
+    deployment's configured ceiling are one number.
+    """
+    request = dispatch_api.DispatchRequest(prompt="hi", allowed_tools=[])
+
+    assert request.max_turns == dispatch_api.DISPATCH_MAX_TURNS
+
+
+def test_dispatch_request_max_turns_is_taken_from_the_body_when_given() -> None:
+    """A trigger that names its own ceiling overrides the deployment's."""
+    request = dispatch_api.DispatchRequest(prompt="hi", allowed_tools=[], max_turns=60)
+
+    assert request.max_turns == 60

--- a/tests/va/test_serving_entrypoint.py
+++ b/tests/va/test_serving_entrypoint.py
@@ -36,6 +36,7 @@ from lume.model import LUMEModel
 from lume.variables import ScalarVariable
 
 from osprey.services.virtual_accelerator import entrypoint as ep
+from osprey.services.virtual_accelerator.ioc import engine_source as engine_source_module
 from osprey.services.virtual_accelerator.manifest import (
     PARTITION_PYAT_COUPLED,
     PARTITION_SP_ECHO,
@@ -265,6 +266,7 @@ class FakeEngineSource:
     static_noisy: dict[str, Any]
     data_dir: Path
     state_dir: Path | None = None
+    noise_level: float | None = None
     setpoint_echo_records: dict[str, Any] | None = None
 
 
@@ -512,7 +514,52 @@ class TestBootOrder:
         boot = _boot(monkeypatch, facility)
         source, interval = boot.one("engine-thread")
         assert source is boot.engine_source
-        assert interval == ep.ENGINE_POLL_INTERVAL_S
+        assert interval == engine_source_module.DEFAULT_POLL_INTERVAL_S
+
+    def test_the_poll_interval_is_read_from_the_environment(
+        self, monkeypatch: pytest.MonkeyPatch, facility: Path
+    ) -> None:
+        """A facility that wants livelier telemetry sets VA_POLL_INTERVAL_S."""
+        boot = _boot(monkeypatch, facility, env={"VA_POLL_INTERVAL_S": "0.25"})
+        _source, interval = boot.one("engine-thread")
+
+        assert interval == 0.25
+
+    def test_the_noise_level_reaches_the_engine_source(
+        self, monkeypatch: pytest.MonkeyPatch, facility: Path
+    ) -> None:
+        """VA_NOISE_LEVEL is forwarded; before, the constructor never saw one."""
+        boot = _boot(monkeypatch, facility, env={"VA_NOISE_LEVEL": "0.05"})
+
+        assert boot.engine_source.noise_level == 0.05
+
+    def test_the_noise_level_defaults_to_the_engine_source_constant(
+        self, monkeypatch: pytest.MonkeyPatch, facility: Path
+    ) -> None:
+        """One place the number is written down, and the entrypoint reads it."""
+        boot = _boot(monkeypatch, facility)
+
+        assert boot.engine_source.noise_level == engine_source_module.DEFAULT_NOISE_LEVEL
+
+    def test_an_unusable_poll_interval_refuses_the_boot(
+        self, monkeypatch: pytest.MonkeyPatch, facility: Path
+    ) -> None:
+        """Refused, not clamped: a typo has to be visible in the container log."""
+        with pytest.raises(SystemExit, match="VA_POLL_INTERVAL_S"):
+            _boot(monkeypatch, facility, env={"VA_POLL_INTERVAL_S": "0"})
+
+        with pytest.raises(SystemExit, match="VA_POLL_INTERVAL_S"):
+            _boot(monkeypatch, facility, env={"VA_POLL_INTERVAL_S": "fast"})
+
+    def test_a_negative_noise_level_refuses_the_boot(
+        self, monkeypatch: pytest.MonkeyPatch, facility: Path
+    ) -> None:
+        """Zero noise is a legitimate ask; below zero is not a fraction."""
+        with pytest.raises(SystemExit, match="VA_NOISE_LEVEL"):
+            _boot(monkeypatch, facility, env={"VA_NOISE_LEVEL": "-0.1"})
+
+        boot = _boot(monkeypatch, facility, env={"VA_NOISE_LEVEL": "0"})
+        assert boot.engine_source.noise_level == 0.0
 
     def test_stop_signals_are_installed_only_once_the_servers_are_up(
         self, monkeypatch: pytest.MonkeyPatch, facility: Path


### PR DESCRIPTION
Sixteen operational limits and budgets that a facility will hit move out of module constants and into the config block their siblings already use, and two seams that already existed are honoured where they were bypassed.

- `feat(bluesky): settle timeout and tolerance as profile keys`
- `feat(bluesky): live-run buffer caps as profile keys`
- `feat(auth): configurable OIDC scopes`
- `feat(dispatch): max_turns as a profile key and trigger field`
- `feat(graphdb): services.graphdb.database on the resolved connection`
- `feat(artifacts): timeseries file cap as artifact_server key`
- `feat(ariel): semantic-processor input budget key`
- `feat(ariel): attachment size cap as config key`
- `feat(ariel): pgvector index list count as config key`
- `feat(deploy): qmd first-index grace period as services.qmd key`
- `feat(va): poll cadence and noise level as env passthrough`
- `feat(channel-finder): middle-layer SQL row cap as config key`
- `fix(agent-runner): MCP readiness timeout loses its E2E name`
- `fix(deploy): graph store host budget covers the template's start_period`
- `feat(deploy): let a facility service declare it speaks HTTP`
- `feat(connectors): step-read timeout as a connector config key`

## Why

Each of these was a number chosen for one kind of machine and then fixed in the code, sitting beside a sibling that was already a config key. A deployment whose devices physically move could not raise the Bluesky settle budget; one whose logbook entries run long could not send more of them for summarising; one whose graph store keeps the corpus in a differently-named database could not say so; one whose own service answers HTTP could not have its address printed as a link. None of that needed a code change to be a deployment's decision — it needed the key.

A deployer can now author each of them where its siblings live: `bluesky.settle_timeout_s` / `settle_tolerance` / `live_max_runs` / `live_max_rows_per_run`, `modules.web_terminals.auth.oidc.scopes`, `dispatch.max_turns` (and a per-trigger `max_turns:`), `services.graphdb.database`, `artifact_server.max_timeseries_file_mb`, `ariel.attachments.max_file_mb`, `ariel.enhancement_modules.semantic_processor.max_input_chars`, `ariel.enhancement_modules.text_embedding.index_lists`, `services.qmd.first_index_grace`, `channel_finder.query_max_rows`, `control_system.connector.<type>.step_read_timeout_s`, `services.<name>.config.http`, and the `VA_POLL_INTERVAL_S` / `VA_NOISE_LEVEL` passthroughs. Every one keeps today's value when it is unset, and each carries its manifest row, its stanza in the presets that can use it, and a line in the docs.

Two fixes ride along. The MCP readiness budget is renamed `OSPREY_MCP_READY_TIMEOUT` and documented: it gates production `osprey query` as much as it gates a test, which the old `OSPREY_E2E_` name denied (the old name still works for one release). And the host-side wait for the graph store to accept a connection was shorter than the store's own healthcheck grace period, so a first deploy gave up while the container was still coming up and skipped the corpus seed — silently, because nothing had failed. It is now longer than the template's `start_period`, with a test pinning the pair.

Three behaviours are new rather than newly configurable, all fail-closed: an OIDC scope list without `openid` refuses to serve, a VA poll interval or noise level out of range refuses the boot rather than being clamped, and a truncated `run_sql` answer now names the key that cut it. The build refuses two authored values it could otherwise drop in silence: a `dispatch.max_turns` that is not a positive integer, and an `auth.oidc.scopes` whose shape renders no scopes line at all. A trigger's own `max_turns:` is typed when the triggers file loads, and a settle budget the move loop cannot use fails the plan worker's start rather than the first write of the first plan.

## Not in this PR

- Per-channel settle tolerance from the limits database, and any change to the tolerance model itself — the key ships with today's absolute rule and today's value.
- Serving the Bluesky run-data route over Tiled rather than a truncated buffer.
- Deriving the pgvector `lists` count from a row count, or switching the index to HNSW.
- Making `control_system.connector.mock.noise_level` the single producer forwarded into the VA environment at build time.
- Replacing the deploy summary's `_HTTP_SERVICES` / slot tables with a per-template manifest.
- The dispatch input-file caps, the sidecar asset budget and the venv install budget, which are coupled to the body cap or are host properties.


