### PR TITLE
Deflake, polish and gate residue of #897

### DIFF
--- a/changelog.d/cborg-model-defaults.changed.md
+++ b/changelog.d/cborg-model-defaults.changed.md
@@ -1,0 +1,3 @@
+The CBORG provider's `sonnet` and `opus` tiers resolve to `claude-sonnet-5` and
+`claude-opus-5`; `haiku` is unchanged. The gateway's own catalog is the source of
+the ids, and its listed models for the adapter now match what it serves.

--- a/changelog.d/config-drift-write-tools.fixed.md
+++ b/changelog.d/config-drift-write-tools.fixed.md
@@ -1,0 +1,5 @@
+The session-start config drift check no longer goes quiet on a deployment that
+lists extra `control_system.write_tools`. Those tools are approved per call and
+never enter the agent config's deny list, so the check read their absence as a
+hand-edited file and said nothing when config.yml had writes on but the agent
+config still blocked them.

--- a/changelog.d/connectors-offload.changed.md
+++ b/changelog.d/connectors-offload.changed.md
@@ -1,0 +1,6 @@
+The DOOCS and Tango connectors now run limits validation and the write itself in
+one background thread. A `max_step` check reads the channel's present value from
+the control system first, and that read no longer stalls everything else the
+assistant is doing while it is in flight. Every outcome word is unchanged: a
+write refused by validation still sends nothing, and a value the device did not
+take is still reported as a failure.

--- a/changelog.d/control-context-diagnostics.added.md
+++ b/changelog.d/control-context-diagnostics.added.md
@@ -1,0 +1,6 @@
+The control-context hook now leaves a trace of every run in the hook debug log
+when `hooks.debug` is on. Each run records why it ended — the status line went
+out, or the event was not one this hook answers, no control record was written
+yet, the session could not be identified, nothing had moved, or the hook hit an
+error and stayed quiet. Until now the hook's normal silence and a hook that
+never ran looked the same from outside.

--- a/changelog.d/dock-boot-layout-settled.internal.md
+++ b/changelog.d/dock-boot-layout-settled.internal.md
@@ -1,0 +1,3 @@
+The web terminal's dock reports whether its boot layout has settled, so a caller
+that must not act on the shell while panels are still being placed can wait for
+the arrangement to be final rather than guess at how long it takes.

--- a/changelog.d/dotenv-lock-path.changed.md
+++ b/changelog.d/dotenv-lock-path.changed.md
@@ -1,0 +1,3 @@
+The sibling lock file guarding a `.env` is now named in one place,
+`env_lock_path`, instead of having its `.lock` suffix spelled out at each site
+that derives it. Naming is unchanged; nothing on disk moves.

--- a/changelog.d/facility-knowledge-test-reset.internal.md
+++ b/changelog.d/facility-knowledge-test-reset.internal.md
@@ -1,0 +1,3 @@
+The facility-knowledge MCP server can clear the bundle it resolved at startup,
+so a test that starts the server no longer leaves its startup outcome standing
+for every test that runs after it.

--- a/changelog.d/handoff-idle-restart.changed.md
+++ b/changelog.d/handoff-idle-restart.changed.md
@@ -1,0 +1,5 @@
+Switching between the Simple and Expert views no longer shows "Finishing in
+the other view" with a running clock when the other view's agent is idle. The
+overlay now says the agent is being restarted in this view; the clock and
+"Stop and switch now" appear only when the other view is mid-turn, or when a
+restart takes longer than expected.

--- a/changelog.d/ingestion-transport-adapters.security.md
+++ b/changelog.d/ingestion-transport-adapters.security.md
@@ -1,0 +1,6 @@
+ARIEL logbook ingestion honors the `ariel.ingestion` transport settings on every
+adapter. The generic-JSON, JLab and ORNL fetches previously ignored them, so on
+a proxied deployment their traffic went direct and a site CA named in the
+config was not used. An `ariel.ingestion.verify_ssl:` key left without a value
+no longer turns verification off; the default stays on unless the key says
+`false`.

--- a/changelog.d/limits-shim.fixed.md
+++ b/changelog.d/limits-shim.fixed.md
@@ -1,0 +1,4 @@
+A mediated channel write now names the limits check it applies instead of
+picking it at run time. The tool imports its validator from the same installed
+OSPREY, so the older-validator fallback it used to select could never be taken,
+and it obscured which checks a refusal had actually made.

--- a/changelog.d/limits-tango-caproto.security.md
+++ b/changelog.d/limits-tango-caproto.security.md
@@ -1,0 +1,6 @@
+A `readwrite` run checks channel limits on Tango's asynchronous, write-read and
+`AttributeProxy` attribute writes and on caproto's `read_write_read`, `Batch`
+and asyncio `PV` writes, which reached the machine unbounded before. The
+`max_step` pre-read carries an explicit timeout on every caproto client, and a
+Tango attribute passed as an `AttributeInfo` or `DeviceAttribute` object is
+checked under the channel its name addresses.

--- a/changelog.d/notebookedit-permission-rule.fixed.md
+++ b/changelog.d/notebookedit-permission-rule.fixed.md
@@ -1,0 +1,6 @@
+Generated `.claude/settings.json` files no longer make the OSPREY agent print
+two "Permission allow rule ... NotebookEdit(...) is not matched by file
+permission checks" warnings at every start. The agent-data notebook and
+artifact trees are now allowed with `Edit(<path>/**)` rules, the form Claude
+Code consults for every file-editing tool. Rebuild a deployment to pick up the
+change.

--- a/changelog.d/scaffold-detail-fetch.fixed.md
+++ b/changelog.d/scaffold-detail-fetch.fixed.md
@@ -1,0 +1,4 @@
+The scaffold panel now loads a file once when it opens the editor for it,
+instead of twice. Taking ownership of a framework file, and creating a new
+artifact, both opened the file in Preview and switched to Edit on the next
+statement, so two requests for the same file raced for the same pane.

--- a/changelog.d/workspace-rail-gating.changed.md
+++ b/changelog.d/workspace-rail-gating.changed.md
@@ -1,0 +1,17 @@
+`add_panel_to_rail`, `remove_panel_from_rail` and `register_panel` now ask for
+approval first. They decide what an operator can launch at all, and they used to
+run unannounced. The layout tools — `open_panel`, `close_panel` and
+`arrange_workspace` — still run without a prompt. Set
+`approval.tools.<tool>: skip` in `config.yml` on a deployment that would rather
+not be asked — `skip` is the only policy that silences a prompt.
+
+Six workspace tools that carried no policy either way are auto-allowed instead
+of falling through: `artifact_pin` and the lattice dashboard's
+`lattice_get_data`, `lattice_get_figure`, `lattice_get_settings`,
+`lattice_update_settings` and `lattice_clear_baseline`. None of them reaches
+hardware. Re-running `lattice_init` sets a fresh baseline, so
+`lattice_clear_baseline` is undone by it; a settings change or a pin stands
+until it is set back.
+
+The three rail tools are refused outright in a headless read-only run, as
+`lattice_clear_baseline` is.

--- a/docs/source/architecture/mcp-servers.rst
+++ b/docs/source/architecture/mcp-servers.rst
@@ -195,8 +195,23 @@ them (``artifact_list(category="archiver_data")``).
 - ``list_panels`` -- List the panels available in the Web Terminal (built-in and custom).
 - ``open_panel`` -- Put a panel on screen in front of the operator.
 - ``close_panel`` -- Take a panel's tile off screen, leaving it on the rail.
-- ``add_panel_to_rail`` -- Make a panel launchable from the rail in one click.
-- ``remove_panel_from_rail`` -- Take a panel off the rail (and off screen with it).
+- ``arrange_workspace`` -- State a whole layout: exactly these tiles on screen,
+  in this order.
+- ``add_panel_to_rail`` -- Make a panel launchable from the rail in one click
+  (requires human approval).
+- ``remove_panel_from_rail`` -- Take a panel off the rail (and off screen with it)
+  (requires human approval).
+- ``register_panel`` -- Add a rail entry at runtime for an upstream URL the Web
+  Terminal proxies (requires human approval).
+
+The three rail tools ask because rail membership is their whole effect:
+removing an entry costs the operator the ability to launch that panel back, and
+adding or registering one puts a new entry in front of them. The layout tools
+say what is on screen and are auto-allowed, even where a layout implies a rail
+change: ``open_panel`` adds the rail entry when the panel is off the rail, and
+``arrange_workspace`` adds any listed panel that was not on it (with a
+``preset``, it also drops non-members -- the same pruning the operator gets by
+clicking that layout).
 
 **Screen Capture:**
 

--- a/docs/source/architecture/python-executor.rst
+++ b/docs/source/architecture/python-executor.rst
@@ -136,8 +136,11 @@ Nine safety layers are applied in sequence:
    intercept is checked against the channel limits database before it
    leaves, and an out-of-range value never reaches the machine. That covers
    pyepics, aioca, pvaPy, all four p4p clients including the raw one
-   underneath them, caproto's ``sync.client.write`` and threading
-   ``PV.write``, Tango attribute writes and DOOCS. A structured payload is
+   underneath them, all three caproto clients --- the sync client's
+   ``write`` and ``read_write_read``, the threading client's ``PV`` and
+   ``Batch``, and the asyncio client's ``PV`` --- the attribute-write
+   spellings on Tango's ``DeviceProxy`` and ``AttributeProxy``, asynchronous
+   and write-read forms included, and DOOCS. A structured payload is
    checked on the number it carries; a p4p payload written as JSON is
    decoded first, ``bytes`` included --- which p4p itself would not decode,
    so such a write is checked on the number it *would* become rather than
@@ -150,15 +153,17 @@ Nine safety layers are applied in sequence:
    write, which fans one value out to many devices with no single channel
    to bound it under.
 
-   A few routes are neither checked nor refused: Tango's asynchronous and
-   read-write attribute spellings, ``AttributeProxy`` writes, caproto's
-   ``Batch``, asyncio and ``read_write_read`` writes, and the ctypes
-   binding underneath aioca, ``epicscorelibs.ca.cadef.ca_array_put``. The
-   code names the first group ``_LIMITS_NOT_YET_WRAPPED`` and the ctypes
-   binding ``_LIMITS_UNWRAPPABLE``, rather than leaving the gap
-   implicit---a ``readwrite`` run reaches hardware through any of them
-   without passing the limits database, while a ``readonly`` run refuses
-   them like everything else.
+   Two routes to hardware are neither checked nor refused: the ctypes
+   bindings underneath aioca, ``epicscorelibs.ca.cadef.ca_array_put`` and
+   ``ca_array_put_callback``. By the time a call reaches either one the
+   value has been marshalled into C memory and the channel is an opaque
+   handle, so there is no number left to bound and no channel name to look
+   the limits up under; pyepics loads a second ``libca`` of its own, so this
+   binding is not the one place ctypes-level puts pass through either. The
+   code lists them in ``_LIMITS_UNWRAPPABLE`` rather than leaving the gap
+   implicit---a ``readwrite`` run reaches hardware through them without
+   passing the limits database, while a ``readonly`` run refuses them like
+   everything else.
 
 8. **Process isolation**---code always runs in a separate subprocess, never
    inside the MCP server process.

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -185,8 +185,8 @@ see what the two source files become. The whole catalog appears under
            # Use pinned versions here — unversioned aliases like
            # anthropic/claude-sonnet break the agent's capability detection.
            haiku: claude-haiku-4-5
-           sonnet: claude-sonnet-4-6
-           opus: claude-opus-4-7
+           sonnet: claude-sonnet-5
+           opus: claude-opus-5
 
        stanford:
          api_key: ${STANFORD_API_KEY}

--- a/docs/source/how-to/web-terminal/panels.rst
+++ b/docs/source/how-to/web-terminal/panels.rst
@@ -263,8 +263,10 @@ skipped. When no ``web.presets`` are configured — the default — the ``+`` me
 unchanged, so layouts never add clutter to a deployment that has not opted in.
 
 Layouts are just a shortcut over adding and removing rail entries, so the OSPREY
-agent can achieve the same result with its ``add_panel_to_rail`` /
-``remove_panel_from_rail`` tools;
+agent can reach the same end state either way — but not with the same prompting.
+Applying a layout with ``arrange_workspace`` does not ask; the
+``add_panel_to_rail`` / ``remove_panel_from_rail`` tools ask the operator to
+approve each call on a stock build.
 ``list_panels`` reports the configured layouts so the agent can honor a request
 like "set up for machine setup."
 

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/doocs_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/doocs_connector.py
@@ -179,40 +179,57 @@ class DOOCSConnector(ControlSystemConnector):
             ChannelLimitsViolationError: If limits validation fails (when enabled)
         """
 
-        # Step 1: Validate limits (FAIL CLOSED). A limits violation propagates
-        # unchanged; any other error means the check could not be made, and an
-        # unmade check is not permission to write.
-        if self._limits_validator:
-            # Import here to avoid circular dependency
-            from osprey_connectors.errors import ChannelLimitsViolationError
+        # Import here to avoid circular dependency
+        from osprey_connectors.errors import ChannelLimitsViolationError
 
+        # Step 1: Validate limits (FAIL CLOSED) and send the value in ONE thread
+        # offload, so a caller on the event loop is never stalled by the blocking
+        # `doocs4py.get()` that max_step validation performs, nor by the send.
+        #
+        # A limits violation propagates unchanged; any other validation error
+        # means the check could not be made, and an unmade check is not
+        # permission to write — the closure hands that case back as a sentinel
+        # and the refusal itself is built on the loop, by the base class's one
+        # helper, so all four connectors word it identically.
+        def _validate_and_set():
+            if self._limits_validator:
+                try:
+                    self._limits_validator.validate(
+                        channel_address, value, read_current=self._current_value_reader()
+                    )
+                    logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
+                except ChannelLimitsViolationError:
+                    raise  # limits refusal propagates unchanged (carries LIMITS semantics)
+                except Exception as e:
+                    return ("refused", e)  # sentinel: no set issued
             try:
-                self._limits_validator.validate(
-                    channel_address, value, read_current=self._current_value_reader()
-                )
-                logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
-            except ChannelLimitsViolationError:
-                raise
+                self._doocs4py.set(channel_address, value)
             except Exception as e:
-                return self._validation_refusal(channel_address, value, e)
+                return ("send_failed", e)
+            return ("ok", None)
 
-        # Step 2: Resolve the confirmation policy. An explicit confirm — False
-        # every bit as much as True — is an answer and is taken as given; only
-        # an omitted one is resolved from the limits database.
-        if confirm is None:
-            confirm = self._resolve_confirm(channel_address)
+        send_result, payload = await asyncio.to_thread(_validate_and_set)
 
-        # Step 3: Send the value
-        try:
-            self._doocs4py.set(channel_address, value)
-        except Exception as e:
+        if send_result == "refused":
+            return self._validation_refusal(channel_address, value, payload)
+
+        if send_result == "send_failed":
             return ChannelWriteResult(
                 channel_address=channel_address,
                 value_written=value,
                 outcome=WriteOutcome.FAILED,
-                error_message=f"Failed to write to '{channel_address}': {e}",
+                error_message=f"Failed to write to '{channel_address}': {payload}",
                 notes="DOOCS did not take the value",
             )
+
+        # Step 2: Resolve the confirmation policy, now that a value has actually
+        # gone out. An explicit confirm — False every bit as much as True — is an
+        # answer and is taken as given; only an omitted one is resolved from the
+        # limits database. `doocs4py.set` does not consume it and the lookup is a
+        # pure in-memory read, so resolving it after the send changes nothing an
+        # observer can see.
+        if confirm is None:
+            confirm = self._resolve_confirm(channel_address)
 
         if not confirm:
             logger.debug(f"DOOCS write (unconfirmed by request): {channel_address} = {value}")
@@ -223,7 +240,7 @@ class DOOCSConnector(ControlSystemConnector):
                 notes="No confirmation requested",
             )
 
-        # Step 4: Confirm with one fresh read
+        # Step 3: Confirm with one fresh read
         try:
             readback = await self.read_channel(channel_address, timeout=timeout)
         except Exception as e:

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/tango_connector.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/tango_connector.py
@@ -349,42 +349,57 @@ class TangoConnector(ControlSystemConnector):
         # The address must parse before anything is validated or sent.
         device_name, attribute = _split_address(channel_address)
 
-        # Step 1: Validate limits (FAIL CLOSED). A limits violation propagates
-        # unchanged; any other error means the check could not be made, and an
-        # unmade check is not permission to write.
-        if self._limits_validator:
-            # Import here to avoid circular dependency
-            from osprey_connectors.errors import ChannelLimitsViolationError
+        # Import here to avoid circular dependency
+        from osprey_connectors.errors import ChannelLimitsViolationError
 
+        # Steps 1-2: Validate limits (FAIL CLOSED) and send the value in ONE
+        # thread offload, so a caller on the event loop is never stalled by the
+        # blocking read_attribute that max_step validation performs — nor by
+        # the two device round trips that follow it, which used to cost an
+        # offload each. The closure decides nothing: it hands back a three-way
+        # sentinel and every result is built on the loop, in the words the
+        # cross-connector contract owns.
+        def _validate_and_write():
+            if self._limits_validator:
+                try:
+                    self._limits_validator.validate(
+                        channel_address, value, read_current=self._current_value_reader()
+                    )
+                    logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
+                except ChannelLimitsViolationError:
+                    raise  # limits refusal propagates unchanged (carries LIMITS semantics)
+                except Exception as e:
+                    # An unmade check is not permission to write: nothing is sent.
+                    return ("refused", e)
             try:
-                self._limits_validator.validate(
-                    channel_address, value, read_current=self._current_value_reader()
-                )
-                logger.debug(f"✓ Limits validation passed: {channel_address}={value}")
-            except ChannelLimitsViolationError:
-                raise
+                # Creating a DeviceProxy is itself a database round trip, so a
+                # cold cache is filled in the thread too.
+                self._get_proxy(device_name).write_attribute(attribute, value)
             except Exception as e:
-                return self._validation_refusal(channel_address, value, e)
+                return ("send_failed", e)
+            return ("ok", None)
 
-        # Step 2: Resolve the confirmation policy. An explicit confirm — False
-        # every bit as much as True — is an answer and is taken as given; only
-        # an omitted one is resolved from the limits database.
-        if confirm is None:
-            confirm = self._resolve_confirm(channel_address)
+        step, payload = await asyncio.to_thread(_validate_and_write)
 
-        # Step 3: Send the value. Creating a DeviceProxy is itself a database
-        # round trip, so a cold cache is filled in the thread too.
-        try:
-            proxy = await asyncio.to_thread(self._get_proxy, device_name)
-            await asyncio.to_thread(proxy.write_attribute, attribute, value)
-        except Exception as e:
+        if step == "refused":
+            return self._validation_refusal(channel_address, value, payload)
+
+        if step == "send_failed":
             return ChannelWriteResult(
                 channel_address=channel_address,
                 value_written=value,
                 outcome=WriteOutcome.FAILED,
-                error_message=f"Failed to write to '{channel_address}': {e}",
+                error_message=f"Failed to write to '{channel_address}': {payload}",
                 notes="TANGO did not take the value",
             )
+
+        # Step 3: Resolve the confirmation policy, now that the value is away.
+        # An explicit confirm — False every bit as much as True — is an answer
+        # and is taken as given; only an omitted one is resolved from the limits
+        # database. Nothing in the send consumes it and the lookup is a pure
+        # in-memory read, so asking after the write is not observable.
+        if confirm is None:
+            confirm = self._resolve_confirm(channel_address)
 
         if not confirm:
             logger.debug(f"TANGO write (unconfirmed by request): {channel_address} = {value}")

--- a/packages/osprey-connectors/src/osprey_connectors/dotenv.py
+++ b/packages/osprey-connectors/src/osprey_connectors/dotenv.py
@@ -277,6 +277,28 @@ _ENV_LOCK_REGISTRY_GUARD = threading.Lock()
 _env_lock_state = threading.local()
 
 
+def env_lock_path(env_path: Path) -> Path:
+    """The sibling lock file that guards *env_path*, derived and nothing more.
+
+    THE one spelling of the ``<name>.lock`` suffix. It was written out by hand
+    at three sites, so a change to the naming would have had to be found in
+    three places -- one of them a test that would have kept passing against the
+    old spelling.
+
+    **The path is not resolved.** :func:`env_file_lock` resolves its own key
+    first, deliberately, because the flock must land on one inode however many
+    symlinks reach it; it then calls this on the path it already resolved. The
+    other callers want the opposite: they hold a directory by the name the user
+    gave them and list what is inside it, so resolving here would hand them a
+    name from somewhere else entirely.
+
+    :param env_path: The ``.env`` whose lock file is wanted.
+    :returns: ``env_path`` with ``.lock`` appended to its final component.
+    """
+    env_path = Path(env_path)
+    return env_path.with_name(env_path.name + ".lock")
+
+
 @contextmanager
 def env_file_lock(env_path: Path) -> Iterator[None]:
     """Hold the exclusive lock guarding one ``.env``'s read-modify-write.
@@ -320,7 +342,7 @@ def env_file_lock(env_path: Path) -> Iterator[None]:
             # thread. Re-locking would block forever on our own flock.
             yield
             return
-        lock_path = Path(key).with_name(Path(key).name + ".lock")
+        lock_path = env_lock_path(Path(key))
         with open(lock_path, "a+", encoding="utf-8") as lock_handle:
             fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
             held.add(key)

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -57,14 +57,15 @@ CLAUDE_CODE_PROVIDERS: dict[str, dict] = {
         "base_url": "https://api.cborg.lbl.gov",  # Well-known URL (no /v1)
         "default_model_tier": "haiku",
         # Fallback model IDs (used when api.providers.cborg.models is absent).
-        # Pinned to specific versions so Claude Code can pattern-match the model
-        # and send the correct thinking/effort schema (e.g. adaptive for 4.7).
-        # Unversioned aliases like "anthropic/claude-opus" break capability
-        # detection and cause 400s on Vertex-backed Opus 4.7.
+        # Pinned to versioned ids so Claude Code can pattern-match the model and
+        # send the thinking/effort schema that model accepts. CBORG also serves
+        # floating aliases ("claude-opus", "anthropic/claude-opus"); those carry
+        # no version for the harness to match, so capability detection falls
+        # through and the Vertex-backed models answer 400.
         "models": {
             "haiku": "claude-haiku-4-5",
-            "sonnet": "claude-sonnet-4-6",
-            "opus": "claude-opus-4-7",
+            "sonnet": "claude-sonnet-5",
+            "opus": "claude-opus-5",
         },
     },
     "als-apg": {

--- a/src/osprey/cli/audit_prompts.py
+++ b/src/osprey/cli/audit_prompts.py
@@ -42,8 +42,12 @@ OSPREY enforces a human-in-the-loop architecture for all hardware writes:
 explicit user approval via ask-permission.
 - **python server**: `execute` requires explicit user approval. No tools are \
 auto-allowed.
-- **workspace server**: Read/visualization tools are auto-allowed; `setup_patch` \
-requires approval.
+- **workspace server**: Read/visualization tools are auto-allowed, as are the \
+layout verbs (`open_panel`, `close_panel`, `arrange_workspace` -- which states a \
+whole layout, including rail membership, and under a `preset` drops non-members \
+from the rail) and the lattice dashboard's own scratch state. `setup_patch` \
+requires approval, and so do the three tools whose whole effect is rail \
+membership: `add_panel_to_rail`, `remove_panel_from_rail` and `register_panel`.
 
 ### Safety Hook Chain for channel_write
 Every `channel_write` call passes through three hooks in sequence:

--- a/src/osprey/cli/profile_cmd.py
+++ b/src/osprey/cli/profile_cmd.py
@@ -1555,6 +1555,8 @@ def _materialize_profile_directory(
     """
     import shutil
 
+    from osprey.utils.dotenv import env_lock_path
+
     from .build_profile import (
         EXTENDS_OVERRIDE_REFUSAL,
         _normalize_preset_name,
@@ -1728,8 +1730,10 @@ def _materialize_profile_directory(
         if not env_pre_existed and (target / _PROFILE_ENV_FILENAME).exists():
             # The sibling lock file is created beside the `.env` by the shared
             # writer and deliberately never removed while the `.env` lives; a
-            # discarded `.env` takes it along.
-            run_written += [_PROFILE_ENV_FILENAME, f"{_PROFILE_ENV_FILENAME}.lock"]
+            # discarded `.env` takes it along. `_cleanup` joins these names onto
+            # `target`, so the name is what is wanted, un-resolved.
+            env_path = target / _PROFILE_ENV_FILENAME
+            run_written += [_PROFILE_ENV_FILENAME, env_lock_path(env_path).name]
         if shell_keys.skipped:
             # Debug only. `osprey init`'s summary prints the same sentence from
             # the same helper, and this is the only caller, so logging it here

--- a/src/osprey/interfaces/web_terminal/routes/websocket.py
+++ b/src/osprey/interfaces/web_terminal/routes/websocket.py
@@ -181,6 +181,24 @@ def _holds_a_chat_pool_entry(app, session_id: str) -> bool:
     return getter(session_id) is not None
 
 
+def _chat_is_busy(app, session_id: str) -> bool:
+    """Whether the chat pooled under *session_id* is mid-turn right now.
+
+    The one question the ``handoff_pending`` frame answers beyond "the chat
+    holds the key": whether the door is about to wait on a turn or merely
+    restart an idle agent. A creation still inside ``start()`` has no turn
+    yet and reads idle, as does a key no pool answers for — the frame is a
+    description of this moment, and the door's wait is what enforces it.
+    """
+    registry = getattr(app.state, "operator_registry", None)
+    pool = getattr(registry, "chats", None)
+    getter = getattr(pool, "get", None)
+    if not callable(getter):
+        return False
+    chat = getter(session_id)
+    return bool(getattr(chat, "is_busy", False))
+
+
 def _chat_pool_answers_to(app, session_id: str) -> bool:
     """Whether the chat pool would answer to *session_id* at all.
 
@@ -760,10 +778,16 @@ async def _open_surface(
     The ``handoff_pending`` frame goes out first whenever the chat surface
     holds the key, which is the one case the door waits on a foreign entry
     for a terminal; the client shows the transitional state until
-    ``session_info`` (or ``error``) replaces it.
+    ``session_info`` (or ``error``) replaces it. ``busy`` says whether that
+    chat is mid-turn: a busy chat is waited on for as long as its turn takes,
+    and the client shows that wait with its clock and its way out; an idle
+    one is only restarted here, which the client shows as a restart. Read off
+    the pooled session at this moment, not under the door's lock — a turn
+    that starts in the gap is the door's to wait on, and the client escalates
+    a restart that outlasts its budget to the wait on its own.
     """
     if _chat_pool_answers_to(app, key):
-        await channel.send_json({"type": "handoff_pending"})
+        await channel.send_json({"type": "handoff_pending", "busy": _chat_is_busy(app, key)})
     try:
         return await channel.acquire(app, key, interrupt=interrupt, spawn=spawn)
     except session_handoff.HandoffRefused as refused:
@@ -807,7 +831,7 @@ async def terminal_ws(websocket: WebSocket):
     - Server -> Client JSON: {"type": "exit", "code": N}
     - Server -> Client JSON: {"type": "session_switched", "session_id": UUID}
     - Server -> Client JSON: {"type": "session_info", "session_id": UUID}
-    - Server -> Client JSON: {"type": "handoff_pending"}
+    - Server -> Client JSON: {"type": "handoff_pending", "busy": bool}
     - Server -> Client JSON: {"type": "transcript_missing", "session_id": UUID, "code"?: N}
     - Server -> Client JSON: {"type": "error", "message": str}
 

--- a/src/osprey/interfaces/web_terminal/static/js/chat.js
+++ b/src/osprey/interfaces/web_terminal/static/js/chat.js
@@ -27,6 +27,11 @@ import { createChatRenderer, elem } from './chat-render.js';
 import { buildEmptyState, onKindChange, onSettled, renderEmptyStateContent } from './first-contact.js';
 import { getPointer, setPointer, subscribe as subscribeToPointer } from './session-pointer.js';
 import { notifySessionChange } from './terminal.js';
+import {
+  HANDOFF_PENDING_MESSAGE,
+  HANDOFF_RESTART_BUDGET_MS,
+  HANDOFF_RESTARTING_MESSAGE,
+} from './terminal-handoff.js';
 
 /** Max textarea height (px) before it scrolls — matches operator.css. */
 const MAX_INPUT_HEIGHT = 120;
@@ -104,9 +109,6 @@ const HANDOFF_REFUSALS = {
 
 /** Overlay copy for a hand-off that failed with no reason this view knows. */
 const HANDOFF_FALLBACK = { message: 'The hand-off failed.', action: /** @type {'retry'} */ ('retry') };
-
-/** Copy shown while the outgoing view finishes the turn it is on. */
-const HANDOFF_PENDING_MESSAGE = 'Finishing in the other view · ';
 
 /**
  * Build the operator console interior — session bar, message list, hand-off
@@ -307,11 +309,17 @@ export function initChat(containerId = 'operator-container') {
   /** The in-flight hand-off request, so a retry can abandon it first. */
   let handoffAbort = /** @type {AbortController | null} */ (null);
 
-  /** When the current hand-off wait started, or null when none is showing. */
+  /** When the current hand-off began, or null when none is showing. */
   let waitStartedAt = /** @type {number | null} */ (null);
 
   /** The 1 Hz elapsed-time ticker, or null when nothing is counting. */
   let ticker = /** @type {number | null} */ (null);
+
+  /** The timer that turns a long restart into the wait, or null when none is armed. */
+  let escalation = /** @type {number | null} */ (null);
+
+  /** Whether the wait is on screen; it never steps back to a restart. */
+  let waiting = false;
 
   const isSimpleMode = () =>
     document.documentElement.getAttribute('data-ui-mode') === 'simple';
@@ -400,13 +408,23 @@ export function initChat(containerId = 'operator-container') {
     elapsed.textContent = `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
   }
 
-  /** Stop the elapsed counter and forget when the wait began. */
+  /** Stop the clock and the escalation, and forget when the hand-off began. */
   function stopTicker() {
     if (ticker !== null) {
       clearInterval(ticker);
       ticker = null;
     }
+    disarmEscalation();
     waitStartedAt = null;
+    waiting = false;
+  }
+
+  /** Cancel a pending restart-to-wait escalation. */
+  function disarmEscalation() {
+    if (escalation !== null) {
+      clearTimeout(escalation);
+      escalation = null;
+    }
   }
 
   /**
@@ -444,22 +462,48 @@ export function initChat(containerId = 'operator-container') {
   }
 
   /**
-   * Show the transitional state: the other view's agent is finishing its turn
-   * and this one is waiting for it. There is no bound on that wait, so the
-   * elapsed time is the honest thing to show, and the button is the way out.
+   * Show the transitional state. The hand-off route answers only once the
+   * session is this view's, so nothing here says up front whether the other
+   * view's agent is mid-turn: the restart is shown first — the agent is being
+   * stopped there and started here — and the wait, with its clock and its way
+   * out, once the restart outlasts its budget. A hand-off that cuts a running
+   * turn short is a wait from the start.
+   * @param {boolean} cutRunningTurn
    */
-  function showHandoffPending() {
-    // A retry continues the wait the operator is already watching rather than
-    // restarting its clock.
+  function showHandoffPending(cutRunningTurn) {
+    // A retry continues the hand-off the operator is already watching rather
+    // than restarting its clock.
     if (waitStartedAt === null) waitStartedAt = Date.now();
+    if (cutRunningTurn || waiting) {
+      showWait();
+    } else {
+      setOverlayMessage(HANDOFF_RESTARTING_MESSAGE, false);
+      setOverlayAction('', null);
+      if (escalation === null) {
+        escalation = window.setTimeout(() => {
+          escalation = null;
+          showWait();
+        }, HANDOFF_RESTART_BUDGET_MS);
+      }
+    }
+    overlay.hidden = false;
+    setTransitioning(true);
+  }
+
+  /**
+   * The wait: the other view's agent is finishing its turn and this one is
+   * waiting for it. There is no bound on that wait, so the elapsed time is
+   * the honest thing to show, and the button is the way out.
+   */
+  function showWait() {
+    waiting = true;
+    disarmEscalation();
     setOverlayMessage(HANDOFF_PENDING_MESSAGE, true);
     renderElapsed();
     if (ticker === null) ticker = window.setInterval(renderElapsed, 1000);
     setOverlayAction('Stop and switch now', () => {
       void runHandoff(true);
     });
-    overlay.hidden = false;
-    setTransitioning(true);
   }
 
   /**
@@ -545,7 +589,7 @@ export function initChat(containerId = 'operator-container') {
     handoffAbort = controller;
 
     const key = boundKey;
-    showHandoffPending();
+    showHandoffPending(cutRunningTurn);
     /** @type {{ state: string, session_id: string } | null} */
     let handed = null;
     try {

--- a/src/osprey/interfaces/web_terminal/static/js/config-render-helpers.js
+++ b/src/osprey/interfaces/web_terminal/static/js/config-render-helpers.js
@@ -56,7 +56,7 @@ export function _groupPermissions(entries) {
     } else if (entry.startsWith('Task(')) {
       const agentName = entry.replace(/^Task\(/, '').replace(/\)$/, '');
       addTo('agents', entry, agentName);
-    } else if (entry.startsWith('Read(') || entry.startsWith('NotebookEdit(')) {
+    } else if (entry.startsWith('Read(') || entry.startsWith('Edit(')) {
       const match = entry.match(/^(\w+)\((.+)\)$/);
       if (match) {
         addTo('file access', entry, `${match[1]}: ${match[2]}`);

--- a/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
+++ b/src/osprey/interfaces/web_terminal/static/js/dock-workspace.js
@@ -140,6 +140,16 @@ export function setLayoutRestoredHook(fn) {
   if (layoutRestoredAlready) fn();
 }
 
+/**
+ * Whether the boot layout has settled: the arrangement on screen is the final
+ * one and no restore is pending that would re-apply it. False until the boot
+ * layout is announced, true from then on.
+ * @returns {boolean}
+ */
+export function bootLayoutSettled() {
+  return layoutRestoredAlready;
+}
+
 /** Announce the boot layout as final, latching it for any later subscriber. */
 function announceLayoutRestored() {
   layoutRestoredAlready = true;

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold-gallery.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold-gallery.js
@@ -342,9 +342,12 @@ class ArtifactGallery {
   // view.js, detail-content.js). renderEdit and the edit/save/ownership
   // workflow live in scaffold/edit-form.js and scaffold/edit.js (below).
 
-  /** @param {any} artifact */
-  openDetail(artifact) {
-    return this._detail.openDetail(artifact);
+  /**
+   * @param {any} artifact
+   * @param {'preview'|'diff'|'edit'} [initialMode] Mode to open in; defaults to Preview.
+   */
+  openDetail(artifact, initialMode) {
+    return this._detail.openDetail(artifact, initialMode);
   }
 
   /** @param {string} category */

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold/detail.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold/detail.js
@@ -72,13 +72,27 @@ export function createScaffoldGalleryDetail(gallery) {
   const { renderPreview, renderDiff } = createScaffoldGalleryDetailContent(gallery);
 
   /**
+   * Open the detail view on an artifact, in `initialMode`.
+   *
+   * The mode is a parameter rather than a flip afterwards because the flows
+   * that want the editor -- claim-on-first-edit and create -- used to open in
+   * Preview and switch to Edit on the next statement. Both renders then ran
+   * against the same pane over the same `GET /api/scaffold/<name>`: one of the
+   * two fetches was always wasted, and which one drew was decided by whichever
+   * response happened to land last. Opening directly in the mode the caller
+   * wants leaves a single render, so there is nothing to race.
+   *
+   * (renderDetailContent's sequence claim still stands: a mode click during a
+   * slow fetch starts a second render the same way, and that one is real.)
+   *
    * @param {any} artifact
+   * @param {'preview'|'diff'|'edit'} [initialMode] Mode to open in; defaults to Preview.
    * @returns {void}
    */
-  function openDetail(artifact) {
+  function openDetail(artifact, initialMode = 'preview') {
     gallery.selectedArtifact = artifact;
     gallery.currentView = 'detail';
-    gallery.detailMode = 'preview';
+    gallery.detailMode = initialMode;
     gallery.editDirty = false;
 
     if (gallery.galleryView) gallery.galleryView.style.display = 'none';
@@ -115,11 +129,9 @@ export function createScaffoldGalleryDetail(gallery) {
         gallery.load().then(() => {
           const newArt = gallery.artifacts.find((a) => a.name === result.canonical_name);
           if (newArt) {
-            openDetail(newArt);
-            // Switch to edit mode inline (no switchMode method exists)
-            gallery.detailMode = 'edit';
-            renderDetailModes();
-            renderDetailContent();
+            // A just-created artifact is empty, so the editor is the only
+            // useful first view of it.
+            openDetail(newArt, 'edit');
           }
         });
       })
@@ -324,7 +336,7 @@ export function createScaffoldGalleryDetail(gallery) {
    * starts a Preview (openDetail) and an Edit back to back, and a mode click
    * during a slow fetch does the same. The two GETs are independent and
    * nothing orders their responses, so without a claim on the pane the render
-   * that finished last won, whatever the operator last asked for. Each render
+   * that finishes last wins, whatever the operator last asked for. Each render
    * takes the next sequence number and every renderer re-checks it after its
    * await: a render that has been superseded returns without drawing.
    *

--- a/src/osprey/interfaces/web_terminal/static/js/scaffold/edit.js
+++ b/src/osprey/interfaces/web_terminal/static/js/scaffold/edit.js
@@ -47,7 +47,7 @@ import { apiRequest } from './data.js';
  * @property {HTMLElement|null} galleryView
  * @property {HTMLElement|null} detailView
  * @property {(() => void)|null} onDetailClose
- * @property {(artifact: any) => void} openDetail
+ * @property {(artifact: any, initialMode?: 'preview'|'diff'|'edit') => void} openDetail
  * @property {() => void} renderDetailModes
  * @property {() => void} renderDetailContent
  * @property {() => void} renderGallery
@@ -154,12 +154,9 @@ export function createScaffoldGalleryEdit(gallery) {
       const updated = gallery.artifacts.find((a) => a.name === gallery.selectedArtifact.name);
       if (updated) {
         // openDetail restores detail-view visibility (reloadFull's gallery
-        // re-render flipped back to the grid); then switch to edit mode
-        // inline — same pattern as detail.js's showCreateDialog.
-        gallery.openDetail(updated);
-        gallery.detailMode = 'edit';
-        gallery.renderDetailModes();
-        gallery.renderDetailContent();
+        // re-render flipped back to the grid) and opens straight in edit mode
+        // — the operator asked to edit, and one render means one content GET.
+        gallery.openDetail(updated, 'edit');
       }
     } catch (e) {
       showWriteError('Scaffold failed', e);

--- a/src/osprey/interfaces/web_terminal/static/js/terminal-handoff.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal-handoff.js
@@ -14,19 +14,49 @@ import { WS_CLOSE_OUTGOING_RUNNING } from './api.js';
  * on demand and removed when it clears, so the card carries no extra DOM in
  * the ordinary case.
  *
+ * The pending state has two faces. An outgoing agent that is idle is only
+ * stopped in its view and started in this one, which takes about a second:
+ * that is a restart, and it is shown as one — no clock, no way out, because
+ * there is nothing to cut short. An outgoing agent that is mid-turn is
+ * waited on for as long as the turn takes: that is the wait, with its
+ * elapsed clock and "Stop and switch now". The server says which on the
+ * frame; a restart that outlasts {@link HANDOFF_RESTART_BUDGET_MS} becomes
+ * the wait on its own, and the wait never steps back to a restart.
+ *
  * The module owns the overlay's DOM, copy and clock, and nothing else:
  * connecting, retrying and interrupting are the caller's, handed in as
  * callbacks.
  */
 const OVERLAY_ID = 'terminal-handoff';
 
-/** When the current hand-off wait started, or null when none is showing. */
+/** Copy shown while the outgoing view finishes the turn it is on. */
+export const HANDOFF_PENDING_MESSAGE = 'Finishing in the other view · ';
+
+/** Copy shown while an idle agent is stopped in the other view and started here. */
+export const HANDOFF_RESTARTING_MESSAGE = 'Restarting the agent in this view…';
+
+/**
+ * How long a restart may take before it is shown as a wait. A restart is the
+ * outgoing process exiting cleanly plus the incoming one connecting, a few
+ * seconds at most; past that the operator is waiting on something, and the
+ * wait's clock and way out are the honest thing to show.
+ */
+export const HANDOFF_RESTART_BUDGET_MS = 4000;
+
+/** When the current hand-off began, or null when none is showing. */
 /** @type {number|null} */
 let startedAt = null;
 
 /** The 1 Hz elapsed-time ticker, or null when nothing is counting. */
 /** @type {number|null} */
 let ticker = null;
+
+/** The timer that turns a long restart into the wait, or null when none is armed. */
+/** @type {number|null} */
+let escalation = null;
+
+/** Whether the wait is on screen; it never steps back to a restart. */
+let waiting = false;
 
 /**
  * Elapsed wait as `m:ss`.
@@ -110,25 +140,56 @@ function actionButton() {
 }
 
 /**
- * Show the transitional state: the other view's agent is finishing its turn
- * and this connection is waiting for it. There is no bound on that wait, so
- * the elapsed time is the honest thing to show, and the button is the
- * operator's way out of it.
+ * Show the transitional state. With `busy` the other view's agent is
+ * finishing its turn and this connection is waiting for it: there is no bound
+ * on that wait, so the elapsed time is the honest thing to show, and the
+ * button is the operator's way out of it. Without it the agent is only being
+ * restarted here, and that is what is shown — until the restart outlasts its
+ * budget, when the wait takes over.
  *
  * @param {() => void} onInterrupt - "Stop and switch now". The button
  *   disables itself before this runs, and a later `handoff_pending` re-enables
  *   it, so one press cannot become two.
+ * @param {{ busy?: boolean }} [state] - What the server said about the other
+ *   view's agent. Omitted, it is taken to be idle.
  */
-export function showHandoffPending(onInterrupt) {
+export function showHandoffPending(onInterrupt, state = {}) {
   const overlay = ensureOverlay();
   if (!overlay) return;
 
   // A second `handoff_pending` — including the one an interrupt's reconnect
-  // brings back — continues the wait the operator is already watching rather
-  // than restarting its clock.
+  // brings back — continues the hand-off the operator is already watching
+  // rather than restarting its clock.
   if (startedAt === null) startedAt = Date.now();
 
-  setMessage(overlay, 'Finishing in the other view · ', true);
+  if (state.busy || waiting) {
+    showWait(overlay, onInterrupt);
+    return;
+  }
+  setMessage(overlay, HANDOFF_RESTARTING_MESSAGE, false);
+  const action = actionButton();
+  if (action) {
+    action.hidden = true;
+    action.onclick = null;
+  }
+  if (escalation === null) {
+    escalation = window.setTimeout(() => {
+      escalation = null;
+      showWait(overlay, onInterrupt);
+    }, HANDOFF_RESTART_BUDGET_MS);
+  }
+}
+
+/**
+ * The wait: the elapsed clock, counted from when the hand-off began, and the
+ * way out of it.
+ * @param {HTMLElement} overlay
+ * @param {() => void} onInterrupt
+ */
+function showWait(overlay, onInterrupt) {
+  waiting = true;
+  disarmEscalation();
+  setMessage(overlay, HANDOFF_PENDING_MESSAGE, true);
   renderElapsed();
   if (ticker === null) ticker = window.setInterval(renderElapsed, 1000);
 
@@ -144,6 +205,14 @@ export function showHandoffPending(onInterrupt) {
   // Moves the caret out of the terminal, which takes no input while the
   // hand-off is pending.
   action.focus();
+}
+
+/** Cancel a pending restart-to-wait escalation. */
+function disarmEscalation() {
+  if (escalation !== null) {
+    clearTimeout(escalation);
+    escalation = null;
+  }
 }
 
 /**
@@ -184,13 +253,15 @@ export function showHandoffRefused(code, onRetry) {
     : null;
 }
 
-/** Stop the elapsed counter and forget when the wait began. */
+/** Stop the clock and the escalation, and forget when the hand-off began. */
 function stopTicker() {
   if (ticker !== null) {
     clearInterval(ticker);
     ticker = null;
   }
+  disarmEscalation();
   startedAt = null;
+  waiting = false;
 }
 
 /** Clear the overlay entirely. */

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -393,15 +393,16 @@ export function startTerminal(sessionId = null, mode = 'new', { interrupt = fals
             // agent (or the one an interrupt forces) would read as a dead id
             // and drop the key both views are on.
             autoResumeFailoverId = null;
-            // The other view still holds the session and its agent is mid-turn.
-            // The server waits for that turn to end rather than killing it, so
-            // this connection has no bound on how long it sits here — show the
-            // wait, and the way to end it: ask for the same session again with
-            // `interrupt=1`, which ends that turn instead of waiting it out.
+            // The other view still holds the session. Idle, its agent is only
+            // restarted here; mid-turn (`busy`), the server waits for that turn
+            // to end rather than killing it, so this connection has no bound
+            // on how long it sits here — show the wait, and the way to end it:
+            // ask for the same session again with `interrupt=1`, which ends
+            // that turn instead of waiting it out.
             showHandoffPending(() => {
               dropConnection();
               startExpert({ interrupt: true });
-            });
+            }, { busy: msg.busy === true });
           } else if (msg.type === 'session_info') {
             // On resume, msg.session_id is the id ACTUALLY attached, which
             // may differ from the stale id we asked for (the server

--- a/src/osprey/mcp_server/control_system/tools/channel_write.py
+++ b/src/osprey/mcp_server/control_system/tools/channel_write.py
@@ -700,10 +700,10 @@ async def channel_write(
                 # down, deliberately as late as possible. That connector makes
                 # the step check itself, on the write. Refusing here for want of
                 # a reader would take max_step off this path rather than
-                # enforcing it. `validate` remains the fallback for a validator
-                # older than this entry point.
-                check = getattr(validator, "validate_without_step_check", validator.validate)
-                check(channel, value)
+                # enforcing it. The validator above is imported from the same
+                # installed osprey as this tool, so this entry point is always
+                # the one it has — no version skew is reachable here.
+                validator.validate_without_step_check(channel, value)
             except Exception as exc:
                 violation = {
                     "channel": channel,

--- a/src/osprey/mcp_server/facility_knowledge/server.py
+++ b/src/osprey/mcp_server/facility_knowledge/server.py
@@ -270,6 +270,22 @@ def create_server() -> FastMCP:
     return mcp
 
 
+def reset_bundle() -> None:
+    """Clear the bundle singletons that :func:`create_server` resolves at startup.
+
+    Both ``_bundle`` and ``_bundle_error`` are process-wide, so a test that
+    starts the server hands its result to every test that runs after it in the
+    same worker. A startup that recorded ``bundle_not_configured`` left that
+    cause standing, and the next test asking for the genuine "the server was
+    never started" branch got the earlier test's answer instead. Tests reset on
+    both sides so that state stays inside the test that created it.
+    """
+    global _bundle, _bundle_error
+
+    _bundle = None
+    _bundle_error = None
+
+
 # ---------------------------------------------------------------------------
 # Tool error envelope
 # ---------------------------------------------------------------------------

--- a/src/osprey/models/providers/cborg.py
+++ b/src/osprey/models/providers/cborg.py
@@ -24,12 +24,13 @@ class CBorgProviderAdapter(LiteLLMDelegatingProvider):
     default_model_id = "anthropic/claude-haiku"  # Claude Haiku via CBORG for general use
     health_check_model_id = "anthropic/claude-haiku"  # Fast and cost-effective for health checks
     available_models = [
+        "anthropic/claude-opus",
         "anthropic/claude-sonnet",
         "anthropic/claude-haiku",
-        "google/gemini-flash",
-        "google/gemini-pro",
-        "openai/gpt-4o",
-        "openai/gpt-4o-mini",
+        "gemini-pro",
+        "gemini-flash",
+        "gpt-4o",
+        "gpt-4o-mini",
     ]
 
     # API key acquisition information

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -769,11 +769,16 @@ keys:
     note: >-
       Extra tool names a project folds into the writes kill switch, commented
       in the two presets that carry the stanza, so no preset's resolved
-      config carries it. The reader is the claude_code renderer, which hands the list
-      to `hook_config.json` as `control_system_write_tools`; the writes-check
-      hook reads it from there. Tools named here are refused per call and never
-      enter `permissions.deny`, which is why a mixed-posture render can gate
-      them at all.
+      config carries it. The reader is the claude_code renderer, which folds the
+      list into `hook_config.json`'s `write_tools` — the key the writes-check
+      hook, the headless disallow list and the audit middleware all read. The
+      entries the renderer actually appended (an extra that merely re-states a
+      server-derived matcher is not one) are ALSO emitted under
+      `control_system_write_tools`, read by the config-drift hook alone, which
+      subtracts them from the kill-switch set it compares against a
+      deployment's `permissions.deny`. That subtraction is needed because tools
+      named here are refused per call and never enter `permissions.deny`, which
+      is also why a mixed-posture render can gate them at all.
     default: []
   control_system.target_display_names:
     rendered: false

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -632,9 +632,10 @@ keys:
   approval.tools:
     covered-by: approval
     note: >-
-      Absent from channel_finder_standalone by design — its only
-      approval-governed tool (setup_patch) is covered by default_policy.
-      See governed_sets.
+      Absent from channel-finder-standalone by design — that deployment runs
+      no control system, and each of the four tools its servers do govern
+      (setup_patch and the three panel-rail verbs) is covered by
+      default_policy. See governed_sets.
     default: {}
   approval.tools.channel_write:
     evidence: 'approval\.tools\.channel_write'
@@ -675,6 +676,19 @@ keys:
       reason entry_create is.
     default: derived
     default_note: falls through to approval.default_policy
+  # The panel-rail verbs. Spelled in exactly the three presets that ship an
+  # approval table for a workspace tool; `covered-by` rather than `evidence`
+  # because the reader is the same approval table `execute` is read from, and a
+  # bare literal would pin the tool name instead of the policy key.
+  approval.tools.add_panel_to_rail:
+    {covered-by: approval.tools, default: derived,
+     default_note: falls through to approval.default_policy}
+  approval.tools.remove_panel_from_rail:
+    {covered-by: approval.tools, default: derived,
+     default_note: falls through to approval.default_policy}
+  approval.tools.register_panel:
+    {covered-by: approval.tools, default: derived,
+     default_note: falls through to approval.default_policy}
   hooks:
     all-templates: true
     evidence: 'full_config\.get\("hooks", \{\}\)'
@@ -2284,23 +2298,18 @@ render_contexts:
     panels_on: web.panels.channel-finder.enabled
     default_panel_set: web.default_panel
     panel_presets_set: web.presets
-  expected_union_size: 353
+  expected_union_size: 357
   note_union_size: >-
     Informational, not an assertion — it moves whenever the framework template
-    or a preset gains or loses a key. The guard reports a diff against this
-    number rather than failing on it. Because it cannot fail, it only stays
-    useful if it is re-derived whenever a source's key set changes; it had
-    drifted 9 low before the qmd blocks landed, which is exactly how a soft
-    counter stops being a signal.
-    309 -> 353 is the app-template deletion, and the arithmetic is deliberately
-    NOT carried over from the old number: the union changed sources, so it was
-    re-derived by running the guard on the new one. Two movements make up the
-    difference and both are structural rather than a change in what ships. The
-    presets carry keys the app templates never rendered because they were always
-    preset-side (the whole modules.web_terminals roster, deploy.fqdn,
-    claude_code.permissions), and the framework template renders every builtin
-    panel's web.panels.<id> block plus web.default_panel and web.presets, which
-    the old five-template matrix's two-panel selection never reached.
+    or a preset gains or loses a key, and the guard reports a diff against it
+    rather than failing on it. Because it cannot fail, it is a signal only while
+    it is re-derived whenever a source's key set changes: a counter left behind
+    reads as an agreement it has not earned.
+
+    Re-derive it by running the guard and recording the number it reports, never
+    by adding an expected delta to the number already written here. The union is
+    taken over the rendered sources, so a change in what those sources are moves
+    it by an amount arithmetic on the previous figure cannot predict.
 
 # ---------------------------------------------------------------------------
 # governed_sets — ADDENDUM 2. Two safety stanzas make EXHAUSTIVE claims that no
@@ -2334,14 +2343,15 @@ governed_sets:
   claims:
     ariel-standalone:
       preset: src/osprey/profiles/presets/ariel-standalone.yml
-      comment_claim: 'here ARIEL `entry_create` and `entry_publish`, workspace `setup_patch` and facility-knowledge `draft_concept`'
+      comment_claim: 'here ARIEL `entry_create` and `entry_publish`, workspace `setup_patch`, `add_panel_to_rail`, `remove_panel_from_rail` and `register_panel`, and facility-knowledge `draft_concept`'
       exhaustive: true
-      tools: [entry_create, entry_publish, setup_patch, draft_concept]
+      tools: [entry_create, entry_publish, setup_patch, add_panel_to_rail,
+              remove_panel_from_rail, register_panel, draft_concept]
     channel-finder-standalone:
       preset: src/osprey/profiles/presets/channel-finder-standalone.yml
-      comment_claim: 'in this deployment that is the workspace setup_patch tool alone'
+      comment_claim: 'in this deployment that is the workspace `setup_patch` tool plus the three panel-rail verbs `add_panel_to_rail`, `remove_panel_from_rail` and `register_panel`'
       exhaustive: true
-      tools: [setup_patch]
+      tools: [setup_patch, add_panel_to_rail, remove_panel_from_rail, register_panel]
   reference_counts:
     note: >-
       Not exhaustive claims in any shipped comment — recorded so a future
@@ -2356,8 +2366,11 @@ governed_sets:
       the same approval hook and were never in a template's render.
       entry_publish joined every set that already carried entry_create when the
       ariel server gave it the same approval hook.
-    control-assistant: [archiver_read, channel_read, channel_write, control_target_set, draft_concept, entry_create, entry_publish, execute, execute_file, queue_add, queue_remove, queue_start, queue_stop, setup_patch, stop_run, validate_plan, write_plan]
-    hello-world: [archiver_read, channel_read, channel_write, control_target_set, draft_concept, execute, execute_file, setup_patch]
+      add_panel_to_rail, remove_panel_from_rail and register_panel joined every
+      set when the workspace server gave the panel-rail verbs the same approval
+      hook: the rail is what the next operator sees, so changing it asks first.
+    control-assistant: [add_panel_to_rail, archiver_read, channel_read, channel_write, control_target_set, draft_concept, entry_create, entry_publish, execute, execute_file, queue_add, queue_remove, queue_start, queue_stop, register_panel, remove_panel_from_rail, setup_patch, stop_run, validate_plan, write_plan]
+    hello-world: [add_panel_to_rail, archiver_read, channel_read, channel_write, control_target_set, draft_concept, execute, execute_file, register_panel, remove_panel_from_rail, setup_patch]
   draft_concept_note: >-
     draft_concept is approval-governed in control-assistant and hello-world
     (osprey_facility_knowledge is enabled by default and carries the hook) but
@@ -2370,6 +2383,17 @@ governed_sets:
     approval.tools block, so it too falls to default_policy. execute_file is
     the third of this kind: it shares execute's policy unit (same server, same
     hooks) but no approval.tools block names it.
+  rail_tools_note: >-
+    add_panel_to_rail, remove_panel_from_rail and register_panel are governed
+    wherever the workspace server runs, which is every preset. Three presets —
+    ariel-standalone, hello-world and control-assistant, whose six `extends`
+    children inherit the lines — spell `always` for each of them, so the
+    shipped policy is explicit there. channel-finder-standalone deliberately
+    ships no approval.tools block at all, so its rail verbs fall to
+    default_policy: always, the same fail-closed route draft_concept and
+    control_target_set take. Same outcome, stated in a different place: do not
+    "fix" the missing keys, and do not read their absence as the rail being
+    ungated.
 
 # ---------------------------------------------------------------------------
 # kept_readers — code that legitimately still mentions a DELETED key. These are

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -186,7 +186,8 @@ config:
 
   # ── Approval ───────────────────────────────────────────────────────────────
   # Applied by the approval hook, so it reaches only hook-wired tools: here
-  # ARIEL `entry_create` and `entry_publish`, workspace `setup_patch` and
+  # ARIEL `entry_create` and `entry_publish`, workspace `setup_patch`,
+  # `add_panel_to_rail`, `remove_panel_from_rail` and `register_panel`, and
   # facility-knowledge `draft_concept`. Everything else is gated by the
   # rendered settings.json permissions.
   approval.enabled: true
@@ -196,6 +197,11 @@ config:
   approval.tools.entry_create: always
   # Publishing it through to the facility's logbook does too.
   approval.tools.entry_publish: always
+  # The panel rail is the operator's own view. Adding or removing a panel, and
+  # registering a new one, changes what the next person sees, so each asks.
+  approval.tools.add_panel_to_rail: always
+  approval.tools.remove_panel_from_rail: always
+  approval.tools.register_panel: always
 
   # ── Hook observability ─────────────────────────────────────────────────────
   # On here. Every hook call logs one line to stderr and appends to

--- a/src/osprey/profiles/presets/channel-finder-standalone.yml
+++ b/src/osprey/profiles/presets/channel-finder-standalone.yml
@@ -134,10 +134,13 @@ config:
   # channel_finder.benchmark.dataset_path: data/benchmarks/queries.json
 
   # ── Approval ───────────────────────────────────────────────────────────────
-  # The channel finder is read-only, so no write tool is gated here. The
-  # approval hook reaches only hook-wired tools; in this deployment that is
-  # the workspace setup_patch tool alone. Everything else is gated by the
-  # rendered settings.json permissions.
+  # The channel finder is read-only, so no control-system write is gated here.
+  # The approval hook reaches only hook-wired tools; in this deployment that is
+  # the workspace `setup_patch` tool plus the three panel-rail verbs
+  # `add_panel_to_rail`, `remove_panel_from_rail` and `register_panel`, which
+  # change what the next operator sees. No `approval.tools` key names any of
+  # the four, so all of them fall to the default policy below. Everything else
+  # is gated by the rendered settings.json permissions.
   approval.enabled: true
   # Policy for any hook-wired tool not listed: "always" is fail-closed.
   approval.default_policy: always

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -430,6 +430,11 @@ config:
   approval.tools.entry_create: always
   # Publishing it through to the facility's logbook does too.
   approval.tools.entry_publish: always
+  # The panel rail is the operator's own view. Adding or removing a panel, and
+  # registering a new one, changes what the next person sees, so each asks.
+  approval.tools.add_panel_to_rail: always
+  approval.tools.remove_panel_from_rail: always
+  approval.tools.register_panel: always
 
   # ── Hook observability ─────────────────────────────────────────────────────
   # On here. Every hook call logs one line to stderr and appends to

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -182,6 +182,11 @@ config:
   # ARIEL logbook writes. Inert here: the ariel server is off below.
   approval.tools.entry_create: always
   approval.tools.entry_publish: always
+  # The panel rail is the operator's own view. Adding or removing a panel, and
+  # registering a new one, changes what the next person sees, so each asks.
+  approval.tools.add_panel_to_rail: always
+  approval.tools.remove_panel_from_rail: always
+  approval.tools.register_panel: always
 
   # ── Hook observability ─────────────────────────────────────────────────────
   # Off here. On, every hook call logs one line to stderr and appends to

--- a/src/osprey/profiles/providers.yml
+++ b/src/osprey/profiles/providers.yml
@@ -29,8 +29,8 @@ providers:
     base_url: https://api.cborg.lbl.gov/v1
     models:                        # Model IDs as named by this provider
       haiku: claude-haiku-4-5
-      sonnet: claude-sonnet-4-6
-      opus: claude-opus-4-7
+      sonnet: claude-sonnet-5
+      opus: claude-opus-5
   amsc-i2:
     api_key: ${AMSC_I2_API_KEY}
     base_url: https://api.i2-core.american-science-cloud.org/v1

--- a/src/osprey/registry/mcp.py
+++ b/src/osprey/registry/mcp.py
@@ -265,6 +265,7 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "artifact_read",
             "artifact_get",
             "artifact_focus",
+            "artifact_pin",
             "artifact_export",
             "create_static_plot",
             "create_interactive_plot",
@@ -282,21 +283,59 @@ FRAMEWORK_SERVERS: dict[str, ServerDefinition] = {
             "lattice_state",
             "lattice_set_param",
             "lattice_refresh",
+            "lattice_get_data",
+            "lattice_get_figure",
+            "lattice_get_settings",
+            "lattice_update_settings",
+            # Baseline and settings are the simulation's own scratch state:
+            # nothing here reaches hardware. lattice_init sets a fresh
+            # baseline, so lattice_clear_baseline is undone by re-running it;
+            # settings are carried across a re-init instead, so a settings
+            # change stands until it is set back. Neither is worth a prompt.
+            # lattice_clear_baseline is nonetheless auto-classified
+            # side-effecting by agent_runner.write_tools (it matches the
+            # "clear" destructive marker) and blocked under the headless
+            # read-only floor regardless of this allow-listing — expected
+            # posture; do not rename the tool to dodge it.
             "lattice_set_baseline",
+            "lattice_clear_baseline",
             "list_panels",
             # The on-screen axis: both halves are reversible in one operator
-            # click, so neither is worth a prompt. The rail axis
-            # (add_panel_to_rail/remove_panel_from_rail) is deliberately absent —
-            # taking a panel off the rail costs the operator the ability to
-            # launch it back, which is worth asking about.
+            # click, so neither is worth a prompt. The rail axis is the
+            # exception and asks instead — see permissions_ask below.
             "open_panel",
             "close_panel",
             "arrange_workspace",
         ],
-        permissions_ask=["setup_patch"],
+        # The rail axis changes what the operator can launch at all, which the
+        # on-screen verbs above do not: remove_panel_from_rail costs them the
+        # ability to launch the panel back, add_panel_to_rail puts an entry in
+        # front of them, and register_panel adds a proxied upstream. One
+        # literal matcher per tool, the shape every other approval rule here
+        # uses: the approval hook and the SDK's disallow engine match tool
+        # names exactly, so an alternation group would gate nothing — and it is
+        # the only shape check_config_keys.py's matcher extractor can read.
+        permissions_ask=[
+            "setup_patch",
+            "add_panel_to_rail",
+            "remove_panel_from_rail",
+            "register_panel",
+        ],
         hooks_pre=[
             HookRule(
                 matcher="mcp__osprey_workspace__setup_patch",
+                hooks=[_APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__osprey_workspace__add_panel_to_rail",
+                hooks=[_APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__osprey_workspace__remove_panel_from_rail",
+                hooks=[_APPROVAL],
+            ),
+            HookRule(
+                matcher="mcp__osprey_workspace__register_panel",
                 hooks=[_APPROVAL],
             ),
         ],

--- a/src/osprey/services/ariel_search/ingestion/adapters/als.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/als.py
@@ -7,7 +7,6 @@ to the ALS olog RPC API.
 
 import asyncio
 import json
-import os
 import ssl
 import xml.etree.ElementTree as ET
 from collections.abc import AsyncIterator
@@ -23,7 +22,6 @@ from osprey.services.ariel_search.exceptions import (
     IngestionError,
 )
 from osprey.services.ariel_search.ingestion.base import FacilityAdapter
-from osprey.services.ariel_search.ingestion.http import build_ssl_context
 from osprey.services.ariel_search.models import AttachmentInfo, EnhancedLogbookEntry
 from osprey.utils.logger import get_logger
 
@@ -104,9 +102,6 @@ class ALSLogbookAdapter(FacilityAdapter):
         self.attachment_url_prefix = "https://elog.als.lbl.gov/"
         self.skip_empty_entries = True
 
-        self.proxy_url = config.ingestion.proxy_url or os.environ.get("ARIEL_SOCKS_PROXY")
-        self.verify_ssl = config.ingestion.verify_ssl
-        self.ca_bundle = config.ingestion.ca_bundle
         self.chunk_days = config.ingestion.chunk_days or 365
         self.request_timeout = config.ingestion.request_timeout_seconds or 60
         self.max_retries = config.ingestion.max_retries or 3
@@ -297,8 +292,7 @@ class ALSLogbookAdapter(FacilityAdapter):
             IngestionError: If the POST fails after retries.
         """
         connector = self._create_connector()
-
-        ssl_context = build_ssl_context(self.verify_ssl, self.ca_bundle)
+        ssl_context = self._ssl_context()
 
         timeout = aiohttp.ClientTimeout(total=self.request_timeout)
         last_error: Exception | None = None
@@ -395,8 +389,7 @@ class ALSLogbookAdapter(FacilityAdapter):
         count = 0
 
         connector = self._create_connector()
-
-        ssl_context = build_ssl_context(self.verify_ssl, self.ca_bundle)
+        ssl_context = self._ssl_context()
 
         timeout = aiohttp.ClientTimeout(total=self.request_timeout)
 
@@ -573,31 +566,6 @@ class ALSLogbookAdapter(FacilityAdapter):
 
             logger.debug(f"Fetched {len(data)} entries from window")
             return data
-
-    def _create_connector(self) -> aiohttp.BaseConnector:
-        """Create aiohttp connector with optional SOCKS proxy support.
-
-        Returns:
-            aiohttp connector (with proxy if configured)
-
-        Raises:
-            IngestionError: If proxy is configured but aiohttp-socks is not installed
-        """
-        if not self.proxy_url:
-            return aiohttp.TCPConnector()
-
-        try:
-            from aiohttp_socks import ProxyConnector
-        except ImportError as e:
-            raise IngestionError(
-                "SOCKS proxy configured but aiohttp-socks is not installed. "
-                "Install with: pip install osprey-framework",
-                source_system=self.source_system_name,
-            ) from e
-
-        logger.info(f"Using SOCKS proxy: {self.proxy_url}")
-        connector: aiohttp.BaseConnector = ProxyConnector.from_url(self.proxy_url)
-        return connector
 
     def _convert_entry(self, data: dict[str, Any]) -> EnhancedLogbookEntry:
         """Convert ALS JSON entry to EnhancedLogbookEntry."""

--- a/src/osprey/services/ariel_search/ingestion/adapters/generic.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/generic.py
@@ -193,8 +193,8 @@ class GenericJSONAdapter(FacilityAdapter):
             try:
                 import aiohttp
 
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(self.source_url) as response:
+                async with aiohttp.ClientSession(connector=self._create_connector()) as session:
+                    async with session.get(self.source_url, ssl=self._ssl_context()) as response:
                         if response.status != 200:
                             raise IngestionError(
                                 f"HTTP request failed with status {response.status}",

--- a/src/osprey/services/ariel_search/ingestion/adapters/jlab.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/jlab.py
@@ -101,8 +101,8 @@ class JLabLogbookAdapter(FacilityAdapter):
             try:
                 import aiohttp
 
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(self.source_url) as response:
+                async with aiohttp.ClientSession(connector=self._create_connector()) as session:
+                    async with session.get(self.source_url, ssl=self._ssl_context()) as response:
                         if response.status != 200:
                             raise IngestionError(
                                 f"HTTP request failed with status {response.status}",

--- a/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
@@ -101,8 +101,8 @@ class ORNLLogbookAdapter(FacilityAdapter):
             try:
                 import aiohttp
 
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(self.source_url) as response:
+                async with aiohttp.ClientSession(connector=self._create_connector()) as session:
+                    async with session.get(self.source_url, ssl=self._ssl_context()) as response:
                         if response.status != 200:
                             raise IngestionError(
                                 f"HTTP request failed with status {response.status}",

--- a/src/osprey/services/ariel_search/ingestion/base.py
+++ b/src/osprey/services/ariel_search/ingestion/base.py
@@ -3,10 +3,17 @@
 This module defines the abstract base class for ARIEL ingestion adapters.
 """
 
+import ssl
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import TYPE_CHECKING
+
+import aiohttp
+
+from osprey.services.ariel_search.exceptions import IngestionError
+from osprey.services.ariel_search.ingestion.http import build_ssl_context
+from osprey.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from osprey.services.ariel_search.config import ARIELConfig
@@ -14,6 +21,8 @@ if TYPE_CHECKING:
         EnhancedLogbookEntry,
         FacilityEntryCreateRequest,
     )
+
+logger = get_logger(__name__)
 
 
 class FacilityAdapter(ABC):
@@ -32,10 +41,29 @@ class FacilityAdapter(ABC):
             otherwise get no metadata at all and say nothing about it. A name
             that never matches is simply a no-op, so this needs no enable
             switch beside it.
+        proxy_url: SOCKS proxy for outbound logbook requests, or ``None`` for a
+            direct connection.
+        verify_ssl: Whether outbound logbook requests verify TLS certificates.
+        ca_bundle: PEM bundle those requests verify against, or ``None`` to use
+            the trust store the image ships.
+
+    The three transport attributes are class-level defaults so that every
+    adapter answers the TLS and proxy questions the same way, whether or not it
+    remembered to read the ingestion config. An adapter that never sets them
+    still verifies certificates and still goes direct.
     """
 
     #: See the class docstring. Lower-case comparison, so case does not matter.
     metadata_sidecar_names: tuple[str, ...] = ("metadata.json",)
+
+    #: See the class docstring. Already resolved by ``IngestionConfig.from_dict``.
+    proxy_url: str | None = None
+
+    #: See the class docstring. Defaults on, so silence never means "off".
+    verify_ssl: bool = True
+
+    #: See the class docstring. ``None`` leaves aiohttp on the image trust store.
+    ca_bundle: str | None = None
 
     def __init__(self, config: "ARIELConfig") -> None:
         """Initialize the adapter with configuration.
@@ -44,6 +72,56 @@ class FacilityAdapter(ABC):
             config: ARIEL configuration
         """
         self.config = config
+        ingestion = config.ingestion
+        if ingestion is not None:
+            # A configured value wins; ``None`` falls through to the class
+            # default rather than overwriting it. A YAML key written with an
+            # empty value (``verify_ssl:``) arrives here as ``None``, and
+            # assigning it would turn certificate checking off by silence --
+            # exactly what the defaults above exist to prevent.
+            if ingestion.proxy_url is not None:
+                # Already resolved: IngestionConfig.from_dict folds
+                # ARIEL_SOCKS_PROXY in, so no adapter re-reads the environment.
+                self.proxy_url = ingestion.proxy_url
+            if ingestion.verify_ssl is not None:
+                self.verify_ssl = ingestion.verify_ssl
+            if ingestion.ca_bundle is not None:
+                self.ca_bundle = ingestion.ca_bundle
+
+    def _create_connector(self) -> aiohttp.BaseConnector:
+        """Create aiohttp connector with optional SOCKS proxy support.
+
+        Returns:
+            aiohttp connector (with proxy if configured)
+
+        Raises:
+            IngestionError: If proxy is configured but aiohttp-socks is not installed
+        """
+        if not self.proxy_url:
+            return aiohttp.TCPConnector()
+
+        try:
+            from aiohttp_socks import ProxyConnector
+        except ImportError as e:
+            raise IngestionError(
+                "SOCKS proxy configured but aiohttp-socks is not installed. "
+                "Install with: pip install osprey-framework",
+                source_system=self.source_system_name,
+            ) from e
+
+        logger.info(f"Using SOCKS proxy: {self.proxy_url}")
+        connector: aiohttp.BaseConnector = ProxyConnector.from_url(self.proxy_url)
+        return connector
+
+    def _ssl_context(self) -> ssl.SSLContext | bool:
+        """Return the ``ssl=`` argument for this adapter's outbound requests.
+
+        Returns:
+            Whatever :func:`build_ssl_context` makes of ``verify_ssl`` and
+            ``ca_bundle`` — one place decides, so no adapter can ship a quieter
+            answer of its own.
+        """
+        return build_ssl_context(self.verify_ssl, self.ca_bundle)
 
     @property
     @abstractmethod

--- a/src/osprey/services/ariel_search/ingestion/metadata_attachment.py
+++ b/src/osprey/services/ariel_search/ingestion/metadata_attachment.py
@@ -114,11 +114,9 @@ async def _fetch_metadata(
             ssl_context = build_ssl_context(ingestion.verify_ssl, ingestion.ca_bundle)
 
         # The adapter's own connector, so a SOCKS proxy the ingest goes
-        # through carries this request too.
-        connector = None
-        make_connector = getattr(adapter, "_create_connector", None)
-        if callable(make_connector):
-            connector = make_connector()
+        # through carries this request too. A sidecar fetched without an
+        # adapter has none to inherit and goes out on aiohttp's default.
+        connector = adapter._create_connector() if adapter is not None else None
 
         async with aiohttp.ClientSession(connector=connector) as session:
             async with session.get(

--- a/src/osprey/services/python_executor/execution/wrapper.py
+++ b/src/osprey/services/python_executor/execution/wrapper.py
@@ -917,7 +917,18 @@ if not _execution_dir.exists():
                     import tango as _tango
 
                     def _tango_channel(_proxy, _attr):
-                        return f"{{_proxy.dev_name()}}/{{_attr}}"
+                        '''The device/attribute address a write is bounded under.
+
+                        PyTango takes the attribute as a name or as an object
+                        carrying one -- an ``AttributeInfo``, a
+                        ``DeviceAttribute``. Interpolating the object builds an
+                        address the limits database has never heard of, which
+                        on a deployment that allows unlisted channels is a
+                        write that passes with no bound applied, so the
+                        argument is reduced to its name first.
+                        '''
+                        _name = getattr(_attr, 'name', _attr)
+                        return f"{{_proxy.dev_name()}}/{{_name}}"
 
                     def _tango_current_value(_proxy):
                         '''A reader for the max_step check, bound to the writing proxy.
@@ -955,6 +966,126 @@ if not _execution_dir.exists():
                                 ) from _shape_error
                             _pairs.append((_attr, _value))
                         return _pairs
+
+                    def _tango_checked_write(_original):
+                        '''Wrap a DeviceProxy spelling that writes ONE attribute.
+
+                        Every ``(attribute, value)`` spelling shares this
+                        shape: the value is bounded against the full
+                        device/attribute address, and whatever the original
+                        answers -- nothing, a request id, a read-back
+                        attribute -- is passed back untouched.
+                        '''
+
+                        def _checked(self, attr_name, value, *args, **kwargs):
+                            _limits_validator.validate(
+                                _tango_channel(self, attr_name),
+                                value,
+                                read_current=_tango_current_value(self),
+                            )
+                            return _original(self, attr_name, value, *args, **kwargs)
+
+                        return _checked
+
+                    def _tango_checked_write_many(_original):
+                        '''Wrap a DeviceProxy spelling that writes MANY attributes.
+
+                        Every pair is bounded before any of them is written,
+                        and the answer is passed back untouched. PyTango names
+                        the pairs ``name_val`` on some spellings and
+                        ``attr_values`` on others, so they are taken
+                        positionally or under either name and forwarded the way
+                        they arrived; a guard that accepted one spelling would
+                        break the other with a TypeError naming its own
+                        internals.
+                        '''
+
+                        def _checked(self, *args, **kwargs):
+                            _keyword = None
+                            if args:
+                                _name_val = args[0]
+                            else:
+                                for _spelling in ('name_val', 'attr_values'):
+                                    if _spelling in kwargs:
+                                        _keyword = _spelling
+                                        break
+                                if _keyword is None:
+                                    raise ValueError(
+                                        "tango write_attributes requires (attribute, "
+                                        "value) pairs so each write can be "
+                                        "limits-checked"
+                                    )
+                                _name_val = kwargs[_keyword]
+                            _pairs = _tango_pairs(_name_val)
+                            _read_current = _tango_current_value(self)
+                            for _attr, _value in _pairs:
+                                _limits_validator.validate(
+                                    _tango_channel(self, _attr),
+                                    _value,
+                                    read_current=_read_current,
+                                )
+                            # The materialised pairs, not the argument: a
+                            # generator was consumed by the check above, and
+                            # forwarding it would write nothing at all.
+                            if _keyword is None:
+                                return _original(self, _pairs, *args[1:], **kwargs)
+                            _forwarded = dict(kwargs)
+                            _forwarded[_keyword] = _pairs
+                            return _original(self, **_forwarded)
+
+                        return _checked
+
+                    # An ``AttributeProxy`` addresses one attribute for its
+                    # whole life, so its writes carry a value alone. The
+                    # channel address is rebuilt from the device proxy behind
+                    # it and the attribute's own name.
+                    def _tango_attribute_channel(_proxy):
+                        return f"{{_proxy.get_device_proxy().dev_name()}}/{{_proxy.name()}}"
+
+                    def _tango_attribute_current_value(_proxy):
+                        '''A reader for the max_step check, bound to the writing proxy.
+
+                        The proxy already points at the attribute being
+                        written, so the address the validator passes names
+                        that same channel and nothing is looked up from it.
+                        '''
+                        if not hasattr(_proxy, 'read'):
+                            return None
+
+                        def _read(_address):
+                            _value = _proxy.read()
+                            return getattr(_value, 'value', _value)
+
+                        return _read
+
+                    def _tango_checked_attribute_write(_original):
+                        '''Wrap an AttributeProxy spelling that writes its attribute.'''
+
+                        def _checked(self, value, *args, **kwargs):
+                            _limits_validator.validate(
+                                _tango_attribute_channel(self),
+                                value,
+                                read_current=_tango_attribute_current_value(self),
+                            )
+                            return _original(self, value, *args, **kwargs)
+
+                        return _checked
+
+                    def _tango_wrap_on(_class_name, _spellings):
+                        '''Install a limits-checked wrapper per spelling the class carries.
+
+                        Answers the names installed, so the success line can
+                        say what this binding actually had; a tango without
+                        the class answers an empty list.
+                        '''
+                        _cls = getattr(_tango, _class_name, None)
+                        _installed = []
+                        if _cls is not None:
+                            for _name, _wrap in _spellings:
+                                if hasattr(_cls, _name):
+                                    setattr(_cls, _name, _wrap(getattr(_cls, _name)))
+                                    _installed.append(_name)
+                        return _installed
 
                     # A Tango COMMAND is not a channel write. It names an
                     # operation on the device, and its argument is whatever
@@ -1004,46 +1135,31 @@ if not _execution_dir.exists():
                         ('command_inout', _tango_refuse_command),
                         ('command_inout_asynch', _tango_refuse_command),
                     )
+                    # Every attribute-write spelling DeviceProxy carries.
+                    # The asynchronous and write-read spellings drive the same
+                    # device with the same value as the plain write, so each
+                    # one is checked; a spelling left out is a live unchecked
+                    # write under a guard reporting itself installed.
+                    _tango_device_writes = (
+                        ('write_attribute', _tango_checked_write),
+                        ('write_attribute_asynch', _tango_checked_write),
+                        ('write_read_attribute', _tango_checked_write),
+                        ('write_attributes', _tango_checked_write_many),
+                        ('write_attributes_asynch', _tango_checked_write_many),
+                        ('write_read_attributes', _tango_checked_write_many),
+                    )
+                    _tango_attribute_writes = (
+                        ('write', _tango_checked_attribute_write),
+                        ('write_asynch', _tango_checked_attribute_write),
+                        ('write_read', _tango_checked_attribute_write),
+                    )
                     _tango_wrapped = []
+                    _tango_attribute_wrapped = []
                     _tango_refused = []
                     _tango_refused_base = []
 
                     if hasattr(_tango, "DeviceProxy"):
-                        if hasattr(_tango.DeviceProxy, "write_attribute"):
-                            _orig_tango_write = _tango.DeviceProxy.write_attribute
-
-                            def _checked_tango_write(self, attr_name, value, *args, **kwargs):
-                                '''Limits-checked wrapper for DeviceProxy.write_attribute().'''
-                                _limits_validator.validate(
-                                    _tango_channel(self, attr_name),
-                                    value,
-                                    read_current=_tango_current_value(self),
-                                )
-                                return _orig_tango_write(self, attr_name, value, *args, **kwargs)
-
-                            _tango.DeviceProxy.write_attribute = _checked_tango_write
-                            _tango_wrapped.append("write_attribute")
-
-                        if hasattr(_tango.DeviceProxy, "write_attributes"):
-                            _orig_tango_write_many = _tango.DeviceProxy.write_attributes
-
-                            def _checked_tango_write_many(self, name_val, *args, **kwargs):
-                                '''Limits-checked wrapper for DeviceProxy.write_attributes().'''
-                                _pairs = _tango_pairs(name_val)
-                                _read_current = _tango_current_value(self)
-                                for _attr, _value in _pairs:
-                                    _limits_validator.validate(
-                                        _tango_channel(self, _attr),
-                                        _value,
-                                        read_current=_read_current,
-                                    )
-                                # The materialised pairs, not the argument: a
-                                # generator was consumed by the check above, and
-                                # forwarding it would write nothing at all.
-                                return _orig_tango_write_many(self, _pairs, *args, **kwargs)
-
-                            _tango.DeviceProxy.write_attributes = _checked_tango_write_many
-                            _tango_wrapped.append("write_attributes")
+                        _tango_wrapped = _tango_wrap_on('DeviceProxy', _tango_device_writes)
 
                         _tango_refused = _tango_refuse_on('DeviceProxy', _tango_commands)
 
@@ -1069,6 +1185,19 @@ if not _execution_dir.exists():
                         # nothing on it, and must not report it guarded.
                         print("⚠️  tango guard failed: no DeviceProxy class")
 
+                    # ``tango.AttributeProxy`` is its own class, bound to one
+                    # attribute rather than to a device, so neither install
+                    # above reaches it. It is patched on its own, outside the
+                    # DeviceProxy branch: an AttributeProxy is a write surface
+                    # whether or not a DeviceProxy sits beside it. Its writes
+                    # forward to the DeviceProxy methods wrapped above, so a
+                    # value is bounded twice and a max_step channel is read
+                    # twice; the outer check is kept deliberately, because it
+                    # is the only one left if the DeviceProxy install fails.
+                    _tango_attribute_wrapped = _tango_wrap_on(
+                        'AttributeProxy', _tango_attribute_writes
+                    )
+
                     # ``tango.Group`` is not a Connection subclass. It is a
                     # separate pure-Python class carrying its own commands AND
                     # its own attribute writes, so neither install above
@@ -1092,6 +1221,7 @@ if not _execution_dir.exists():
                         _tango_label + ", ".join(_n + "()" for _n in _tango_names)
                         for _tango_label, _tango_names in (
                             ("wrapped on DeviceProxy: ", _tango_wrapped),
+                            ("wrapped on AttributeProxy: ", _tango_attribute_wrapped),
                             ("refused on DeviceProxy: ", _tango_refused),
                             ("refused on Connection: ", _tango_refused_base),
                             ("refused on Group: ", _tango_refused_group),
@@ -1144,9 +1274,12 @@ if not _execution_dir.exists():
                 except Exception as _doocs_error:
                     print(f"⚠️  doocs4py guard failed: {{_doocs_error}}")
 
-                # --- caproto. Two entry points, in two modules: the sync
-                # client's module-level write() and the threading client's
-                # PV.write(), which knows its own channel name.
+                # --- caproto. Write entry points in three modules, one per
+                # concurrency flavor: the sync client's module-level functions,
+                # the threading client's PV and Batch classes, and the asyncio
+                # client's own PV. Each module is imported and patched in its
+                # OWN try/except - a flavor missing from this environment must
+                # not take the guards for the others with it.
                 def _caproto_scalar(_response):
                     '''The number in a caproto read response.
 
@@ -1164,8 +1297,16 @@ if not _execution_dir.exists():
                     import caproto.sync.client as _caproto_sync
 
                     def _caproto_sync_current_value(_address):
-                        '''A reader for the max_step check, over caproto's own client.'''
-                        return _caproto_scalar(_caproto_sync.read(_address))
+                        '''A reader for the max_step check, over caproto's own client.
+
+                        The step-read ceiling is passed explicitly rather than
+                        left to caproto's own default, so a channel that never
+                        answers fails the check closed quickly instead of
+                        holding the write open.
+                        '''
+                        return _caproto_scalar(
+                            _caproto_sync.read(_address, timeout=STEP_READ_TIMEOUT_SECONDS)
+                        )
 
                     _caproto_sync_reader = (
                         _caproto_sync_current_value
@@ -1173,19 +1314,56 @@ if not _execution_dir.exists():
                         else None
                     )
 
-                    if hasattr(_caproto_sync, "write"):
-                        _orig_caproto_write = _caproto_sync.write
+                    # Both module-level spellings lead with the channel name
+                    # and the value, and ``read_write_read`` differs only in
+                    # reading the channel back afterwards - it drives the
+                    # channel with the same value, so it is bounded the same
+                    # way. The pair is taken positionally or under the names
+                    # caproto gives it, and the call is forwarded exactly as
+                    # it arrived.
+                    def _caproto_sync_checked(_original):
+                        '''Wrap a sync-client spelling that writes a channel.'''
 
-                        def _checked_caproto_write(pv_name, data, *args, **kwargs):
-                            '''Limits-checked wrapper for caproto.sync.client.write().'''
+                        def _checked(*args, **kwargs):
+                            _pv_name = args[0] if args else kwargs.get('pv_name')
+                            _data = args[1] if len(args) > 1 else kwargs.get('data')
+                            if _pv_name is None:
+                                raise ValueError(
+                                    "caproto write requires a channel name so "
+                                    "the write can be limits-checked"
+                                )
                             _limits_validator.validate(
-                                pv_name, data, read_current=_caproto_sync_reader
+                                _pv_name, _data, read_current=_caproto_sync_reader
                             )
-                            return _orig_caproto_write(pv_name, data, *args, **kwargs)
+                            return _original(*args, **kwargs)
 
-                        _caproto_sync.write = _checked_caproto_write
+                        return _checked
 
-                    print("✅ Monkeypatched caproto.sync.client.write()")
+                    _caproto_sync_wrapped = []
+                    for _caproto_name in ('write', 'read_write_read'):
+                        if hasattr(_caproto_sync, _caproto_name):
+                            setattr(
+                                _caproto_sync,
+                                _caproto_name,
+                                _caproto_sync_checked(
+                                    getattr(_caproto_sync, _caproto_name)
+                                ),
+                            )
+                            _caproto_sync_wrapped.append(_caproto_name)
+
+                    # The success line is the operator's only evidence the
+                    # guard is on, so it names what this binding actually
+                    # carried rather than what the block can install.
+                    if _caproto_sync_wrapped:
+                        print(
+                            "✅ Monkeypatched caproto.sync.client: "
+                            + ", ".join(_n + "()" for _n in _caproto_sync_wrapped)
+                        )
+                    else:
+                        print(
+                            "⚠️  caproto.sync.client guard failed: "
+                            "no write function"
+                        )
                 except ImportError:
                     print(
                         "ℹ️  caproto.sync.client not available - "
@@ -1195,19 +1373,30 @@ if not _execution_dir.exists():
                     print(f"⚠️  caproto.sync.client guard failed: {{_caproto_error}}")
 
                 try:
-                    from caproto.threading.client import PV as _CaprotoPV
+                    import caproto.threading.client as _caproto_threading
 
                     def _caproto_pv_current_value(_pv):
-                        '''A reader for the max_step check, bound to the writing PV.'''
+                        '''A reader for the max_step check, bound to the writing PV.
+
+                        The step-read ceiling is passed explicitly rather than
+                        left to the client context's own timeout, which a
+                        script is free to set to None.
+                        '''
                         if not hasattr(_pv, 'read'):
                             return None
 
                         def _read(_address):
-                            return _caproto_scalar(_pv.read())
+                            return _caproto_scalar(
+                                _pv.read(timeout=STEP_READ_TIMEOUT_SECONDS)
+                            )
 
                         return _read
 
-                    if hasattr(_CaprotoPV, "write"):
+                    _caproto_threading_wrapped = []
+                    _CaprotoPV = getattr(_caproto_threading, 'PV', None)
+                    _CaprotoBatch = getattr(_caproto_threading, 'Batch', None)
+
+                    if _CaprotoPV is not None and hasattr(_CaprotoPV, "write"):
                         _orig_caproto_pv_write = _CaprotoPV.write
 
                         def _checked_caproto_pv_write(self, data, *args, **kwargs):
@@ -1218,8 +1407,46 @@ if not _execution_dir.exists():
                             return _orig_caproto_pv_write(self, data, *args, **kwargs)
 
                         _CaprotoPV.write = _checked_caproto_pv_write
+                        _caproto_threading_wrapped.append('PV.write')
 
-                    print("✅ Monkeypatched caproto.threading.client PV.write()")
+                    # A ``Batch`` groups requests it is handed and sends them
+                    # together, so its write carries the PV to drive rather
+                    # than being bound to one. The channel is that PV's own
+                    # name and the step is measured over that PV's own read -
+                    # the same two answers the PV.write wrapper uses, taken
+                    # from the argument instead of from ``self``.
+                    if _CaprotoBatch is not None and hasattr(_CaprotoBatch, "write"):
+                        _orig_caproto_batch_write = _CaprotoBatch.write
+
+                        def _checked_caproto_batch_write(self, *args, **kwargs):
+                            '''Limits-checked wrapper for caproto threading Batch.write().'''
+                            _pv = args[0] if args else kwargs.get('pv')
+                            _data = args[1] if len(args) > 1 else kwargs.get('data')
+                            if _pv is None:
+                                raise ValueError(
+                                    "caproto Batch.write requires a pv so the "
+                                    "write can be limits-checked"
+                                )
+                            _limits_validator.validate(
+                                getattr(_pv, 'name', _pv),
+                                _data,
+                                read_current=_caproto_pv_current_value(_pv),
+                            )
+                            return _orig_caproto_batch_write(self, *args, **kwargs)
+
+                        _CaprotoBatch.write = _checked_caproto_batch_write
+                        _caproto_threading_wrapped.append('Batch.write')
+
+                    if _caproto_threading_wrapped:
+                        print(
+                            "✅ Monkeypatched caproto.threading.client: "
+                            + ", ".join(_n + "()" for _n in _caproto_threading_wrapped)
+                        )
+                    else:
+                        print(
+                            "⚠️  caproto.threading.client guard failed: "
+                            "no write method"
+                        )
                 except ImportError:
                     print(
                         "ℹ️  caproto.threading.client not available - "
@@ -1227,6 +1454,58 @@ if not _execution_dir.exists():
                     )
                 except Exception as _caproto_error:
                     print(f"⚠️  caproto.threading.client guard failed: {{_caproto_error}}")
+
+                try:
+                    import caproto.asyncio.client as _caproto_asyncio
+
+                    _CaprotoAsyncPV = getattr(_caproto_asyncio, 'PV', None)
+
+                    if _CaprotoAsyncPV is not None and hasattr(_CaprotoAsyncPV, "write"):
+                        _orig_caproto_async_write = _CaprotoAsyncPV.write
+
+                        async def _checked_caproto_async_write(self, data, *args, **kwargs):
+                            '''Limits-checked wrapper for caproto asyncio PV.write().
+
+                            The guard is a coroutine, so unlike the synchronous
+                            clients it can await the max_step read itself and
+                            hand the validator a plain value. That read is
+                            bought only by a channel that configures max_step,
+                            and a read that fails answers None, which fails the
+                            step check closed. The ceiling is passed explicitly
+                            rather than left to the client context's own
+                            timeout, which a script is free to set to None.
+                            '''
+                            _cfg = _limits_validator.get_limits_config(self.name)
+                            _current = None
+                            if _cfg and _cfg['max_step'] is not None:
+                                try:
+                                    _current = _caproto_scalar(
+                                        await self.read(timeout=STEP_READ_TIMEOUT_SECONDS)
+                                    )
+                                except Exception:
+                                    _current = None
+
+                            _limits_validator.validate(
+                                self.name, data, read_current=lambda _address: _current
+                            )
+                            return await _orig_caproto_async_write(
+                                self, data, *args, **kwargs
+                            )
+
+                        _CaprotoAsyncPV.write = _checked_caproto_async_write
+                        print("✅ Monkeypatched caproto.asyncio.client PV.write()")
+                    else:
+                        print(
+                            "⚠️  caproto.asyncio.client guard failed: "
+                            "no PV.write method"
+                        )
+                except ImportError:
+                    print(
+                        "ℹ️  caproto.asyncio.client not available - "
+                        "caproto limits checking disabled"
+                    )
+                except Exception as _caproto_error:
+                    print(f"⚠️  caproto.asyncio.client guard failed: {{_caproto_error}}")
             except Exception as e:
                 print(f"⚠️  Limits checking setup failed: {{e}}")
                 import traceback

--- a/src/osprey/services/python_executor/write_surface.py
+++ b/src/osprey/services/python_executor/write_surface.py
@@ -27,13 +27,12 @@ is what makes the guard immune to spelling. ``importlib.import_module("epics")``
 up holding the refusing function, because they all resolve through the one
 module object the guard mutates.
 
-The floor of that technique is the Python name. A handle that has already left
-Python cannot be re-pointed: ``cadef.libca['ca_array_put']`` fetches a fresh
-function pointer out of the shared library on every call. The immutable
-C-extension type ``p4p._p4p.ClientOperation`` is the same kind of floor, and it
-deliberately has **no row** in the table below. The type refuses ``setattr``, so
-it cannot be patched; the two names that hand it out cannot be patched either
-without breaking reads, because ``p4p/client/raw.py`` subclasses the type at
+The floor of that technique is the Python name. An object that cannot be
+re-pointed from Python is out of its reach: the immutable C-extension type
+``p4p._p4p.ClientOperation`` is one such floor, and it deliberately has **no
+row** in the table below. The type refuses ``setattr``, so it cannot be
+patched; the two names that hand it out cannot be patched either without
+breaking reads, because ``p4p/client/raw.py`` subclasses the type at
 import time and resolves the subclass — the *same* object — for ``get`` as well
 as for ``put`` and ``rpc``. Refusing those names would refuse every PVAccess
 read, which is the path readonly mode exists to keep open. That route is
@@ -70,11 +69,11 @@ differently by the *static* import check:
 
 Refusing a write is one question; letting an *approved* write through only
 within the channel's limits is another, and the second is answered for fewer
-entry points than the first. :data:`_LIMITS_WRAPPED`, :data:`_LIMITS_REFUSED`,
-:data:`_LIMITS_UNWRAPPABLE` and :data:`_LIMITS_NOT_YET_WRAPPED` partition
-:data:`_CLIENT_WRITE_TARGETS` by what a limits-checked run does with each entry
-point, so "which client writes are bounded" has a written answer instead of
-being read out of the generated monkeypatch. ``tests/services/python_executor/
+entry points than the first. :data:`_LIMITS_WRAPPED`, :data:`_LIMITS_REFUSED`
+and :data:`_LIMITS_UNWRAPPABLE` partition :data:`_CLIENT_WRITE_TARGETS` by what
+a limits-checked run does with each entry point, so "which client writes are
+bounded" has a written answer instead of being read out of the generated
+monkeypatch. ``tests/services/python_executor/
 execution/test_limits_parity.py`` holds the partition to the table.
 """
 
@@ -97,10 +96,13 @@ _CLIENT_WRITE_TARGETS: tuple[tuple[str, tuple[str, ...]], ...] = (
     # --- Channel Access (epicscorelibs). The ctypes binding that aioca loads
     # ``libca`` through, so it is a client route in its own right. Listing it
     # also puts ``epicscorelibs`` in :data:`READONLY_DENIED_IMPORTS`, which is
-    # the half that holds: the module attributes are only re-pointable until
-    # something re-fetches the function pointer out of ``libca`` itself.
-    # pyepics is unaffected — its ``epics.ca.libca`` is ``None`` until
-    # ``initialize_libca()`` runs.
+    # what closes the route in a readonly run: the import is refused, so the
+    # binding is never reached. A limits-checked run has no bound to put on it
+    # — the call carries a value already marshalled into C memory and an
+    # opaque channel handle — which is why both names sit in
+    # :data:`_LIMITS_UNWRAPPABLE`. pyepics is unaffected: its
+    # ``epics.ca.libca`` is ``None`` until ``initialize_libca()`` runs, and
+    # that call loads a handle of its own rather than this one.
     ("epicscorelibs.ca.cadef", ("ca_array_put", "ca_array_put_callback")),
     # --- PVAccess (p4p): one client Context per concurrency flavour, plus the
     # server-side SharedPV, which puts values on the wire when it is opened or
@@ -280,7 +282,7 @@ READONLY_DENIED_IMPORTS: frozenset[str] = frozenset(
 #: What a *limits-checked* run does with each client entry point, wrapped in
 #: :data:`_LIMITS_WRAPPED`: the value is how the check is reached, either
 #: ``"direct"`` — the guard patches this very name — or the name it is checked
-#: through. The four buckets below partition :data:`_CLIENT_WRITE_TARGETS`
+#: through. The three buckets below partition :data:`_CLIENT_WRITE_TARGETS`
 #: exactly, and are keyed by the canonical ``tango`` spelling: a
 #: ``PyTango.DeviceProxy`` row resolves to the same class object, so its fate is
 #: the ``tango.DeviceProxy`` row's fate and it carries no separate entry.
@@ -308,7 +310,19 @@ _LIMITS_WRAPPED: dict[tuple[str, str], str] = {
     ("p4p.client.asyncio.Context", "put"): "direct",
     ("p4p.client.cothread.Context", "put"): "direct",
     ("caproto.sync.client", "write"): "direct",
+    ("caproto.sync.client", "read_write_read"): (
+        "direct — it drives the channel with the value the plain write drives, so it "
+        "is bounded the same way and the reads around it are left alone"
+    ),
     ("caproto.threading.client.PV", "write"): "direct — the PV knows its own channel",
+    ("caproto.threading.client.Batch", "write"): (
+        "direct — bounded under the name of the PV the call carries, since a batch is "
+        "handed the PV to drive rather than being bound to one"
+    ),
+    ("caproto.asyncio.client.PV", "write"): (
+        "direct — a coroutine guard, so a max_step channel is read through the PV's "
+        "own await before the check rather than through a reader handed to it"
+    ),
     ("pvaccess.Channel", "put"): "direct — swept by the put prefix",
     ("pvaccess.Channel", "putGet"): "direct — swept by the put prefix",
     ("pvaccess.Channel", "asyncPut"): "direct — swept by the asyncPut prefix",
@@ -317,6 +331,34 @@ _LIMITS_WRAPPED: dict[tuple[str, str], str] = {
         "direct — the channel is rebuilt as dev_name()/attribute"
     ),
     ("tango.DeviceProxy", "write_attributes"): "direct — one check per (attribute, value) pair",
+    ("tango.DeviceProxy", "write_attribute_asynch"): (
+        "direct — the asynchronous spelling drives the same device with the same "
+        "value, and is checked against the same rebuilt address"
+    ),
+    ("tango.DeviceProxy", "write_attributes_asynch"): (
+        "direct — one check per (attribute, value) pair, taken positionally or under "
+        "either keyword PyTango names the pairs by"
+    ),
+    ("tango.DeviceProxy", "write_read_attribute"): (
+        "direct — reading the attribute back afterwards does not change the value "
+        "written, so it is bounded like the plain write"
+    ),
+    ("tango.DeviceProxy", "write_read_attributes"): (
+        "direct — one check per (attribute, value) pair, taken positionally or under "
+        "either keyword PyTango names the pairs by"
+    ),
+    ("tango.AttributeProxy", "write"): (
+        "direct — the address is rebuilt from the device proxy behind the attribute "
+        "and the attribute's own name; the call forwards to a wrapped DeviceProxy "
+        "spelling, so the bound is applied twice and the outer check is the one left "
+        "if the DeviceProxy install fails"
+    ),
+    ("tango.AttributeProxy", "write_asynch"): (
+        "direct — the same rebuilt address as the plain attribute write"
+    ),
+    ("tango.AttributeProxy", "write_read"): (
+        "direct — the same rebuilt address as the plain attribute write"
+    ),
 }
 
 #: Entry points a limits-checked run refuses outright, in range or not, with
@@ -366,14 +408,14 @@ _LIMITS_REFUSED: dict[tuple[str, str], str] = {
 #: partition stays honest about them: a readonly run still refuses every one.
 _LIMITS_UNWRAPPABLE: dict[tuple[str, str], str] = {
     ("epicscorelibs.ca.cadef", "ca_array_put"): (
-        "a patch would have a floor under it, because "
-        "cadef.libca['ca_array_put'] re-fetches the function pointer out of "
-        "the shared library"
+        "the call carries a value already marshalled into C memory and an "
+        "opaque channel handle: no number left to bound and no channel name "
+        "to look limits up under"
     ),
     ("epicscorelibs.ca.cadef", "ca_array_put_callback"): (
-        "a patch would have a floor under it, because "
-        "cadef.libca['ca_array_put_callback'] re-fetches the function pointer "
-        "out of the shared library"
+        "the call carries a value already marshalled into C memory and an "
+        "opaque channel handle: no number left to bound and no channel name "
+        "to look limits up under"
     ),
     ("p4p.server.raw.SharedPV", "post"): "server side — serves a PV, writes no device",
     ("p4p.server.raw.SharedPV", "open"): "server side — serves a PV, writes no device",
@@ -384,28 +426,11 @@ _LIMITS_UNWRAPPABLE: dict[tuple[str, str], str] = {
     ("tango.DeviceProxy", "put_property"): "writes the Tango database, not a channel",
 }
 
-#: Entry points that COULD be limits-checked and are not yet. A readwrite run
-#: reaches the machine through any of them without passing the limits database,
-#: which is why the bucket is named rather than left implicit.
-_LIMITS_NOT_YET_WRAPPED: dict[tuple[str, str], str] = {
-    ("tango.DeviceProxy", "write_attribute_asynch"): "followups-897 item 16",
-    ("tango.DeviceProxy", "write_attributes_asynch"): "followups-897 item 16",
-    ("tango.DeviceProxy", "write_read_attribute"): "followups-897 item 16",
-    ("tango.DeviceProxy", "write_read_attributes"): "followups-897 item 16",
-    ("tango.AttributeProxy", "write"): "followups-897 item 16",
-    ("tango.AttributeProxy", "write_asynch"): "followups-897 item 16",
-    ("tango.AttributeProxy", "write_read"): "followups-897 item 16",
-    ("caproto.sync.client", "read_write_read"): "followups-897 item 16",
-    ("caproto.threading.client.Batch", "write"): "followups-897 item 16",
-    ("caproto.asyncio.client.PV", "write"): "followups-897 item 16",
-}
-
 __all__ = [
     "READONLY_DENIED_IMPORTS",
     "_CLIENT_WRITE_TARGETS",
     "_ESCAPE_ROUTES",
     "_FRAMEWORK_WRITE_TARGETS",
-    "_LIMITS_NOT_YET_WRAPPED",
     "_LIMITS_REFUSED",
     "_LIMITS_UNWRAPPABLE",
     "_LIMITS_WRAPPED",

--- a/src/osprey/templates/claude_code/claude/hooks/hook_config.json.j2
+++ b/src/osprey/templates/claude_code/claude/hooks/hook_config.json.j2
@@ -11,10 +11,20 @@
   read_only_disallowed_tools is built from), and the hooks' shared
   `is_write_tool` honours the trailing wildcard — so every tool on such a
   server is gated, reads included.
+
+  `control_system_write_tools` is the subset of the project's
+  `control_system.write_tools` that this render actually APPENDED to
+  `write_tools` — an extra naming a matcher a server already contributed is
+  left out, because that one does reach `permissions.deny` under the writes
+  kill switch. The appended ones never do: they are refused per call. Only
+  osprey_config_drift.py reads this key, to keep those names out of the set it
+  compares against a deployment's stale deny list; every other consumer reads
+  `write_tools`, which is unchanged.
 -#}
 {%- set server_pfx = [] -%}
 {%- set approval_pfx = [] -%}
 {%- set write_tools = [] -%}
+{%- set appended_extras = [] -%}
 {%- for s in servers if s.enabled -%}
   {%- set _ = server_pfx.append("mcp__" ~ s.name ~ "__") -%}
   {%- for rule in s.hooks_pre -%}
@@ -31,12 +41,14 @@
 {%- for extra in control_system_write_tools -%}
   {%- if extra not in write_tools -%}
     {%- set _ = write_tools.append(extra) -%}
+    {%- set _ = appended_extras.append(extra) -%}
   {%- endif -%}
 {%- endfor -%}
 {
   "server_prefixes": {{ server_pfx | tojson }},
   "approval_prefixes": {{ approval_pfx | tojson }},
   "write_tools": {{ write_tools | tojson }},
+  "control_system_write_tools": {{ appended_extras | tojson }},
   "mixed_read_write_tools": {{ mixed_read_write_tools | default([], true) | tojson }},
   "lane_addressed_tools": {{ lane_addressed_tools | default([], true) | tojson }}
 }

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -5,7 +5,7 @@ name: Human Approval Gate
 description: Requires human approval for dangerous operations based on per-tool policy
 summary: Requires human approval for dangerous operations
 event: PreToolUse
-tools: channel_write, execute, setup_patch, entry_create, entry_publish, queue_add, queue_start, queue_stop, queue_remove, stop_run
+tools: channel_write, execute, setup_patch, entry_create, entry_publish, queue_add, queue_start, queue_stop, queue_remove, stop_run, add_panel_to_rail, remove_panel_from_rail, register_panel
 safety_layer: 2
 ---
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_config_drift.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_config_drift.py
@@ -122,12 +122,16 @@ def _kill_switch_tools(hook_config_path: Path) -> tuple[str, ...]:
     nothing about either — and on a deployment whose only write tool is a clone
     it claimed nothing at all while looking like it had checked.
 
-    Two kinds of entry are dropped:
+    Three kinds of entry are dropped:
 
     * wildcard matchers — they name no tool that could be in ``permissions.deny``;
     * ``mixed_read_write_tools`` — tools whose reads stay available with writes
       off, so they are not denied outright and their absence from ``deny`` says
-      nothing about the posture.
+      nothing about the posture;
+    * ``control_system_write_tools`` — tools the project appended via
+      ``control_system.write_tools``, gated per call rather than by the kill
+      switch, so they never enter ``deny`` either. Read with ``.get``, so a
+      render from before the key existed behaves as it did then.
 
     An unreadable or malformed file falls back to the framework's own controls
     tool, which is what this check was written against before there was a file
@@ -142,12 +146,15 @@ def _kill_switch_tools(hook_config_path: Path) -> tuple[str, ...]:
     tools = data.get("write_tools")
     if not isinstance(tools, list):
         return _FALLBACK_WRITE_TOOLS
-    mixed = data.get("mixed_read_write_tools")
-    mixed_set = {t for t in mixed if isinstance(t, str)} if isinstance(mixed, list) else set()
+    excluded: set[str] = set()
+    for key in ("mixed_read_write_tools", "control_system_write_tools"):
+        value = data.get(key)
+        if isinstance(value, list):
+            excluded.update(t for t in value if isinstance(t, str))
     return tuple(
         tool
         for tool in tools
-        if isinstance(tool, str) and not tool.endswith(_MATCHER_WILDCARD) and tool not in mixed_set
+        if isinstance(tool, str) and not tool.endswith(_MATCHER_WILDCARD) and tool not in excluded
     )
 
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_control_context.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_control_context.py
@@ -93,6 +93,15 @@ block on every prompt is the cost this hook exists to avoid.
 Every failure — an unreadable record, an unwritable temp directory, a payload
 that is not JSON — exits 0 with no output. This hook only describes; a turn
 must never be held up by its absence.
+
+## Saying which of those happened
+
+Silence is this hook's normal outcome and it has five different meanings, so
+every run ends with one ``log_hook`` record naming which: ``emit`` when a block
+went out, ``skip:not-our-event``, ``skip:no-record``, ``skip:no-session`` and
+``skip:unchanged`` for the four quiet ends, and ``error`` for a failure the
+fail-open rule above swallowed. Debug-gated like every ``log_hook`` call, so it
+costs a run nothing until someone turns it on.
 """
 
 import json
@@ -101,7 +110,7 @@ import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from osprey_hook_log import load_osprey_config
+from osprey_hook_log import load_osprey_config, log_hook
 
 try:
     import osprey_target_state as _target_state
@@ -236,21 +245,57 @@ def _emit(event, block):
     print(json.dumps({"hookSpecificOutput": {"hookEventName": event, "additionalContext": block}}))
 
 
+#: The status word for each way :func:`main` can end. Six outcomes: the one that
+#: put a block in front of the agent, the four ordinary reasons there was nothing
+#: to say, and the failure.
+STATUS_EMIT = "emit"
+STATUS_NOT_OUR_EVENT = "skip:not-our-event"
+STATUS_NO_RECORD = "skip:no-record"
+STATUS_NO_SESSION = "skip:no-session"
+STATUS_UNCHANGED = "skip:unchanged"
+STATUS_ERROR = "error"
+
+
+def _log(payload, status, detail=""):
+    """Record how this run ended, when hook debug is on. Never raises.
+
+    This hook is otherwise invisible. It is registered with ``2>/dev/null``, it
+    writes its memo into ``TMPDIR``, and a silent exit is its normal outcome for
+    four different reasons — so "the agent got no block" and "the hook never ran"
+    look identical from outside. :func:`osprey_hook_log.log_hook` is the channel
+    that separates them: off by default, and when on it appends one record per
+    run to ``<project>/.claude/hooks/hook_debug.jsonl``, which is also what the
+    web terminal's hook-activity feed reads.
+
+    Wrapped the way every other hook wraps it (``osprey_writes_check``'s deny
+    path is the precedent): a diagnostic may never cost the block it describes.
+    """
+    try:
+        log_hook("control_context", payload, status=status, detail=detail)
+    except Exception:
+        pass  # logging must never cost the emit
+
+
 def main():
+    payload = {}
     try:
         payload = _read_payload()
         event = payload.get("hook_event_name")
         if event not in (_SESSION_START, _USER_PROMPT):
+            _log(payload, STATUS_NOT_OUR_EVENT)
             return
         state = current_state(payload)
         if state is None:
+            _log(payload, STATUS_NO_RECORD)
             return
         session_id = _session_id(payload)
         if event == _SESSION_START:
             _emit(event, render_block(state))
             _remember(session_id, state)
+            _log(payload, STATUS_EMIT)
             return
         if session_id is None:
+            _log(payload, STATUS_NO_SESSION)
             return
         previous = _remembered(session_id)
         if previous is None:
@@ -258,9 +303,12 @@ def main():
         elif previous != state:
             _emit(event, render_block(state, previous))
         else:
+            _log(payload, STATUS_UNCHANGED)
             return
         _remember(session_id, state)
-    except Exception:
+        _log(payload, STATUS_EMIT)
+    except Exception as exc:
+        _log(payload, STATUS_ERROR, detail=f"exception={type(exc).__name__}")
         return
 
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_memory_guard.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_memory_guard.py
@@ -64,13 +64,14 @@ automatically.
 
 ``NotebookEdit`` is held to ``<agent_data_root>/artifacts/`` and
 ``<agent_data_root>/notebooks/`` instead, mirroring the scoped
-``NotebookEdit(<agent_data_root>/artifacts/**)`` and
-``NotebookEdit(<agent_data_root>/notebooks/**)`` allow rules that
-``settings.json.j2`` renders. Both trees hold the agent's own notebooks — the
-artifact tree the gallery serves, and the notebooks tree the Jupyter panel
-serves. Holding them to the memory directory would deny the agent its own
-notebooks, and holding them to nothing at all would reopen arbitrary writes
-under a different tool name.
+``Edit(<agent_data_root>/artifacts/**)`` and
+``Edit(<agent_data_root>/notebooks/**)`` allow rules that
+``settings.json.j2`` renders (Claude Code matches every file-editing tool,
+``NotebookEdit`` included, against ``Edit(path)`` rules). Both trees hold the
+agent's own notebooks — the artifact tree the gallery serves, and the
+notebooks tree the Jupyter panel serves. Holding them to the memory directory
+would deny the agent its own notebooks, and holding them to nothing at all
+would reopen arbitrary writes under a different tool name.
 
 All other targets are denied — the agent never sees a user prompt for a write
 this guard does not recognise.
@@ -124,8 +125,8 @@ _PATH_KEYS = {
 #: Subdirectories of the agent-data root that ``NotebookEdit`` may write into:
 #: ``artifacts`` for the agent's generated output, ``notebooks`` for the tree the
 #: Jupyter panel serves. These are the two subdirectories in the
-#: ``NotebookEdit(<agent_data_root>/artifacts/**)`` and
-#: ``NotebookEdit(<agent_data_root>/notebooks/**)`` allow rules as rendered by
+#: ``Edit(<agent_data_root>/artifacts/**)`` and
+#: ``Edit(<agent_data_root>/notebooks/**)`` allow rules as rendered by
 #: ``settings.json.j2``. The order is the order a refusal lists them in.
 _NOTEBOOK_SUBDIRS = ("artifacts", "notebooks")
 
@@ -169,7 +170,7 @@ def agent_data_base_dir(config: dict | None) -> str:
     is duplicated: the hook runs in user projects where ``osprey`` may not be
     importable. The key is the single spelling of the agent-data root, so a
     project that relocates it keeps this guard and the rendered
-    ``NotebookEdit`` allow rule pointing at the same tree.
+    ``Edit(...)`` allow rules pointing at the same tree.
 
     Args:
         config: Loaded ``config.yml`` mapping, or ``None``.

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_notebook_update.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_notebook_update.py
@@ -112,7 +112,7 @@ from osprey_hook_log import (
 )
 
 #: Subdirectory of the agent-data root that holds the agent's notebooks. This
-#: is the ``notebooks`` in ``NotebookEdit(<agent_data_root>/notebooks/**)`` as
+#: is the ``notebooks`` in ``Edit(<agent_data_root>/notebooks/**)`` as
 #: rendered by ``settings.json.j2`` and gated by ``osprey_memory_guard.py``.
 _NOTEBOOKS_SUBDIR = "notebooks"
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_panels_context.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_panels_context.py
@@ -314,12 +314,11 @@ def _build_inventory(data):
     return (
         f"Web terminal panels (right pane tabs): {panel_list}. "
         f"{active_part} "
-        "Put one in front of the operator with open_panel(id) and take it off "
-        "screen again with close_panel(id). Rail membership is separate: "
-        "add_panel_to_rail(id)/remove_panel_from_rail(id) control whether the "
-        "operator can launch a panel in one click. An off-rail panel is already "
-        "running — open_panel puts it on the rail and on screen in one step. "
-        "Add an ad-hoc URL tab with register_panel(...)."
+        "open_panel(id) puts one on screen and leaves it on the rail in one "
+        "step, close_panel(id) takes it off; add_panel_to_rail(id)/"
+        "remove_panel_from_rail(id) move only whether it is one click away, "
+        "and register_panel(...) adds an ad-hoc URL tab. Those three ask the "
+        "operator to approve the call unless the deployment says otherwise."
     )
 
 

--- a/src/osprey/templates/claude_code/claude/settings.json.j2
+++ b/src/osprey/templates/claude_code/claude/settings.json.j2
@@ -78,8 +78,15 @@
 {%- set _ = allow_entries.append('"' ~ entry ~ '"') -%}
 {%- endfor -%}
 {%- endfor -%}
-{%- set _ = allow_entries.append('"NotebookEdit(' ~ agent_data_root ~ '/artifacts/**)"') -%}
-{%- set _ = allow_entries.append('"NotebookEdit(' ~ agent_data_root ~ '/notebooks/**)"') -%}
+{#- NotebookEdit is scoped to the agent's own notebook trees. Claude Code
+    checks every file-editing tool (Write, MultiEdit, NotebookEdit) against
+    `Edit(path)` rules only, so the rule is spelled `Edit(...)`; a
+    `NotebookEdit(path)` rule grants nothing and is reported as a
+    misconfiguration at every agent start. The bare `Edit` in the deny floor
+    outranks these, so the Edit tool itself stays denied, and the memory-guard
+    hook still refuses Write/MultiEdit under these trees. -#}
+{%- set _ = allow_entries.append('"Edit(' ~ agent_data_root ~ '/artifacts/**)"') -%}
+{%- set _ = allow_entries.append('"Edit(' ~ agent_data_root ~ '/notebooks/**)"') -%}
 {#- Per-agent Task() permissions -#}
 {%- for a in agents if a.enabled -%}
 {%- set _ = allow_entries.append('"Task(' ~ a.name ~ ')"') -%}

--- a/src/osprey/templates/claude_code/claude/skills/demo-ui/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/demo-ui/SKILL.md
@@ -39,6 +39,19 @@ with a glow but puts nothing on screen, and removing takes the entry away (and
 with it any open tile — an unlaunchable panel is not left stranded). The chat is
 the SESSION tile, operator-only — never script the agent driving it.
 
+## The rail verbs ask
+
+On a stock build `add_panel_to_rail`, `remove_panel_from_rail` and
+`register_panel` each prompt the operator for approval, so a prompt appears
+inside every rail beat below. Narrate it rather than working around it — the
+same gate the audience is there to see — and let the operator answer it. The
+on-screen verbs `open_panel` and `close_panel` do not ask on a stock build.
+
+A deployment that wants those beats to run uninterrupted sets
+`approval.tools.add_panel_to_rail: skip` in its `config.yml`, and the same for
+the other two. `skip` is the only value that silences a prompt: the policies are
+`skip`, `always` and `selective`, and there is no `never`.
+
 ## Pick a workflow
 
 Ask which one, unless the request already names it or implies it:

--- a/tests/agent_runner/test_write_tools.py
+++ b/tests/agent_runner/test_write_tools.py
@@ -637,10 +637,17 @@ def test_read_only_disallowed_covers_registry_side_effect_tools(tmp_path: Path) 
     """Drift guard: every framework-server permissions_ask tool and every
     writes-check-gated matcher in the registry must appear in the read-only
     disallow set. Adding a new approval-required tool to a server thus
-    auto-extends the read-only floor (or fails this test)."""
+    auto-extends the read-only floor (or fails this test).
+
+    The rail verbs and ``register_panel`` arrive through the walk below, since
+    they are ``permissions_ask``. ``lattice_clear_baseline`` does not — it is
+    auto-allowed and reaches the floor only through the destructive-name rule
+    ("clear"), so it is pinned by name."""
     from osprey.registry.mcp import _WRITES_CHECK, FRAMEWORK_SERVERS
 
     result = set(read_only_disallowed_tools(tmp_path))
+
+    assert "mcp__osprey_workspace__lattice_clear_baseline" in result
 
     for server in FRAMEWORK_SERVERS.values():
         # Both ask lists render into the interactive approval list → side-effecting.

--- a/tests/agent_runner/test_write_tools.py
+++ b/tests/agent_runner/test_write_tools.py
@@ -666,6 +666,12 @@ def test_python_server_registers_only_execute_tools_we_block(tmp_path: Path) -> 
     Introspects the FastMCP singleton directly (importing the tool modules
     registers them) rather than running create_server(), which would do heavy
     config/workspace startup.
+
+    The listing comes from the public ``list_tools()``, which filters out
+    disabled, backend-only and auth-gated tools — so an empty or shrunken
+    result would make the loop below vacuously pass. The name floor pins the
+    two tools that must always be in the listing; the loop then proves every
+    listed tool is blocked.
     """
     import asyncio
 
@@ -675,9 +681,12 @@ def test_python_server_registers_only_execute_tools_we_block(tmp_path: Path) -> 
         python_execute_file,
     )
 
-    tools = asyncio.run(py_server.mcp._list_tools())
+    tools = asyncio.run(py_server.mcp.list_tools())
     registered = {getattr(t, "name", t) for t in tools}
-    assert registered, "expected the python server to register at least one tool"
+    assert {"execute", "execute_file"} <= registered, (
+        f"python executor server must register execute and execute_file; "
+        f"list_tools() returned {sorted(registered)}"
+    )
 
     result = set(read_only_disallowed_tools(tmp_path))
     for short in registered:

--- a/tests/cli/test_claude_code_integration.py
+++ b/tests/cli/test_claude_code_integration.py
@@ -207,10 +207,14 @@ class TestClaudeCodeFileContents:
         assert "WebFetch" in deny
         assert "WebSearch" in deny
 
-        # NotebookEdit moved to allow (restricted to artifacts dir)
+        # NotebookEdit is not denied; it is scoped to the agent-data trees via
+        # Edit(path) allow rules, the only rule form Claude Code consults for
+        # file-editing tools (a NotebookEdit(path) rule is ignored and warned on).
         assert "NotebookEdit" not in deny
         allow = data["permissions"]["allow"]
-        assert any("NotebookEdit" in a for a in allow)
+        assert "Edit(var/agent_data/artifacts/**)" in allow
+        assert "Edit(var/agent_data/notebooks/**)" in allow
+        assert not any(a.startswith("NotebookEdit(") for a in allow)
 
         # Channel-finder tools not in deny (server is agent-exclusive via inline mcpServers)
         assert "mcp__channel-finder__*" not in deny

--- a/tests/cli/test_claude_code_resolver.py
+++ b/tests/cli/test_claude_code_resolver.py
@@ -94,8 +94,8 @@ class TestCBORGProvider:
     def test_model_tiers(self):
         spec = ClaudeCodeModelResolver.resolve({"provider": "cborg"})
         assert spec.tier_to_model["haiku"] == "claude-haiku-4-5"
-        assert spec.tier_to_model["sonnet"] == "claude-sonnet-4-6"
-        assert spec.tier_to_model["opus"] == "claude-opus-4-7"
+        assert spec.tier_to_model["sonnet"] == "claude-sonnet-5"
+        assert spec.tier_to_model["opus"] == "claude-opus-5"
 
 
 class TestAlsApgProvider:
@@ -337,11 +337,11 @@ class TestAgentModel:
         spec = ClaudeCodeModelResolver.resolve(
             {"provider": "cborg", "agent_models": {"channel-finder": "sonnet"}}
         )
-        assert spec.agent_model("channel-finder") == "claude-sonnet-4-6"
+        assert spec.agent_model("channel-finder") == "claude-sonnet-5"
 
     def test_unknown_agent_returns_sonnet(self):
         spec = ClaudeCodeModelResolver.resolve({"provider": "cborg"})
-        assert spec.agent_model("unknown-agent") == "claude-sonnet-4-6"
+        assert spec.agent_model("unknown-agent") == "claude-sonnet-5"
 
     def test_logbook_deep_research_default_opus(self):
         spec = ClaudeCodeModelResolver.resolve({"provider": "anthropic"})
@@ -512,8 +512,8 @@ class TestEnvBlockTierModels:
     def test_cborg_has_all_tier_model_vars(self):
         spec = ClaudeCodeModelResolver.resolve({"provider": "cborg"})
         assert spec.env_block["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "claude-haiku-4-5"
-        assert spec.env_block["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude-sonnet-4-6"
-        assert spec.env_block["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-4-7"
+        assert spec.env_block["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude-sonnet-5"
+        assert spec.env_block["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-5"
 
     def test_custom_tier_override_propagates_to_env_block(self):
         spec = ClaudeCodeModelResolver.resolve(
@@ -522,7 +522,7 @@ class TestEnvBlockTierModels:
         assert spec.env_block["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "anthropic/claude-sonnet-v2"
         # Others unchanged
         assert spec.env_block["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "claude-haiku-4-5"
-        assert spec.env_block["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-4-7"
+        assert spec.env_block["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-5"
 
     def test_all_three_vars_always_present(self):
         for provider_name in CLAUDE_CODE_PROVIDERS:

--- a/tests/cli/test_default_model_three_branch.py
+++ b/tests/cli/test_default_model_three_branch.py
@@ -54,9 +54,9 @@ class TestBranchTwoExplicitModelId:
 
     def test_builtin_provider_model_id_passes_through(self):
         spec = ClaudeCodeModelResolver.resolve(
-            {"provider": "cborg", "default_model": "claude-opus-4-7"}
+            {"provider": "cborg", "default_model": "claude-opus-5"}
         )
-        assert spec.env_block["ANTHROPIC_MODEL"] == "claude-opus-4-7"
+        assert spec.env_block["ANTHROPIC_MODEL"] == "claude-opus-5"
 
     def test_model_id_from_api_providers_map_is_accepted(self):
         spec = ClaudeCodeModelResolver.resolve(
@@ -82,10 +82,10 @@ class TestBranchTwoExplicitModelId:
         ``channel_finder/benchmarks/sdk.py`` both do exactly this lookup.
         """
         spec = ClaudeCodeModelResolver.resolve(
-            {"provider": "cborg", "default_model": "claude-opus-4-7"}
+            {"provider": "cborg", "default_model": "claude-opus-5"}
         )
         assert spec.default_model_tier == "opus"
-        assert spec.tier_to_model[spec.default_model_tier] == "claude-opus-4-7"
+        assert spec.tier_to_model[spec.default_model_tier] == "claude-opus-5"
 
 
 class TestBranchFourFreeFormPassThrough:
@@ -125,7 +125,7 @@ class TestBranchFourFreeFormPassThrough:
         for cc_config in (
             {"provider": "cborg"},
             {"provider": "cborg", "default_model": "sonnet"},
-            {"provider": "cborg", "default_model": "claude-opus-4-7"},
+            {"provider": "cborg", "default_model": "claude-opus-5"},
         ):
             spec = ClaudeCodeModelResolver.resolve(cc_config)
             assert spec.default_model_id is None, cc_config

--- a/tests/cli/test_explicit_config_equivalence.py
+++ b/tests/cli/test_explicit_config_equivalence.py
@@ -48,11 +48,14 @@ which land with the tasks that cause them:
 that whole mapping (it resolves to an interpreter path), so it can never surface
 as a delta and needs no entry here.
 
-One more delta is declared that Requirement 1 did not foresee:
-``approval.tools.entry_publish`` reaches every render made from a preset that
-spells an ARIEL approval policy. The fixtures were frozen while that tool was
-gated nowhere, so the leaf is genuinely new rather than a render the conversion
-moved.
+Two more deltas are declared that Requirement 1 did not foresee, both from
+later gating work rather than from the conversion. ``approval.tools.entry_publish``
+reaches every render made from a preset that spells an ARIEL approval policy,
+and the three panel-rail verbs — ``approval.tools.add_panel_to_rail``,
+``approval.tools.remove_panel_from_rail`` and ``approval.tools.register_panel``
+— reach every render made from a preset that names its approval policy tool by
+tool. The fixtures were frozen while all four were gated nowhere, so those
+leaves are genuinely new.
 
 One leaf is exempt from the table rather than declared in it. ``osprey build``
 answers the presets' ``container_runtime: auto`` with the runtime that served
@@ -323,6 +326,45 @@ def _entry_publish_deltas(*documents: str) -> tuple[Delta, ...]:
     )
 
 
+#: The panel-rail verbs that moved behind the approval hook.
+_RAIL_TOOLS = ("add_panel_to_rail", "remove_panel_from_rail", "register_panel")
+
+
+def _rail_tool_deltas(*documents: str) -> tuple[Delta, ...]:
+    """The panel-rail policy every render with a named approval table gained.
+
+    The rail axis decides what an operator can launch at all, which the
+    on-screen verbs beside it do not: ``remove_panel_from_rail`` costs them the
+    ability to launch the panel back, ``add_panel_to_rail`` puts an entry in
+    front of them, and ``register_panel`` adds a proxied upstream. Gating the
+    three put ``approval.tools.<tool>: always`` in every preset that names its
+    approval policy tool by tool, so every document those presets render gains
+    the three leaves. The fixtures were frozen before that, which is why it
+    reads as a difference here rather than as a render the conversion changed.
+
+    channel-finder-standalone names no ``approval.tools`` entry at all — its
+    rail verbs fall to ``approval.default_policy``, which the freeze already
+    recorded — so its cells gain nothing and are absent below.
+
+    Args:
+        documents: The rendered documents the cell emits, ``root`` plus one per
+            persona.
+
+    Returns:
+        One delta per rail verb per document.
+    """
+    return tuple(
+        Delta(
+            document=document,
+            path=f"approval.tools.{tool}",
+            fixture=ABSENT,
+            live="always",
+        )
+        for document in documents
+        for tool in _RAIL_TOOLS
+    )
+
+
 #: The documents a control-assistant cell renders: the root config plus one per
 #: persona in the preset's roster.
 _CONTROL_ASSISTANT_DOCUMENTS = (
@@ -342,19 +384,26 @@ CELL_DELTAS: dict[str, tuple[Delta, ...]] = {
     "hello-world/unset": (
         Delta(document="root", path="hooks.debug", fixture=ABSENT, live=False),
         *_entry_publish_deltas("root"),
+        *_rail_tool_deltas("root"),
     ),
-    "ariel-standalone/unset": _standalone_catalog_delta() + _entry_publish_deltas("root"),
+    "ariel-standalone/unset": _standalone_catalog_delta()
+    + _entry_publish_deltas("root")
+    + _rail_tool_deltas("root"),
     "channel-finder-standalone/in_context": _standalone_catalog_delta(),
     "channel-finder-standalone/hierarchical": _standalone_catalog_delta(),
     "channel-finder-standalone/middle_layer": _standalone_catalog_delta(),
     "control-assistant/in_context": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/hierarchical": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/middle_layer": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
     "control-assistant/graph": _control_assistant_persona_deltas()
-    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
+    + _entry_publish_deltas(*_CONTROL_ASSISTANT_DOCUMENTS)
+    + _rail_tool_deltas(*_CONTROL_ASSISTANT_DOCUMENTS),
 }
 
 

--- a/tests/cli/test_explicit_config_partition.py
+++ b/tests/cli/test_explicit_config_partition.py
@@ -244,15 +244,21 @@ def test_root_render_is_partitioned_between_its_sources(
     assert sets["Panels"] == _panel_switches(document), directory
     assert not {key for key in config if key in sets["Panels"]}
 
-    # Every key the preset states reaches the render, save two the fixtures
-    # were frozen before: hello-world gains `hooks.debug: false`, which the old
-    # template shipped commented out, and every preset that spells an ARIEL
-    # approval policy gains `approval.tools.entry_publish`, the logbook
-    # write-through that was gated nowhere when the freeze ran.
+    # Every key the preset states reaches the render, save the ones the
+    # fixtures were frozen before: hello-world gains `hooks.debug: false`,
+    # which the old template shipped commented out; every preset that spells an
+    # ARIEL approval policy gains `approval.tools.entry_publish`, the logbook
+    # write-through that was gated nowhere when the freeze ran; and every
+    # preset that names its approval policy tool by tool gains the three
+    # panel-rail verbs, which decide what an operator can launch at all and
+    # were likewise gated nowhere then.
     missing = set(config) - set(render)
     expected_gain = {"hooks.debug"} if preset == "hello-world" else set()
     if "approval.tools.entry_publish" in config:
         expected_gain = expected_gain | {"approval.tools.entry_publish"}
+    for tool in ("add_panel_to_rail", "remove_panel_from_rail", "register_panel"):
+        if f"approval.tools.{tool}" in config:
+            expected_gain = expected_gain | {f"approval.tools.{tool}"}
     assert missing == expected_gain, (
         f"{directory}: preset keys absent from the render: {sorted(missing)}"
     )

--- a/tests/cli/test_failure_replay.py
+++ b/tests/cli/test_failure_replay.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import logging
 import signal
+import time
+from collections.abc import Callable
 from pathlib import Path
 
 import click
@@ -38,6 +40,14 @@ from osprey.cli.main import cli
 #: produces it — the error message quotes the command, and a marker that also
 #: appeared there would make "the spool was printed once" unaskable.
 POISON = "the-child-said-this"
+
+#: Ceiling on "the child has produced output". Only ever spent on a run that is
+#: already failing: the wait returns the instant the spool has content, so a
+#: healthy run never approaches it.
+ARM_BUDGET = 30.0
+
+#: How often the timer looks for that output.
+ARM_POLL = 0.02
 
 
 def run_verb(*args: str) -> int:
@@ -230,7 +240,7 @@ def test_a_start_that_fails_on_a_captured_child_replays_it_too(
 
 @pytest.fixture
 def alarm_sigint():
-    """Deliver a real SIGINT to this process shortly after the child starts.
+    """Deliver a real SIGINT to this process once the child has produced output.
 
     An alarm rather than a helper thread: ``SIGALRM`` reaches the main thread,
     which is the one parked in the child's ``waitpid``, so the interrupt lands
@@ -245,15 +255,36 @@ def alarm_sigint():
     capture then runs to completion with nothing to show that an interrupt was
     ever delivered. Installing the default handler for the duration makes the
     test state its premise instead of inheriting it.
+
+    The timer polls a caller-supplied condition and re-arms until it holds. A
+    fixed delay cannot serve: the interrupt has to land after the child has
+    written and before the child exits, and the near edge of that window is two
+    ``fork``/``exec`` pairs away — tens of milliseconds on an idle box, but with
+    a tail under a parallel run's fork pressure that overruns any constant small
+    enough to be worth waiting for on every green run. Re-arming converges on
+    the condition instead, so the wait costs what the child actually took.
+
+    :data:`ARM_BUDGET` bounds it, and a child that never writes is interrupted
+    anyway: the test then fails on its own assertion about the spool rather than
+    hanging with nothing to read.
     """
 
-    def fire(_signum, _frame):
-        signal.raise_signal(signal.SIGINT)
+    def arm(ready: Callable[[], bool]) -> None:
+        deadline = time.monotonic() + ARM_BUDGET
 
-    previous_alarm = signal.signal(signal.SIGALRM, fire)
+        def fire(_signum, _frame) -> None:
+            if ready() or time.monotonic() >= deadline:
+                signal.raise_signal(signal.SIGINT)
+            else:
+                signal.setitimer(signal.ITIMER_REAL, ARM_POLL)
+
+        signal.signal(signal.SIGALRM, fire)
+        signal.setitimer(signal.ITIMER_REAL, ARM_POLL)
+
+    previous_alarm = signal.getsignal(signal.SIGALRM)
     previous_interrupt = signal.signal(signal.SIGINT, signal.default_int_handler)
     try:
-        yield lambda seconds=0.4: signal.setitimer(signal.ITIMER_REAL, seconds)
+        yield arm
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0)
         signal.signal(signal.SIGINT, previous_interrupt)
@@ -276,7 +307,7 @@ def test_an_interrupted_capture_names_its_partial_spool_and_does_not_replay_it(
 
     def interrupted(*args, **kwargs) -> None:
         repo_root = Path(args[0])
-        alarm_sigint()
+        alarm_sigint(lambda: any(spool.stat().st_size for spool in spools(repo_root)))
         run_captured(
             ["sh", "-c", "cat poison.txt; sleep 30"],
             cwd=repo_root,
@@ -291,7 +322,7 @@ def test_an_interrupted_capture_names_its_partial_spool_and_does_not_replay_it(
     assert status != 0
     out = capfd.readouterr().out
 
-    # The child got far enough to write, and what it wrote survived the kill.
+    # What the child wrote survived the kill.
     spool = spools(repo)[0]
     assert POISON in spool.read_text()
 

--- a/tests/cli/test_failure_replay.py
+++ b/tests/cli/test_failure_replay.py
@@ -237,17 +237,27 @@ def alarm_sigint():
     inside the capture instead of after it. What the handler then raises is the
     genuine signal — the ``KeyboardInterrupt`` comes from Python's own SIGINT
     handling, not from the test.
+
+    Both dispositions are taken and given back, SIGINT included. A signal's
+    handler is process-global state with no owner, and the whole mechanism here
+    rests on SIGINT's being Python's own: a handler that merely records the
+    signal — a shutdown flag, an event loop's wakeup — absorbs it, and the
+    capture then runs to completion with nothing to show that an interrupt was
+    ever delivered. Installing the default handler for the duration makes the
+    test state its premise instead of inheriting it.
     """
 
     def fire(_signum, _frame):
         signal.raise_signal(signal.SIGINT)
 
-    previous = signal.signal(signal.SIGALRM, fire)
+    previous_alarm = signal.signal(signal.SIGALRM, fire)
+    previous_interrupt = signal.signal(signal.SIGINT, signal.default_int_handler)
     try:
         yield lambda seconds=0.4: signal.setitimer(signal.ITIMER_REAL, seconds)
     finally:
         signal.setitimer(signal.ITIMER_REAL, 0)
-        signal.signal(signal.SIGALRM, previous)
+        signal.signal(signal.SIGINT, previous_interrupt)
+        signal.signal(signal.SIGALRM, previous_alarm)
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="POSIX signal delivery")

--- a/tests/cli/test_hook_config_render.py
+++ b/tests/cli/test_hook_config_render.py
@@ -49,6 +49,7 @@ _EXPECTED_KEYS = {
     "server_prefixes",
     "approval_prefixes",
     "write_tools",
+    "control_system_write_tools",
     "mixed_read_write_tools",
     "lane_addressed_tools",
 }
@@ -351,6 +352,30 @@ def test_write_tools_still_carries_exact_names_and_the_custom_regex(tmp_path):
     # aware `is_write_tool` gates every tool on that server off it, and
     # read_only_disallowed_tools is built from the same entry.
     assert "mcp__sitectl__.*" in write_tools
+
+
+# ---------------------------------------------------------------------------
+# control_system_write_tools: the appended extras, and nothing else
+# ---------------------------------------------------------------------------
+
+
+def test_control_system_write_tools_is_empty_when_the_project_names_no_extras(tmp_path):
+    """The default: a populated ``write_tools`` beside an EMPTY extras list.
+
+    ``control_system_write_tools`` names only what this render appended on top
+    of the server-derived matchers, so a project that sets no
+    ``control_system.write_tools`` renders it empty — while ``write_tools``
+    itself is full. Emitting the two the other way round (the whole write set,
+    or the whole configured list) would hand osprey_config_drift.py names that
+    ARE in the kill-switch deny and silence the drift warning it exists to
+    raise.
+    """
+    manager, project_dir = _create_project(tmp_path)
+    _reconfigure(project_dir, claude_code_servers=_MULTI_SERVER)
+    config = _regenerate(manager, project_dir)
+
+    assert config["control_system_write_tools"] == []
+    assert config["write_tools"], "vacuous: nothing was rendered to be excluded from"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -47,32 +47,43 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # ARIEL server and has no approval table for it, so it alone stands still.
     # A rebuilt project prompts before a publish, so the staleness advisory
     # firing on already-deployed projects is the correct signal.
-    "ariel-standalone": ("sha256:2522f525c8850daf2915e59b898a13269d1c924d59d0d0f868b219a2b8e72c6d"),
+    # The fifth move, and again nine of ten: the panel-rail verbs
+    # (`add_panel_to_rail`, `remove_panel_from_rail`, `register_panel`) became
+    # approval-governed, and the three presets that ship an approval table —
+    # ariel-standalone, hello-world, control-assistant, whose six `extends`
+    # children inherit the lines — each gained an `always` entry for them.
+    # channel-finder-standalone ships no approval table at all: its rail verbs
+    # are governed too but fall to `default_policy`, so nothing in its resolved
+    # content moved and its digest alone stands still. Rewriting its approval
+    # comment did not move it either — the hash is over resolved content, not
+    # over the file's text. A rebuilt project prompts before the rail changes,
+    # so the staleness advisory firing on already-deployed projects is correct.
+    "ariel-standalone": ("sha256:53afe2c27732088ac35b8b3e044b946783f1eb147d831c32c3b11bcda504c62c"),
     "channel-finder-standalone": (
         "sha256:5c5d670fb6d048e854dfa5ecff9b02d6b9bf504a4cd574d6a5f66b34e18e3fa1"
     ),
     "control-assistant": (
-        "sha256:e1cd276ba9e3062452b5afe86daed341be5c8cfa12b6a992d7b4ea0e33c2ff05"
+        "sha256:b2719e48731ecf85e505686d4c929c72103091cb317b70d6845dc775c8d2186d"
     ),
     "control-assistant-admin": (
-        "sha256:c29f07d93cee491afda6276603d5a86a9cf0e919960ba598f78c8906e419eb3c"
+        "sha256:8ad7421b03092bd2aca4bf328975ff859424d7084dfdfcf709c1121216ed3091"
     ),
     "control-assistant-knowledge": (
-        "sha256:84fb320d701ef1d14d18155c0c59dfff4b2bcc2d5441175733f7fb6d2aad90f0"
+        "sha256:212af69627d533b4714bd838e82c99187e55c1ccfbaf2dec66ac518484dc066b"
     ),
     "control-assistant-logbook": (
-        "sha256:a63cee6c479a8bee82c1f6e261b921ea96708226cb9e0d331d52d9e800b195e4"
+        "sha256:40585b7f5b80f9b6794fee9726be84a093c65fcc956dfe7e592714df857ae53f"
     ),
     "control-assistant-readonly": (
-        "sha256:99a75fd3714a9114fd527724b77de6b7bd36aac571b821882b8903be6c626c3c"
+        "sha256:6f7bfd43d8e3765509247fbeca4282261b0a33d86630aabe8aa8f4e5601bd311"
     ),
     "control-assistant-readwrite": (
-        "sha256:3a8c88791900e5c0d7bff064db59f65a1244dd07425a90e1e17301311aa63a19"
+        "sha256:ca9356ff5249d68e8272e78a6616614c454f3bcbe0b3d98718a17750281de861"
     ),
     "control-assistant-va-readwrite": (
-        "sha256:93c34788a885b8013162c85bb9f39fd506b6950c210fc8f07ae1579e13f42f20"
+        "sha256:13904af0b3dff63d30e0dfb01fcb493590c50b39bfc47e015d0762bf9a4bace9"
     ),
-    "hello-world": ("sha256:5f23b2a31f03c885b20dae82781aa87efda81db3960d6865c3bc93e54e4ca837"),
+    "hello-world": ("sha256:10ce4bc73c7a244debbf355189dfbcd13feb7d31007c79e83c93aec978831b65"),
 }
 
 

--- a/tests/cli/test_profile_to_claude_contract.py
+++ b/tests/cli/test_profile_to_claude_contract.py
@@ -721,6 +721,14 @@ def test_hook_config_write_tools_dedupe(tmp_path):
     assert write_tools == [*baseline, "mcp__facility__custom_write"], (
         f"expected only the new entry appended to {baseline}; got {write_tools}"
     )
+    # The appended-only semantics, on a real build path: the re-stated matcher
+    # is already in the writes kill switch's deny list, so it must NOT appear
+    # here — osprey_config_drift.py subtracts this key from the set it compares
+    # against a deployment's stale deny list, and an entry that IS denied
+    # belongs in that comparison.
+    assert _read_hook_config(project)["control_system_write_tools"] == [
+        "mcp__facility__custom_write"
+    ]
 
 
 def test_hook_config_with_no_enabled_servers(tmp_path):
@@ -756,6 +764,9 @@ def test_hook_config_with_no_enabled_servers(tmp_path):
         "server_prefixes": [],
         "approval_prefixes": [],
         "write_tools": [],
+        # Only the extras this render APPENDED to write_tools; the project
+        # names none, and with every server off there is nothing to append to.
+        "control_system_write_tools": [],
         "mixed_read_write_tools": [],
         # Not a per-server list: it names the tools the writes-check hook leaves
         # to their own lane gate, and renders whether or not any server is on.

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -428,8 +428,8 @@ class TestResolveEnvBlockRegression:
         assert spec.env_block == {
             "ANTHROPIC_BASE_URL": "https://api.cborg.lbl.gov",
             "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5",
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-5",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-5",
             "ANTHROPIC_MODEL": "claude-haiku-4-5",
         }
 

--- a/tests/cli/test_resolver_cborg_oss.py
+++ b/tests/cli/test_resolver_cborg_oss.py
@@ -56,7 +56,7 @@ def test_builtin_cborg_is_anthropic_native_no_proxy():
     assert spec.needs_proxy is False
     assert spec.upstream_base_url is None
     # Built-in cborg pins Claude models, not self-hosted ones:
-    assert spec.tier_to_model["sonnet"] == "claude-sonnet-4-6"
+    assert spec.tier_to_model["sonnet"] == "claude-sonnet-5"
 
 
 def test_auth_secret_env_is_derived_from_provider_name():

--- a/tests/cli/test_source_zone_materialization.py
+++ b/tests/cli/test_source_zone_materialization.py
@@ -1150,7 +1150,8 @@ def test_a_data_edit_is_rejected(runner: CliRunner, tmp_path: Path) -> None:
 
     assert result.exit_code == 2
     assert "data" in result.output
-    assert not target.exists()
+    leftover = sorted(p.name for p in target.iterdir()) if target.is_dir() else []
+    assert not target.exists(), f"a rejected data edit materialized the target: {leftover}"
 
 
 def test_failure_after_mkdir_removes_the_target(
@@ -1173,7 +1174,8 @@ def test_failure_after_mkdir_removes_the_target(
     result = _new(runner, target, "hello-world")
 
     assert result.exit_code != 0
-    assert not target.exists(), "a partial profile directory survived the failure"
+    leftover = sorted(p.name for p in target.iterdir()) if target.is_dir() else []
+    assert not target.exists(), f"a partial profile directory survived the failure: {leftover}"
     # The original cause is not swallowed by the cleanup.
     assert result.exception is boom
     assert profile_cmd is not None  # import kept meaningful for the reader
@@ -1204,7 +1206,8 @@ def test_failed_round_trip_after_mkdir_removes_the_target(
     assert result.exit_code == 2
     assert "simulated round-trip failure" in result.output
     assert "Nothing was materialized" in result.output
-    assert not target.exists()
+    leftover = sorted(p.name for p in target.iterdir()) if target.is_dir() else []
+    assert not target.exists(), f"a partial profile directory survived the round trip: {leftover}"
 
 
 def test_failed_round_trip_discards_the_env_it_seeded(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,6 +178,118 @@ def session_posture_leak_guard(monkeypatch):
 
 _REAL_DEPLOYMENT_LANES = ("tests/e2e/", "tests/va/e2e/")
 
+#: ``<repo>/var/agent_data`` — the directory :func:`no_agent_data_in_the_repo`
+#: watches. Spelled once, at import, because the creator hook below needs it
+#: before any fixture has run.
+_AGENT_DATA_MARKER = _REPO_ROOT / "var" / "agent_data"
+
+#: Whether that directory was already there when this conftest was imported.
+#: A pre-existing one belongs to a real local deployment, so nothing about it
+#: is the suite's business and the creator hook stays quiet for the session.
+_AGENT_DATA_PRE_EXISTED = _AGENT_DATA_MARKER.exists()
+
+#: The first test in THIS worker whose teardown found the directory there,
+#: ``None`` while none has. Recorded by :func:`pytest_runtest_teardown` and
+#: read by the guard.
+_AGENT_DATA_FIRST_SEEN: str | None = None
+
+
+def pytest_runtest_teardown(item):
+    """Timestamp the appearance of ``<repo>/var/agent_data`` against a test.
+
+    The guard below runs once per worker at session teardown and can only
+    report *that* the directory appeared, which is the least useful half of the
+    finding: the run is over, and the reader is left grepping a whole tree of
+    app fixtures for whichever one resolved the agent-data root to the
+    checkout. This narrows it to a window instead — the first test that ran
+    with the directory already present.
+
+    Deliberately reported as an upper bound rather than as blame. The writer is
+    typically not the test named: the last one measured was a uvicorn daemon
+    thread that ``ServerLauncher`` auto-launched out of an interface app's
+    lifespan and that reached its ``mkdir`` some tests later, in a worker that
+    had moved on. Under ``-n`` the naming worker may not even be the one that
+    created it. What the name is good for is bounding the search — nothing in
+    this worker before it can be the cause.
+
+    One ``stat`` per test, and only until the first hit — cheap enough to leave
+    armed for every lane rather than gated behind a flag nobody would set
+    before the leak had already cost them an afternoon.
+    """
+    global _AGENT_DATA_FIRST_SEEN
+    if _AGENT_DATA_PRE_EXISTED or _AGENT_DATA_FIRST_SEEN is not None:
+        return
+    if _AGENT_DATA_MARKER.exists():
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+        _AGENT_DATA_FIRST_SEEN = f"{item.nodeid} (worker {worker})"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def agent_data_never_the_checkout(request, tmp_path_factory):
+    """Divert a resolution that lands on THIS checkout to a throwaway root.
+
+    Every path to the agent-data root funnels through
+    ``osprey_connectors.workspace.resolve_project_root`` — ``resolve_shared_data_root``
+    and ``resolve_agent_data_root`` both anchor ``agent_data.base_dir`` on
+    whatever it answers, and ``writer.audit_dir`` anchors the ledger on it too.
+    It is also the only seam in that chain that is looked up by module global at
+    call time, so binding it here reaches every caller regardless of how it
+    imported its own resolver: the modules that did ``from ... import
+    resolve_shared_data_root`` at import time still run the original function
+    body, and that body reads this name.
+
+    Session-scoped because the leak it closes is won by a RACE, not by a test.
+    The directory is created inside a uvicorn daemon thread — the artifacts
+    gallery that ``ServerLauncher`` auto-launches from an interface app's
+    lifespan, whose ``store_watcher.start()`` mkdirs
+    ``<root>/artifacts`` — and that thread outlives the test that started it by
+    an unbounded margin. A function-scoped redirection is therefore not merely
+    untidy but unsound: ``monkeypatch`` undoes it at teardown and the thread
+    then resolves against the real checkout, which is exactly the intermittency
+    that made this leak look like a different module every run. A module-scoped
+    one loses the same race, one module later.
+
+    A WRAPPER, not a constant. A blanket redirect would answer the same tmp
+    directory for a test that configured its own ``project_root`` and asserts
+    what a tool derived from it — so only the one case that constitutes the
+    leak is diverted: resolution landing on the checkout the suite is running
+    in. Everything else, including every test that patches a resolver of its
+    own further up the stack, is untouched — this sits BELOW those patches
+    rather than overriding them, which is what a suite-wide
+    ``OSPREY_AGENT_DATA_ROOT`` stamp cannot say for itself (see
+    :func:`session_posture_leak_guard`).
+
+    Disarmed for the real-deployment lanes, on the same predicate as
+    :func:`no_agent_data_in_the_repo`: they run agents and servers with this
+    checkout as the project root on purpose, and diverting it would be
+    rewriting the thing under test.
+    """
+    from osprey_connectors import workspace as connector_workspace
+
+    if any(item.nodeid.startswith(_REAL_DEPLOYMENT_LANES) for item in request.session.items):
+        yield
+        return
+
+    real_resolve_project_root = connector_workspace.resolve_project_root
+    diverted = tmp_path_factory.mktemp("project-root-not-the-checkout")
+
+    def _never_the_checkout(config=None):
+        root = real_resolve_project_root(config)
+        try:
+            landed_here = Path(root).resolve() == _REPO_ROOT
+        except OSError:  # pragma: no cover - a root that vanished mid-run
+            return root
+        return diverted if landed_here else root
+
+    # Installed for the lifetime of the process, with no undo. The thread this
+    # exists to catch is a uvicorn daemon that outlives the fixture that started
+    # it, so a redirect lifted at teardown leaves it resolving against the real
+    # checkout for as long as the interpreter is still up -- the same unsoundness
+    # a function-scoped redirect has, one scope later. Nothing runs after a
+    # session fixture's teardown that needs the original back.
+    connector_workspace.resolve_project_root = _never_the_checkout
+    yield
+
 
 @pytest.fixture(autouse=True, scope="session")
 def no_agent_data_in_the_repo(request):
@@ -205,7 +317,7 @@ def no_agent_data_in_the_repo(request):
     fixture's mistake. The guard is armed only in a session that collects none
     of them — the unit lane it was written for.
     """
-    marker = Path(__file__).resolve().parent.parent / "var" / "agent_data"
+    marker = _AGENT_DATA_MARKER
     real_deployment_lane = any(
         item.nodeid.startswith(_REAL_DEPLOYMENT_LANES) for item in request.session.items
     )
@@ -214,11 +326,22 @@ def no_agent_data_in_the_repo(request):
     if real_deployment_lane:
         return
     if not existed and marker.exists():
+        culprit = (
+            "\nalready present by the end of "
+            f"{_AGENT_DATA_FIRST_SEEN} — the writer is at or before that point, "
+            "and may be a background thread an earlier test started"
+            if _AGENT_DATA_FIRST_SEEN
+            else ""
+        )
         raise AssertionError(
             f"the test run created {marker} — something resolved the agent-data root "
             "to the repository. A test that writes the posture store or a control-target "
             "state file must stamp OSPREY_AGENT_DATA_ROOT at a tmp path (see "
             "session_posture_leak_guard) rather than leave it to resolve_shared_data_root()."
+            f"{culprit}"
+            "\nThe bound above names only what this xdist worker ran: a writer in "
+            "another worker, in a subprocess, or in a module that bound its resolver "
+            "at import time is not narrowed by it."
         )
 
 

--- a/tests/connectors/test_doocs_connector.py
+++ b/tests/connectors/test_doocs_connector.py
@@ -4,7 +4,10 @@ Unit tests for DOOCSConnector.
 All tests mock doocs4py so no installed DOOCS environment is required.
 """
 
+import asyncio
 import sys
+import time
+from contextlib import suppress
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -372,6 +375,112 @@ class TestConfirmResolution:
 
         assert result.outcome is WriteOutcome.CONFIRMED
         mock_d4py.get.assert_called_once_with("FAC/DEV/LOC/PROP")
+
+
+class TestNonBlockingOffload:
+    """Limits validation and the send share ONE thread offload.
+
+    A max_step check reads the property's present value with a blocking
+    ``doocs4py.get()``, so running validation on the event loop would stall
+    every other coroutine in the process for the length of that read.
+    """
+
+    async def test_validate_runs_off_the_event_loop(self):
+        """A slow (blocking) validate() must NOT starve the event loop.
+
+        Stands in for max_step's blocking read with a 0.3 s ``time.sleep``
+        inside validate(). While the write is in flight, a concurrently awaited
+        0.05 s sleep must still finish promptly and a 0.005 s ticker must keep
+        advancing — neither is possible if validation runs on the loop.
+        """
+        validator = _make_limits_validator(confirm=False)
+
+        def slow_validate(_address, _value, *, read_current=None):
+            time.sleep(0.3)  # stand-in for max_step's blocking fresh read
+
+        validator.validate = MagicMock(side_effect=slow_validate)
+
+        mock_d4py = _make_doocs4py()
+
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.005)
+                ticks += 1
+
+        with (
+            patch.dict(sys.modules, {"doocs4py": mock_d4py}),
+            patch(_LIMITS_PATCH, return_value=validator),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+        ):
+            from osprey.connectors.control_system.doocs_connector import DOOCSConnector
+
+            conn = DOOCSConnector()
+            await conn.connect({})
+
+            ticker_task = asyncio.create_task(ticker())
+            write_task = asyncio.create_task(
+                conn.write_channel("FAC/DEV/LOC/PROP", 10.0, confirm=False)
+            )
+
+            # Let the write reach its offload, then measure how long a short
+            # concurrent sleep takes while validate() blocks a worker thread.
+            start = time.monotonic()
+            await asyncio.sleep(0.05)
+            elapsed = time.monotonic() - start
+
+            result = await write_task
+            ticker_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await ticker_task
+            await conn.disconnect()
+
+        assert elapsed < 0.2, f"event loop was blocked for {elapsed:.3f}s"
+        assert ticks > 0, "concurrent coroutine was starved (loop blocked)"
+        # The check was still made, and the value still went out.
+        validator.validate.assert_called_once()
+        assert result.outcome is WriteOutcome.UNREQUESTED
+        mock_d4py.set.assert_called_once_with("FAC/DEV/LOC/PROP", 10.0)
+
+    async def test_a_limits_refusal_raised_in_the_offload_sends_nothing(self):
+        """A refusal from the worker thread reaches the caller as itself.
+
+        Validation and the send share one offload, so the refusal is raised off
+        the loop and has a thread boundary to cross. It must arrive carrying its
+        LIMITS meaning rather than flattened into a failed write, and the value
+        it refused must never reach ``doocs4py.set``.
+        """
+        from osprey_connectors.errors import ChannelLimitsViolationError
+
+        refusal = ChannelLimitsViolationError(
+            "FAC/DEV/LOC/PROP", 10.0, "max_value", "above the configured ceiling"
+        )
+        validator = _make_limits_validator()
+        validator.validate = MagicMock(side_effect=refusal)
+
+        mock_d4py = _make_doocs4py()
+
+        with (
+            patch.dict(sys.modules, {"doocs4py": mock_d4py}),
+            patch(_LIMITS_PATCH, return_value=validator),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+        ):
+            from osprey.connectors.control_system.doocs_connector import DOOCSConnector
+
+            conn = DOOCSConnector()
+            await conn.connect({})
+
+            with pytest.raises(ChannelLimitsViolationError) as raised:
+                await conn.write_channel("FAC/DEV/LOC/PROP", 10.0, confirm=False)
+
+            await conn.disconnect()
+
+        assert raised.value is refusal
+        mock_d4py.set.assert_not_called()
 
 
 class _Incomparable:

--- a/tests/connectors/test_tango_connector.py
+++ b/tests/connectors/test_tango_connector.py
@@ -9,6 +9,7 @@ PyTango.
 
 import asyncio
 import sys
+import time
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -529,6 +530,111 @@ class TestConfirmResolution:
         )
         with pytest.raises(ChannelLimitsViolationError):
             await _write_with_validator(validator, value=1e9)
+
+
+class TestNonBlockingOffload:
+    """Validation and the send run in ONE thread offload.
+
+    ``max_step`` validation reads the attribute's present value through a
+    blocking ``read_attribute``, and both the ``DeviceProxy`` lookup and the
+    ``write_attribute`` that follow it are blocking device round trips. All of
+    them belong off the event loop, so a caller awaiting a write never stalls
+    the loop it is running on.
+    """
+
+    async def test_validate_and_send_run_off_the_event_loop(self):
+        """A slow (blocking) validate() must NOT starve the event loop.
+
+        Stands in for max_step's blocking fresh read with a 0.3 s
+        ``time.sleep`` inside validate(). While the write is in flight, a
+        concurrently-awaited 0.05 s sleep must still complete promptly and a
+        ticker must advance — neither is possible if validate ran on the loop.
+        """
+        validator = _make_limits_validator(confirm=False)
+
+        def slow_validate(_addr, _val, *, read_current=None):
+            time.sleep(0.3)  # stand-in for max_step's blocking fresh read
+
+        validator.validate = MagicMock(side_effect=slow_validate)
+
+        proxy = _make_proxy()
+        mock_tango = _make_tango(proxy)
+
+        # A concurrent ticker that can only advance if the loop is being serviced.
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.005)
+                ticks += 1
+
+        with (
+            patch.dict(sys.modules, {"tango": mock_tango}),
+            patch(_LIMITS_PATCH, return_value=validator),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+        ):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            await conn.connect({})
+
+            ticker_task = asyncio.create_task(ticker())
+            write_task = asyncio.create_task(conn.write_channel(_ADDRESS, 10.0, confirm=False))
+
+            # Give the write time to reach its offload, then measure how long a
+            # short concurrent sleep takes while validate() blocks a thread.
+            start = time.monotonic()
+            await asyncio.sleep(0.05)
+            elapsed = time.monotonic() - start
+
+            result = await write_task
+            ticker_task.cancel()
+            await conn.disconnect()
+
+        assert elapsed < 0.2, f"event loop was blocked for {elapsed:.3f}s"
+        assert ticks > 0, "concurrent coroutine was starved (loop blocked)"
+        validator.validate.assert_called_once()
+        assert result.outcome is WriteOutcome.UNREQUESTED
+        proxy.write_attribute.assert_called_once_with("Current", 10.0)
+
+    async def test_confirm_is_resolved_only_once_the_value_is_away(self):
+        """A write that never left is not a confirmation question.
+
+        The policy lookup happens on the branch where the value was actually
+        sent, so neither a refused write nor a failed one asks the limits
+        database whether it should be read back.
+        """
+        validator = _make_limits_validator()
+        validator.validate.side_effect = RuntimeError("limits database unreachable")
+        refused, proxy = await _write_with_validator(validator)
+        assert refused.outcome is WriteOutcome.REFUSED
+        assert refused.refusal_reason == "VALIDATION_ERROR"
+        proxy.write_attribute.assert_not_called()
+        validator.resolve_confirm.assert_not_called()
+
+        validator = _make_limits_validator()
+        proxy = _make_proxy()
+        proxy.write_attribute.side_effect = RuntimeError("write refused by device")
+        mock_tango = _make_tango(proxy)
+        with (
+            patch.dict(sys.modules, {"tango": mock_tango}),
+            patch(_LIMITS_PATCH, return_value=validator),
+            patch(_TZ_PATCH, return_value=UTC),
+            patch("osprey.utils.config.get_config_value", side_effect=_writes_enabled),
+        ):
+            from osprey.connectors.control_system.tango_connector import TangoConnector
+
+            conn = TangoConnector()
+            await conn.connect({})
+            failed = await conn.write_channel(_ADDRESS, 10.0)
+            await conn.disconnect()
+
+        assert failed.outcome is WriteOutcome.FAILED
+        assert failed.notes == "TANGO did not take the value"
+        proxy.read_attribute.assert_not_called()
+        validator.resolve_confirm.assert_not_called()
 
 
 class TestWriteTextIsDisplayOnly:

--- a/tests/deployment/goldens/exemplar-profile/providers.yml
+++ b/tests/deployment/goldens/exemplar-profile/providers.yml
@@ -24,8 +24,8 @@ providers:
     base_url: https://api.cborg.lbl.gov/v1
     models:                        # Model IDs as named by this provider
       haiku: claude-haiku-4-5
-      sonnet: claude-sonnet-4-6
-      opus: claude-opus-4-7
+      sonnet: claude-sonnet-5
+      opus: claude-opus-5
   amsc-i2:
     api_key: ${AMSC_I2_API_KEY}
     base_url: https://api.i2-core.american-science-cloud.org/v1

--- a/tests/deployment/web_terminals/test_auth_credentials.py
+++ b/tests/deployment/web_terminals/test_auth_credentials.py
@@ -42,6 +42,7 @@ from osprey.utils.dotenv import (
     append_profile_env,
     dotenv_line_var,
     env_file_lock,
+    env_lock_path,
     parse_dotenv_file,
 )
 
@@ -1277,7 +1278,7 @@ def test_purge_leaves_no_temporary_file_and_keeps_the_mode(tmp_path: Path) -> No
 
     assert file_mode(tmp_path / ENV_LOCAL_FILENAME) == 0o600
     assert [path.name for path in tmp_path.iterdir() if path.name != ENV_LOCAL_FILENAME] == [
-        f"{ENV_LOCAL_FILENAME}.lock"
+        env_lock_path(tmp_path / ENV_LOCAL_FILENAME).name
     ]
 
 

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -95,6 +95,7 @@ from osprey.agent_runner.primitives import (
 from osprey.agent_runner.primitives import (
     provider_env_for_project as provider_env_for_project,  # re-exported for e2e tests
 )
+from osprey.agent_runner.project_paths import claude_project_dir
 from osprey.utils.workspace import (
     BUILD_DIR_NAME,
     DEFAULT_AGENT_DATA_BASE_DIR,
@@ -1227,6 +1228,66 @@ async def run_sdk_query_with_hooks(
 
 
 # ---------------------------------------------------------------------------
+# Hook stdout, read back out of the session transcript
+# ---------------------------------------------------------------------------
+
+
+#: Prefix shared by every transcript record that carries a hook's own stdout.
+#:
+#: ``hook_success`` — a hook that exited 0 — is the one spelling verified
+#: against CLI 2.1.241. The kinds Claude Code writes when a hook fails, times
+#: out, or is killed share this prefix, but their exact spelling is NOT
+#: verified here, which is why this matches on the prefix rather than on a
+#: literal set: a hook that died mid-approval is precisely the run someone
+#: needs to read, and an allow-list of one would drop it silently.
+HOOK_ATTACHMENT_PREFIX = "hook_"
+
+
+def hook_attachments(result: SDKWorkflowResult, render: Path) -> list[dict[str, Any]]:
+    """Every hook-stdout attachment in this session's transcript, in order.
+
+    Claude Code does not put a hook's output on the SDK wire. It writes each
+    invocation's raw stdout into the session transcript as an attachment record
+    carrying ``hookName``, ``hookEvent``, the ``toolUseID`` it gated, and the
+    ``stdout`` itself — so that text is recoverable exactly, and joins to a tool
+    trace by id rather than by guessing at ordering. This is the only channel
+    that carries it; see :func:`tests.e2e.test_target_switch_agentic.approval_prompts`
+    for the SDK field that looks like it should and does not.
+
+    Dicts come back raw and unprojected. A reader chasing an unexplained
+    refusal does not know in advance which key holds the answer, and a helper
+    that decides for them turns a diagnostic into a guess.
+
+    Returns an empty list when the session id or the transcript cannot be
+    resolved, and skips any line that is not a JSON object: callers assert on
+    what they expected to find, and a bare "nothing here" is a clearer failure
+    than an exception thrown from a path that only exists to observe.
+    """
+    session_id = getattr(result.result, "session_id", None)
+    if not session_id:
+        return []
+    transcript = claude_project_dir(Path(render).resolve()) / f"{session_id}.jsonl"
+    if not transcript.is_file():
+        return []
+
+    attachments: list[dict[str, Any]] = []
+    for line in transcript.read_text(encoding="utf-8").splitlines():
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        attachment = record.get("attachment")
+        if not isinstance(attachment, dict):
+            continue
+        if not str(attachment.get("type") or "").startswith(HOOK_ATTACHMENT_PREFIX):
+            continue
+        attachments.append(attachment)
+    return attachments
+
+
+# ---------------------------------------------------------------------------
 # Agent transcripts as CI artifacts
 # ---------------------------------------------------------------------------
 
@@ -1238,7 +1299,9 @@ async def run_sdk_query_with_hooks(
 TRANSCRIPT_SUBDIR = "agent"
 
 
-def _transcript_payload(name: str, result: SDKWorkflowResult) -> dict[str, Any]:
+def _transcript_payload(
+    name: str, result: SDKWorkflowResult, render: Path | None = None
+) -> dict[str, Any]:
     """The serialisable form of one agent run — deliberately UNTRUNCATED.
 
     Truncation is the whole reason this exists. ``_to_workflow_result``
@@ -1253,8 +1316,13 @@ def _transcript_payload(name: str, result: SDKWorkflowResult) -> dict[str, Any]:
     ``mcp_server_status`` is included because it is the infra-vs-model
     discriminator: a tool the agent never called means one thing if the
     handshake offered it and quite another if it never registered.
+
+    ``hook_attachments`` appears only when *render* is given, so a caller with
+    no render on hand keeps exactly the payload it had. Its absence and an
+    empty list mean different things: no key says nobody looked, and ``[]``
+    says the transcript was read and held no hook output.
     """
-    return {
+    payload: dict[str, Any] = {
         "name": name,
         # Every turn's prose, joined the way the judge is given it, but whole.
         "response": "\n".join(result.text_blocks).strip(),
@@ -1273,9 +1341,14 @@ def _transcript_payload(name: str, result: SDKWorkflowResult) -> dict[str, Any]:
         "mcp_server_status": result.mcp_server_status,
         "registered_tools": result.registered_tools,
     }
+    if render is not None:
+        payload["hook_attachments"] = hook_attachments(result, render)
+    return payload
 
 
-def dump_agent_transcript(name: str, result: SDKWorkflowResult) -> Path | None:
+def dump_agent_transcript(
+    name: str, result: SDKWorkflowResult, *, render: Path | None = None
+) -> Path | None:
     """Persist one agent run's full response and tool traces as a CI artifact.
 
     Gated on ``OSPREY_CI_DIAG_DIR`` exactly like :mod:`tests.ci_diagnostics`:
@@ -1288,9 +1361,17 @@ def dump_agent_transcript(name: str, result: SDKWorkflowResult) -> Path | None:
     the ones that fail, and a dump placed below a judge assertion never
     executes on exactly those.
 
+    Pass *render* for a run whose hooks matter. The artifact then also carries
+    every hook's raw stdout (see :func:`hook_attachments`), which is the only
+    record of why a call was asked about or refused — tool traces show that a
+    write was gated, never what the operator was asked. Omit it and the payload
+    is unchanged.
+
     Never raises. A diagnostic that can fail the test it was only meant to
     observe would mask the very failure it exists to explain — the same reason
-    every probe in the capture action ends in ``|| true``.
+    every probe in the capture action ends in ``|| true``. That covers the
+    transcript read too: it happens inside the same guard, below the arming
+    check, so an unarmed run never goes near the session directory.
     """
     directory = os.environ.get(ci_diagnostics.ENV_DIR)
     if not directory:
@@ -1302,7 +1383,7 @@ def dump_agent_transcript(name: str, result: SDKWorkflowResult) -> Path | None:
         safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in name) or "transcript"
         target = target_dir / f"{safe}.json"
         target.write_text(
-            json.dumps(_transcript_payload(name, result), indent=2, default=str),
+            json.dumps(_transcript_payload(name, result, render), indent=2, default=str),
             encoding="utf-8",
         )
         return target

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -723,8 +723,8 @@ def _default_opus_model(repo: Path) -> str:
     """
     spec = _resolve_project_spec(render_dir(repo))
     if spec is not None:
-        return spec.tier_to_model.get("opus", "claude-opus-4-7")
-    return "claude-opus-4-7"
+        return spec.tier_to_model.get("opus", "claude-opus-5")
+    return "claude-opus-5"
 
 
 def find_png_files(root: Path) -> list[Path]:

--- a/tests/e2e/test_jupyter_panel_lifecycle.py
+++ b/tests/e2e/test_jupyter_panel_lifecycle.py
@@ -43,8 +43,9 @@ switch in 4 moves off the target it narrowed, and the down/up must come last.
    target and writes there. Nothing is restarted: a kernel re-routes itself
    from the record before every cell, which is the one thing that separates it
    from an executor sandbox.
-5. ``NotebookEdit`` under ``notebooks/`` is allowed by the rendered settings and
-   the guard hook and badges the panel; outside it is denied.
+5. ``NotebookEdit`` under ``notebooks/`` is allowed by the rendered
+   ``Edit(...)`` rules and the guard hook and badges the panel; outside it is
+   denied.
 6. The sidecar's runtime directory is not under the agent-data root.
 7. Notebooks survive ``osprey down && osprey up``; kernels do not.
 
@@ -905,8 +906,9 @@ def test_notebook_edit_is_allowed_under_notebooks_and_badges_the_panel(terminal:
         )
     )
     allow = settings["permissions"]["allow"]
-    assert "NotebookEdit(var/agent_data/notebooks/**)" in allow, allow
-    assert "NotebookEdit(var/agent_data/artifacts/**)" in allow, allow
+    assert "Edit(var/agent_data/notebooks/**)" in allow, allow
+    assert "Edit(var/agent_data/artifacts/**)" in allow, allow
+    assert not any(a.startswith("NotebookEdit(") for a in allow), allow
 
     agent_env = _process_env(terminal.pty_pid)
     config_path = agent_env["OSPREY_CONFIG"]

--- a/tests/e2e/test_sdk_helpers.py
+++ b/tests/e2e/test_sdk_helpers.py
@@ -8,17 +8,22 @@ about the model under test.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from osprey.agent_runner.primitives import SDKWorkflowResult, ToolTrace
+from osprey.agent_runner.project_paths import claude_project_dir
 from tests.e2e.sdk_helpers import (
     _DEFAULT_ARIEL_DB_URI,
+    HOOK_ATTACHMENT_PREFIX,
     TRANSCRIPT_SUBDIR,
     HookEvent,
     _bind_approval_policy,
     _override_ariel_db_uri,
     dump_agent_transcript,
+    hook_attachments,
 )
 
 _PER_CELL_URI = "postgresql://ariel:ariel@localhost:5432/ariel_gpt-oss-20b_seed1"
@@ -117,7 +122,12 @@ def test_transcript_dump_is_inert_when_unarmed(tmp_path, monkeypatch):
     monkeypatch.delenv("OSPREY_CI_DIAG_DIR", raising=False)
     monkeypatch.chdir(tmp_path)
 
-    assert dump_agent_transcript("orbit_response", _result_with_a_long_tool_result()) is None
+    # ``render`` is passed to prove the transcript read is downstream of the
+    # arming check: an unarmed run must not go near the session directory.
+    assert (
+        dump_agent_transcript("orbit_response", _result_with_a_long_tool_result(), render=tmp_path)
+        is None
+    )
     assert list(tmp_path.iterdir()) == []
 
 
@@ -138,6 +148,9 @@ def test_transcript_dump_keeps_tool_results_whole(tmp_path, monkeypatch):
     payload = json.loads(target.read_text(encoding="utf-8"))
     assert len(payload["tool_traces"][0]["result"]) == 5000
     assert payload["response"] == "I measured the ring.\nThe response is linear."
+    # No render, no hook stdout: the six plan-stack dump sites that call this
+    # without one must keep exactly the payload they had.
+    assert "hook_attachments" not in payload
 
 
 @pytest.mark.unit
@@ -146,11 +159,15 @@ def test_transcript_dump_sanitises_the_name(tmp_path, monkeypatch):
     the diagnostics directory or produce an unopenable filename."""
     monkeypatch.setenv("OSPREY_CI_DIAG_DIR", str(tmp_path))
 
-    target = dump_agent_transcript("../grid[two_axis]", SDKWorkflowResult())
+    target = dump_agent_transcript("../grid[two_axis]", SDKWorkflowResult(), render=tmp_path)
 
     assert target is not None
     assert target.parent == tmp_path / TRANSCRIPT_SUBDIR
     assert target.name == ".._grid_two_axis_.json"
+    # A result with no session id resolves to no transcript, and the key is
+    # still written — an empty list says "looked, found none", which a missing
+    # key cannot.
+    assert json.loads(target.read_text(encoding="utf-8"))["hook_attachments"] == []
 
 
 @pytest.mark.unit
@@ -162,7 +179,156 @@ def test_transcript_dump_never_raises(tmp_path, monkeypatch):
     blocker.write_text("not a directory", encoding="utf-8")
     monkeypatch.setenv("OSPREY_CI_DIAG_DIR", str(blocker))
 
-    assert dump_agent_transcript("orbit_response", SDKWorkflowResult()) is None
+    assert dump_agent_transcript("orbit_response", SDKWorkflowResult(), render=blocker) is None
+
+
+# ---------------------------------------------------------------------------
+# Hook stdout read back out of the session transcript. Synthetic JSONL: the
+# layout is Claude Code's, not ours, so these pin what the reader tolerates
+# rather than what the CLI happens to write.
+# ---------------------------------------------------------------------------
+
+
+def _session_result(session_id: str) -> SDKWorkflowResult:
+    """A workflow result carrying nothing but the session id the reader needs."""
+    return SDKWorkflowResult(result=SimpleNamespace(session_id=session_id))  # type: ignore[arg-type]
+
+
+def _write_transcript(tmp_path, monkeypatch, session_id: str, records: list) -> Path:
+    """Plant a session transcript where `claude_project_dir` will look for it.
+
+    Returns the render directory to hand the reader. `CLAUDE_CONFIG_DIR` is
+    redirected so the test never reads — or creates — anything under the
+    developer's real ~/.claude.
+    """
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    render = (tmp_path / "render").resolve()
+    render.mkdir(parents=True, exist_ok=True)
+    transcript = claude_project_dir(render) / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+    )
+    return render
+
+
+@pytest.mark.unit
+def test_hook_attachments_reads_every_hook_prefixed_attachment(tmp_path, monkeypatch):
+    """Prefix match, not an allow-list of one.
+
+    `hook_success` is the only spelling verified against CLI 2.1.241, so a hook
+    that failed or timed out is recorded under a type this test cannot name.
+    Matching the prefix is what keeps that hook's stdout in the CI artifact —
+    and a hook that died mid-approval is exactly the run someone needs to read.
+    """
+    render = _write_transcript(
+        tmp_path,
+        monkeypatch,
+        "sess-1",
+        [
+            {"type": "user", "message": {"role": "user", "content": "hi"}},
+            {"attachment": {"type": "selected_lines_in_ide", "stdout": "not a hook"}},
+            {
+                "attachment": {
+                    "type": "hook_success",
+                    "hookName": "PreToolUse:mcp__controls__channel_write",
+                    "hookEvent": "PreToolUse",
+                    "toolUseID": "tu_ok",
+                    "stdout": '{"hookSpecificOutput": {"permissionDecision": "ask"}}',
+                }
+            },
+            {
+                "attachment": {
+                    "type": "hook_error",
+                    "hookName": "PreToolUse:mcp__controls__channel_write",
+                    "hookEvent": "PreToolUse",
+                    "toolUseID": "tu_broken",
+                    "stdout": "Traceback (most recent call last):",
+                }
+            },
+        ],
+    )
+
+    found = hook_attachments(_session_result("sess-1"), render)
+
+    assert [a["toolUseID"] for a in found] == ["tu_ok", "tu_broken"]
+    assert all(a["type"].startswith(HOOK_ATTACHMENT_PREFIX) for a in found)
+    # The dicts come back raw — nothing is projected away, because a reader
+    # chasing an unexplained refusal does not know in advance which key holds
+    # the answer.
+    assert found[1]["stdout"] == "Traceback (most recent call last):"
+    assert found[1]["hookName"] == "PreToolUse:mcp__controls__channel_write"
+
+
+@pytest.mark.unit
+def test_hook_attachments_survives_a_malformed_transcript(tmp_path, monkeypatch):
+    """A truncated write or a bare JSON scalar must not raise out of a
+    diagnostic path — the run being diagnosed is the one that already failed."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    render = (tmp_path / "render").resolve()
+    render.mkdir(parents=True, exist_ok=True)
+    transcript = claude_project_dir(render) / "sess-2.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        "\n".join(
+            [
+                "{not json at all",
+                '"a bare string"',
+                "[1, 2, 3]",
+                json.dumps({"attachment": "not a dict"}),
+                json.dumps({"attachment": {"type": "hook_success", "toolUseID": "tu_1"}}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert [a["toolUseID"] for a in hook_attachments(_session_result("sess-2"), render)] == ["tu_1"]
+
+
+@pytest.mark.unit
+def test_hook_attachments_empty_without_a_session_or_transcript(tmp_path, monkeypatch):
+    """No session id and no transcript both mean "nothing to read", not an error.
+
+    Callers assert on what they expected to find; a bare empty list is a
+    clearer failure than an exception raised from an observer.
+    """
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    render = (tmp_path / "render").resolve()
+    render.mkdir(parents=True, exist_ok=True)
+
+    assert hook_attachments(SDKWorkflowResult(), render) == []
+    assert hook_attachments(_session_result("never-written"), render) == []
+
+
+@pytest.mark.unit
+def test_transcript_dump_carries_the_hook_stdout_when_given_a_render(tmp_path, monkeypatch):
+    """The artifact reason this exists: tool traces alone cannot say why a call
+    was asked about, because the approval wording only ever reaches the
+    transcript."""
+    render = _write_transcript(
+        tmp_path,
+        monkeypatch,
+        "sess-3",
+        [
+            {
+                "attachment": {
+                    "type": "hook_success",
+                    "hookName": "PreToolUse:mcp__controls__channel_write",
+                    "hookEvent": "PreToolUse",
+                    "toolUseID": "tu_1",
+                    "stdout": '{"hookSpecificOutput": {"permissionDecisionReason": "live machine"}}',
+                }
+            }
+        ],
+    )
+    monkeypatch.setenv("OSPREY_CI_DIAG_DIR", str(tmp_path / "diag"))
+
+    target = dump_agent_transcript("switch_run", _session_result("sess-3"), render=render)
+
+    assert target is not None
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert [a["toolUseID"] for a in payload["hook_attachments"]] == ["tu_1"]
+    assert "live machine" in payload["hook_attachments"][0]["stdout"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_target_switch_agentic.py
+++ b/tests/e2e/test_target_switch_agentic.py
@@ -83,7 +83,6 @@ import yaml
 
 from osprey.agent_runner import await_mcp_ready, expected_mcp_servers, sdk_env
 from osprey.agent_runner.primitives import _ingest_tool_result
-from osprey.agent_runner.project_paths import claude_project_dir
 from osprey.mcp_server.control_system.connector_host_manager import baseline_target
 from osprey.mcp_server.control_system.target_state import (
     INFLIGHT_FILE_GLOB,
@@ -113,6 +112,7 @@ from tests.e2e.sdk_helpers import (
     _persist_mcp_sidecar,
     dump_agent_transcript,
     e2e_budget_scale,
+    hook_attachments,
     is_claude_code_available,
     render_dir,
     run_sdk_query_with_hooks,
@@ -796,9 +796,11 @@ async def run_switch_session(
 # Reading the approval prompt back
 # ---------------------------------------------------------------------------
 
-#: The transcript records that carry a hook's own stdout, and the event whose
-#: output can ask for approval.
-_HOOK_ATTACHMENT_TYPE = "hook_success"
+#: The attachment type of a hook that exited 0, and the event whose output can
+#: ask for approval. :func:`~tests.e2e.sdk_helpers.hook_attachments` hands back
+#: every ``hook_``-prefixed attachment, failures included; only a hook that
+#: succeeded had its decision honoured, so only those are approval prompts.
+_HOOK_SUCCESS_TYPE = "hook_success"
 _PRE_TOOL_USE = "PreToolUse"
 
 
@@ -835,36 +837,23 @@ def approval_prompts(result: HookObservedResult, render: Path) -> list[ApprovalP
     raw stdout into the session transcript as a ``hook_success`` attachment
     carrying the ``toolUseID`` it gated, so the prompt an operator would have
     read is recoverable exactly, and joins to a tool trace by id rather than by
-    guessing at ordering.
+    guessing at ordering. Reading the transcript is
+    :func:`~tests.e2e.sdk_helpers.hook_attachments`, which the CI artifact dump
+    also uses; what remains here is the approval-specific filter over it.
 
     **This helper is meant to retire.** When a CLI populates
     ``decision_reason``, that field becomes the preferred path — it needs no
-    disk, no session id, and no transcript layout — and this reader should move
-    into ``sdk_helpers`` or disappear. Until then it is the only channel that
-    carries the wording, so every scenario asserting on approval text goes
-    through it.
+    disk, no session id, and no transcript layout — and this filter disappears.
+    Until then it is the only channel that carries the wording, so every
+    scenario asserting on approval text goes through it.
 
     Returns an empty list when the session id or the transcript cannot be
     resolved: callers assert on what they expected to find, and a bare "no
     prompts" is a clearer failure than an exception from a diagnostic path.
     """
-    session_id = getattr(result.result, "session_id", None)
-    if not session_id:
-        return []
-    transcript = claude_project_dir(Path(render).resolve()) / f"{session_id}.jsonl"
-    if not transcript.is_file():
-        return []
-
     prompts: list[ApprovalPrompt] = []
-    for line in transcript.read_text(encoding="utf-8").splitlines():
-        try:
-            record = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        attachment = record.get("attachment")
-        if not isinstance(attachment, dict):
-            continue
-        if attachment.get("type") != _HOOK_ATTACHMENT_TYPE:
+    for attachment in hook_attachments(result, render):
+        if attachment.get("type") != _HOOK_SUCCESS_TYPE:
             continue
         if attachment.get("hookEvent") != _PRE_TOOL_USE:
             continue
@@ -1134,7 +1123,9 @@ async def test_the_approval_prompt_text_reaches_the_test(
         max_turns=10,
         max_budget_usd=2.0,
     )
-    dump_agent_transcript("target_switch_agentic_fr7_smoke", result)
+    dump_agent_transcript(
+        "target_switch_agentic_fr7_smoke", result, render=switch_deployment.render
+    )
 
     assert result.hook_events, (
         "no hook events recorded — the approval hook never returned 'ask'. Either the agent "
@@ -1786,7 +1777,9 @@ async def test_agent_rehearses_on_the_simulator_then_moves_the_live_machine(
         between=_move_to_the_simulator,
     )
     result = conversation.result
-    dump_agent_transcript("target_switch_agentic_s1_rehearse_then_live", result)
+    dump_agent_transcript(
+        "target_switch_agentic_s1_rehearse_then_live", result, render=switch_deployment.render
+    )
 
     # -- floor: the roster was consulted, and it was consulted FIRST -----------
     rehearsal = conversation.phase(0)
@@ -1952,7 +1945,9 @@ async def test_a_refused_write_is_not_retried_on_the_live_machine(
         max_budget_usd=3.0,
         disallowed_tools=SCENARIO_INTEGRITY_DISALLOWED_TOOLS,
     )
-    dump_agent_transcript("target_switch_agentic_s3_refused_channel", result)
+    dump_agent_transcript(
+        "target_switch_agentic_s3_refused_channel", result, render=switch_deployment.render
+    )
 
     traces = indexed(result)
     switches = traces_named(traces, CONTROL_TARGET_SET_TOOL)
@@ -2129,7 +2124,9 @@ async def test_the_agent_is_honest_when_the_live_machine_stops_answering(
             _wait_for_bench(switch_deployment, answering=True, timeout=BENCH_BOOT_TIMEOUT_S)
 
     result = conversation.result
-    dump_agent_transcript("target_switch_agentic_s4_live_outage", result)
+    dump_agent_transcript(
+        "target_switch_agentic_s4_live_outage", result, render=switch_deployment.render
+    )
 
     # -- floor: the session really was on the live machine when it died -------
     live_phase = conversation.phase(0)
@@ -2269,7 +2266,9 @@ async def test_a_denied_switch_leaves_the_session_where_it_was(
         max_budget_usd=3.0,
         disallowed_tools=SCENARIO_INTEGRITY_DISALLOWED_TOOLS,
     )
-    dump_agent_transcript("target_switch_agentic_s6_denied_switch", result)
+    dump_agent_transcript(
+        "target_switch_agentic_s6_denied_switch", result, render=switch_deployment.render
+    )
 
     # -- floor: the switch was asked for, and refused -------------------------
     denials = [

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -570,6 +570,11 @@ config:
   approval.tools.entry_create: always
   # Publishing it through to the facility's logbook does too.
   approval.tools.entry_publish: always
+  # The panel rail is the operator's own view. Adding or removing a panel, and
+  # registering a new one, changes what the next person sees, so each asks.
+  approval.tools.add_panel_to_rail: always
+  approval.tools.remove_panel_from_rail: always
+  approval.tools.register_panel: always
 
   # ── Hook observability ─────────────────────────────────────────────────────
   # On here. Every hook call logs one line to stderr and appends to

--- a/tests/hooks/test_config_drift_hook.py
+++ b/tests/hooks/test_config_drift_hook.py
@@ -36,6 +36,12 @@ CHANNEL_WRITE = "mcp__controls__channel_write"
 # looking like it had checked.
 CLONE_CHANNEL_WRITE = "mcp__ring__channel_write"
 
+# A per-call-gated write tool a project appends via `control_system.write_tools`.
+# The renderer folds it into `write_tools` but the kill switch never denies it, so
+# a hook that expects to find it in `permissions.deny` sees a partial overlap and
+# abstains — on every deployment that sets the key.
+SITE_CUSTOM_WRITE = "mcp__site__custom_write"
+
 # Channel-write states a rendered settings.json can be in.
 DENIED = "denied"
 ALLOWED = "allowed"
@@ -76,7 +82,12 @@ class _RaisingPath:
 
 
 def _make_project(
-    project_dir, *, writes_enabled: bool | None, channel_write: str, write_tool: str = CHANNEL_WRITE
+    project_dir,
+    *,
+    writes_enabled: bool | None,
+    channel_write: str,
+    write_tool: str = CHANNEL_WRITE,
+    extras: tuple[str, ...] = (),
 ):
     """Write config.yml + .claude/settings.json in a chosen (possibly drifted) state.
 
@@ -91,11 +102,17 @@ def _make_project(
         "\n".join(lines) + "\n",
         channel_write=channel_write,
         write_tool=write_tool,
+        extras=extras,
     )
 
 
 def _make_project_from_text(
-    project_dir, config_text: str, *, channel_write: str, write_tool: str = CHANNEL_WRITE
+    project_dir,
+    config_text: str,
+    *,
+    channel_write: str,
+    write_tool: str = CHANNEL_WRITE,
+    extras: tuple[str, ...] = (),
 ):
     """Same, for a config.yml whose exact text matters (shapes a bool cannot express).
 
@@ -103,6 +120,11 @@ def _make_project_from_text(
     default, a clone's when the test is about a clone. It is written into both
     ``hook_config.json`` (where the hook reads the set from) and
     ``permissions.deny`` (where the kill switch puts it).
+
+    ``extras`` names the tools the project appended via
+    ``control_system.write_tools``: the renderer folds them into ``write_tools``
+    and repeats them under ``control_system_write_tools``, and the kill switch
+    leaves them out of ``permissions.deny``.
     """
     (project_dir / ".claude" / "hooks").mkdir(parents=True, exist_ok=True)
     config_path = project_dir / "config.yml"
@@ -110,7 +132,15 @@ def _make_project_from_text(
     hook_config_path = project_dir / ".claude" / "hooks" / "hook_config.json"
 
     config_path.write_text(config_text, encoding="utf-8")
-    hook_config_path.write_text(json.dumps({"write_tools": [write_tool]}), encoding="utf-8")
+    hook_config_path.write_text(
+        json.dumps(
+            {
+                "write_tools": [write_tool, *extras],
+                "control_system_write_tools": list(extras),
+            }
+        ),
+        encoding="utf-8",
+    )
 
     if channel_write == NO_PERMISSIONS:
         settings = {"hooks": {}}
@@ -231,10 +261,36 @@ def test_writes_enabled_in_config_is_none_when_unreadable(tmp_path):
             ),
             (CHANNEL_WRITE,),
         ),
+        # A tool the project appended via `control_system.write_tools` is gated
+        # per call, not by the kill switch, so it is never in deny either.
+        (
+            json.dumps(
+                {
+                    "write_tools": [CHANNEL_WRITE, SITE_CUSTOM_WRITE],
+                    "control_system_write_tools": [SITE_CUSTOM_WRITE],
+                }
+            ),
+            (CHANNEL_WRITE,),
+        ),
+        # A render from before the key existed: nothing to subtract, same answer
+        # as that render's hook gave.
+        (
+            json.dumps({"write_tools": [CHANNEL_WRITE, CLONE_CHANNEL_WRITE]}),
+            (CHANNEL_WRITE, CLONE_CHANNEL_WRITE),
+        ),
         (json.dumps({"write_tools": []}), ()),
         (json.dumps({"write_tools": [1, None]}), ()),
     ],
-    ids=["clone-only", "framework-and-clone", "wildcard-dropped", "mixed-dropped", "empty", "junk"],
+    ids=[
+        "clone-only",
+        "framework-and-clone",
+        "wildcard-dropped",
+        "mixed-dropped",
+        "extras-dropped",
+        "extras-key-absent",
+        "empty",
+        "junk",
+    ],
 )
 def test_kill_switch_tools(tmp_path, payload, expected):
     hook_config_path = tmp_path / "hook_config.json"
@@ -477,6 +533,26 @@ def test_warns_on_writes_mismatch(tmp_path, run_drift):
     assert "writes_enabled: true" in payload["hookSpecificOutput"]["additionalContext"]
 
 
+def test_warns_on_writes_mismatch_when_the_project_appends_write_tools(tmp_path, run_drift):
+    # Same drift, on a deployment that sets `control_system.write_tools`. Those
+    # extras are gated per call and never enter `permissions.deny`, so counting
+    # them as kill-switch tools makes every such deployment look like a
+    # hand-edited settings.json and the check goes quiet — the signal is lost
+    # exactly where the config says writes are on and the artifacts still block.
+    config_path, settings_path = _make_project(
+        tmp_path, writes_enabled=True, channel_write=DENIED, extras=(SITE_CUSTOM_WRITE,)
+    )
+    _set_mtimes(config_path, settings_path, config_newer=False)
+
+    code, out, err = run_drift(tmp_path)
+
+    assert code == 0
+    assert "writes_enabled: true" in err
+    assert "blocks writes" in err
+    payload = json.loads(out)
+    assert "blocks writes" in payload["hookSpecificOutput"]["additionalContext"]
+
+
 def test_warns_when_config_disables_writes_but_agent_permits(tmp_path, run_drift):
     # The safety-critical direction: config.yml turned writes OFF, but the stale
     # artifacts still permit them — the agent could write hardware the operator
@@ -494,6 +570,22 @@ def test_warns_when_config_disables_writes_but_agent_permits(tmp_path, run_drift
     assert "osprey build" in err
     payload = json.loads(out)
     assert "permits writes" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_warns_when_writes_are_off_and_permitted_with_appended_write_tools(tmp_path, run_drift):
+    # The writes-off direction already warned with extras present — an empty
+    # overlap is not a partial one — and must keep warning after the extras are
+    # subtracted.
+    config_path, settings_path = _make_project(
+        tmp_path, writes_enabled=False, channel_write=ALLOWED, extras=(SITE_CUSTOM_WRITE,)
+    )
+    _set_mtimes(config_path, settings_path, config_newer=False)
+
+    code, out, err = run_drift(tmp_path)
+
+    assert code == 0
+    assert "writes_enabled: false" in err
+    assert "permits writes" in err
 
 
 def test_warns_on_mtime_drift(tmp_path, run_drift):

--- a/tests/hooks/test_control_context_hook.py
+++ b/tests/hooks/test_control_context_hook.py
@@ -201,3 +201,132 @@ def test_the_envelope_names_the_event_it_was_emitted_for(tmp_path, envelope):
     _record(tmp_path, "live", 3)
     prompt = envelope("UserPromptSubmit")
     assert prompt["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+
+# ---------------------------------------------------------------------------
+# The debug trace
+# ---------------------------------------------------------------------------
+
+
+def _debug_records(project_dir):
+    """Every ``control_context`` record in the run's ``hook_debug.jsonl``."""
+    log_path = project_dir / ".claude" / "hooks" / "hook_debug.jsonl"
+    records = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    return [record for record in records if record["hook"] == "control_context"]
+
+
+def test_every_way_the_hook_ends_leaves_one_debug_record(
+    tmp_path, hook_runner_raw, make_config, monkeypatch
+):
+    """Silence has five meanings; the JSONL channel is what tells them apart.
+
+    The hook is registered with ``2>/dev/null`` and its memo lives in ``TMPDIR``,
+    so a run that said nothing is indistinguishable from a run that never
+    happened — which is exactly the state the envelope bug shipped in. Drive all
+    seven exits and assert the file, not stderr: the file is what the web
+    terminal's hook-activity feed reads and what survives the shell redirect.
+    """
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    monkeypatch.setenv("OSPREY_HOOK_DEBUG", "1")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    # log_hook appends; it does not create the directory it appends into.
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    config_path = make_config(ARMED_BOTH)
+
+    session = SESSION_ID
+    other = SESSION_ID[:-2] + "bb"
+    corrupt = SESSION_ID[:-2] + "cc"
+
+    def _run(event, session_id=session, **extra):
+        payload = {"hook_event_name": event, **extra}
+        if session_id is not None:
+            payload["session_id"] = session_id
+        returncode, _stdout, _stderr = hook_runner_raw(
+            "osprey_control_context.py",
+            "",
+            {},
+            config_path=config_path,
+            cwd=tmp_path,
+            hook_input_extra=payload,
+        )
+        assert returncode == 0, "the hook describes; it never holds up a turn"
+
+    _run("SessionStart")  # skip:no-record — nothing written yet
+    _record(tmp_path, "va", 2)
+    _run("PreToolUse")  # skip:not-our-event
+    _run("SessionStart")  # emit, and the memo now holds va/2
+    _run("UserPromptSubmit", session_id=None)  # skip:no-session
+    _run("UserPromptSubmit")  # skip:unchanged
+    _record(tmp_path, "live", 3)
+    _run("UserPromptSubmit")  # emit — the switch, marked
+    _run("UserPromptSubmit", session_id=other)  # emit — nothing remembered
+    # A memo whose `writes` is not a mapping: render_block walks straight into it.
+    (tmp_path / "tmp" / f"osprey-control-context-{corrupt}.json").write_text(
+        json.dumps({"target": "va", "generation": 1, "writes": 0})
+    )
+    _run("UserPromptSubmit", session_id=corrupt)  # error
+
+    statuses = [record["status"] for record in _debug_records(tmp_path)]
+
+    assert statuses == [
+        "skip:no-record",
+        "skip:not-our-event",
+        "emit",
+        "skip:no-session",
+        "skip:unchanged",
+        "emit",
+        "emit",
+        "error",
+    ]
+
+
+def test_the_error_record_names_what_went_wrong(
+    tmp_path, hook_runner_raw, make_config, monkeypatch
+):
+    """An ``error`` with no exception in it is a dead end for whoever reads it."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    monkeypatch.setenv("OSPREY_HOOK_DEBUG", "1")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    _record(tmp_path, "va", 2)
+    (tmp_path / "tmp" / f"osprey-control-context-{SESSION_ID}.json").write_text(
+        json.dumps({"target": "live", "generation": 1, "writes": 0})
+    )
+
+    hook_runner_raw(
+        "osprey_control_context.py",
+        "",
+        {},
+        config_path=make_config(ARMED_BOTH),
+        cwd=tmp_path,
+        hook_input_extra={"hook_event_name": "UserPromptSubmit", "session_id": SESSION_ID},
+    )
+
+    (record,) = _debug_records(tmp_path)
+    assert record["status"] == "error"
+    assert record["detail"] == "exception=TypeError"
+
+
+def test_the_trace_stays_off_until_it_is_asked_for(
+    tmp_path, hook_runner_raw, make_config, monkeypatch
+):
+    """A debug facility that files on every deployment is not a debug facility."""
+    monkeypatch.setenv("TMPDIR", str(tmp_path / "tmp"))
+    (tmp_path / "tmp").mkdir()
+    monkeypatch.delenv("OSPREY_HOOK_DEBUG", raising=False)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    _record(tmp_path, "va", 2)
+
+    hook_runner_raw(
+        "osprey_control_context.py",
+        "",
+        {},
+        config_path=make_config(ARMED_BOTH),
+        cwd=tmp_path,
+        hook_input_extra={"hook_event_name": "SessionStart", "session_id": SESSION_ID},
+    )
+
+    assert not (tmp_path / ".claude" / "hooks" / "hook_debug.jsonl").exists()

--- a/tests/hooks/test_limits_hook.py
+++ b/tests/hooks/test_limits_hook.py
@@ -820,9 +820,11 @@ def test_osprey_unimportable_allows_the_write(tmp_path, hook_module, monkeypatch
 
 # -- Branches only reachable from inside the interpreter --
 #
-# Three of the hook's decisions cannot be driven through `hook_runner`: a render
-# without the sibling target-state reader, that reader raising, and a framework
-# older than the render it is answering. All three are exercised in-process,
+# Five of the hook's decisions cannot be driven through `hook_runner`: a render
+# without the sibling target-state reader, that reader raising, a framework
+# older than the render it is answering, and the two shapes the check itself can
+# meet — a validator carrying `validate_without_step_check` and one that only
+# has `validate`. All five are exercised in-process,
 # against a stand-in validator rather than the real one, because config loading
 # is a process-wide singleton keyed on `CONFIG_FILE` at first use — a test that
 # pointed it at its own file would either read a config an earlier test cached
@@ -848,12 +850,17 @@ STAND_IN_POSTURES = {
 }
 
 
-def _stand_in_validator_class(calls, per_target_api=True):
+def _stand_in_validator_class(calls, per_target_api=True, checks=None, step_check_api=True):
     """A `LimitsValidator` stand-in that records which entry point was asked.
 
     With *per_target_api* false it exposes only the old no-arg `from_config` and
     no `from_config_most_restrictive` — the shape a service still running an
     older `osprey` image presents to a freshly rendered hook.
+
+    With *step_check_api* false it exposes only `validate`, the shape of a
+    validator predating `validate_without_step_check`. Either way the name of
+    the method the hook actually called is appended to *checks* when one is
+    given, so a test can say which of the two the hook chose.
     """
 
     class _StandIn:
@@ -861,13 +868,25 @@ def _stand_in_validator_class(calls, per_target_api=True):
             self._allow_unlisted = allow_unlisted
             self._key = key
 
-        def validate(self, channel, value):
+        def _checked(self, entry_point, channel):
+            if checks is not None:
+                checks.append(entry_point)
             if channel in KNOWN_DB or self._allow_unlisted:
                 return
             raise ValueError(
                 f"Channel '{channel}' not in limits database "
                 f"('{self._key}' does not allow unlisted channels)"
             )
+
+        def validate(self, channel, value):
+            self._checked("validate", channel)
+
+    if step_check_api:
+
+        def validate_without_step_check(self, channel, value):
+            self._checked("validate_without_step_check", channel)
+
+        _StandIn.validate_without_step_check = validate_without_step_check
 
     def _built(entry, target):
         calls.append((entry, target))
@@ -1007,4 +1026,64 @@ def test_an_older_framework_falls_back_to_the_deployment_wide_block(
     assert calls == [("deployment_wide", None)]
     assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert DEPLOYMENT_WIDE_KEY in decision["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "Traceback" not in stderr
+
+
+@pytest.mark.unit
+def test_the_hook_leaves_the_step_check_to_the_writer(tmp_path, hook_module, monkeypatch, capsys):
+    """Against a current framework the hook asks for every check but `max_step`.
+
+    The step check needs a fresh read of the channel over the client the write
+    goes through, and this hook is not the writer — the connector makes it
+    moments later. Asking `validate` here would either read the channel over
+    some other client or fail closed for want of a reader, and failing closed
+    would take `max_step` off the mediated write path instead of enforcing it.
+    """
+    # Arrange
+    hook = hook_module("osprey_limits")
+    monkeypatch.setattr(hook, "_target_state", None)
+    calls, checks = [], []
+
+    # Act
+    code, decision, _stderr = _run_in_process(
+        hook,
+        monkeypatch,
+        capsys,
+        tmp_path,
+        _stand_in_validator_class(calls, checks=checks),
+    )
+
+    # Assert
+    assert checks == ["validate_without_step_check"]
+    assert code == 0
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+@pytest.mark.unit
+def test_a_framework_without_the_step_free_check_still_gets_checked(
+    tmp_path, hook_module, monkeypatch, capsys
+):
+    """A validator predating the step-free entry point is asked the one it has.
+
+    `osprey build` renders hooks onto the host while a service keeps the image
+    it was built with, so a render can meet a framework whose validator has
+    only `validate`. Calling the newer name unguarded there would raise inside
+    the hook and exit it non-zero with no decision, which the agent runtime
+    reads as no opinion — an unlisted write reaching the machine unchecked.
+    `validate` applies the same limits and reads the channel itself for the
+    step check, which is what that framework always did.
+    """
+    # Arrange
+    hook = hook_module("osprey_limits")
+    monkeypatch.setattr(hook, "_target_state", None)
+    calls, checks = [], []
+    older = _stand_in_validator_class(calls, checks=checks, step_check_api=False)
+
+    # Act
+    code, decision, stderr = _run_in_process(hook, monkeypatch, capsys, tmp_path, older)
+
+    # Assert
+    assert checks == ["validate"]
+    assert code == 0
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert "Traceback" not in stderr

--- a/tests/hooks/test_notebook_update_hook.py
+++ b/tests/hooks/test_notebook_update_hook.py
@@ -24,7 +24,7 @@ from osprey.utils.workspace import DEFAULT_AGENT_DATA_BASE_DIR
 HOOK_NAME = "osprey_notebook_update.py"
 
 #: The agent-data subdirectory the badge fires for. Kept in step with the
-#: hook's own ``_NOTEBOOKS_SUBDIR`` and the rendered ``NotebookEdit`` allow.
+#: hook's own ``_NOTEBOOKS_SUBDIR`` and the rendered ``Edit(...)`` allow.
 NOTEBOOKS_SUBDIR = "notebooks"
 
 

--- a/tests/integration/_mcp_handshake.py
+++ b/tests/integration/_mcp_handshake.py
@@ -10,10 +10,27 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import threading
+import time
 from collections.abc import Iterable
 from queue import Empty, Queue
+
+#: One completed startup phase, as ``osprey.mcp_server.startup.run_mcp_server``
+#: reports it on stderr: ``[STARTUP-TIMING] <server> | <phase>: <n>ms``. The
+#: first lands within milliseconds of the spawn, which is what makes the marker
+#: usable as an announcement rather than only as a measurement.
+_STARTUP_TIMING = re.compile(r"\[STARTUP-TIMING\][^|]*\|\s*(\w+):\s*[0-9.]+\s*ms")
+
+#: The phase reported immediately before the server begins reading frames.
+_SERVING_PHASE = "total_startup"
+
+#: How long a server that has announced itself may take to finish starting.
+#: Separate from the handshake budget on purpose: time spent importing a module
+#: is not time the server was given to answer, and on a loaded machine the
+#: control-system import alone runs to tens of seconds.
+_STARTUP_BUDGET_S = 120.0
 
 
 class MCPHandshakeError(RuntimeError):
@@ -37,6 +54,15 @@ def list_mcp_tools(
     Sends JSON-RPC initialize, notifications/initialized, then tools/list,
     one frame per line. Reads stdout line-by-line, ignoring lines that do
     not parse as JSON-RPC (servers may emit log lines).
+
+    ``timeout`` is how long the server gets to ANSWER, not how long it gets to
+    exist. Before its first read a server spends time that belongs to no frame:
+    interpreter start, dotenv, the module import, building the server. A budget
+    measured from ``Popen`` is spent on that, and reports a slow start as an
+    unanswered handshake. A server that reports its startup phases is therefore
+    held to a separate startup allowance first, and only once it says it is
+    serving does the handshake clock start. A server that reports nothing is
+    indistinguishable from one that is stuck and keeps the literal timeout.
 
     Raises MCPHandshakeError on spawn failure, timeout, or protocol error.
     """
@@ -67,19 +93,57 @@ def list_mcp_tools(
         proc.stdin.write(json.dumps(msg) + "\n")
         proc.stdin.flush()
 
-    def _recv(target_id: int, deadline: float) -> dict:
-        import time
+    stderr_seen: list[str] = []
+    announced = False
+    serving_at: float | None = None
 
+    def _read_stderr() -> None:
+        """Drain what the child has said, and note how far its startup has got."""
+        nonlocal announced, serving_at
+        try:
+            while True:
+                line = stderr_q.get_nowait()
+                stderr_seen.append(line)
+                phase = _STARTUP_TIMING.search(line)
+                if phase:
+                    announced = True
+                    if phase.group(1) == _SERVING_PHASE and serving_at is None:
+                        serving_at = time.monotonic()
+        except Empty:
+            pass
+
+    def _stderr_text() -> str:
+        _read_stderr()
+        return "".join(stderr_seen)
+
+    def _deadline() -> float:
+        """When the wait expires, given how far the child has got.
+
+        Three cases, and the middle one is the point. A server that has
+        announced its startup but not finished it is starting rather than
+        stalling, so it is held to the startup allowance instead of the answer
+        budget; once it says it is serving, the answer budget starts from
+        there. A server that has announced nothing is indistinguishable from
+        one that is stuck, and keeps the caller's budget exactly as given.
+        """
+        if serving_at is not None:
+            return serving_at + timeout
+        if announced:
+            return max(spawn_deadline, spawned_at + _STARTUP_BUDGET_S)
+        return spawn_deadline
+
+    def _recv(target_id: int) -> dict:
         while True:
-            remaining = deadline - time.monotonic()
+            _read_stderr()
+            remaining = _deadline() - time.monotonic()
             if remaining <= 0:
                 raise MCPHandshakeError(
-                    f"timeout waiting for id={target_id}; stderr: {_collect(stderr_q)[:600]}"
+                    f"timeout waiting for id={target_id}; stderr: {_stderr_text()[:600]}"
                 )
             if proc.poll() is not None:
                 raise MCPHandshakeError(
                     f"server exited rc={proc.returncode} before responding to id={target_id}; "
-                    f"stderr: {_collect(stderr_q)[:600]}"
+                    f"stderr: {_stderr_text()[:600]}"
                 )
             try:
                 line = stdout_q.get(timeout=min(0.25, remaining))
@@ -97,9 +161,8 @@ def list_mcp_tools(
                     raise MCPHandshakeError(f"JSON-RPC error: {msg['error']}")
                 return msg
 
-    import time
-
-    deadline = time.monotonic() + timeout
+    spawned_at = time.monotonic()
+    spawn_deadline = spawned_at + timeout
 
     try:
         _send(
@@ -114,12 +177,12 @@ def list_mcp_tools(
                 },
             }
         )
-        _recv(1, deadline)
+        _recv(1)
 
         _send({"jsonrpc": "2.0", "method": "notifications/initialized"})
 
         _send({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
-        resp = _recv(2, deadline)
+        resp = _recv(2)
         tools = resp.get("result", {}).get("tools", [])
         return [t["name"] for t in tools if isinstance(t, dict) and "name" in t]
     finally:
@@ -128,16 +191,6 @@ def list_mcp_tools(
             proc.wait(timeout=2)
         except subprocess.TimeoutExpired:
             proc.kill()
-
-
-def _collect(q: Queue) -> str:
-    parts: list[str] = []
-    try:
-        while True:
-            parts.append(q.get_nowait())
-    except Empty:
-        pass
-    return "".join(parts)
 
 
 def assert_tools_superset(

--- a/tests/integration/test_graph_mcp.py
+++ b/tests/integration/test_graph_mcp.py
@@ -205,6 +205,17 @@ def demo_store(graph_mcp_plugin_dir: Path) -> Iterator[str]:
 # ---------------------------------------------------------------------------
 
 
+#: Query budget for the store these tests talk to, replacing the product default.
+#: That default sizes a query against the turn an agent has to act within, which
+#: is a statement about a deployed store on a machine of its own. The store here
+#: is a container sharing a host with the rest of the suite, where the same
+#: traversal costs an order of magnitude more, so the product number would make
+#: host contention read as a store that timed out. What these tests assert is
+#: what a query answers, never how quickly: the case that covers the timeout path
+#: sets its own budget low enough to trip on purpose, and keeps it.
+_INTEGRATION_QUERY_TIMEOUT_S = 60
+
+
 @contextmanager
 def _installed_context(uri: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
     """Install a GraphContext singleton pointed at *uri*.
@@ -230,6 +241,7 @@ def _installed_context(uri: str, monkeypatch: pytest.MonkeyPatch) -> Iterator[An
     monkeypatch.setattr(graph_ctx, "get_config_value", lambda key, default=None: default)
 
     context = graph_ctx.initialize_server_context()
+    context.query_timeout_s = _INTEGRATION_QUERY_TIMEOUT_S
     try:
         # Inside the try: initialize() has already installed the singleton, so
         # a failed assertion here must still tear it down or every later test

--- a/tests/interfaces/artifacts/test_store_watcher.py
+++ b/tests/interfaces/artifacts/test_store_watcher.py
@@ -16,6 +16,7 @@ import pytest
 
 from osprey.interfaces.artifacts.store_watcher import StoreIndexWatcher
 from osprey.stores.artifact_store import ArtifactStore
+from tests.interfaces.fsevents_wait import poke_until
 
 
 def _make_watcher(tmp_path):
@@ -31,39 +32,55 @@ def _make_watcher(tmp_path):
     return watcher, broadcaster, artifact_store
 
 
-def _wait_for_broadcast(broadcaster, expected_calls=1, timeout=10.0):
-    """Wait until the broadcaster has been called at least expected_calls times.
+def _wait_for_broadcast(broadcaster, external_store, expected_calls=1, *, what):
+    """Wait until the broadcaster has been called at least *expected_calls* times.
 
-    The timeout is generous (10s) because this polls for a filesystem watcher to
-    fire — debounce + OS event latency varies widely on loaded CI runners, and
-    the loop returns the instant the broadcast arrives, so a high ceiling adds
-    headroom for slow runners without slowing the happy path.
+    Not a longer timeout. The observer's stream can still be arming when the
+    external write lands, and a change made inside that window is delivered late
+    or not at all — no ceiling recovers an event the stream never saw. So this
+    re-applies the stimulus by calling ``_save_index()`` on the store that made
+    it: the same tempfile-plus-``os.replace`` the real save and delete go
+    through, writing the identical index the test already produced.
+
+    The write path matters more than the file does. An atomic replace is
+    delivered by Linux inotify as ``on_moved`` and nothing else — that is why
+    ``StoreIndexWatcher`` overrides ``on_moved`` and routes on ``dest_path``.
+    Poking with a plain in-place rewrite would substitute an ``on_modified``,
+    and a regression in the ``on_moved`` route would then be answered by the
+    poke's own event class and pass on CI. Going back through the store keeps
+    the poke indistinguishable from the stimulus under test.
+
+    The handler answers each replace by re-reading the index and diffing against
+    the ids it snapshotted at ``start()``, so a re-save re-delivers exactly the
+    addition or removal the test made — the poke carries no state of its own.
+
+    Args:
+        broadcaster: The ``MagicMock`` standing in for the SSE broadcaster.
+        external_store: The store whose write produced the change under test.
+        expected_calls: Broadcasts to wait for.
+        what: Named in the failure message.
     """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if broadcaster.broadcast.call_count >= expected_calls:
-            return True
-        time.sleep(0.05)
-    return broadcaster.broadcast.call_count >= expected_calls
+    poke_until(
+        lambda: broadcaster.broadcast.call_count >= expected_calls,
+        external_store._save_index,
+        what=what,
+    )
 
 
 @pytest.mark.unit
 class TestStoreWatcher:
     """Tests for StoreIndexWatcher."""
 
-    # Filesystem-watcher tests depend on the OS delivering an inotify/FSEvents
-    # change event after observer startup. On loaded CI runners that event is
-    # occasionally missed entirely (not merely late — the poll wait below is
-    # already condition-based with a 10s ceiling), so re-run to re-initialize
-    # the observer rather than flake the whole suite.
-    @pytest.mark.flaky(reruns=2, reruns_delay=1)
+    # No ``flaky`` marker any more. These two used to carry ``reruns=2`` because
+    # the OS occasionally missed the change event entirely, and a rerun was the
+    # only way to get a freshly armed observer. ``_wait_for_broadcast`` now
+    # re-applies the stimulus instead, which arms in-test and converges without
+    # a second attempt — so a red here is a real regression again, not weather.
     def test_detects_new_artifact_entry(self, tmp_path):
         """External write to artifacts.json triggers SSE broadcast."""
         watcher, broadcaster, artifact_store = _make_watcher(tmp_path)
         watcher.start()
         try:
-            time.sleep(0.3)
-
             # Simulate external process saving an artifact
             external_store = ArtifactStore(workspace_root=tmp_path)
             external_store.save_file(
@@ -76,16 +93,17 @@ class TestStoreWatcher:
                 tool_source="test",
             )
 
-            assert _wait_for_broadcast(broadcaster, 1)
+            _wait_for_broadcast(
+                broadcaster,
+                external_store,
+                what="the broadcast for an externally saved artifact",
+            )
             call_data = broadcaster.broadcast.call_args_list[0][0][0]
             assert call_data["type"] == "artifact"
             assert call_data["title"] == "External Plot"
         finally:
             watcher.stop()
 
-    @pytest.mark.flaky(
-        reruns=2, reruns_delay=1
-    )  # same inotify-miss risk as test_detects_new_artifact_entry
     def test_detects_deleted_entry(self, tmp_path):
         """Removing an entry from the index externally triggers delete broadcast."""
         # Pre-populate with an artifact
@@ -103,13 +121,15 @@ class TestStoreWatcher:
         watcher, broadcaster, artifact_store = _make_watcher(tmp_path)
         watcher.start()
         try:
-            time.sleep(0.3)
-
             # Simulate external process deleting the entry
             external_store = ArtifactStore(workspace_root=tmp_path)
             external_store.delete_entry(entry.id)
 
-            assert _wait_for_broadcast(broadcaster, 1)
+            _wait_for_broadcast(
+                broadcaster,
+                external_store,
+                what="the broadcast for an externally deleted artifact",
+            )
             call_data = broadcaster.broadcast.call_args_list[0][0][0]
             assert call_data["type"] == "artifact_deleted"
             assert call_data["id"] == entry.id

--- a/tests/interfaces/conftest.py
+++ b/tests/interfaces/conftest.py
@@ -387,6 +387,49 @@ def launch_graph_channel_finder(
 # ordering-dependent failures that a session-scoped fixture would cause.
 
 
+#: Seeded into every context this fixture hands out: the onboarding tour is
+#: already dismissed. Under the default ``once`` policy the invite card opens a
+#: short while after boot on the fresh profile a browser test runs under, takes
+#: focus and lays a scrim over the shell — so a test still working when it
+#: arrives reads a click that never lands, or focus outside the dialog it was
+#: walking. The delay is what makes it a question of timing rather than a
+#: constant, and the shell it covers belongs to no one suite, so the seed
+#: belongs here rather than in each of them. No coverage is lost to it: the
+#: invite card's own behaviour belongs to tour.test.mjs, and
+#: web_terminal/test_tour.py owns policy resolution and the /api/panels echo,
+#: neither of which opens a browser.
+#:
+#: The key is answered rather than only written. tour.js reads it through
+#: ``scopedStorageKey``, so on a multi-user mount it is per persona
+#: (``…-v1--alice``) and the scope comes from an attribute the server stamps on
+#: ``<html>`` — which an init script cannot read, because it runs before that
+#: element exists. Seeding the bare key alone therefore dismisses the invite on
+#: a single-user page and leaves it armed on a scoped one. Answering the key
+#: and its scoped variants needs neither the scope nor an ordering, and the
+#: bare key is written too so a page that enumerates storage still sees it.
+#:
+#: A browser test that wants the invite opts out in its own page-level init
+#: script, which runs after the context's, by putting back the reader this one
+#: parked on ``Storage.prototype.getItem.osprey_real``. Clearing the key is not
+#: enough on its own: while the wrapper is installed it answers for the key
+#: whatever storage holds.
+_DISMISS_TOUR = """
+(function () {
+  var BASE = 'osprey-tour-dismissed-v1';
+  var SCOPED = BASE + '--';
+  try { localStorage.setItem(BASE, '1'); } catch (e) {}
+  var read = Storage.prototype.getItem;
+  var wrapper = function (key) {
+    var name = String(key);
+    var mine = name === BASE || name.indexOf(SCOPED) === 0;
+    return mine ? '1' : read.call(this, key);
+  };
+  wrapper.osprey_real = read;
+  Storage.prototype.getItem = wrapper;
+})();
+"""
+
+
 def _install_auth_seam(browser: Browser) -> None:
     """Wrap ``browser.new_context``/``new_page`` so each is authorized on creation.
 
@@ -414,11 +457,13 @@ def _install_auth_seam(browser: Browser) -> None:
     def new_context(*args, **kwargs):
         context = original_new_context(*args, **kwargs)
         _authorize_browser_context(context)
+        context.add_init_script(_DISMISS_TOUR)
         return context
 
     def new_page(*args, **kwargs):
         page = original_new_page(*args, **kwargs)
         _authorize_browser_context(page.context)
+        page.context.add_init_script(_DISMISS_TOUR)
         return page
 
     browser.new_context = new_context

--- a/tests/interfaces/fsevents_wait.py
+++ b/tests/interfaces/fsevents_wait.py
@@ -1,0 +1,211 @@
+"""One wait-side mechanism for the tests that drive a real filesystem observer.
+
+A watchdog observer is not delivering the moment ``start()`` returns. The
+emitter thread must still create, schedule and start its stream before it
+reaches the run loop that dispatches callbacks — on macOS that is
+``_fsevents.add_watch`` at ``watchdog/observers/fsevents.py`` line 307, with the
+run loop one line further on at 308. Sampled stacks from an 18-worker box catch
+emitters in both frames, so the arming window is seconds wide there, and a
+stimulus applied inside it is delivered late or not at all.
+
+A fixed pre-write sleep cannot bound that window. Too short and the stimulus
+lands before the stream is live; large enough to be safe under load and it is a
+tax every green run pays. So nothing here waits longer.
+
+**These helpers re-apply the stimulus.** ``poke`` is a callable that reproduces
+the same filesystem change without altering what the test asserts about —
+rewriting a control note with the same bytes, re-saving an index through the
+store's own atomic write — and it is called once per interval until the expected
+delivery is observed. Whichever way the arming window bit (an event lost
+outright, or an event merely slow), a poke issued after the stream is live is
+delivered, so the wait converges instead of expiring. A poke that changes what
+is under test is a bug in the caller, not a licence this module grants.
+
+**A poke must reproduce the event CLASS, not merely the path.** Every handler
+here dispatches on kind — ``created``/``modified``/``deleted`` in the workspace
+watcher, and ``on_moved`` in the store watcher, which is the *only* event Linux
+inotify delivers for a tempfile-plus-``os.replace`` index write. A poke that
+touches the right file by the wrong mechanism answers the wait with a frame the
+test's own stimulus would never have produced, and a regression in the handling
+of the real class then passes unseen. So a creation is re-applied by removing
+and recreating, an atomic replace by another atomic replace — and where the
+distinction carries the test, :func:`collect_frames` with ``until_type`` makes
+the wait itself hold out for the right kind of frame.
+
+Budget exhaustion is reported as a failure naming what never arrived. It is not
+absorbed and it is not retried at the test level: an observer that never
+delivers in :data:`ARM_BUDGET` seconds of repeated stimulus is broken, not slow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from typing import Any
+
+#: Overall ceiling on "this observer is delivering". Generous on purpose: it is
+#: only ever spent on a run that is already failing, and the poke loop returns
+#: the instant a frame lands, so a healthy run never approaches it.
+ARM_BUDGET = 60.0
+
+#: Seconds between re-applications of the stimulus. Comfortably above the 0.1 s
+#: per-path debounce both handlers apply, so a poke is never swallowed as a
+#: duplicate of the poke before it.
+POKE_INTERVAL = 1.0
+
+#: How often the wait looks at the queue while it is not poking.
+POLL = 0.05
+
+#: Quiet period that ends a drain, and the hard stop on extending it. A frame
+#: coalesced by the OS can trail the one that was waited for by a beat; each
+#: further frame restarts the floor, and the ceiling stops a stream that is
+#: still producing from holding the test open indefinitely.
+DRAIN_FLOOR = 0.5
+DRAIN_CEILING = 2.0
+
+
+def poke_until(
+    check: Callable[[], bool],
+    poke: Callable[[], Any],
+    *,
+    what: str,
+    budget: float = ARM_BUDGET,
+) -> None:
+    """Re-apply *poke* until *check* passes, then return; fail at *budget*.
+
+    The caller has already applied the stimulus once, so the first poke comes
+    one :data:`POKE_INTERVAL` later rather than immediately.
+
+    Args:
+        check: True once the delivery under test has been observed. Called
+            first, before any poke, so an already-delivered event costs nothing.
+        poke: Reproduces the stimulus. Must not change what the test asserts.
+        what: Named in the failure message — say what never arrived.
+        budget: Seconds of repeated stimulus before giving up.
+
+    Raises:
+        AssertionError: *check* never passed within *budget*.
+    """
+    started = time.monotonic()
+    deadline = started + budget
+    next_poke = started + POKE_INTERVAL
+    pokes = 0
+    while True:
+        if check():
+            return
+        now = time.monotonic()
+        if now >= deadline:
+            raise AssertionError(
+                f"{what} was never delivered in {budget:.0f}s of a live observer, "
+                f"across {pokes} re-applications of the stimulus — the observer is "
+                f"not delivering, rather than delivering late"
+            )
+        if now >= next_poke:
+            poke()
+            pokes += 1
+            next_poke = now + POKE_INTERVAL
+        time.sleep(POLL)
+
+
+def drain(pump: Callable[[], bool]) -> None:
+    """Collect whatever is still in flight behind the frame already waited for.
+
+    Waits :data:`DRAIN_FLOOR` seconds of quiet, restarts that quiet window every
+    time *pump* reports another frame, and stops at :data:`DRAIN_CEILING` regardless — a stream still
+    producing at the ceiling has said enough, and the caller keeps what it
+    collected rather than waiting on a tail that may not end. The ceiling branch
+    pumps once on its way out, so nothing already queued is left behind.
+
+    Args:
+        pump: Takes everything currently available; True if it took anything.
+    """
+    started = time.monotonic()
+    quiet_until = started + DRAIN_FLOOR
+    hard_stop = started + DRAIN_CEILING
+    while True:
+        now = time.monotonic()
+        if now >= hard_stop:
+            # Take what is already queued before leaving: the contract is that
+            # ceiling exhaustion returns what was *collected*, and a frame
+            # sitting in the queue at the instant the ceiling passes has been
+            # delivered. Dropping it would make an absence assertion read as
+            # clean when the frame it forbids had in fact arrived.
+            pump()
+            return
+        if pump():
+            quiet_until = now + DRAIN_FLOOR
+        elif now >= quiet_until:
+            return
+        else:
+            time.sleep(POLL)
+
+
+def collect_frames(
+    queue: asyncio.Queue,
+    *,
+    until: str,
+    poke: Callable[[], Any],
+    until_type: str | None = None,
+    budget: float = ARM_BUDGET,
+) -> list[dict]:
+    """Every frame a broadcaster queue delivers up to and shortly after *until*.
+
+    The frame-queue shape of :func:`poke_until` plus :func:`drain`, shared by the
+    workspace-watcher tests: wait for the sentinel frame, re-applying the change
+    that produces it until it arrives, then take the coalesced tail behind it.
+
+    Frames are returned whole rather than flattened to paths, because a poke
+    only proves what it reproduces: a test whose subject is a *creation* has to
+    be able to require a ``created`` frame, or a re-applied modification of the
+    same path would answer for it. Pass *until_type* to make the wait itself
+    require that class, so the poke loop keeps going until the right kind of
+    frame lands rather than stopping at the first frame naming the path.
+
+    Args:
+        queue: A ``FileEventBroadcaster`` subscription.
+        until: The workspace-relative path whose frame ends the wait.
+        poke: Re-applies the change that produces the *until* frame.
+        until_type: When given, only a frame of this ``type`` ends the wait.
+        budget: Seconds of repeated stimulus before failing.
+
+    Returns:
+        Every frame delivered, in arrival order, sentinel included.
+    """
+    frames: list[dict] = []
+
+    def pump() -> bool:
+        took = False
+        while True:
+            try:
+                frames.append(queue.get_nowait())
+            except asyncio.QueueEmpty:
+                return took
+            took = True
+
+    def matched(frame: dict) -> bool:
+        return frame["path"] == until and (until_type is None or frame["type"] == until_type)
+
+    def arrived() -> bool:
+        pump()
+        return any(matched(frame) for frame in frames)
+
+    wanted = f"a {until_type!r} frame for {until!r}" if until_type else f"a frame for {until!r}"
+    poke_until(arrived, poke, what=wanted, budget=budget)
+    drain(pump)
+    return frames
+
+
+def collect_paths(
+    queue: asyncio.Queue,
+    *,
+    until: str,
+    poke: Callable[[], Any],
+    budget: float = ARM_BUDGET,
+) -> list[str]:
+    """The paths of :func:`collect_frames`, for callers that assert on path alone.
+
+    Only for tests whose subject is *which* paths reached the panel, never
+    whether a particular kind of change did — those must read the frames.
+    """
+    return [frame["path"] for frame in collect_frames(queue, until=until, poke=poke, budget=budget)]

--- a/tests/interfaces/web_terminal/chat.test.mjs
+++ b/tests/interfaces/web_terminal/chat.test.mjs
@@ -30,6 +30,7 @@
 import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
 import { transportNotice } from '../../../src/osprey/interfaces/web_terminal/static/js/chat.js';
+import { HANDOFF_RESTART_BUDGET_MS } from '../../../src/osprey/interfaces/web_terminal/static/js/terminal-handoff.js';
 
 const CHAT_JS = '../../../src/osprey/interfaces/web_terminal/static/js/chat.js';
 const STORAGE_KEY = 'osprey-pty-session';
@@ -303,8 +304,11 @@ describe('enterFromExpert', () => {
 
     const entered = chat.enterFromExpert();
     expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(false);
-    expect(textOf('.op-handoff-message')).toContain('Finishing in the other view');
-    expect(textOf('.op-handoff-action')).toBe('Stop and switch now');
+    // Nothing says the other view is mid-turn, so what is on screen is the
+    // restart: no clock, no way out, because there is nothing to cut short.
+    expect(textOf('.op-handoff-message')).toBe('Restarting the agent in this view…');
+    expect(one('.op-handoff-elapsed')).toBeNull();
+    expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).hidden).toBe(true);
     expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(true);
 
     admit({ state: 'simple', session_id: 'K1' });
@@ -318,6 +322,34 @@ describe('enterFromExpert', () => {
     expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(false);
   });
 
+  test('a restart that outlasts its budget becomes the wait, clocked from the flip', async () => {
+    vi.useFakeTimers();
+    transport.requestHandoff.mockReturnValue(new Promise(() => {}));
+    await mountChat({ pointer: 'K1' });
+
+    void chat.enterFromExpert();
+    vi.advanceTimersByTime(HANDOFF_RESTART_BUDGET_MS - 1);
+    expect(textOf('.op-handoff-message')).toBe('Restarting the agent in this view…');
+
+    vi.advanceTimersByTime(1);
+    expect(textOf('.op-handoff-message')).toBe('Finishing in the other view · 0:04');
+    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
+    expect(action.hidden).toBe(false);
+    expect(action.textContent).toBe('Stop and switch now');
+  });
+
+  test('a restart that completes in budget never shows the wait', async () => {
+    vi.useFakeTimers();
+    transport.requestHandoff.mockResolvedValue({ state: 'simple', session_id: 'K1' });
+    await mountChat({ pointer: 'K1' });
+
+    await chat.enterFromExpert();
+    vi.advanceTimersByTime(HANDOFF_RESTART_BUDGET_MS * 2);
+
+    expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(true);
+    expect(textOf('.op-handoff-message')).not.toContain('Finishing in the other view');
+  });
+
   test('the elapsed counter ticks while the wait runs', async () => {
     vi.useFakeTimers();
     transport.requestHandoff.mockReturnValue(new Promise(() => {}));
@@ -326,6 +358,18 @@ describe('enterFromExpert', () => {
     void chat.enterFromExpert();
     vi.advanceTimersByTime(62_000);
     expect(textOf('.op-handoff-elapsed')).toBe('1:02');
+  });
+
+  test('"Stop and switch now" shows the wait at once: a turn is being cut short', async () => {
+    transport.requestHandoff.mockRejectedValueOnce(transportError(409, 'handoff_needs_interrupt'));
+    await mountChat({ pointer: 'K1' });
+    await chat.enterFromExpert();
+
+    transport.requestHandoff.mockReturnValue(new Promise(() => {}));
+    /** @type {HTMLButtonElement} */ (one('.op-handoff-action')).click();
+    await Promise.resolve();
+
+    expect(textOf('.op-handoff-message')).toBe('Finishing in the other view · 0:00');
   });
 
   test('a hook-less refusal offers only the stop, which re-asks with interrupt', async () => {
@@ -411,10 +455,11 @@ describe('enterFromExpert', () => {
     expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).textContent).toBe('Retry');
   });
 
-  test('an abandoned request (204, no body) leaves the wait exactly as it was', async () => {
+  test('an abandoned request (204, no body) leaves the state exactly as it was', async () => {
     // The server saw this request's channel close and handed nothing over.
-    // Nothing failed, so there is nothing to say — and the wait on screen is
-    // still the true state, with its one action still open.
+    // Nothing failed, so there is nothing to say — and the restart on screen
+    // is still the true state, its budget still running toward the wait.
+    vi.useFakeTimers();
     transport.requestHandoff.mockResolvedValue(null);
     await mountChat({ pointer: 'K1' });
     transport.fetchHistory.mockClear();
@@ -422,13 +467,16 @@ describe('enterFromExpert', () => {
     await chat.enterFromExpert();
 
     expect(/** @type {HTMLElement} */ (one('.op-handoff')).hidden).toBe(false);
-    expect(textOf('.op-handoff-message')).toContain('Finishing in the other view');
-    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
-    expect(action.textContent).toBe('Stop and switch now');
-    expect(action.hidden).toBe(false);
+    expect(textOf('.op-handoff-message')).toBe('Restarting the agent in this view…');
+    expect(/** @type {HTMLButtonElement} */ (one('.op-handoff-action')).hidden).toBe(true);
     expect(/** @type {HTMLTextAreaElement} */ (one('textarea')).disabled).toBe(true);
     // Nothing was handed over, so nothing is replayed.
     expect(transport.fetchHistory).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(HANDOFF_RESTART_BUDGET_MS);
+    const action = /** @type {HTMLButtonElement} */ (one('.op-handoff-action'));
+    expect(action.textContent).toBe('Stop and switch now');
+    expect(action.hidden).toBe(false);
   });
 
   test('a superseded attempt finishing last does not open the console over the newer wait', async () => {
@@ -470,10 +518,12 @@ describe('enterFromExpert', () => {
   });
 
   test('the elapsed counter is not announced on every tick', async () => {
+    vi.useFakeTimers();
     transport.requestHandoff.mockReturnValue(new Promise(() => {}));
     await mountChat({ pointer: 'K1' });
 
     void chat.enterFromExpert();
+    vi.advanceTimersByTime(HANDOFF_RESTART_BUDGET_MS);
     expect(one('.op-handoff')?.getAttribute('aria-live')).toBe('polite');
     expect(one('.op-handoff-elapsed')?.getAttribute('aria-live')).toBe('off');
   });

--- a/tests/interfaces/web_terminal/config-render-helpers.test.mjs
+++ b/tests/interfaces/web_terminal/config-render-helpers.test.mjs
@@ -19,7 +19,10 @@
 import { test, expect, describe } from 'vitest';
 
 import { qs } from '../_support/dom.mjs';
-import { _renderHookEvents } from '../../../src/osprey/interfaces/web_terminal/static/js/config-render-helpers.js';
+import {
+  _groupPermissions,
+  _renderHookEvents,
+} from '../../../src/osprey/interfaces/web_terminal/static/js/config-render-helpers.js';
 
 /** Render into a container so class queries work on a rooted tree.
  * @param {Record<string, Array<{matcher?: string, hooks?: Array<{command?: string, timeout?: number}>}>>} hooks
@@ -84,5 +87,28 @@ describe('_renderHookEvents', () => {
     expect(container.querySelector('img')).toBeNull();
     const nameSpan = qs(container, '.config-hook-event-header').children[1];
     expect(nameSpan.textContent).toBe('<img src=x onerror=hack()>');
+  });
+});
+
+describe('_groupPermissions', () => {
+  test('path-scoped file rules land in the file access group', () => {
+    const groups = _groupPermissions([
+      'Read(var/agent_data/**)',
+      'Edit(var/agent_data/notebooks/**)',
+      'mcp__control_system__channel_read',
+      'Task(data-visualizer)',
+    ]);
+
+    expect(groups['file access'].map((g) => g.display)).toEqual([
+      'Read: var/agent_data/**',
+      'Edit: var/agent_data/notebooks/**',
+    ]);
+    expect(groups['file access'].map((g) => g.raw)).toEqual([
+      'Read(var/agent_data/**)',
+      'Edit(var/agent_data/notebooks/**)',
+    ]);
+    expect(groups.control_system).toHaveLength(1);
+    expect(groups.agents[0].display).toBe('data-visualizer');
+    expect(groups._ungrouped).toBeUndefined();
   });
 });

--- a/tests/interfaces/web_terminal/scaffold-detail.test.mjs
+++ b/tests/interfaces/web_terminal/scaffold-detail.test.mjs
@@ -32,6 +32,8 @@ import { qs } from '../_support/dom.mjs';
 
 import { createScaffoldGalleryDetail } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/detail.js';
 import { createScaffoldGalleryDetailContent } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/detail-content.js';
+import { createScaffoldGalleryEditForm } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/edit-form.js';
+import { resetFetchCache } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/data.js';
 
 /**
  * @typedef {import('../../../src/osprey/interfaces/web_terminal/static/js/scaffold/detail.js').ScaffoldGalleryDetailHost} ScaffoldGalleryDetailHost
@@ -82,6 +84,9 @@ function makeGallery(overrides = {}) {
 }
 
 beforeEach(() => {
+  // The detail renderers read through the module-level fetch cache, so a
+  // response one test seeded would answer the next one's first render.
+  resetFetchCache();
   vi.stubGlobal('confirm', vi.fn(() => true));
   vi.stubGlobal('prompt', vi.fn(() => null));
   vi.stubGlobal('alert', vi.fn());
@@ -251,6 +256,18 @@ describe('openDetail', () => {
     expect(onDetailOpen).toHaveBeenCalledOnce();
     expect(qs(gallery.detailHeaderEl, '.prompts-detail-name').textContent).toBe('my-artifact');
   });
+
+  test('opens in the mode the caller asked for, rendering it once', () => {
+    const gallery = makeGallery();
+    const detail = createScaffoldGalleryDetail(gallery);
+
+    detail.openDetail({ name: 'my-artifact', status: 'user-owned' }, 'edit');
+
+    expect(gallery.detailMode).toBe('edit');
+    // The editor is the only render: no Preview goes out first for it to
+    // replace, so there is no second fetch and no race to resolve.
+    expect(gallery.renderEdit).toHaveBeenCalledOnce();
+  });
 });
 
 describe('showCreateDialog', () => {
@@ -274,6 +291,44 @@ describe('showCreateDialog', () => {
     expect(fetchMock).toHaveBeenCalledWith('/u/alice/api/scaffold/create', expect.objectContaining({
       method: 'POST',
     }));
+  });
+
+  test('opens the new artifact straight in Edit, fetching its content once', async () => {
+    // A just-created artifact used to be opened in Preview and flipped to Edit
+    // on the next statement, so the same GET went out twice and whichever
+    // response landed last decided what the pane showed. renderEdit here is
+    // the REAL edit-form renderer, wired the way ArtifactGallery wires it — a
+    // stub issues no fetch, so it could not tell one render from two.
+    vi.stubGlobal('prompt', vi.fn(() => 'my new agent'));
+
+    /** @type {string[]} */
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn((/** @type {string} */ url, /** @type {RequestInit} */ init) => {
+      calls.push(`${(init && init.method) || 'GET'} ${url}`);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          canonical_name: 'my-new-agent', content: 'seeded body', language: 'text',
+        }),
+      });
+    }));
+
+    const gallery = makeGallery();
+    gallery.load = () => {
+      gallery.artifacts = [{ name: 'my-new-agent', status: 'user-owned', custom: true }];
+      return Promise.resolve();
+    };
+    gallery.renderEdit = createScaffoldGalleryEditForm(gallery).renderEdit;
+
+    const detail = createScaffoldGalleryDetail(gallery);
+    detail.showCreateDialog('agents');
+    // showCreateDialog's fetch chain is .then-based, not awaited internally.
+    for (let i = 0; i < 4; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(gallery.detailMode).toBe('edit');
+    expect(calls).toContain('POST /api/scaffold/create');
+    expect(calls.filter((c) => c === 'GET /api/scaffold/my-new-agent')).toHaveLength(1);
+    expect(qs(gallery.detailContentEl, '.prompts-edit-textarea')).toBeTruthy();
   });
 });
 

--- a/tests/interfaces/web_terminal/scaffold-edit.test.mjs
+++ b/tests/interfaces/web_terminal/scaffold-edit.test.mjs
@@ -31,6 +31,7 @@ import { qs } from '../_support/dom.mjs';
 
 import { createScaffoldGalleryEditForm } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/edit-form.js';
 import { createScaffoldGalleryEdit } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/edit.js';
+import { createScaffoldGalleryDetail } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/detail.js';
 import { resetFetchCache } from '../../../src/osprey/interfaces/web_terminal/static/js/scaffold/data.js';
 
 /**
@@ -491,12 +492,74 @@ describe('takeOwnership / releaseToFramework / handleEditFramework', () => {
     await edit.handleEditFramework();
 
     expect(gallery.reloadFull).toHaveBeenCalledOnce();
+    // Edit mode is an argument to the open, not a flip afterwards: the flip
+    // left a Preview render already in flight against the same pane.
     expect(gallery.openDetail).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'a', status: 'user-owned' })
+      expect.objectContaining({ name: 'a', status: 'user-owned' }),
+      'edit'
     );
+    expect(gallery.renderDetailModes).not.toHaveBeenCalled();
+    expect(gallery.renderDetailContent).not.toHaveBeenCalled();
+  });
+
+  test('handleEditFramework fetches the claimed file once, not once per render', async () => {
+    // The real detail shell and edit-form renderer, wired the way
+    // ArtifactGallery wires them: a stubbed openDetail issues no fetch, so it
+    // cannot tell one render from the two this flow used to start.
+    /** @type {string[]} */
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn((/** @type {string} */ url, /** @type {RequestInit} */ init) => {
+      calls.push(`${(init && init.method) || 'GET'} ${url}`);
+      return Promise.resolve({
+        ok: true, json: () => Promise.resolve({ content: 'framework body', language: 'text' }),
+      });
+    }));
+
+    const gallery = /** @type {any} */ ({
+      selectedArtifact: { name: 'a', status: 'framework' },
+      artifacts: [],
+      currentView: 'detail',
+      detailMode: 'preview',
+      detailRenderSeq: 0,
+      editDirty: false,
+      galleryView: document.createElement('div'),
+      detailView: document.createElement('div'),
+      detailHeaderEl: document.createElement('div'),
+      detailModesEl: document.createElement('div'),
+      detailContentEl: document.createElement('div'),
+      errorEl: document.createElement('div'),
+      onDetailOpen: null,
+      onDetailClose: null,
+      load: () => Promise.resolve(),
+      renderGallery: vi.fn(),
+      handleEditFramework: vi.fn(),
+      discardEdits: vi.fn(),
+      saveOverride: vi.fn(),
+      takeOwnership: vi.fn(),
+      releaseToFramework: vi.fn(),
+      closeDetail: vi.fn(),
+    });
+    gallery.reloadFull = vi.fn(async () => {
+      gallery.artifacts = [{ name: 'a', category: 'agents', status: 'user-owned' }];
+      gallery.renderGallery();
+    });
+    gallery.renderEdit = createScaffoldGalleryEditForm(gallery).renderEdit;
+
+    const detail = createScaffoldGalleryDetail(gallery);
+    gallery.openDetail = detail.openDetail;
+    gallery.renderDetailHeader = detail.renderDetailHeader;
+    gallery.renderDetailModes = detail.renderDetailModes;
+    gallery.renderDetailContent = detail.renderDetailContent;
+
+    const edit = createScaffoldGalleryEdit(gallery);
+    await edit.handleEditFramework();
+    // openDetail's render is started, not awaited.
+    for (let i = 0; i < 3; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(gallery.detailMode).toBe('edit');
-    expect(gallery.renderDetailModes).toHaveBeenCalledOnce();
-    expect(gallery.renderDetailContent).toHaveBeenCalledOnce();
+    expect(calls).toContain('POST /api/scaffold/a/claim');
+    expect(calls.filter((c) => c === 'GET /api/scaffold/a')).toHaveLength(1);
+    expect(qs(gallery.detailContentEl, '.prompts-edit-textarea')).toBeTruthy();
   });
 });
 

--- a/tests/interfaces/web_terminal/terminal-handoff.test.mjs
+++ b/tests/interfaces/web_terminal/terminal-handoff.test.mjs
@@ -18,6 +18,8 @@
 
 import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
+import { HANDOFF_RESTART_BUDGET_MS } from '../../../src/osprey/interfaces/web_terminal/static/js/terminal-handoff.js';
+
 /** @type {typeof import('../../../src/osprey/interfaces/web_terminal/static/js/terminal.js')} */
 let terminal;
 
@@ -264,7 +266,7 @@ describe('startExpert settles when the acquire has an answer', () => {
   test('a pending hand-off does not settle it', async () => {
     const settled = flipToExpert();
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
 
     const race = await Promise.race([
       settled.then(() => 'settled'),
@@ -363,7 +365,7 @@ describe('handoff_pending: the transitional state', () => {
     localStorage.setItem(STORAGE_KEY, 'shared-key');
     terminal.initTerminal('terminal-container');
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
   }
 
   test('says what is happening and how long it has been', () => {
@@ -465,13 +467,97 @@ describe('handoff_pending: the transitional state', () => {
   });
 });
 
+describe('handoff_pending on an idle chat: a restart, not a wait', () => {
+  // The server says whether the chat holding the key is mid-turn. When it is
+  // not, nothing is being finished anywhere: the session's agent is stopped
+  // in the other view and started in this one, which takes about a second.
+  // Showing that as a wait with a clock and a way out would be untrue.
+
+  /** Flip to Expert on a stored key; the server reports the chat idle. */
+  function idle() {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'handoff_pending', busy: false });
+  }
+
+  test('says the agent is restarting here, with no clock and no way out', () => {
+    idle();
+
+    expect(overlayText()).toBe('Restarting the agent in this view…');
+    expect(document.querySelector('.terminal-handoff-elapsed')).toBeNull();
+    expect(overlayAction()?.hidden).toBe(true);
+  });
+
+  test('a frame that says nothing about the turn is read as idle', () => {
+    localStorage.setItem(STORAGE_KEY, 'shared-key');
+    terminal.initTerminal('terminal-container');
+    openSocket();
+    receive({ type: 'handoff_pending' });
+
+    expect(overlayText()).toBe('Restarting the agent in this view…');
+  });
+
+  test('a restart that outlasts its budget becomes the wait, clocked from the flip', () => {
+    vi.useFakeTimers();
+    try {
+      idle();
+      vi.advanceTimersByTime(HANDOFF_RESTART_BUDGET_MS - 1);
+      expect(overlayText()).toBe('Restarting the agent in this view…');
+
+      vi.advanceTimersByTime(1);
+
+      expect(overlayText()).toBe('Finishing in the other view · 0:04');
+      expect(overlayAction()?.hidden).toBe(false);
+      expect(overlayAction()?.textContent).toBe('Stop and switch now');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('session_info in budget clears it, and no wait appears afterwards', () => {
+    vi.useFakeTimers();
+    try {
+      idle();
+      receive({ type: 'session_info', session_id: 'shared-key' });
+      vi.advanceTimersByTime(HANDOFF_RESTART_BUDGET_MS * 2);
+
+      expect(document.querySelector('.terminal-handoff')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('a busy frame after the wait is up keeps the wait, and so does an idle one', () => {
+    // An interrupt's reconnect brings a second frame. The chat it cut short
+    // may report idle by then; the operator is already watching a wait, and
+    // that state never steps back to a restart.
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem(STORAGE_KEY, 'shared-key');
+      terminal.initTerminal('terminal-container');
+      openSocket();
+      receive({ type: 'handoff_pending', busy: true });
+      vi.advanceTimersByTime(3_000);
+      /** @type {HTMLButtonElement} */ (overlayAction()).click();
+      openSocket();
+      receive({ type: 'handoff_pending', busy: false });
+
+      expect(overlayText()).toBe('Finishing in the other view · 0:03');
+      expect(overlayAction()?.hidden).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('"Stop and switch now"', () => {
   /** Reach the pending state and press the button. */
   function interrupt() {
     localStorage.setItem(STORAGE_KEY, 'shared-key');
     terminal.initTerminal('terminal-container');
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
     /** @type {HTMLButtonElement} */ (overlayAction()).click();
   }
 
@@ -488,7 +574,7 @@ describe('"Stop and switch now"', () => {
     localStorage.setItem(STORAGE_KEY, 'shared-key');
     terminal.initTerminal('terminal-container');
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
     const socketsBefore = FakeWebSocket.created;
 
     /** @type {HTMLButtonElement} */ (overlayAction()).click();
@@ -508,11 +594,11 @@ describe('"Stop and switch now"', () => {
       localStorage.setItem(STORAGE_KEY, 'shared-key');
       terminal.initTerminal('terminal-container');
       openSocket();
-      receive({ type: 'handoff_pending' });
+      receive({ type: 'handoff_pending', busy: true });
       vi.advanceTimersByTime(30_000);
       /** @type {HTMLButtonElement} */ (overlayAction()).click();
       openSocket();
-      receive({ type: 'handoff_pending' });
+      receive({ type: 'handoff_pending', busy: true });
 
       // 0:30 and counting, not back to 0:00.
       expect(overlayText()).toBe('Finishing in the other view · 0:30');
@@ -647,10 +733,10 @@ describe('a refused connection', () => {
     terminal.initTerminal('terminal-container');
     const abandoned = /** @type {FakeWebSocket} */ (FakeWebSocket.last);
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
     /** @type {HTMLButtonElement} */ (overlayAction()).click();
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
 
     // The abandoned socket's refusal lands late.
     /** @type {(ev: any) => void} */ (abandoned.onclose)({
@@ -665,7 +751,7 @@ describe('a refused connection', () => {
     localStorage.setItem(STORAGE_KEY, 'shared-key');
     terminal.initTerminal('terminal-container');
     openSocket();
-    receive({ type: 'handoff_pending' });
+    receive({ type: 'handoff_pending', busy: true });
 
     refuse(WS_CLOSE_OUTGOING_RUNNING);
 

--- a/tests/interfaces/web_terminal/test_bar_items_browser.py
+++ b/tests/interfaces/web_terminal/test_bar_items_browser.py
@@ -257,10 +257,48 @@ def _types(page: Page, host: str) -> list[str]:
     return page.eval_on_selector_all(selector, "els => els.map((el) => el.dataset.barItem)")
 
 
-def _center(locator: Locator) -> tuple[float, float]:
+def _box(locator: Locator) -> dict[str, float]:
+    """The layout box of an element, once it is actually on screen.
+
+    The wait is load-bearing. An item whose target is a per-deployment fact
+    ships ``hidden`` and is revealed only when boot applies that fact -- the
+    docs item is href-less and hidden until ``web.docs_url`` arrives in the
+    ``GET /api/panels`` payload -- so a shell is routinely in the document,
+    hydrated and keyed, several frames before it has a layout box.
+    ``bounding_box()`` does not wait for that: it answers ``None`` for an
+    element with no box and returns immediately, which reports a bar still
+    filling in as a bar missing an item.
+    """
+    locator.wait_for(state="visible", timeout=10_000)
     box = locator.bounding_box()
-    assert box is not None, "element has no bounding box -- is it rendered and visible?"
+    # Narrowing, not a check: the wait above is what an element with no box
+    # fails on, and it fails as a locator timeout naming the selector.
+    assert box is not None
+    return box
+
+
+def _center(locator: Locator) -> tuple[float, float]:
+    """The middle of an item, once it is actually on screen."""
+    box = _box(locator)
     return box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
+
+
+def _settled(page: Page, host: str, types: list[str]) -> None:
+    """Wait until every item seeded into *host* is on screen.
+
+    A coordinate read from a bar that is still filling in is stale by the time
+    a gesture uses it: an item that ships hidden until boot resolves the fact it
+    renders joins the run late and moves everything already placed. Waiting for
+    the whole seeded arrangement puts the reflow before every measurement
+    rather than between two of them.
+
+    *types* must therefore be the host's ENTIRE seeded run, the items that ship
+    hidden until boot resolves their fact included. Naming only the items a
+    test goes on to measure leaves the rest to arrive mid-gesture, which is the
+    reflow this exists to put first.
+    """
+    for type_ in types:
+        expect(_shell(page, host, type_)).to_be_visible(timeout=10_000)
 
 
 def _drag(page: Page, start: tuple[float, float], end: tuple[float, float]) -> None:
@@ -334,8 +372,8 @@ def test_a_tile_dragged_from_the_sheet_lands_where_it_was_dropped(tmp_path, chro
 
         tile = _tile(page, "stopwatch")
         expect(tile).to_be_enabled()
-        clock_box = _shell(page, "status", "clock").bounding_box()
-        assert clock_box is not None
+        _settled(page, "status", ["clock", "docs"])
+        clock_box = _box(_shell(page, "status", "clock"))
         _drag(
             page,
             _center(tile),
@@ -375,9 +413,9 @@ def test_a_drag_inside_one_bar_reorders_it(tmp_path, chromium_browser):
         assert _types(page, "status") == ["clock", "stopwatch", "feedback"]
         _enter_edit_mode(page)
 
+        _settled(page, "status", ["clock", "stopwatch", "feedback"])
         feedback = _shell(page, "status", "feedback")
-        clock_box = _shell(page, "status", "clock").bounding_box()
-        assert clock_box is not None
+        clock_box = _box(_shell(page, "status", "clock"))
         _drag(
             page,
             _center(feedback),
@@ -852,6 +890,15 @@ def test_reset_to_default_discards_the_stored_arrangement(tmp_path, chromium_bro
 #: not on the tab around it, so the press lands on the session label -- the
 #: same way the panels suite reaches a service tile's menu through its title.
 TERMINAL_TILE_HEADER = ".tile-tab-terminal .terminal-label"
+#: A rendered rail entry -- the signal that panel-manager has run its
+#: registration pass. A tile header exists from the first paint, but its
+#: right-click is answered by the handler panel-manager hands to dock-tab
+#: (`setTileContextMenuHandler`) in the same pass that renders the rail, so a
+#: right-click before this is on screen opens nothing and reports no menu.
+#: The terminal entry rather than a panel's: `renderRail` emits it first and
+#: unconditionally, so the wait states panel-manager's progress and not one
+#: deployment's panel membership.
+PANEL_MANAGER_READY = 'button.panel-rail-button[data-panel-id="terminal"]'
 PANEL_MENU = ".rail-context-menu"
 PANEL_MENU_ITEM = ".rail-context-item"
 
@@ -881,6 +928,8 @@ def test_a_hidden_header_comes_back_from_the_terminal_tile_menu(tmp_path, chromi
         page.wait_for_selector(HYDRATED_SHELL, state="attached", timeout=15_000)
         expect(page.locator("html")).to_have_attribute("data-header-bar", "hidden")
         expect(page.locator(HEADER_HOST)).to_be_hidden()
+
+        expect(page.locator(PANEL_MANAGER_READY)).to_be_attached(timeout=15_000)
 
         page.locator(TERMINAL_TILE_HEADER).click(button="right")
         menu = page.locator(PANEL_MENU)

--- a/tests/interfaces/web_terminal/test_bar_items_routes.py
+++ b/tests/interfaces/web_terminal/test_bar_items_routes.py
@@ -37,7 +37,6 @@ import inspect
 import json
 import os
 import re
-import time
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -56,8 +55,29 @@ from osprey.interfaces.web_terminal.app import (
 from osprey.interfaces.web_terminal.bar_items_store import LAYOUT_FILENAME
 from osprey.interfaces.web_terminal.routes import bar_items as bar_items_routes
 from osprey.interfaces.web_terminal.routes.bar_items import MAX_REQUEST_BYTES
+from tests.interfaces.fsevents_wait import collect_paths
 
 # ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def no_companion_servers():
+    """No companion web server is launched for any app this module boots.
+
+    The lifespan auto-launches the framework's web servers, and the artifact
+    server writes ``agent_data/artifacts`` under the shared data root as soon
+    as it starts. The concealment tests below site that root *inside* the
+    watched tree, so those writes reach the file watcher as frames under
+    ``agent_data/`` — the very prefix their absence assertions check — and a
+    test about the bar-items store then fails on a path it never wrote.
+
+    Patched on the launcher module rather than on ``app``: the lifespan
+    imports the name at call time, so that is the binding it resolves. Autouse
+    because both entry points into the app — the ``client`` fixture and
+    :func:`_app_over` — boot it the same way.
+    """
+    with patch("osprey.infrastructure.server_launcher.ensure_web_server", lambda key: None):
+        yield
 
 
 @pytest.fixture
@@ -657,30 +677,47 @@ class TestAStoredDocumentThisBuildCannotRead:
 # ── the watcher does not announce a save ───────────────────────────────────
 
 
-def _broadcast_paths(queue, *, until: str, timeout: float = 15.0) -> list[str]:
+def _broadcast_paths(queue, *, until: str, poke) -> list[str]:
     """Every path broadcast up to and shortly after *until* arrives.
 
     The control write is made **after** the save, so its frame arriving is
     proof the observer has caught up past the save — the ordering that makes an
-    assertion about the save's *absence* a real one rather than a race. A short
-    drain afterwards catches a coalesced frame delivered a beat late.
+    assertion about the save's *absence* a real one rather than a race.
+
+    *poke* rewrites the file *until* names, and it is what makes that proof
+    obtainable rather than hoped for. A watchdog observer is not delivering the
+    moment the lifespan's ``start()`` returns; a control write made while its
+    stream is still arming is delivered late or not at all, and waiting longer
+    cannot recover a stimulus the stream never saw. So the wait re-applies the
+    stimulus instead of extending — see ``tests/interfaces/fsevents_wait.py``,
+    which also owns the trailing drain that catches a coalesced frame arriving a
+    beat behind the sentinel.
+
+    Rewriting an ordinary workspace note can only add more of the frames these
+    tests require to be *present*. It cannot manufacture one they require to be
+    absent, so the assertions below keep their full strength.
     """
-    paths: list[str] = []
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            paths.append(queue.get_nowait()["path"])
-        except asyncio.QueueEmpty:
-            time.sleep(0.05)
-            continue
-        if paths[-1] == until:
-            break
-    time.sleep(0.5)
-    while True:
-        try:
-            paths.append(queue.get_nowait()["path"])
-        except asyncio.QueueEmpty:
-            return paths
+    return collect_paths(queue, until=until, poke=poke)
+
+
+def _arm(queue, workspace) -> None:
+    """Block until this queue's observer is proven to be delivering.
+
+    A poke re-applies the write it is given, and the only write these tests can
+    safely re-apply is an ordinary note — never the save, which must happen
+    exactly once. So the save's own delivery cannot be waited for; what can be
+    waited for is the observer, *before* the save is made. This writes a note
+    and does not return until its frame arrives, so every PUT below lands on a
+    live stream instead of possibly into the arming window, where nothing is
+    broadcast whether the route conceals the store or not.
+
+    That is what keeps the absence assertions from going vacuous: a save whose
+    frames were lost while arming would satisfy them for the wrong reason, and
+    no later poke can re-issue a save to find out.
+    """
+    note = workspace / "settle-note.txt"
+    note.write_text("first")
+    _broadcast_paths(queue, until="settle-note.txt", poke=lambda: note.write_text("first"))
 
 
 @pytest.mark.real_workspace_watcher
@@ -727,16 +764,22 @@ class TestALayoutSaveIsNotAFileChange:
         # modifies its parent, and that parent frame belongs to the first-save
         # test below rather than to this one.
         watched_client.put("/api/bar-items", json=document(0))
-        (watched_workspace / "settle-note.txt").write_text("first")
-        _broadcast_paths(queue, until="settle-note.txt")
+        # Doubles as the arming probe: this returns only once the observer has
+        # actually delivered, so the save below is made against a live stream.
+        _arm(queue, watched_workspace)
 
         saved = watched_client.put(
             "/api/bar-items", json=document(1, status=[{"type": "separator"}])
         )
         assert saved.status_code == 200
-        (watched_workspace / "control-note.txt").write_text("ordinary workspace content")
+        control_note = watched_workspace / "control-note.txt"
+        control_note.write_text("ordinary workspace content")
 
-        paths = _broadcast_paths(queue, until="control-note.txt")
+        paths = _broadcast_paths(
+            queue,
+            until="control-note.txt",
+            poke=lambda: control_note.write_text("ordinary workspace content"),
+        )
 
         assert "control-note.txt" in paths, "the observer is live and the tree is watched"
         # Everything *below* the agent-data root, not the root's own directory
@@ -768,11 +811,17 @@ class TestALayoutSaveIsNotAFileChange:
             ) as unconcealed:
                 assert unconcealed.app.state.bar_items_rel is None
                 queue = unconcealed.app.state.broadcaster.subscribe()
+                _arm(queue, watched_workspace)
 
                 unconcealed.put("/api/bar-items", json=document(0))
-                (watched_workspace / "control-note.txt").write_text("ordinary content")
+                control_note = watched_workspace / "control-note.txt"
+                control_note.write_text("ordinary content")
 
-                paths = _broadcast_paths(queue, until="control-note.txt")
+                paths = _broadcast_paths(
+                    queue,
+                    until="control-note.txt",
+                    poke=lambda: control_note.write_text("ordinary content"),
+                )
 
         assert [path for path in paths if path.startswith("agent_data/")] != []
 
@@ -785,11 +834,20 @@ class TestALayoutSaveIsNotAFileChange:
         must never appear is the store or the document inside it: those are
         concealed, and they are the paths that would repeat on every edit."""
         queue = watched_client.app.state.broadcaster.subscribe()
+        # Before the save, not after: the absence assertions below are the ones
+        # that would go vacuous if the save's frames were lost while the stream
+        # was still arming, and the poke can only ever re-issue the note.
+        _arm(queue, watched_workspace)
 
         watched_client.put("/api/bar-items", json=document(0, status=[{"type": "separator"}]))
-        (watched_workspace / "control-note.txt").write_text("ordinary workspace content")
+        control_note = watched_workspace / "control-note.txt"
+        control_note.write_text("ordinary workspace content")
 
-        paths = _broadcast_paths(queue, until="control-note.txt")
+        paths = _broadcast_paths(
+            queue,
+            until="control-note.txt",
+            poke=lambda: control_note.write_text("ordinary workspace content"),
+        )
 
         assert "control-note.txt" in paths
         assert [path for path in paths if path.startswith("agent_data/bar_items")] == []

--- a/tests/interfaces/web_terminal/test_chat_browser.py
+++ b/tests/interfaces/web_terminal/test_chat_browser.py
@@ -87,6 +87,7 @@ from tests.interfaces.web_terminal.test_operator_session import (
 
 try:
     from playwright.sync_api import Page, expect
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
     _PLAYWRIGHT_AVAILABLE = True
 except ImportError:  # pragma: no cover
@@ -505,6 +506,66 @@ _PROBE_INIT_SCRIPT = """
 _DISMISS_TOUR = "try { localStorage.setItem('osprey-tour-dismissed-v1', '1') } catch (e) {}"
 
 
+#: Resolves once the dock has finished arranging the shell: the boot layout is
+#: announced final AND the console has held its place for a frame after it. The
+#: announcement lands in the same frame as the last re-parent, so the flag alone
+#: is the boundary rather than the far side of it.
+_DOCK_SETTLED_JS = """
+async (budgetMs) => {
+  const dock = await import('/static/js/dock-workspace.js');
+  const place = () => {
+    let out = '';
+    for (let n = document.querySelector('#operator-container'); n; n = n.parentElement) {
+      out += '>' + (n.id || n.className || n.tagName);
+    }
+    return out;
+  };
+  const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  const deadline = Date.now() + budgetMs;
+  let previous = null;
+  while (Date.now() < deadline) {
+    await frame();
+    const current = place();
+    if (dock.bootLayoutSettled() && current === previous) return true;
+    previous = current;
+  }
+  return false;
+}
+"""
+
+
+def _wait_for_dock_settled(page: Page) -> None:
+    """Block until the dock has finished arranging the shell.
+
+    The terminal card carrying both ``#terminal-container`` and
+    ``#operator-container`` is server-rendered into ``#dock-panel-sources`` and
+    re-parented twice on the way to its tile: once when the dock adopts the
+    subtree, and again when the boot layout is applied over the default
+    arrangement. The console mounts independently of either, so its textarea is
+    on screen and actionable before the shell is still.
+
+    Typing into it there is lost rather than delayed. Playwright checks
+    actionability and then writes, and a re-parent between those two steps takes
+    focus off the element, so the text is never inserted: the box reads empty,
+    ``submit`` finds no prompt and returns, and the turn never starts. The
+    equivalent hazard for a keystroke is the event landing on whatever the
+    detached node left behind.
+
+    Both moves are boot-only, so waiting for them here puts every re-parent
+    ahead of every interaction rather than between two of them.
+
+    Call this AFTER the page's own mount check, never before. The wait reads the
+    dock's state by importing its module, and a caller that has not yet waited
+    for anything makes that a cold fetch of a module graph still being loaded --
+    which fails outright rather than waiting, and reports a fetch error in place
+    of whatever the test was doing.
+    """
+    assert page.evaluate(_DOCK_SETTLED_JS, 10_000), (
+        "the dock never settled: the boot layout was not announced final, or the "
+        "console was still being re-parented when the wait ran out"
+    )
+
+
 def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
     """Open a fresh page (on a browser or a context) and wait for the console."""
     page: Page = opener.new_page()
@@ -514,6 +575,7 @@ def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
     # initChat builds the console on DOMContentLoaded; the input row is the
     # last thing appended, so its presence means the console is mounted.
     expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_visible(timeout=10_000)
+    _wait_for_dock_settled(page)
     return page
 
 
@@ -524,6 +586,7 @@ def _open_expert_page(opener, base_url: str, query: str = "") -> Page:
     page.add_init_script(_PROBE_INIT_SCRIPT)
     page.goto(f"{base_url}{query}", wait_until="domcontentloaded")
     expect(page.locator("#terminal-container .xterm")).to_be_visible(timeout=10_000)
+    _wait_for_dock_settled(page)
     return page
 
 
@@ -639,6 +702,46 @@ def _pty_is_live(base_url: str, key: str) -> bool:
     resp = requests.get(f"{base_url}/__test__/pty-state", params={"session_id": key})
     resp.raise_for_status()
     return bool(resp.json()["live"])
+
+
+def _wait_for_attached_session(page: Page, timeout: float = 20.0) -> str:
+    """The key the terminal is attached to, once the server has confirmed it.
+
+    An Expert page writes the pointer twice on boot. The console mints a key
+    for a tab that has none, and the terminal then stores the id the server
+    confirms on the socket -- a different one, and a third when a page-load
+    resume's child exits early and the terminal falls back to a fresh session.
+    Only the last of those is a key a PTY is running under, and the gap between
+    the console's write and the terminal's is tens of milliseconds, well inside
+    the window between the xterm becoming visible and the first read: a page
+    that latched the first write names a session that never existed, and every
+    server-side question asked about it -- is its PTY live, what was it spawned
+    with -- answers no.
+
+    The session label is the terminal's own report of the id it attached to,
+    painted from the frame that stores it, so a pointer that agrees with the
+    label is a pointer the terminal is on.
+    """
+    deadline = time.monotonic() + timeout
+    label = page.locator("#terminal-label")
+    key: str | None = None
+    shown = ""
+    while time.monotonic() < deadline:
+        # Bounded well inside the deadline above. The default read waits half a
+        # minute for a label to attach, which on a page carrying no terminal
+        # outlives this helper and answers with a locator timeout instead of
+        # the message below, which names both halves of the condition.
+        try:
+            shown = (label.text_content(timeout=1_000) or "").strip()
+        except PlaywrightTimeoutError:
+            shown = ""
+        key = _pointer(page)
+        if key and shown == f"Session {key[:8]}":
+            return key
+        page.wait_for_timeout(50)
+    raise AssertionError(
+        f"the terminal never settled on a session: label {shown!r}, pointer {key!r}"
+    )
 
 
 def _wait_for_chat_options(base_url: str, timeout: float = 20.0) -> list[dict]:
@@ -1069,7 +1172,7 @@ def test_handoff_expert_to_simple_and_back_keeps_one_session(tmp_path, chromium_
     with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
         _PLANS["and then"] = [("text", "the newer answer"), ("result",)]
         page = _open_expert_page(chromium_browser, base_url)
-        key = _wait_for_pointer(page)
+        key = _wait_for_attached_session(page)
 
         # Nothing to resume yet, so the terminal child was started under the key.
         first = _wait_for_pty_spawns(base_url, 1)[0]
@@ -1137,7 +1240,7 @@ def test_handoff_before_any_prompt_starts_the_chat_under_the_key(tmp_path, chrom
     """
     with _live_chat_server(tmp_path, ui_mode="expert") as (base_url, _app):
         page = _open_expert_page(chromium_browser, base_url)
-        key = _wait_for_pointer(page)
+        key = _wait_for_attached_session(page)
         first = _wait_for_pty_spawns(base_url, 1)[0]
         assert _identity_of(first) == ("--session-id", key)
 
@@ -1216,7 +1319,7 @@ def _flip_into_a_busy_terminal(base_url: str, chromium_browser) -> tuple[Page, s
     the fork: what the operator does about the wait is what differs.
     """
     page = _open_expert_page(chromium_browser, base_url)
-    key = _wait_for_pointer(page)
+    key = _wait_for_attached_session(page)
     _wait_for_pty_spawns(base_url, 1)
     assert _pty_is_live(base_url, key)
 
@@ -1300,8 +1403,10 @@ def test_handoff_refused_while_another_tab_holds_the_session(tmp_path, chromium_
         context = chromium_browser.new_context()
 
         holder = _open_expert_page(context, base_url)
-        key = _wait_for_pointer(holder)
         _wait_for_pty_spawns(base_url, 1)
+        # The key the second tab will adopt, which is the attached one rather
+        # than whatever the console minted on its way to it.
+        key = _wait_for_attached_session(holder)
 
         # A second tab, opened in the Simple view on the same pointer.
         second = _open_chat_page(context, base_url, "/?mode=simple")

--- a/tests/interfaces/web_terminal/test_chat_browser.py
+++ b/tests/interfaces/web_terminal/test_chat_browser.py
@@ -1195,8 +1195,10 @@ def test_handoff_expert_to_simple_and_back_keeps_one_session(tmp_path, chromium_
         expect(page.locator(f"{_OP} .op-entry.assistant")).to_contain_text("the earlier answer")
         # ...the input is usable again...
         expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_enabled()
-        # ...and the wait was on screen while it happened.
-        assert any("Finishing in the other view" in line for line in _handoff_log(page)), (
+        # ...and the restart was on screen while it happened. The terminal was
+        # idle, so what the operator watched was the agent moving, not a turn
+        # finishing.
+        assert any("Restarting the agent in this view" in line for line in _handoff_log(page)), (
             f"the transitional state was never shown: {_handoff_log(page)}"
         )
 
@@ -1330,7 +1332,12 @@ def _flip_into_a_busy_terminal(base_url: str, chromium_browser) -> tuple[Page, s
 
     overlay = page.locator(f"{_OP} .op-handoff")
     expect(overlay).to_be_visible(timeout=10_000)
-    expect(overlay.locator(".op-handoff-message")).to_contain_text("Finishing in the other view")
+    # The console has no word from the server on whether the terminal is
+    # mid-turn, so it shows the restart first and the wait once the restart
+    # budget is spent — the copy below arrives a few seconds in.
+    expect(overlay.locator(".op-handoff-message")).to_contain_text(
+        "Finishing in the other view", timeout=15_000
+    )
     expect(overlay.locator(".op-handoff-elapsed")).to_have_text(re.compile(r"^\d+:\d{2}$"))
     # The input stays out of reach: the session is not this view's yet.
     expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_disabled()

--- a/tests/interfaces/web_terminal/test_file_watcher.py
+++ b/tests/interfaces/web_terminal/test_file_watcher.py
@@ -17,6 +17,7 @@ from osprey.interfaces.web_terminal.file_watcher import (
     WorkspaceWatcher,
     _WorkspaceHandler,
 )
+from tests.interfaces.fsevents_wait import collect_frames
 
 #: Tighter than the unit lane's 600 s cap, because this file is the one that
 #: has actually hung: ``test_start_creates_directory_if_missing`` sat inside
@@ -103,22 +104,45 @@ class TestWorkspaceWatcher:
         watcher.start()
 
         try:
-            # Create a file
-            (tmp_path / "new_file.txt").write_text("hello")
+            new_file = tmp_path / "new_file.txt"
+            new_file.write_text("hello")
 
-            # Wait for event (watchdog is async, give it time)
-            deadline = time.monotonic() + 3
-            events = []
-            while time.monotonic() < deadline:
-                try:
-                    event = q.get_nowait()
-                    events.append(event)
-                    if any(e["path"] == "new_file.txt" for e in events):
-                        break
-                except asyncio.QueueEmpty:
-                    time.sleep(0.1)
+            # The observer's stream can still be arming when the write lands,
+            # and a stimulus applied inside that window is delivered late or not
+            # at all — so re-apply the write until its frame arrives rather than
+            # waiting a fixed span for an event the stream may never have seen.
+            #
+            # The subject here is *creation*, so the poke removes the file and
+            # creates it again: rewriting a file that already exists would
+            # re-apply the stimulus as a modification, and a regression that
+            # dropped ``on_created`` would then be answered by an ``on_modified``
+            # frame for the same path and pass unnoticed. The handler debounces
+            # per path for 0.1 s, so the recreate waits out that window — without
+            # the pause the ``created`` event is discarded as a duplicate of the
+            # ``deleted`` one and the frame under test never arrives.
+            def recreate() -> None:
+                new_file.unlink(missing_ok=True)
+                time.sleep(0.2)
+                new_file.write_text("hello")
 
-            assert any(e["path"] == "new_file.txt" for e in events)
+            frames = collect_frames(
+                q,
+                until="new_file.txt",
+                until_type="created",
+                poke=recreate,
+                # Under the module's own 60 s ``timeout`` marker, a wait carrying
+                # the default 60 s budget can never reach its own diagnostic:
+                # pytest-timeout fires first and reports ``Failed`` rather than
+                # the assertion naming what was never delivered.
+                budget=30,
+            )
+
+            # Implied by ``until_type`` above, and kept anyway: it is what states
+            # the subject in the body, so a wait later relaxed to any frame for the
+            # path cannot carry the creation requirement away with it.
+            assert {"created"} <= {
+                frame["type"] for frame in frames if frame["path"] == "new_file.txt"
+            }, f"no created frame for new_file.txt among {frames}"
         finally:
             watcher.stop()
 

--- a/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
+++ b/tests/interfaces/web_terminal/test_proxy_jupyter_integration.py
@@ -21,8 +21,10 @@ import urllib.error
 import urllib.request
 import uuid
 from collections.abc import Iterator
+from concurrent.futures import Future
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 from urllib.parse import urljoin
@@ -31,7 +33,11 @@ import httpx
 import pytest
 import websockets
 from fastapi.testclient import TestClient
+from starlette.testclient import WebSocketTestSession
+from starlette.websockets import WebSocketDisconnect
 
+from osprey.audit import writer
+from osprey.audit.posture import OSPREY_AGENT_DATA_ROOT
 from osprey.interfaces.common_middleware import compute_url_prefix
 from osprey.interfaces.web_terminal.app import UNIVERSAL_PANELS, create_app
 from osprey.interfaces.web_terminal.jupyter_sidecar import (
@@ -82,29 +88,41 @@ KERNEL_WS_PROTOCOL_V1 = "v1.kernel.websocket.jupyter.org"
 
 @pytest.fixture(scope="module")
 def notebook_env(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
-    """The environment a sidecar launch reads, and a root to keep it all under."""
+    """The environment a sidecar launch reads, and a root to keep it all under.
+
+    The redirections at the end are what keep this module's own records out of
+    the repository, and both have to be made HERE rather than left to the
+    directory-wide autouse fixtures that already do the same job for every
+    other app test. Those are function-scoped, and pytest sets a module-scoped
+    fixture up before any function-scoped one: ``proxied`` enters the app's
+    lifespan, and ``started_session`` posts a session through it, while
+    ``conftest._isolate_audit_zone`` has not run yet. Unredirected in that
+    window the app files ``http_mutation`` and ``web_auth`` lines under
+    ``var/audit/`` in the checkout.
+
+    ``writer.audit_dir`` is the ledger's single seam, the same one the
+    directory's autouse fixture uses — pointed at this module's own tmp root
+    here, and re-pointed at each test's ``tmp_path`` there.
+
+    The agent-data stamp is set for the SIDECAR, which is a real subprocess:
+    a monkeypatched resolver does not cross that boundary, and the sidecar is
+    spawned from a module-scoped fixture, before any test body has had the
+    stamp cleared out from under it (``session_posture_leak_guard``). The
+    in-process resolvers need no patching here — every one of them anchors on
+    ``resolve_project_root``, which ``agent_data_never_the_checkout``
+    (tests/conftest.py) diverts for the whole session, at a scope no
+    module-scoped fixture can outrun.
+    """
     root = tmp_path_factory.mktemp("notebook-panel")
+    agent_data = root / "agent_data"
     with pytest.MonkeyPatch.context() as environment:
         environment.setenv("OSPREY_CONFIG", str(root / "does-not-exist.yml"))
         # Keep every per-launch tempdir under the test's own tree.
         environment.setenv("TMPDIR", str(root))
         environment.setenv("OSPREY_AUDIT_IDENTITY", AUDIT_IDENTITY)
         environment.setenv(TERMINAL_FAMILY_PROBE, "reachable-from-the-terminal")
-        # And the agent-data root, here rather than from the autouse stamp in
-        # tests/interfaces/conftest.py. That one is function-scoped, and the
-        # fixtures below it are module-scoped: pytest builds the module scope
-        # first, so the app lifespan ``proxied`` enters — which claims the
-        # control-context record — runs before any per-test stamp exists and
-        # resolves the root to the checkout. The result is a real
-        # ``<repo>/var/agent_data`` that ``no_agent_data_in_the_repo`` fails the
-        # whole session over, from a module that never asked for one.
-        environment.setenv("OSPREY_AGENT_DATA_ROOT", str(root / "var" / "agent_data"))
-        # The audit zone too, for the same reason: the app's HTTP mutation
-        # records would otherwise land in ``<repo>/var/audit`` under the
-        # identity stamped above.
-        from osprey.audit import writer as audit_writer
-
-        environment.setattr(audit_writer, "audit_dir", lambda: root / "var" / "audit")
+        environment.setenv(OSPREY_AGENT_DATA_ROOT, str(agent_data))
+        environment.setattr(writer, "audit_dir", lambda: root / "audit" / "var" / "audit")
         yield root
 
 
@@ -188,7 +206,7 @@ def kernel_id(started_session: httpx.Response) -> str:
 
 
 @pytest.fixture(autouse=True)
-def sidecar_stderr_on_failure(sidecar: JupyterSidecar) -> Iterator[None]:
+def sidecar_stderr_on_failure(request: pytest.FixtureRequest) -> Iterator[None]:
     """The sidecar's last stderr lines, printed once the test is over.
 
     Captured stdout is shown for a failing test only, so a green run stays
@@ -197,9 +215,16 @@ def sidecar_stderr_on_failure(sidecar: JupyterSidecar) -> Iterator[None]:
     of it -- nudge attempts, a ``kernel_info`` timeout, an error in the
     websocket handler -- is on the stderr the sidecar keeps only for its
     failure report. Printing it here puts that account in the test's own log.
+
+    The sidecar is looked up through ``request`` instead of taken as a
+    parameter so that this autouse fixture does not itself pull one in: the
+    helper unit tests at the bottom of the module talk to a fake socket and
+    must not spawn a server to do it.
     """
     yield
-    tail = sidecar.stderr_tail
+    if "sidecar" not in request.fixturenames:
+        return
+    tail = request.getfixturevalue("sidecar").stderr_tail
     if tail:
         print(f"--- notebook sidecar stderr tail ---\n{tail}")
 
@@ -228,19 +253,101 @@ def _message(msg_type: str, content: dict[str, Any], session_id: str) -> dict[st
     }
 
 
+#: The budget for the FIRST frame off a freshly opened socket. The kernel has
+#: to import the whole kernel stack before it can answer anything, and that
+#: import is the slow part. Deliberately not derived from ``READY_TIMEOUT``:
+#: that is the sidecar's boot budget, and it is spent in the module fixture
+#: long before a socket exists.
+FIRST_FRAME_TIMEOUT = 120.0
+
+#: The budget for every later frame. By then the kernel is answering, so a
+#: half-minute gap between frames is already a stall rather than a slow start.
+FRAME_TIMEOUT = 30.0
+
+#: The budget for a whole read loop. Every receive is clamped to what is left of
+#: it, so no single frame wait can outlive the loop; and it sits far enough
+#: under ``KERNEL_TIMEOUT`` (30 s) that a stalled loop still reports its own
+#: last frame instead of being killed by the mark with nothing to say.
+LOOP_DEADLINE = 150.0
+
+#: What a deadline message names when nothing has arrived yet.
+NO_FRAME_YET = "no frame at all"
+
+
+def _last_seen(header: dict[str, Any]) -> str:
+    """How a deadline message names the frame that came before it."""
+    return str(header.get("msg_type") or "a frame with no msg_type")
+
+
+def _receive_message(socket: Any, timeout: float, deadline: float | None, last: str) -> Any:
+    """One frame off *socket*, bounded — starlette's own receive is not.
+
+    ``WebSocketTestSession.receive`` waits in ``portal.call`` with no timeout,
+    so a kernel that goes quiet hangs the test until the outer mark kills it
+    with nothing to show. This takes the same three steps ``receive_json`` and
+    ``receive_bytes`` take — read the frame, raise on a close, read the payload
+    — except that the read goes through ``portal.start_task_soon``, whose
+    ``concurrent.futures.Future`` can be waited on with a timeout. The close
+    check is the session's own bound ``_raise_on_close``, so a close frame
+    still surfaces as ``WebSocketDisconnect`` and not as a missing key.
+
+    *timeout* is this frame's budget and *deadline* the loop's; the wait is
+    clamped to whichever is nearer, and the failure names the bound that bit
+    along with *last*, the frame before this one.
+    """
+    budget = timeout
+    clamped = False
+    if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining < budget:
+            budget, clamped = remaining, True
+    try:
+        message = socket.portal.start_task_soon(socket._send_rx.receive).result(
+            timeout=max(budget, 0.0)
+        )
+    except TimeoutError:
+        if clamped:
+            raise AssertionError(
+                f"no frame within the {LOOP_DEADLINE:.0f} s loop budget; last was {last}"
+            ) from None
+        raise AssertionError(f"no frame within {timeout:.0f} s; last was {last}") from None
+    socket._raise_on_close(message)
+    return message
+
+
+def _receive_json(
+    socket: Any, timeout: float, *, deadline: float | None = None, last: str = NO_FRAME_YET
+) -> Any:
+    """``socket.receive_json()``, bounded by *timeout* and the loop *deadline*."""
+    return json.loads(_receive_message(socket, timeout, deadline, last)["text"])
+
+
+def _receive_bytes(
+    socket: Any, timeout: float, *, deadline: float | None = None, last: str = NO_FRAME_YET
+) -> bytes:
+    """``socket.receive_bytes()``, bounded by *timeout* and the loop *deadline*."""
+    frame: bytes = _receive_message(socket, timeout, deadline, last)["bytes"]
+    return frame
+
+
 def _reply_to(socket: Any, request: dict[str, Any], msg_type: str) -> dict[str, Any]:
     """Read until *request*'s reply of *msg_type* arrives, or fail on the deadline."""
-    deadline = time.monotonic() + KERNEL_TIMEOUT
+    deadline = time.monotonic() + LOOP_DEADLINE
+    budget, last = FIRST_FRAME_TIMEOUT, NO_FRAME_YET
     while time.monotonic() < deadline:
-        message = socket.receive_json()
+        message = _receive_json(socket, budget, deadline=deadline, last=last)
+        budget = FRAME_TIMEOUT
         header = message.get("header") or {}
         parent = message.get("parent_header") or {}
+        last = _last_seen(header)
         if (
             header.get("msg_type") == msg_type
             and parent.get("msg_id") == request["header"]["msg_id"]
         ):
             return message
-    raise AssertionError(f"no {msg_type} within {KERNEL_TIMEOUT:.0f} s")
+    raise AssertionError(
+        f"no {msg_type} within the {LOOP_DEADLINE:.0f} s loop budget; last was {last}"
+    )
 
 
 def _run_cell(socket: Any, code: str, session_id: str) -> str:
@@ -265,11 +372,14 @@ def _run_cell(socket: Any, code: str, session_id: str) -> str:
     socket.send_json(request)
 
     written: list[str] = []
-    deadline = time.monotonic() + KERNEL_TIMEOUT
+    deadline = time.monotonic() + LOOP_DEADLINE
+    budget, last = FIRST_FRAME_TIMEOUT, NO_FRAME_YET
     while time.monotonic() < deadline:
-        message = socket.receive_json()
+        message = _receive_json(socket, budget, deadline=deadline, last=last)
+        budget = FRAME_TIMEOUT
         header = message.get("header") or {}
         parent = message.get("parent_header") or {}
+        last = _last_seen(header)
         if parent.get("msg_id") != request["header"]["msg_id"]:
             continue
         content = message.get("content") or {}
@@ -279,7 +389,9 @@ def _run_cell(socket: Any, code: str, session_id: str) -> str:
             raise AssertionError("\n".join(content.get("traceback", [])))
         elif header.get("msg_type") == "status" and content.get("execution_state") == "idle":
             return "".join(written)
-    raise AssertionError(f"the cell did not finish within {KERNEL_TIMEOUT:.0f} s")
+    raise AssertionError(
+        f"the cell did not finish within the {LOOP_DEADLINE:.0f} s loop budget; last was {last}"
+    )
 
 
 class _RecordingConnect:
@@ -360,7 +472,7 @@ def test_a_session_starts_on_the_osprey_kernelspec(started_session: httpx.Respon
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.timeout(KERNEL_TIMEOUT)
+@pytest.mark.timeout(KERNEL_TIMEOUT, func_only=True)
 def test_a_kernel_answers_over_the_proxied_socket(
     proxied: TestClient, sidecar: JupyterSidecar, kernel_id: str
 ) -> None:
@@ -385,7 +497,7 @@ def test_a_kernel_answers_over_the_proxied_socket(
     assert handshake["authorization"] == f"Bearer {sidecar.token}"
 
 
-@pytest.mark.timeout(KERNEL_TIMEOUT)
+@pytest.mark.timeout(KERNEL_TIMEOUT, func_only=True)
 def test_a_cell_sees_no_server_token_and_no_terminal_family(
     proxied: TestClient, kernel_id: str
 ) -> None:
@@ -406,7 +518,7 @@ def test_a_cell_sees_no_server_token_and_no_terminal_family(
     assert reported == {"tok": False, "term": [], "cfg": True, "audit": True}
 
 
-@pytest.mark.timeout(KERNEL_TIMEOUT)
+@pytest.mark.timeout(KERNEL_TIMEOUT, func_only=True)
 def test_the_kernel_protocol_the_browser_offers_is_negotiated_through_the_proxy(
     proxied: TestClient, kernel_id: str
 ) -> None:
@@ -432,10 +544,14 @@ def test_the_kernel_protocol_the_browser_offers_is_negotiated_through_the_proxy(
         socket.send_bytes(
             serialize_msg_to_ws_v1(request, "shell", pack=lambda obj: json.dumps(obj).encode())
         )
-        deadline = time.monotonic() + KERNEL_TIMEOUT
+        deadline = time.monotonic() + LOOP_DEADLINE
+        budget, last = FIRST_FRAME_TIMEOUT, NO_FRAME_YET
         while time.monotonic() < deadline:
-            _channel, parts = deserialize_msg_from_ws_v1(socket.receive_bytes())
+            frame = _receive_bytes(socket, budget, deadline=deadline, last=last)
+            budget = FRAME_TIMEOUT
+            _channel, parts = deserialize_msg_from_ws_v1(frame)
             header, parent = json.loads(parts[0]), json.loads(parts[1])
+            last = _last_seen(header)
             if (
                 header.get("msg_type") == "kernel_info_reply"
                 and parent.get("msg_id") == request["header"]["msg_id"]
@@ -443,7 +559,10 @@ def test_the_kernel_protocol_the_browser_offers_is_negotiated_through_the_proxy(
                 assert json.loads(parts[3])["status"] == "ok"
                 break
         else:
-            raise AssertionError(f"no kernel_info_reply within {KERNEL_TIMEOUT:.0f} s")
+            raise AssertionError(
+                f"no kernel_info_reply within the {LOOP_DEADLINE:.0f} s loop budget; "
+                f"last was {last}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -665,3 +784,79 @@ def test_the_stylesheets_the_bar_addresses_answer_on_the_panels_paths(
         response = proxied.get(url)
         assert response.status_code == 200, url
         assert response.headers["content-type"].startswith("text/css"), url
+
+
+# ---------------------------------------------------------------------------
+# The bounded receive helpers themselves
+# ---------------------------------------------------------------------------
+#
+# These need no kernel: what they pin is what the helpers do when a frame does
+# NOT arrive, which is exactly the case the sidecar tests above can never stage
+# on purpose. The stand-in below is socket-shaped only where the helpers reach
+# -- the portal, the receive stream, and the close check -- and the close check
+# is the session's REAL one, so a close frame is asserted through the same code
+# a live socket would run.
+
+
+class _StuckPortal:
+    """A ``BlockingPortal`` whose ``start_task_soon`` future never resolves."""
+
+    def __init__(self, message: Any | None = None) -> None:
+        self._message = message
+
+    def start_task_soon(self, func: Any, *args: Any) -> Future[Any]:
+        future: Future[Any] = Future()
+        if self._message is not None:
+            future.set_result(self._message)
+        return future
+
+
+class _FakeSocket:
+    """The three attributes ``_receive_message`` touches, and nothing else."""
+
+    #: The session's own close check, bound here as a method. Its close branch
+    #: reads only the message, so it needs no live session behind it.
+    _raise_on_close = WebSocketTestSession._raise_on_close
+
+    def __init__(self, message: Any | None = None) -> None:
+        self.portal = _StuckPortal(message)
+        self._send_rx = SimpleNamespace(receive=lambda: None)
+
+
+def test_receive_json_names_the_frame_budget_and_the_last_frame() -> None:
+    """A frame that never arrives inside its own budget says which frame stalled."""
+    socket = _FakeSocket()
+
+    with pytest.raises(AssertionError) as stalled:
+        _receive_json(socket, 0.05, last="kernel_info_request")
+
+    assert "loop budget" not in str(stalled.value)
+    assert "last was kernel_info_request" in str(stalled.value)
+
+
+def test_receive_json_names_the_loop_budget_when_the_clamp_binds() -> None:
+    """A nearly spent loop deadline shortens the wait, and says so.
+
+    The frame budget here is the full ``FRAME_TIMEOUT``; the deadline is 50 ms
+    away. If the clamp did not bind, this test would sit for half a minute.
+    """
+    socket = _FakeSocket()
+
+    with pytest.raises(AssertionError) as stalled:
+        _receive_json(
+            socket,
+            FRAME_TIMEOUT,
+            deadline=time.monotonic() + 0.05,
+            last="status",
+        )
+
+    assert f"no frame within the {LOOP_DEADLINE:.0f} s loop budget" in str(stalled.value)
+    assert "last was status" in str(stalled.value)
+
+
+def test_receive_bytes_still_disconnects_on_a_close_frame() -> None:
+    """The bound is added around the close check, not in place of it."""
+    socket = _FakeSocket({"type": "websocket.close", "code": 1000})
+
+    with pytest.raises(WebSocketDisconnect):
+        _receive_bytes(socket, FRAME_TIMEOUT)

--- a/tests/interfaces/web_terminal/test_ws_handoff.py
+++ b/tests/interfaces/web_terminal/test_ws_handoff.py
@@ -216,6 +216,9 @@ def test_a_chat_held_key_is_handed_off_with_the_pending_frame_first(app, session
             frames = _json_frames_until(ws, "session_info")
 
     assert [f["type"] for f in frames] == ["handoff_pending", "session_info"]
+    # An idle chat has no turn to finish: the frame says so, and the client
+    # shows a restart rather than a wait.
+    assert frames[0] == {"type": "handoff_pending", "busy": False}
     assert frames[-1]["session_id"] == sid
     assert chat.teardowns == 1
     assert app.state.operator_registry.chats.get(sid) is None
@@ -315,7 +318,9 @@ def test_a_busy_chat_is_waited_on(app, sessions_dir):
         chat = _chats(app).hold(sid, Chat(busy=True))
         with client.websocket_connect(_resume_url(sid)) as ws:
             _send_resize(ws)
-            _recv_json(ws, "handoff_pending")
+            # Mid-turn: the frame says the wait is real, so the client shows
+            # it as one from the first moment.
+            assert _recv_json(ws, "handoff_pending")["busy"] is True
             time.sleep(0.3)
             assert spawns == []
             assert app.state.operator_registry.chats.get(sid) is chat

--- a/tests/mcp_server/conftest.py
+++ b/tests/mcp_server/conftest.py
@@ -10,6 +10,7 @@ objects. To call the original async function in tests, use the `.fn` attribute:
 
 import asyncio
 import json
+import sys
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock
 
@@ -152,15 +153,29 @@ def registered_tool_names(mcp) -> list[str]:
     return [t.name for t in tools]
 
 
+def _reset_facility_knowledge_bundle() -> None:
+    """Clear the facility-knowledge bundle singletons, if that server was imported.
+
+    Looked up through ``sys.modules`` rather than imported outright: almost no
+    test in this directory touches the facility-knowledge server, and importing
+    it for all of them to clear state only a handful of them create is a cost
+    with no payer. A module nothing imported holds no state to clear.
+    """
+    module = sys.modules.get("osprey.mcp_server.facility_knowledge.server")
+    if module is not None:
+        module.reset_bundle()
+
+
 @pytest.fixture(autouse=True)
 def _reset_singletons(monkeypatch):
     """Reset the MCP registry, ArtifactStore, screen-capture backend and config caches.
 
-    Leak guarded: the server context, artifact store, screen-capture backend and
-    the ``osprey.utils.config`` caches are all process-wide singletons. Every one
-    of them is reset both before and after the test, so a directory that ran
-    earlier in the same worker cannot hand its state to the first test here, and
-    this directory cannot hand its state to whatever runs next.
+    Leak guarded: the server context, artifact store, screen-capture backend,
+    the facility-knowledge bundle and the ``osprey.utils.config`` caches are all
+    process-wide singletons. Every one of them is reset both before and after
+    the test, so a directory that ran earlier in the same worker cannot hand its
+    state to the first test here, and this directory cannot hand its state to
+    whatever runs next.
     """
     import osprey.utils.config as _cfg
 
@@ -168,6 +183,7 @@ def _reset_singletons(monkeypatch):
         reset_server_context()
         reset_artifact_store()
         reset_backend()
+        _reset_facility_knowledge_bundle()
         reset_config_cache()
         _cfg._config_cache.clear()
 

--- a/tests/mcp_server/conftest.py
+++ b/tests/mcp_server/conftest.py
@@ -142,16 +142,13 @@ def extract_response_dict(result) -> dict:
 
 
 def registered_tool_names(mcp) -> list[str]:
-    """Tool names registered on a FastMCP server, across FastMCP versions.
+    """Tool names registered on a FastMCP server.
 
-    ``get_tools()`` is a coroutine on newer FastMCP releases and a plain call on
-    older ones, and its result is a dict on some and a list of tools on others.
+    ``list_tools()`` is FastMCP's public, supported listing API — a coroutine
+    returning the tools a client would actually be offered, with disabled,
+    backend-only and auth-gated ones already filtered out.
     """
-    tools = mcp.get_tools() if hasattr(mcp, "get_tools") else mcp.list_tools()
-    if asyncio.iscoroutine(tools):
-        tools = asyncio.run(tools)
-    if isinstance(tools, dict):
-        return list(tools)
+    tools = asyncio.run(mcp.list_tools())
     return [t.name for t in tools]
 
 

--- a/tests/mcp_server/health/test_server.py
+++ b/tests/mcp_server/health/test_server.py
@@ -5,9 +5,10 @@ returns a FastMCP server exposing exactly ``health_check`` and
 ``health_check_full``, and ``__main__`` follows the shared ``run_mcp_server``
 idiom.
 
-The sibling ``server_context`` module is built concurrently; these tests stub
-it in ``sys.modules`` so they pass regardless of the sibling's timing while
-remaining correct once the real module lands.
+The sibling ``server_context`` module is stubbed in ``sys.modules`` so the
+anatomy tests never start a real health suite. The stub re-exports the real
+``HealthRefreshSuppressedError`` because the tool layer imports it by name and
+catches it — a look-alike would silently stop matching.
 """
 
 import importlib
@@ -23,9 +24,11 @@ def stub_server_context(monkeypatch):
     """Inject a stub ``health.server_context`` module and track init calls.
 
     ``create_server()`` imports ``initialize_server_context`` lazily, so a stub
-    installed here is picked up whether or not the real module exists yet. The
-    stub records that initialization was invoked.
+    installed here is picked up in place of the real module. The stub records
+    that initialization was invoked.
     """
+    from osprey.mcp_server.health.server_context import HealthRefreshSuppressedError
+
     state = {"initialized": 0}
 
     module = types.ModuleType("osprey.mcp_server.health.server_context")
@@ -43,6 +46,9 @@ def stub_server_context(monkeypatch):
     module.initialize_server_context = initialize_server_context
     module.get_server_context = get_server_context
     module.reset_server_context = reset_server_context
+    # The tool layer imports this by name and catches it; re-export the real
+    # class rather than a stand-in so ``except`` keeps matching.
+    module.HealthRefreshSuppressedError = HealthRefreshSuppressedError
 
     monkeypatch.setitem(sys.modules, "osprey.mcp_server.health.server_context", module)
     return state
@@ -50,7 +56,7 @@ def stub_server_context(monkeypatch):
 
 async def _tool_names(server) -> set[str]:
     """Return the set of registered tool names on a FastMCP server."""
-    tools = await server._list_tools()
+    tools = await server.list_tools()
     return {getattr(t, "name", t) for t in tools}
 
 

--- a/tests/profiles/test_providers_catalog.py
+++ b/tests/profiles/test_providers_catalog.py
@@ -61,17 +61,6 @@ class TestPackagedCatalog:
             assert entry["base_url"], name
             assert set(entry["models"]) == {"haiku", "sonnet", "opus"}, name
 
-    def test_packaged_values_match_the_app_template_block(self):
-        """The catalog is a literal lift of the template's `api.providers`."""
-        template = REPO_ROOT / "src/osprey/templates/apps/control_assistant/config.yml.j2"
-        if not template.is_file():  # deleted once the conversion lands
-            pytest.skip("app template already removed")
-        source = template.read_text(encoding="utf-8")
-        # The providers block is plain YAML — no Jinja — so it parses as-is.
-        block = source.split("\napi:\n", 1)[1].split("\ncontainer_runtime:", 1)[0]
-        rendered = yaml.safe_load("api:\n" + block)["api"]["providers"]
-        assert load_provider_catalog(None).entries == rendered
-
     def test_catalog_carries_no_jinja(self):
         text = packaged_catalog_path().read_text(encoding="utf-8")
         assert "{{" not in text

--- a/tests/registry/test_gate_wiring.py
+++ b/tests/registry/test_gate_wiring.py
@@ -74,7 +74,7 @@ def _registered_server_tool_names() -> set[str]:
         stop,
     )
 
-    tools = asyncio.run(bsky_server.mcp._list_tools())
+    tools = asyncio.run(bsky_server.mcp.list_tools())
     return {getattr(t, "name", t) for t in tools}
 
 

--- a/tests/registry/test_mcp.py
+++ b/tests/registry/test_mcp.py
@@ -286,13 +286,56 @@ class TestResolveServers:
         operator the ability to launch the panel back, and ``register_panel``
         adds a proxied upstream, so those stay behind a prompt. This pins that
         split rather than leaving it to the order of a list literal.
+
+        Disjointness alone would stay green if the three fell out of both
+        lists — unclassified, which is what they were — so their membership in
+        ``permissions_ask`` and their approval hooks are pinned by name too.
         """
         ctx = _base_ctx()
         servers = resolve_servers({}, ctx)
         workspace = [s for s in servers if s["name"] == "osprey_workspace"][0]
         allow = set(workspace["permissions_allow"])
+        ask = set(workspace["permissions_ask"])
+        gated = {"add_panel_to_rail", "remove_panel_from_rail", "register_panel"}
         assert {"list_panels", "open_panel", "close_panel", "arrange_workspace"} <= allow
-        assert allow.isdisjoint({"add_panel_to_rail", "remove_panel_from_rail", "register_panel"})
+        assert allow.isdisjoint(gated)
+        assert gated <= ask
+        # A literal matcher per tool: the approval hook and the SDK's disallow
+        # engine both match tool names exactly, so an alternation group would
+        # gate nothing — and it would blind check_config_keys.py's extractor.
+        matchers = {rule["matcher"] for rule in workspace["hooks_pre"]}
+        assert {f"mcp__osprey_workspace__{tool}" for tool in gated} <= matchers
+
+    def test_workspace_read_back_tools_are_auto_approved(self):
+        """The artifact and lattice read-backs resolve to silent-allow.
+
+        ``artifact_pin`` and the five lattice verbs below were unclassified —
+        in neither list — so nothing pinned which side of the split they land
+        on, and the disjointness assertion above stays green either way. They
+        are named here because each is either a read of state the agent just
+        produced or a write to the simulation's own scratch state, which
+        ``lattice_init`` restores; none of it reaches hardware, so a prompt per
+        call would buy nothing.
+
+        ``lattice_clear_baseline`` is allow-listed here and still blocked under
+        the headless read-only floor, which classifies it side-effecting from
+        its name — that is the intended posture, not a contradiction.
+        """
+        ctx = _base_ctx()
+        servers = resolve_servers({}, ctx)
+        workspace = [s for s in servers if s["name"] == "osprey_workspace"][0]
+        allow = set(workspace["permissions_allow"])
+        ask = set(workspace["permissions_ask"])
+        read_back = {
+            "artifact_pin",
+            "lattice_get_data",
+            "lattice_get_figure",
+            "lattice_get_settings",
+            "lattice_update_settings",
+            "lattice_clear_baseline",
+        }
+        assert read_back <= allow
+        assert ask.isdisjoint(read_back)
 
     def test_health_server_entry(self):
         """The health server is an opt-in, read-only server.

--- a/tests/registry/test_tool_classification_drift.py
+++ b/tests/registry/test_tool_classification_drift.py
@@ -11,9 +11,9 @@ facility logbook with no gate at all.
 This test walks the *live* servers rather than any list of names, so a tool
 added to a ``tools/`` module and forgotten in the registry fails here.
 
-The known gaps are recorded rather than waved through: the assertion is
-equality, so closing one shows up as a failure too, and nothing can be added
-to the baseline by accident.
+There are no known gaps left: the baseline is empty and the assertion is
+equality, so a tool that stops being classified fails here and a tool that
+starts being classified cannot be quietly left in a baseline.
 """
 
 import asyncio
@@ -28,22 +28,11 @@ pytestmark = pytest.mark.unit
 
 
 #: Tools registered by a framework server but named nowhere in its registry
-#: entry, as of this test's introduction. Pre-existing, and not this test's
-#: business to fix — recorded so that a NEW one is a failure rather than an
-#: eleventh line in a list nobody reads.
-_UNCLASSIFIED_BASELINE: dict[str, set[str]] = {
-    "osprey_workspace": {
-        "add_panel_to_rail",
-        "artifact_pin",
-        "lattice_clear_baseline",
-        "lattice_get_data",
-        "lattice_get_figure",
-        "lattice_get_settings",
-        "lattice_update_settings",
-        "register_panel",
-        "remove_panel_from_rail",
-    },
-}
+#: entry. Empty: the nine workspace tools this baseline used to carry are now
+#: classified — the rail verbs and ``register_panel`` ask, ``artifact_pin`` and
+#: the five lattice tools are allowed. Keep it empty; a tool belongs in a
+#: permission list, not in a list nobody reads.
+_UNCLASSIFIED_BASELINE: dict[str, set[str]] = {}
 
 
 def _registered_tool_names(module: str) -> set[str]:

--- a/tests/services/ariel_search/test_ingestion.py
+++ b/tests/services/ariel_search/test_ingestion.py
@@ -1565,12 +1565,20 @@ class TestBuildSSLContext:
         assert context.check_hostname is False
 
     def test_adapter_builds_its_context_through_the_helper(self):
-        """The ALS adapter has no private copy of the TLS decision."""
+        """The ALS adapter has no private copy of the TLS decision.
+
+        The decision now reaches the adapter one step further out, through
+        ``FacilityAdapter._ssl_context``, so what this pins is that als.py
+        asks for a context rather than composing one.
+        """
         import inspect
 
+        from osprey.services.ariel_search.ingestion import base
         from osprey.services.ariel_search.ingestion.adapters import als
 
         source = inspect.getsource(als)
 
-        assert "build_ssl_context(" in source
+        assert "self._ssl_context()" in source
         assert "ssl.CERT_NONE" not in source
+        assert "build_ssl_context(" not in source
+        assert "build_ssl_context(" in inspect.getsource(base)

--- a/tests/services/ariel_search/test_ingestion_branches.py
+++ b/tests/services/ariel_search/test_ingestion_branches.py
@@ -7,8 +7,10 @@ malformed entry through instead of stopping the ingest.
 
 Two conventions carry through the file:
 
-* **No network.** Every HTTP path goes through ``patch("aiohttp.ClientSession")``,
-  following the precedent already in ``test_ingestion.py``.
+* **No network.** Every HTTP path goes through ``_patched_session``, which is
+  the one place in this file allowed to patch the aiohttp session. Routing all
+  of them through it keeps the connector stubbed too, so no test can leave a
+  real ``TCPConnector`` open behind a mocked session.
 * **No real sleeping.** Retry backoff is observed by rebinding the adapter
   module's own ``asyncio`` name to :class:`_RecordingAsyncio`. Rebinding the
   module attribute (rather than patching ``asyncio.sleep`` itself) keeps the
@@ -17,6 +19,7 @@ Two conventions carry through the file:
 
 import json
 import logging
+import pathlib
 import ssl
 import sys
 from contextlib import contextmanager
@@ -40,6 +43,7 @@ from osprey.services.ariel_search.ingestion.adapters.als import ALSLogbookAdapte
 from osprey.services.ariel_search.ingestion.adapters.generic import GenericJSONAdapter
 from osprey.services.ariel_search.ingestion.adapters.jlab import JLabLogbookAdapter
 from osprey.services.ariel_search.ingestion.adapters.ornl import ORNLLogbookAdapter
+from osprey.services.ariel_search.ingestion.base import FacilityAdapter
 from osprey.services.ariel_search.models import FacilityEntryCreateRequest
 
 # ---------------------------------------------------------------------------
@@ -116,12 +120,16 @@ def _patched_session(adapter: Any, session: MagicMock):
 
     The connector is stubbed because a real ``TCPConnector`` built against a
     mocked session is never closed by anything.
+
+    Yields the patched ``aiohttp.ClientSession`` so a caller can assert what the
+    adapter handed it — the connector, in particular. Callers that only need the
+    HTTP calls redirected can ignore the value.
     """
     with (
-        patch("aiohttp.ClientSession", return_value=session),
+        patch("aiohttp.ClientSession", return_value=session) as client_session,
         patch.object(adapter, "_create_connector", return_value=MagicMock()),
     ):
-        yield
+        yield client_session
 
 
 @pytest.fixture(autouse=True)
@@ -814,6 +822,196 @@ class TestALSConnector:
         assert "aiohttp-socks is not installed" in str(exc_info.value)
 
 
+class TestFacilityAdapterTransportDefaults:
+    """Transport defaults an adapter inherits without writing any of them down."""
+
+    class _BareAdapter(FacilityAdapter):
+        """The smallest legal adapter: abstract members only, no ``__init__``."""
+
+        @property
+        def source_system_name(self) -> str:
+            return "Bare Logbook"
+
+        async def fetch_entries(self, since=None, until=None, limit=None):  # noqa: ARG002
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+    @pytest.mark.asyncio
+    async def test_bare_subclass_goes_direct_and_verifies(self):
+        """No ingestion block at all still means: no proxy, certificates checked.
+
+        The class-level defaults are what a facility adapter written outside
+        this tree inherits, so they are the ones that decide whether a
+        forgetful adapter reaches the network unverified. It must not.
+        """
+        config = ARIELConfig.from_dict({"database": {"uri": "postgresql://test"}})
+        adapter = self._BareAdapter(config)
+
+        assert adapter.proxy_url is None
+        assert adapter.verify_ssl is True
+        assert adapter.ca_bundle is None
+        assert adapter._ssl_context() is True
+
+        connector = adapter._create_connector()
+        try:
+            assert isinstance(connector, aiohttp.TCPConnector)
+        finally:
+            await connector.close()
+
+    def test_config_opt_out_reaches_the_context(self):
+        """The other half of the rule: a configured value wins over the default.
+
+        ``verify_ssl: false`` is the deployment's explicit opt-out, and it has
+        to survive the trip from the ingestion block through
+        ``FacilityAdapter.__init__`` into ``_ssl_context()``. Without this the
+        base class could ignore the config entirely and still look correct.
+        """
+        adapter = self._BareAdapter(_config("als_logbook", None, verify_ssl=False))
+
+        assert adapter.verify_ssl is False
+        context = adapter._ssl_context()
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_NONE
+
+    def test_config_ca_bundle_reaches_the_context(self, tmp_path):
+        """A site CA named in the config is what the adapter verifies against."""
+        import certifi
+
+        bundle = tmp_path / "site-ca.pem"
+        bundle.write_bytes(pathlib.Path(certifi.where()).read_bytes())
+
+        adapter = self._BareAdapter(_config("als_logbook", None, ca_bundle=str(bundle)))
+
+        assert adapter.ca_bundle == str(bundle)
+        context = adapter._ssl_context()
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_REQUIRED
+
+    def test_blank_config_value_falls_through_to_the_default(self):
+        """HAZARD: ``verify_ssl:`` with no value must not read as "off".
+
+        A YAML key left empty reaches ``IngestionConfig`` as ``None``, which is
+        falsy — so an unguarded assignment would hand ``build_ssl_context`` a
+        ``None`` and disable certificate checking for every adapter, with
+        nothing in the config saying so.
+        """
+        adapter = self._BareAdapter(_config("als_logbook", None, verify_ssl=None))
+
+        assert adapter.verify_ssl is True
+        assert adapter._ssl_context() is True
+
+
+#: The three JSON adapters whose ``_load_data`` fetches over HTTP. They differ
+#: only in which payload shape they expect back, and none of them looks at it
+#: before returning it, so one response double drives all three.
+_JSON_ADAPTERS = [
+    pytest.param(GenericJSONAdapter, "generic_json", id="generic"),
+    pytest.param(JLabLogbookAdapter, "jlab_logbook", id="jlab"),
+    pytest.param(ORNLLogbookAdapter, "ornl_logbook", id="ornl"),
+]
+
+_JSON_SOURCE_URL = "https://logbook.invalid/entries.json"
+
+
+class TestJSONAdapterTransport:
+    """The three JSON adapters fetch through the base class's transport.
+
+    These adapters used to open a bare ``aiohttp.ClientSession()`` and call
+    ``session.get(url)`` with no ``ssl=`` at all, which meant a deployment could
+    configure ``proxy_url``, ``verify_ssl`` or ``ca_bundle``, see them honoured
+    by the ALS adapter, and silently not have them apply here. Each test below
+    asserts the configured value reaches the actual request, not merely that the
+    adapter stored it.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("adapter_cls", "adapter_name"), _JSON_ADAPTERS)
+    async def test_connector_comes_from_the_base_helper(self, adapter_cls, adapter_name):
+        """The session is built with the connector ``_create_connector`` returns.
+
+        That is the seam a SOCKS proxy arrives through, so an adapter that
+        builds its own connector reaches the network past the proxy.
+        """
+        adapter = adapter_cls(_config(adapter_name, _JSON_SOURCE_URL))
+        session = _http_session(get=_http_response(json_data={"entries": []}))
+
+        with _patched_session(adapter, session) as client_session:
+            assert await adapter._load_data() == {"entries": []}
+            assert (
+                client_session.call_args.kwargs["connector"]
+                is adapter._create_connector.return_value
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("adapter_cls", "adapter_name"), _JSON_ADAPTERS)
+    async def test_default_verification_reaches_the_request(self, adapter_cls, adapter_name):
+        """An unconfigured adapter still passes ``ssl=True``, not nothing at all."""
+        adapter = adapter_cls(_config(adapter_name, _JSON_SOURCE_URL))
+        session = _http_session(get=_http_response(json_data={"entries": []}))
+
+        with _patched_session(adapter, session):
+            await adapter._load_data()
+
+        assert session.get.call_args.kwargs["ssl"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("adapter_cls", "adapter_name"), _JSON_ADAPTERS)
+    async def test_verify_ssl_opt_out_reaches_the_request(self, adapter_cls, adapter_name):
+        """``verify_ssl: false`` disables verification on the request itself."""
+        adapter = adapter_cls(_config(adapter_name, _JSON_SOURCE_URL, verify_ssl=False))
+        session = _http_session(get=_http_response(json_data={"entries": []}))
+
+        with _patched_session(adapter, session):
+            await adapter._load_data()
+
+        context = session.get.call_args.kwargs["ssl"]
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_NONE
+        assert context.check_hostname is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("adapter_cls", "adapter_name"), _JSON_ADAPTERS)
+    async def test_ca_bundle_reaches_the_request(self, adapter_cls, adapter_name, tmp_path):
+        """A site CA named in the config is what this adapter verifies against.
+
+        Asserted through the context's properties rather than by comparing it to
+        one built the same way: two ``SSLContext`` objects are never equal.
+        """
+        import certifi
+
+        bundle = tmp_path / "site-ca.pem"
+        bundle.write_bytes(pathlib.Path(certifi.where()).read_bytes())
+
+        adapter = adapter_cls(_config(adapter_name, _JSON_SOURCE_URL, ca_bundle=str(bundle)))
+        session = _http_session(get=_http_response(json_data={"entries": []}))
+
+        with _patched_session(adapter, session):
+            await adapter._load_data()
+
+        context = session.get.call_args.kwargs["ssl"]
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    @pytest.mark.asyncio
+    async def test_proxy_without_aiohttp_socks_fails_the_load(self, monkeypatch):
+        """A proxy that cannot be built stops the fetch instead of going direct.
+
+        The connector is created inside the same ``try`` that maps a missing
+        aiohttp to an install hint, so this also pins that the proxy failure
+        keeps its own message rather than being reported as a missing aiohttp.
+        """
+        adapter = GenericJSONAdapter(
+            _config("generic_json", _JSON_SOURCE_URL, proxy_url="socks5://127.0.0.1:9095")
+        )
+        monkeypatch.setitem(sys.modules, "aiohttp_socks", None)
+
+        with pytest.raises(IngestionError) as exc_info:
+            await adapter._load_data()
+
+        assert "aiohttp-socks is not installed" in str(exc_info.value)
+
+
 class TestALSConvertEntry:
     """Field-level tolerance in the ALS converter."""
 
@@ -1006,7 +1204,7 @@ class TestGenericLoadData:
         adapter = _generic_adapter("https://logbook.invalid/entries.json")
         session = _http_session(get=_http_response(json_data={"entries": [{"id": "1"}]}))
 
-        with patch("aiohttp.ClientSession", return_value=session):
+        with _patched_session(adapter, session):
             data = await adapter._load_data()
 
         assert data == {"entries": [{"id": "1"}]}
@@ -1017,7 +1215,7 @@ class TestGenericLoadData:
         adapter = _generic_adapter("https://logbook.invalid/entries.json")
         session = _http_session(get=_http_response(status=503))
 
-        with patch("aiohttp.ClientSession", return_value=session):
+        with _patched_session(adapter, session):
             with pytest.raises(IngestionError) as exc_info:
                 await adapter._load_data()
 
@@ -1407,7 +1605,7 @@ class TestJLabAdapter:
         adapter = _jlab_adapter("https://logbook.invalid/api/entries")
         session = _http_session(get=_http_response(json_data={"entries": []}))
 
-        with patch("aiohttp.ClientSession", return_value=session):
+        with _patched_session(adapter, session):
             assert await adapter._load_data() == {"entries": []}
 
     @pytest.mark.asyncio
@@ -1416,7 +1614,7 @@ class TestJLabAdapter:
         adapter = _jlab_adapter("https://logbook.invalid/api/entries")
         session = _http_session(get=_http_response(status=500))
 
-        with patch("aiohttp.ClientSession", return_value=session):
+        with _patched_session(adapter, session):
             with pytest.raises(IngestionError) as exc_info:
                 await adapter._load_data()
 
@@ -1664,7 +1862,7 @@ class TestORNLAdapter:
         adapter = _ornl_adapter("https://logbook.invalid/api/entries")
         session = _http_session(get=_http_response(json_data=[{"ID": "1"}]))
 
-        with patch("aiohttp.ClientSession", return_value=session):
+        with _patched_session(adapter, session):
             assert await adapter._load_data() == [{"ID": "1"}]
 
     @pytest.mark.asyncio
@@ -1673,7 +1871,7 @@ class TestORNLAdapter:
         adapter = _ornl_adapter("https://logbook.invalid/api/entries")
         session = _http_session(get=_http_response(status=404))
 
-        with patch("aiohttp.ClientSession", return_value=session):
+        with _patched_session(adapter, session):
             with pytest.raises(IngestionError) as exc_info:
                 await adapter._load_data()
 

--- a/tests/services/auth_sidecar/test_login_audit.py
+++ b/tests/services/auth_sidecar/test_login_audit.py
@@ -925,6 +925,11 @@ class TestThePreExchangeRefusalsAreBounded:
 
     def test_a_flood_of_login_starts_appends_once(self, zone: Path) -> None:
         app = _oidc_app(UNMAPPED_OIDC_ENV)
+        # The flood has to land in ONE window for "appends once" to be the claim
+        # being made, and the window is a real duration the throttle reads off a
+        # clock. Held still, so what is asserted is the fold and not how long
+        # fifty requests happened to take on the machine running them.
+        _with_movable_audit_window(app)
         for _ in range(50):
             assert _oidc_start(app, "bob").status_code == 403
         assert len(_records(zone)) == 1
@@ -960,6 +965,9 @@ class TestThePreExchangeRefusalsAreBounded:
         the second free to lose its bound unnoticed.
         """
         app = _oidc_app(env)
+        # Held still, so what is asserted is the fold and not how long twenty
+        # callbacks happened to take on the machine running them.
+        _with_movable_audit_window(app)
         for _ in range(20):
             assert _callback(app, user="bob").status_code == 403
         assert [record["reason"] for record in _records(zone)] == [reason]

--- a/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
+++ b/tests/services/python_executor/execution/test_client_limits_monkeypatch.py
@@ -27,12 +27,17 @@ from types import ModuleType
 import pytest
 
 from osprey.connectors.control_system.limits_validator import (
+    STEP_READ_TIMEOUT_SECONDS,
     ChannelLimitsConfig,
     LimitsValidator,
 )
 from osprey.errors import ChannelLimitsViolationError
 from osprey.services.python_executor.execution.wrapper import ExecutionWrapper
-from osprey.services.python_executor.write_surface import _CLIENT_WRITE_TARGETS
+from osprey.services.python_executor.write_surface import (
+    _CLIENT_WRITE_TARGETS,
+    _LIMITS_REFUSED,
+    _LIMITS_WRAPPED,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -378,8 +383,8 @@ def _install_fake_pvaccess(monkeypatch, writes=None, reads=None, read=None):
     return mod
 
 
-def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=None):
-    """Inject a ``tango`` whose DeviceProxy and Group record what reaches them.
+def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=None, reads=None):
+    """Inject a ``tango`` whose proxies and Group record what reaches them.
 
     PyTango is not installed in this environment, so this module is the only
     surface the tango branch of the block is ever exercised against, which
@@ -394,6 +399,14 @@ def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=Non
       wait, timeout)`` after ``green()`` rewrites it, and
       ``command_inout_asynch(cmd_name, *args)``, which takes ``forget``
       positionally and rejects it as a keyword.
+
+    ``AttributeProxy`` is here for the third: it is bound to one attribute for
+    its whole life, so its writes carry a value alone and its channel address
+    has to be rebuilt from the device proxy behind it. Its ``read()`` answers a
+    ``DeviceAttribute``, so the value the step is measured from sits behind
+    ``.value`` rather than being the answer itself, and its three writes forward
+    to the DeviceProxy spellings the way upstream binds them --- which is what
+    makes an AttributeProxy write pass the limits check twice.
 
     ``Group`` is here for the same reason and is deliberately NOT a subclass of
     anything: upstream it is a plain Python class (``tango/group.py``) defining
@@ -410,7 +423,25 @@ def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=Non
     writes = [] if writes is None else writes
     commands = [] if commands is None else commands
     group_calls = [] if group_calls is None else group_calls
+    reads = [] if reads is None else reads
     mod = _fake_module("tango")
+
+    class DeviceAttribute:
+        """What a Tango read answers: the value sits behind ``.value``."""
+
+        def __init__(self, value):
+            self.value = value
+
+    class AttributeInfo:
+        """An attribute named by an object rather than by a string.
+
+        PyTango accepts one of these wherever a write takes an attribute name,
+        which is why the guard reduces the argument to ``.name`` before it
+        builds the channel address.
+        """
+
+        def __init__(self, name):
+            self.name = name
 
     class Connection:
         """The class PyTango really defines the two command spellings on."""
@@ -434,12 +465,58 @@ def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=Non
             writes.append((attr, value))
             return "written"
 
+        def write_attribute_asynch(self, attr, value):
+            writes.append((attr, value))
+            return 1
+
+        def write_read_attribute(self, attr, value):
+            writes.append((attr, value))
+            return DeviceAttribute(value)
+
         def write_attributes(self, name_val):
             writes.extend(list(name_val))
             return "written"
 
+        def write_attributes_asynch(self, attr_values, cb=None):
+            # PyTango names the pairs ``attr_values`` on this spelling alone.
+            writes.extend(list(attr_values))
+            return 2
+
+        def write_read_attributes(self, name_val, attr_read_names=None):
+            writes.extend(list(name_val))
+            return "read-back-many"
+
         def read_attribute(self, attr):
+            reads.append(attr)
             return 1.0
+
+    class AttributeProxy:
+        """PyTango's attribute proxy: one attribute, writes that carry a value alone."""
+
+        def __init__(self, full_name):
+            self._device, self._attr = full_name.rsplit("/", 1)
+
+        def get_device_proxy(self):
+            return DeviceProxy(self._device)
+
+        def name(self):
+            return self._attr
+
+        def read(self):
+            reads.append(self._attr)
+            return DeviceAttribute(1.0)
+
+        # Upstream these three are bound onto the class as calls on the device
+        # proxy behind the attribute, so each one reaches the machine through
+        # a DeviceProxy write spelling rather than on its own.
+        def write(self, value):
+            return self.get_device_proxy().write_attribute(self._attr, value)
+
+        def write_asynch(self, value):
+            return self.get_device_proxy().write_attribute_asynch(self._attr, value)
+
+        def write_read(self, value):
+            return self.get_device_proxy().write_read_attribute(self._attr, value)
 
     class Group:
         """PyTango's group: its own class, with its own four write spellings."""
@@ -471,6 +548,8 @@ def _install_fake_tango(monkeypatch, writes=None, commands=None, group_calls=Non
 
     mod.Connection = Connection
     mod.DeviceProxy = DeviceProxy
+    mod.AttributeInfo = AttributeInfo
+    mod.AttributeProxy = AttributeProxy
     mod.Group = Group
     mod.group_calls = group_calls
     monkeypatch.setitem(sys.modules, "tango", mod)
@@ -490,18 +569,40 @@ def _install_fake_doocs(monkeypatch, writes=None):
     return mod
 
 
-def _install_fake_caproto(monkeypatch, writes=None):
-    """Inject a fake ``caproto`` with both write entry points."""
+class _CaprotoResponse:
+    """caproto answers a read with a response whose ``data`` is an array."""
+
+    def __init__(self, value):
+        self.data = [value]
+
+
+def _install_fake_caproto(monkeypatch, writes=None, reads=None, read_kwargs=None):
+    """Inject a fake ``caproto`` with every write entry point, in all three flavors."""
     writes = [] if writes is None else writes
+    reads = [] if reads is None else reads
+    read_kwargs = [] if read_kwargs is None else read_kwargs
     caproto_mod = _fake_module("caproto")
     sync_mod = _fake_module("caproto.sync")
     sync_client = _fake_module("caproto.sync.client")
     threading_mod = _fake_module("caproto.threading")
     threading_client = _fake_module("caproto.threading.client")
+    asyncio_mod = _fake_module("caproto.asyncio")
+    asyncio_client = _fake_module("caproto.asyncio.client")
 
     def write(pv_name, data, **kwargs):
         writes.append((pv_name, data))
         return "written"
+
+    def read(pv_name, **kwargs):
+        reads.append(pv_name)
+        read_kwargs.append(kwargs)
+        return _CaprotoResponse(1.0)
+
+    def read_write_read(pv_name, data, **kwargs):
+        # Upstream this reads the channel, writes it, and reads it back; the
+        # value it drives the channel with is the one the plain write drives.
+        writes.append((pv_name, data))
+        return "read-write-read"
 
     class PV:
         def __init__(self, name):
@@ -511,15 +612,47 @@ def _install_fake_caproto(monkeypatch, writes=None):
             writes.append((self.name, data))
             return "written"
 
-        def read(self):
+        # The bare-value shape ``_caproto_scalar`` reduces alongside a
+        # response object, so both of its branches are exercised here.
+        def read(self, **kwargs):
+            reads.append(self.name)
+            read_kwargs.append(kwargs)
             return 1.0
 
+    class Batch:
+        """caproto's request batcher: its write carries the PV to drive."""
+
+        def write(self, pv, data, callback=None, **kwargs):
+            writes.append((pv.name, data))
+            return "batched"
+
+    class AsyncPV:
+        """caproto's asyncio PV: read and write are coroutines."""
+
+        def __init__(self, name):
+            self.name = name
+
+        async def write(self, data, **kwargs):
+            writes.append((self.name, data))
+            return "written"
+
+        async def read(self, **kwargs):
+            reads.append(self.name)
+            read_kwargs.append(kwargs)
+            return _CaprotoResponse(1.0)
+
     sync_client.write = write
+    sync_client.read = read
+    sync_client.read_write_read = read_write_read
     threading_client.PV = PV
+    threading_client.Batch = Batch
+    asyncio_client.PV = AsyncPV
     sync_mod.client = sync_client
     threading_mod.client = threading_client
+    asyncio_mod.client = asyncio_client
     caproto_mod.sync = sync_mod
     caproto_mod.threading = threading_mod
+    caproto_mod.asyncio = asyncio_mod
 
     for name, mod in (
         ("caproto", caproto_mod),
@@ -527,9 +660,11 @@ def _install_fake_caproto(monkeypatch, writes=None):
         ("caproto.sync.client", sync_client),
         ("caproto.threading", threading_mod),
         ("caproto.threading.client", threading_client),
+        ("caproto.asyncio", asyncio_mod),
+        ("caproto.asyncio.client", asyncio_client),
     ):
         monkeypatch.setitem(sys.modules, name, mod)
-    return sync_client, threading_client
+    return sync_client, threading_client, asyncio_client
 
 
 # ---------------------------------------------------------------------------
@@ -544,6 +679,14 @@ def _make_validator():
         ),
         "sys/tg_test/1/voltage": ChannelLimitsConfig(
             channel_address="sys/tg_test/1/voltage", min_value=0.0, max_value=10.0
+        ),
+        # The Tango channel that configures max_step, so a test can tell a
+        # guard that reads the present value from one that never does.
+        "sys/tg_test/1/step": ChannelLimitsConfig(
+            channel_address="sys/tg_test/1/step",
+            min_value=0.0,
+            max_value=100.0,
+            max_step=2.0,
         ),
         "FACILITY/MAGNET/H1/CURRENT.SP": ChannelLimitsConfig(
             channel_address="FACILITY/MAGNET/H1/CURRENT.SP",
@@ -594,11 +737,21 @@ def _needs_fake(name):
     return entry is _UNSET or not getattr(entry, _FAKE_CLIENT_MARKER, False)
 
 
-def _run_monkeypatch(monkeypatch):
-    """Execute the generated monkeypatch block against fakes; return its stdout."""
+def _install_client_fakes(monkeypatch):
+    """Stand in for every client the block imports, without running it yet.
+
+    ``_run_monkeypatch`` opens with this. A test that has to look at a client
+    object on *both* sides of the block calls it first, so the objects it
+    snapshots are the ones the block goes on to patch.
+    """
     for name, installer in _CLIENT_FAKES:
         if _needs_fake(name):
             installer(monkeypatch)
+
+
+def _run_monkeypatch(monkeypatch):
+    """Execute the generated monkeypatch block against fakes; return its stdout."""
+    _install_client_fakes(monkeypatch)
 
     import osprey.runtime as runtime_module
 
@@ -1293,6 +1446,374 @@ def test_tango_write_attributes_fails_closed_on_an_unpairable_shape(monkeypatch)
     assert writes == []
 
 
+def test_tango_write_attribute_asynch_within_limits_reaches_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attribute_asynch("current", 5.0) == 1, (
+        "the request id the caller polls on must come back untouched"
+    )
+    assert writes == [("current", 5.0)]
+
+
+def test_tango_write_attribute_asynch_out_of_bounds_raises_before_the_device(monkeypatch):
+    """The asynchronous spelling drives the same device with the same value."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attribute_asynch("current", 99.0)
+    assert writes == []
+
+
+def test_tango_write_read_attribute_within_limits_reaches_the_device(monkeypatch):
+    """The read-back the call answers is the caller's result, not the guard's."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_read_attribute("current", 5.0).value == 5.0
+    assert writes == [("current", 5.0)]
+
+
+def test_tango_write_read_attribute_out_of_bounds_raises_before_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_read_attribute("current", 99.0)
+    assert writes == []
+
+
+def test_tango_write_attributes_asynch_checks_every_pair(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attributes_asynch([("current", 5.0), ("voltage", 4.0)]) == 2
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+
+def test_tango_write_attributes_asynch_out_of_bounds_raises_before_the_device(monkeypatch):
+    """One pair out of range stops the batch: none of it reaches the device."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attributes_asynch([("current", 5.0), ("voltage", 99.0)])
+    assert writes == []
+
+
+def test_tango_write_read_attributes_checks_every_pair(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    written = proxy.write_read_attributes([("current", 5.0), ("voltage", 4.0)])
+    assert written == "read-back-many"
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+
+def test_tango_write_read_attributes_out_of_bounds_raises_before_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_read_attributes([("current", 5.0), ("voltage", 99.0)])
+    assert writes == []
+
+
+def test_tango_write_read_attribute_measures_the_step_over_the_writing_proxy(monkeypatch):
+    """A max_step channel is read through the proxy the write goes through."""
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_tango(monkeypatch, writes, reads=reads)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        proxy.write_read_attribute("step", 50.0)
+
+    assert exc.value.violation_type == "MAX_STEP_EXCEEDED"
+    assert reads == ["step"]
+    assert writes == []
+
+    reads.clear()
+    # The fake reads back 1.0, so this is a step of 1.0 against a max of 2.0.
+    assert proxy.write_read_attribute("step", 2.0).value == 2.0
+    assert reads == ["step"]
+    assert writes == [("step", 2.0)]
+
+
+def test_tango_attribute_proxy_write_within_limits_reaches_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/current")
+    assert attribute.write(5.0) == "written"
+    assert writes == [("current", 5.0)]
+
+
+def test_tango_attribute_proxy_write_out_of_bounds_raises_before_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/current")
+    with pytest.raises(ChannelLimitsViolationError):
+        attribute.write(99.0)
+    assert writes == []
+
+
+def test_tango_attribute_proxy_write_asynch_within_limits_reaches_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/current")
+    assert attribute.write_asynch(5.0) == 1, (
+        "the request id the caller polls on must come back untouched"
+    )
+    assert writes == [("current", 5.0)]
+
+
+def test_tango_attribute_proxy_write_asynch_out_of_bounds_raises_before_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/current")
+    with pytest.raises(ChannelLimitsViolationError):
+        attribute.write_asynch(99.0)
+    assert writes == []
+
+
+def test_tango_attribute_proxy_write_read_within_limits_reaches_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/current")
+    assert attribute.write_read(5.0).value == 5.0
+    assert writes == [("current", 5.0)]
+
+
+def test_tango_attribute_proxy_write_read_out_of_bounds_raises_before_the_device(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/current")
+    with pytest.raises(ChannelLimitsViolationError):
+        attribute.write_read(99.0)
+    assert writes == []
+
+
+def test_tango_attribute_proxy_channel_is_the_full_device_attribute_address(monkeypatch):
+    """An AttributeProxy write carries a value alone, so it names no channel.
+
+    The address is rebuilt from the device proxy behind the attribute and the
+    attribute's own name. Validating anything narrower would look up a channel
+    the database has never heard of --- which, on a deployment that allows
+    unlisted channels, is a write that passes without being checked at all.
+    """
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    # The same attribute name on another device is not in the database.
+    attribute = mod.AttributeProxy("sys/tg_test/2/current")
+    with pytest.raises(ChannelLimitsViolationError):
+        attribute.write(5.0)
+    assert writes == []
+
+
+def test_tango_attribute_proxy_measures_the_step_over_its_own_read(monkeypatch):
+    """The step is measured from the value behind the read-back's ``.value``.
+
+    An AttributeProxy read answers a ``DeviceAttribute``, not a number. Left
+    unreduced it is non-numeric, the validator SKIPS the step check, and a
+    49-unit step past a max of 2 reaches the machine --- which is why this
+    asserts the refusal is ``MAX_STEP_EXCEEDED`` and not merely that something
+    raised.
+    """
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_tango(monkeypatch, writes, reads=reads)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/step")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        attribute.write(50.0)
+
+    assert exc.value.violation_type == "MAX_STEP_EXCEEDED"
+    assert reads == ["step"]
+    assert writes == []
+
+    reads.clear()
+    # The fake reads back 1.0, so this is a step of 1.0 against a max of 2.0.
+    # The write forwards to the wrapped DeviceProxy spelling, so the step is
+    # measured once by each proxy's guard.
+    assert attribute.write(2.0) == "written"
+    assert reads == ["step", "step"]
+    assert writes == [("step", 2.0)]
+
+
+def test_tango_attribute_proxy_asynch_and_read_back_writes_measure_the_step(monkeypatch):
+    """The other two AttributeProxy spellings carry a guard of their own.
+
+    All three forward to a DeviceProxy spelling that is itself wrapped, so a
+    refusal alone cannot say which guard produced it: these would still refuse
+    with the AttributeProxy wrappers gone. Counting the reads does say it --- a
+    step measured twice is one measurement per proxy, which only happens while
+    both guards are installed.
+    """
+    writes: list = []
+    reads: list = []
+    mod = _install_fake_tango(monkeypatch, writes, reads=reads)
+    _run_monkeypatch(monkeypatch)
+
+    attribute = mod.AttributeProxy("sys/tg_test/1/step")
+
+    # The fake reads back 1.0, so each of these is a step of 1.0 against a max
+    # of 2.0 --- within limits, and through both guards on the way out.
+    assert attribute.write_asynch(2.0) == 1, (
+        "the request id the caller polls on must come back untouched"
+    )
+    assert reads == ["step", "step"]
+    assert writes == [("step", 2.0)]
+
+    reads.clear()
+    writes.clear()
+    assert attribute.write_read(2.0).value == 2.0
+    assert reads == ["step", "step"]
+    assert writes == [("step", 2.0)]
+
+
+def test_tango_write_attributes_takes_the_pairs_by_keyword(monkeypatch):
+    """PyTango's own keyword form reaches the device through the guard."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attributes(name_val=[("current", 5.0), ("voltage", 4.0)]) == "written"
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+    writes.clear()
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attributes(name_val=[("current", 5.0), ("voltage", 99.0)])
+    assert writes == []
+
+
+def test_tango_write_attributes_asynch_takes_the_pairs_by_its_own_keyword(monkeypatch):
+    """This spelling names the pairs ``attr_values``, and stock PyTango accepts it.
+
+    One factory serves all three many-write spellings, so a guard that knew
+    only ``name_val`` would break a correct call with a TypeError naming its
+    own parameter rather than anything the caller wrote.
+    """
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    assert proxy.write_attributes_asynch(attr_values=[("current", 5.0), ("voltage", 4.0)]) == 2
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+    writes.clear()
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_attributes_asynch(attr_values=[("current", 5.0), ("voltage", 99.0)])
+    assert writes == []
+
+
+def test_tango_write_read_attributes_takes_the_pairs_by_keyword(monkeypatch):
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    written = proxy.write_read_attributes(name_val=[("current", 5.0), ("voltage", 4.0)])
+    assert written == "read-back-many"
+    assert writes == [("current", 5.0), ("voltage", 4.0)]
+
+    writes.clear()
+    with pytest.raises(ChannelLimitsViolationError):
+        proxy.write_read_attributes(name_val=[("current", 5.0), ("voltage", 99.0)])
+    assert writes == []
+
+
+def test_tango_many_write_without_pairs_fails_closed(monkeypatch):
+    """A call carrying no pairs at all cannot be checked, so it does not write."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    with pytest.raises(ValueError, match="pairs"):
+        proxy.write_attributes()
+    assert writes == []
+
+
+def test_tango_write_attribute_addresses_an_attribute_object_by_its_name(monkeypatch):
+    """An attribute named by an object addresses the channel its name does.
+
+    PyTango takes an ``AttributeInfo`` wherever a write takes an attribute
+    name. Interpolated whole, it builds an address the limits database has
+    never heard of --- which on a deployment that allows unlisted channels is a
+    write that passes with no bound applied, so this asserts the refusal is
+    ``MAX_EXCEEDED`` and not merely that something raised.
+    """
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    attribute = mod.AttributeInfo("current")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        proxy.write_attribute(attribute, 99.0)
+
+    assert exc.value.violation_type == "MAX_EXCEEDED"
+    assert writes == []
+
+    # The object itself still reaches the device: it is reduced only to build
+    # the address the value is bounded under.
+    assert proxy.write_attribute(attribute, 5.0) == "written"
+    assert writes == [(attribute, 5.0)]
+
+
+def test_tango_write_attributes_addresses_an_attribute_object_by_its_name(monkeypatch):
+    """The many-write shape reduces each pair's attribute the same way."""
+    writes: list = []
+    mod = _install_fake_tango(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    proxy = mod.DeviceProxy("sys/tg_test/1")
+    attribute = mod.AttributeInfo("current")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        proxy.write_attributes([(attribute, 99.0)])
+
+    assert exc.value.violation_type == "MAX_EXCEEDED"
+    assert writes == []
+
+    assert proxy.write_attributes([(attribute, 5.0)]) == "written"
+    assert writes == [(attribute, 5.0)]
+
+
 def test_tango_command_inout_is_refused(monkeypatch):
     """A command is refused in a limits-checked run, argument or not.
 
@@ -1447,7 +1968,12 @@ def test_tango_success_line_names_the_commands_it_refused(monkeypatch):
     out = _run_monkeypatch(monkeypatch)
 
     assert "✅ Monkeypatched tango: " in out
-    assert "wrapped on DeviceProxy: write_attribute(), write_attributes()" in out
+    assert (
+        "wrapped on DeviceProxy: write_attribute(), write_attribute_asynch(), "
+        "write_read_attribute(), write_attributes(), write_attributes_asynch(), "
+        "write_read_attributes()" in out
+    )
+    assert "wrapped on AttributeProxy: write(), write_asynch(), write_read()" in out
     assert "refused on DeviceProxy: command_inout(), command_inout_asynch()" in out
     assert "refused on Connection: command_inout(), command_inout_asynch()" in out
     assert (
@@ -1530,7 +2056,7 @@ def test_doocs_set_out_of_bounds_raises_before_the_machine(monkeypatch):
 
 def test_caproto_sync_write_is_limits_checked(monkeypatch):
     writes: list = []
-    sync_client, _ = _install_fake_caproto(monkeypatch, writes)
+    sync_client, _, _ = _install_fake_caproto(monkeypatch, writes)
     _run_monkeypatch(monkeypatch)
 
     assert sync_client.write("TEST:MAG:SP", 5.0) == "written"
@@ -1544,7 +2070,7 @@ def test_caproto_sync_write_is_limits_checked(monkeypatch):
 
 def test_caproto_threading_pv_write_is_limits_checked(monkeypatch):
     writes: list = []
-    _, threading_client = _install_fake_caproto(monkeypatch, writes)
+    _, threading_client, _ = _install_fake_caproto(monkeypatch, writes)
     _run_monkeypatch(monkeypatch)
 
     pv = threading_client.PV("TEST:MAG:SP")
@@ -1556,6 +2082,186 @@ def test_caproto_threading_pv_write_is_limits_checked(monkeypatch):
         pv.write(99.0)
     assert writes == []
     assert pv.read() == 1.0, "reads must survive the guard untouched"
+
+
+def test_caproto_sync_read_write_read_refuses_an_out_of_range_value(monkeypatch):
+    """The write-and-read-back spelling is bounded like the plain write.
+
+    It drives the channel with the same value, so a value the plain write is
+    refused for must not reach the machine through this one either.
+    """
+    writes: list = []
+    sync_client, _, _ = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        sync_client.read_write_read("TEST:MAG:SP", 99.0)
+
+    assert exc.value.violation_type == "MAX_EXCEEDED"
+    assert writes == []
+
+
+def test_caproto_sync_read_write_read_passes_an_in_range_value_through(monkeypatch):
+    writes: list = []
+    sync_client, _, _ = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    assert sync_client.read_write_read("TEST:MAG:SP", 5.0) == "read-write-read"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+    # caproto names the pair, so the keyword call has to be checked too.
+    assert sync_client.read_write_read(pv_name="TEST:MAG:SP", data=6.0) == "read-write-read"
+    assert writes == [("TEST:MAG:SP", 5.0), ("TEST:MAG:SP", 6.0)]
+
+
+def test_caproto_batch_write_refuses_an_out_of_range_value(monkeypatch):
+    """A batched write is bounded under the limits of the PV it carries."""
+    writes: list = []
+    _, threading_client, _ = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    pv = threading_client.PV("TEST:MAG:SP")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        threading_client.Batch().write(pv, 99.0)
+
+    assert exc.value.violation_type == "MAX_EXCEEDED"
+    assert writes == []
+
+
+def test_caproto_batch_write_passes_an_in_range_value_through(monkeypatch):
+    writes: list = []
+    _, threading_client, _ = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    pv = threading_client.PV("TEST:MAG:SP")
+    assert threading_client.Batch().write(pv, 5.0) == "batched"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+    # caproto names the pair, so the keyword call has to be checked too.
+    assert threading_client.Batch().write(pv=pv, data=6.0) == "batched"
+    assert writes == [("TEST:MAG:SP", 5.0), ("TEST:MAG:SP", 6.0)]
+
+
+def test_caproto_asyncio_pv_write_refuses_an_out_of_range_value(monkeypatch):
+    """The asyncio client is a third module the other two guards never reach."""
+    writes: list = []
+    _, _, asyncio_client = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    pv = asyncio_client.PV("TEST:MAG:SP")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        asyncio.run(pv.write(99.0))
+
+    assert exc.value.violation_type == "MAX_EXCEEDED"
+    assert writes == []
+
+
+def test_caproto_asyncio_pv_write_passes_an_in_range_value_through(monkeypatch):
+    writes: list = []
+    _, _, asyncio_client = _install_fake_caproto(monkeypatch, writes)
+    _run_monkeypatch(monkeypatch)
+
+    pv = asyncio_client.PV("TEST:MAG:SP")
+    assert asyncio.run(pv.write(5.0)) == "written"
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+
+def test_caproto_asyncio_pv_write_reads_only_for_a_max_step_channel(monkeypatch):
+    """The pre-read is bought by max_step alone, and awaited over the PV itself.
+
+    The guard is a coroutine, so it awaits caproto's own read and hands the
+    validator a plain value. A channel without a max_step never pays for that
+    round trip.
+    """
+    writes: list = []
+    reads: list = []
+    _, _, asyncio_client = _install_fake_caproto(monkeypatch, writes, reads)
+    _run_monkeypatch(monkeypatch)
+
+    assert asyncio.run(asyncio_client.PV("TEST:MAG:SP").write(5.0)) == "written"
+    assert reads == []
+
+    step_pv = asyncio_client.PV("TEST:MAG:STEP")
+    with pytest.raises(ChannelLimitsViolationError) as exc:
+        asyncio.run(step_pv.write(50.0))
+
+    assert exc.value.violation_type == "MAX_STEP_EXCEEDED"
+    assert reads == ["TEST:MAG:STEP"]
+    assert writes == [("TEST:MAG:SP", 5.0)]
+
+    # The fake reads back 1.0, so this is a step of 1.0 against a max of 2.0.
+    assert asyncio.run(step_pv.write(2.0)) == "written"
+    assert reads == ["TEST:MAG:STEP", "TEST:MAG:STEP"]
+    assert writes == [("TEST:MAG:SP", 5.0), ("TEST:MAG:STEP", 2.0)]
+
+
+def test_caproto_pre_reads_carry_the_step_read_ceiling(monkeypatch):
+    """Every max_step pre-read bounds itself, on all four write surfaces.
+
+    caproto lets a client be built with no timeout of its own, and a pre-read
+    inheriting that would hold an operator's write open on a channel that
+    never answers. The ceiling is the guard's, not the client's.
+    """
+    writes: list = []
+    reads: list = []
+    read_kwargs: list = []
+    sync_client, threading_client, asyncio_client = _install_fake_caproto(
+        monkeypatch, writes, reads, read_kwargs
+    )
+    _run_monkeypatch(monkeypatch)
+
+    # The fake reads back 1.0, so each of these is a step of 1.0 against a
+    # max of 2.0 — in range, so the write goes through and the read is real.
+    pv = threading_client.PV("TEST:MAG:STEP")
+    sync_client.write("TEST:MAG:STEP", 2.0)
+    pv.write(2.0)
+    threading_client.Batch().write(pv, 2.0)
+    asyncio.run(asyncio_client.PV("TEST:MAG:STEP").write(2.0))
+
+    assert reads == ["TEST:MAG:STEP"] * 4
+    assert read_kwargs == [{"timeout": STEP_READ_TIMEOUT_SECONDS}] * 4
+    assert writes == [("TEST:MAG:STEP", 2.0)] * 4
+
+
+def test_caproto_report_lines_name_every_wrapped_spelling(monkeypatch):
+    """The success lines are the operator's only evidence the guard is on."""
+    _install_fake_caproto(monkeypatch)
+    out = _run_monkeypatch(monkeypatch)
+
+    success = [line for line in out.splitlines() if line.startswith("✅ Monkeypatched caproto")]
+    assert success == [
+        "✅ Monkeypatched caproto.sync.client: write(), read_write_read()",
+        "✅ Monkeypatched caproto.threading.client: PV.write(), Batch.write()",
+        "✅ Monkeypatched caproto.asyncio.client PV.write()",
+    ]
+
+
+def test_caproto_asyncio_absence_leaves_the_other_flavors_guarded(monkeypatch):
+    """One flavor missing must not take the guards for the other two with it.
+
+    Each flavor is imported and patched in its own try/except; collapsed into
+    one, an environment without the asyncio client would lose the sync and
+    threading guards and say nothing about it.
+    """
+    writes: list = []
+    sync_client, threading_client, _ = _install_fake_caproto(monkeypatch, writes)
+    monkeypatch.setitem(sys.modules, "caproto.asyncio.client", None)
+
+    out = _run_monkeypatch(monkeypatch)
+
+    assert "ℹ️  caproto.asyncio.client not available" in out
+    success = [line for line in out.splitlines() if line.startswith("✅ Monkeypatched caproto")]
+    assert success == [
+        "✅ Monkeypatched caproto.sync.client: write(), read_write_read()",
+        "✅ Monkeypatched caproto.threading.client: PV.write(), Batch.write()",
+    ]
+
+    # The two remaining flavors are guarded, not merely reported.
+    with pytest.raises(ChannelLimitsViolationError):
+        sync_client.read_write_read("TEST:MAG:SP", 99.0)
+    with pytest.raises(ChannelLimitsViolationError):
+        threading_client.Batch().write(threading_client.PV("TEST:MAG:SP"), 99.0)
+    assert writes == []
 
 
 # ---------------------------------------------------------------------------
@@ -1578,6 +2284,8 @@ def test_absent_clients_do_not_stop_the_block(monkeypatch):
         "caproto.sync.client",
         "caproto.threading",
         "caproto.threading.client",
+        "caproto.asyncio",
+        "caproto.asyncio.client",
     ):
         monkeypatch.setitem(sys.modules, name, None)
     writes: list = []
@@ -1586,3 +2294,140 @@ def test_absent_clients_do_not_stop_the_block(monkeypatch):
     out = _run_monkeypatch(monkeypatch)
     assert "tango not available" in out
     assert "✅ Monkeypatched doocs4py.set()" in out
+
+
+# ---------------------------------------------------------------------------
+# The limits buckets, row by row
+# ---------------------------------------------------------------------------
+
+
+_WRAPPED_ROWS = sorted(_LIMITS_WRAPPED)
+_REFUSED_ROWS = sorted(_LIMITS_REFUSED)
+
+
+def _checked_through(dotted, attr, reason):
+    """The name a wrapped row's limits check is actually installed on.
+
+    A ``"direct"`` row is checked on its own name. A ``"via X"`` row is
+    checked on ``X``, written as one dotted name whose last segment is the
+    attribute: pyepics spells a write three ways and all three reach the
+    network through ``epics.ca.put``, so that one name is what the guard
+    rebinds and the only one an assertion can look at.
+    """
+    if reason.startswith("via "):
+        through = reason.split()[1]
+        assert "." in through, (
+            f"_LIMITS_WRAPPED[{dotted}.{attr}] says {reason!r}; the word after "
+            f'"via" has to be the dotted name the check is installed on, and '
+            f"{through!r} carries no attribute to look at"
+        )
+        owner, _, through_attr = through.rpartition(".")
+        return owner, through_attr
+    return dotted, attr
+
+
+#: How to call one refused row: a receiver of its own class, arguments the
+#: unrefused spelling accepts, and the words the refusal answers with. Keyed by
+#: class, because every refused attribute on a class refuses the same way.
+_REFUSAL_CALLS = {
+    "p4p.client.raw.Context": (lambda cls: cls(), ("TEST:MAG:SP", None), "cannot be approved"),
+    "p4p.client.thread.Context": (lambda cls: cls(), ("TEST:MAG:SP", None), "cannot be approved"),
+    "p4p.client.asyncio.Context": (lambda cls: cls(), ("TEST:MAG:SP", None), "cannot be approved"),
+    "p4p.client.cothread.Context": (
+        lambda cls: cls(),
+        ("TEST:MAG:SP", None),
+        "cannot be approved",
+    ),
+    "pvaccess.Channel": (
+        lambda cls: cls("TEST:MAG:SP"),
+        (['{"value": 1.0}'],),
+        "cannot be limits-checked",
+    ),
+    "tango.DeviceProxy": (
+        lambda cls: cls("sys/tg_test/1"),
+        ("On",),
+        "refused in a limits-checked run",
+    ),
+    "tango.Connection": (lambda cls: cls(), ("On",), "refused in a limits-checked run"),
+    "tango.Group": (
+        lambda cls: cls("all"),
+        ("current", 1.0),
+        "refused in a limits-checked run",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("dotted", "attr"),
+    _WRAPPED_ROWS,
+    ids=[f"{dotted}.{attr}" for dotted, attr in _WRAPPED_ROWS],
+)
+def test_every_wrapped_row_is_rebound_by_the_block(monkeypatch, dotted, attr):
+    """Every wrapped row names a Python name the block really re-points.
+
+    A limits check reaches a write only by replacing the object the client
+    library holds. The behaviour tests above prove a guard is somewhere on the
+    path for the spellings they drive; this one proves the rebinding itself,
+    mechanically and for the whole bucket, so a row added to the table with no
+    matching install cannot claim a check it never gets.
+    """
+    reason = _LIMITS_WRAPPED[(dotted, attr)]
+    assert reason.startswith(("direct", "via ")), (
+        f"_LIMITS_WRAPPED[{dotted}.{attr}] says {reason!r}; a row says either "
+        '"direct" or "via <dotted.attribute>", which is what names the object '
+        "this assertion watches"
+    )
+    owner_dotted, owner_attr = _checked_through(dotted, attr, reason)
+
+    _install_client_fakes(monkeypatch)
+    owner = _resolve_target(owner_dotted)
+    assert owner is not None, (
+        f"{owner_dotted} has no stand-in in this suite, so {dotted}.{attr} "
+        "would be asserted against nothing"
+    )
+    assert hasattr(owner, owner_attr), (
+        f"the {owner_dotted} stand-in carries no {owner_attr}, so there is "
+        "nothing here for the block to rebind"
+    )
+    before = getattr(owner, owner_attr)
+
+    _run_monkeypatch(monkeypatch)
+
+    assert getattr(owner, owner_attr) is not before, (
+        f"{dotted}.{attr} is in _LIMITS_WRAPPED, but the block left "
+        f"{owner_dotted}.{owner_attr} pointing at the client's own function"
+    )
+
+
+@pytest.mark.parametrize(
+    ("dotted", "attr"),
+    _REFUSED_ROWS,
+    ids=[f"{dotted}.{attr}" for dotted, attr in _REFUSED_ROWS],
+)
+def test_every_refused_row_refuses_its_call(monkeypatch, dotted, attr):
+    """Every refused row raises instead of reaching the client underneath it.
+
+    The same call is made once before the block runs. A stand-in that raised
+    on its own — a signature the arguments do not fit — would otherwise look
+    exactly like a refusal.
+    """
+    assert dotted in _REFUSAL_CALLS, (
+        f"{dotted} is in _LIMITS_REFUSED but _REFUSAL_CALLS has no entry for "
+        "it: add a receiver factory for the class, the arguments its "
+        "unrefused spelling accepts, and the words its refusal answers with"
+    )
+    receiver_of, args, refusal = _REFUSAL_CALLS[dotted]
+
+    _install_client_fakes(monkeypatch)
+    cls = _resolve_target(dotted)
+    assert cls is not None, f"{dotted} has no stand-in in this suite"
+    getattr(receiver_of(cls), attr)(*args)
+
+    _run_monkeypatch(monkeypatch)
+
+    with pytest.raises((RuntimeError, ValueError)) as refused:
+        getattr(receiver_of(cls), attr)(*args)
+    assert refusal in str(refused.value), (
+        f"{dotted}.{attr} raised {refused.value!r}, which does not read as "
+        "the refusal its bucket entry promises"
+    )

--- a/tests/services/python_executor/execution/test_limits_parity.py
+++ b/tests/services/python_executor/execution/test_limits_parity.py
@@ -2,10 +2,9 @@
 
 A readonly run refuses every entry point in ``_CLIENT_WRITE_TARGETS``. A
 readwrite run does something *different* with each one — checks the value
-against the channel limits, refuses it outright, cannot reach it at all, or
-lets it through unchecked because nobody has wrapped it yet. Those four answers
-are written down as :data:`_LIMITS_WRAPPED`, :data:`_LIMITS_REFUSED`,
-:data:`_LIMITS_UNWRAPPABLE` and :data:`_LIMITS_NOT_YET_WRAPPED`.
+against the channel limits, refuses it outright, or cannot reach it at all.
+Those three answers are written down as :data:`_LIMITS_WRAPPED`,
+:data:`_LIMITS_REFUSED` and :data:`_LIMITS_UNWRAPPABLE`.
 
 Written down, they can go stale: a row added to the table with no bucket would
 quietly claim a limits check it never gets, and a bucket entry left behind by a
@@ -22,7 +21,6 @@ import pytest
 
 from osprey.services.python_executor.write_surface import (
     _CLIENT_WRITE_TARGETS,
-    _LIMITS_NOT_YET_WRAPPED,
     _LIMITS_REFUSED,
     _LIMITS_UNWRAPPABLE,
     _LIMITS_WRAPPED,
@@ -36,7 +34,6 @@ _BUCKETS = {
     "_LIMITS_WRAPPED": _LIMITS_WRAPPED,
     "_LIMITS_REFUSED": _LIMITS_REFUSED,
     "_LIMITS_UNWRAPPABLE": _LIMITS_UNWRAPPABLE,
-    "_LIMITS_NOT_YET_WRAPPED": _LIMITS_NOT_YET_WRAPPED,
 }
 
 _ALIAS_PACKAGE = "PyTango"
@@ -66,8 +63,8 @@ def test_every_client_row_is_in_exactly_one_bucket():
         holders = [name for name, bucket in _BUCKETS.items() if row in bucket]
         assert holders, (
             f"{dotted}.{attr} is in the write surface but in no limits bucket — "
-            "say whether a limits-checked run wraps, refuses, cannot reach or "
-            "does not yet check it"
+            "say whether a limits-checked run wraps it, refuses it, or cannot "
+            "reach it at all"
         )
         assert len(holders) == 1, (
             f"{dotted}.{attr} is in more than one limits bucket: {', '.join(holders)}"
@@ -82,37 +79,6 @@ def test_no_bucket_names_a_row_outside_the_table():
             assert (dotted, attr) in table, (
                 f"{name} names {dotted}.{attr}, which is not in _CLIENT_WRITE_TARGETS"
             )
-
-
-def test_not_yet_wrapped_bucket_holds_ten_rows():
-    """The unchecked remainder is a fixed, countable list, not an open set.
-
-    Ten entry points reach hardware in a readwrite run without passing the
-    limits database. Wrapping one moves it out of here; a new client row
-    landing here instead of in a wrapper is a decision, and this count makes it
-    one somebody has to make on purpose.
-    """
-    assert len(_LIMITS_NOT_YET_WRAPPED) == 10, (
-        "the not-yet-wrapped bucket changed size: "
-        + ", ".join(f"{dotted}.{attr}" for dotted, attr in _LIMITS_NOT_YET_WRAPPED)
-    )
-
-
-def test_not_yet_wrapped_rows_name_the_follow_up():
-    """Every unchecked row is pinned to the one tracker item that closes them.
-
-    The literal is the point: the bucket is deliberately tracked as a single
-    piece of work, so a row that belongs to a different follow-up does not
-    belong here. Splitting the tracking is a decision somebody makes on
-    purpose --- either the row moves to a bucket that fits it, or this pin is
-    widened knowingly --- the same argument the ten-row count makes for itself.
-    """
-    for (dotted, attr), reason in _LIMITS_NOT_YET_WRAPPED.items():
-        assert reason == "followups-897 item 16", (
-            f"{dotted}.{attr} names {reason!r}, but this bucket is pinned to "
-            "the single tracker item 'followups-897 item 16'; move the row to "
-            "a bucket that fits it, or widen the pin here on purpose"
-        )
 
 
 def test_every_bucket_entry_carries_a_reason():

--- a/tests/services/python_executor/execution/test_sandbox_step_reader.py
+++ b/tests/services/python_executor/execution/test_sandbox_step_reader.py
@@ -503,7 +503,7 @@ def _install_fake_caproto(monkeypatch, reads, writes):
         def __init__(self, name):
             self.name = name
 
-        def read(self):
+        def read(self, **kwargs):
             reads.append(self.name)
             return _CaprotoResponse(CURRENT)
 

--- a/tests/templates/test_memory_guard_widening.py
+++ b/tests/templates/test_memory_guard_widening.py
@@ -14,9 +14,12 @@ introduced:
   copied verbatim into the ``PreToolUse`` matcher
   (``osprey.cli.templates.claude_code`` builds the rule from it), so the
   frontmatter *is* the matcher;
-* the ``NotebookEdit`` scope agrees with the ``NotebookEdit(<agent_data_root>/
-  <subdir>/**)`` allow rules ``settings.json.j2`` renders — two independent
-  spellings of one policy, which is exactly the pair that silently forks;
+* the ``NotebookEdit`` scope agrees with the ``Edit(<agent_data_root>/<subdir>/**)``
+  allow rules ``settings.json.j2`` renders — two independent spellings of one
+  policy, which is exactly the pair that silently forks. The rule is spelled
+  ``Edit(...)`` because Claude Code checks every file-editing tool, ``NotebookEdit``
+  included, against ``Edit(path)`` rules only; a ``NotebookEdit(path)`` rule is
+  never consulted and is reported as a misconfiguration at every agent start;
 * each tool is actually gated end to end, by running the hook the way Claude
   Code runs it.
 
@@ -58,13 +61,18 @@ NOTEBOOK_SUBDIRS = frozenset({ARTIFACTS_SUBDIR, NOTEBOOKS_SUBDIR})
 
 #: Both spellings of the allow rule, as they appear in the two files. The
 #: template renders one Jinja append per subdirectory; the hook declares the
-#: same set as a tuple.
-_TEMPLATE_ALLOW_RE = re.compile(r"""NotebookEdit\(' ~ agent_data_root ~ '/([^/]+)/\*\*\)""")
+#: same set as a tuple. The leading quote anchors the tool name so that a
+#: ``NotebookEdit(`` rule cannot pass as an ``Edit(`` one.
+_TEMPLATE_ALLOW_RE = re.compile(r""""Edit\(' ~ agent_data_root ~ '/([^/]+)/\*\*\)""")
+#: The rule form Claude Code does not consult for file-editing tools, as the
+#: template would render it (quote-anchored, so a comment naming the form is
+#: not a rendered rule).
+_TEMPLATE_NOTEBOOKEDIT_RULE_RE = re.compile(r'"NotebookEdit\(')
 _HOOK_SUBDIRS_RE = re.compile(r"_NOTEBOOK_SUBDIRS = \(([^)]*)\)")
 
 
 def _template_notebook_subdirs() -> set[str]:
-    """Every agent-data subdirectory the rendered ``NotebookEdit`` allows name."""
+    """Every agent-data subdirectory the rendered ``Edit(...)`` allows name."""
     return set(_TEMPLATE_ALLOW_RE.findall(SETTINGS_TEMPLATE.read_text(encoding="utf-8")))
 
 
@@ -206,13 +214,24 @@ def test_guard_stays_the_outermost_pretooluse_gate():
 
 @pytest.mark.unit
 def test_settings_template_scopes_notebookedit_to_the_agent_data_subdirs():
-    """``settings.json.j2`` grants ``NotebookEdit`` under those two trees and no other.
+    """``settings.json.j2`` grants file edits under those two trees and no other.
 
     The hook denies outside the same directories. If an allow rule is ever
     respelled or a third tree added, the hook's scope has to move with it or the
     two halves of one policy disagree.
     """
     assert _template_notebook_subdirs() == NOTEBOOK_SUBDIRS
+
+
+@pytest.mark.unit
+def test_settings_template_renders_no_notebookedit_path_rules():
+    """The allow rules are spelled ``Edit(path)``, never ``NotebookEdit(path)``.
+
+    Claude Code matches every file-editing tool against ``Edit(path)`` rules
+    only. A ``NotebookEdit(path)`` rule grants nothing and is reported as a
+    misconfiguration at every agent start.
+    """
+    assert not _TEMPLATE_NOTEBOOKEDIT_RULE_RE.search(SETTINGS_TEMPLATE.read_text(encoding="utf-8"))
 
 
 @pytest.mark.unit

--- a/tests/utils/test_dotenv.py
+++ b/tests/utils/test_dotenv.py
@@ -15,12 +15,15 @@ one exception, ``BUILD_DERIVED_KEYS``, which the build owns outright.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from osprey.utils.dotenv import (
     BUILD_DERIVED_KEYS,
     VA_LATTICE_DEFAULT,
     _dotenv_raw_lines,
+    env_lock_path,
     merge_env_preserving_existing,
     parse_dotenv_file,
     resolved_va_lattice,
@@ -329,3 +332,25 @@ class TestResolvedVaLattice:
         build.mkdir(parents=True)
         (repo / ".env").write_text("VA_LATTICE=none\n")
         assert resolved_va_lattice(repo, build) == "none"
+
+
+class TestEnvLockPath:
+    """``env_lock_path`` — the one derivation of a ``.env``'s sibling lock name."""
+
+    def test_the_lock_is_the_env_s_name_plus_lock(self):
+        """The single spelling every call site now shares."""
+        assert env_lock_path(Path("a/.env")) == Path("a/.env.lock")
+
+    def test_a_symlinked_path_is_not_resolved(self, tmp_path):
+        """Callers pass this a path they already chose to resolve, or not.
+
+        ``env_file_lock`` resolves first and locks the real inode; the
+        name-shaped callers list files inside a directory they hold by name and
+        would be handed a path outside it if this resolved on their behalf.
+        """
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+
+        assert env_lock_path(link / ".env") == link / ".env.lock"


### PR DESCRIPTION

Train #897 left twenty rescued follow-ups. Two closed with the train itself; thirteen are
settled here — five test flakes, seven write-path and diagnostics residues, and one
permission-surface decision — plus three retro-review findings (items 14–16). Every flake
was reproduced before it was touched, no assertion was weakened, and nothing was rerun or
deselected.

Twenty-five commits, bottom-up — independent fixes first, the branch-wide deflakes, then three folded-in hotfixes:

- `fix(control-system): import the limits validator instead of picking one at run time`
- `refactor(connectors): derive the .env lock path in one place`
- `fix(connectors): offload the DOOCS and Tango limits read with the write`
- `test(profiles): delete the skipped providers-catalog test`
- `test(mcp): list tools through the public API`
- `fix(web-terminal): open the scaffold editor with a single fetch`
- `feat(hooks): record why each control-context run ended`
- `test(e2e): read hook attachments through one transcript reader`
- `feat(workspace): auto-allow six lattice and artifact tools, ask before the three rail tools`
- `fix(ariel): apply the ingestion transport settings on every logbook adapter`
- `fix(hooks): keep the config-drift check answering on extra write tools`
- `test(cli): name what a source-zone run left behind`
- `fix(python-executor): bound the remaining Tango and caproto client writes`
- `test(interfaces): bound every notebook-proxy receive and re-root its records`
- `test(interfaces): re-apply the stimulus until the FSEvents observer delivers`
- `test: keep the shared data root out of the checkout`
- `fix(facility-knowledge): let a server clear the bundle it resolved at startup`
- `test(interfaces): wait for the browser shell to settle before driving it`
- `test(auth-sidecar): hold the audit clock still across a folded flood`
- `test(cli): state the SIGINT disposition the interrupt capture relies on`
- `test(integration): read the MCP handshake budget from the server's own phases`
- `test(integration): give the graph suite a query budget of its own`
- `fix(templates): spell the agent-data notebook allow rules as Edit(path)`
- `fix(models): move the CBORG tier map to the current Claude ids`
- `fix(web): show an idle view flip as a restart, not a wait`

The last three were parked on `fix/post-b1-hotfixes-2`: pushed, but never given a PR. They are folded in here so they land rather than sit. That branch and its remote ref can be deleted once this merges.

## Flakes

Each line gives the shape it was run at, the run count, what was observed, and the fate of
the entry. A flake that does not reproduce **stays open by ruling, not by omission** — green
runs cannot clear a failure that was seen once.

- **1a jupyter proxy receive budget** — `test(interfaces): bound every notebook-proxy receive and re-root its records`. Starlette's test websocket receive waits with no timeout, so a kernel that goes quiet hangs the module until the outer mark kills it with nothing to show. Every receive now goes through a helper with three explicit budgets — 120 s for the first frame off a fresh socket, 30 s for every later frame, 150 s for a whole read loop, each clamped to what is left of the loop — and a close frame still surfaces as a disconnect rather than a missing key. Three helper unit tests cover the bounded path, and the module fixture redirects its own audit and data roots so the module stops filing records into the checkout. **Closed.**
- **1b jupyter proxy socket hang** — `pytest tests/interfaces tests/cli -n auto --dist loadgroup --timeout-method=signal`, 18-core macOS/arm64, two independent 10-run campaigns. All 26 tests of the proxy module passed in all twenty runs; the module spans 6.39–14.94 s and its first frame arrives in 1.26–3.76 s against a 120 s first-frame budget. The stack sampler catches at most one frame per run inside the module, and the frames it caught sit in fixture setup or teardown, never in the handshake or a read loop — but the negative rests on 26/26 and the first-frame timings, not on the empty read-loop stacks. No stall mechanism to fix, so nothing under `src/` changed and item 1a's bounded-receive helpers stand as the improvement. **Stays open.**
- **2 a layout save must not reach the file panel** — `pytest tests/interfaces -m "not browser" -n auto --dist loadgroup --timeout=300`, reproduced 10/10, in the missed-delivery direction only: the three assertions that catch a frame arriving when none may are untouched and never fired. The mechanism is watchdog FSEvents observer **arming** — an emitter sampled inside `add_watch` — not a deadline that was merely too short, and no ceiling recovers a change the stream never saw. Fixed on the wait side: the helper re-applies the test's own stimulus once a second until the frame it requires arrives, then drains on a quiet floor with a ceiling. Thirteen full-shape runs and five module runs, every one exit 0. **Closed.**
- **3 ruamel count** — verified fixed by 29ed43cb0, no change. Both file orders, 5× each on one worker (`-n 0 -p no:randomly`): 25 passed in all ten runs. **Closed.**
- **4 source-zone leftover** — not reproduced in 3 runs of `pytest tests/cli tests/infrastructure -n auto --dist loadgroup -p no:randomly`, plus 4 single-worker pair runs in both file orders against the two modules that exercise the unguarded launcher global. No leftover path was ever observed, so `_cleanup` is untouched; the three leftover-listing assertions now name what was left behind if it ever happens. **Stays open.**
- **5 worker abort (`Fatal Python error: Aborted`)** — not reproduced over the ruled scope `tests/connectors tests/va tests/services/python_executor tests/health` in either shape. CI shape (`-n 4 --dist loadgroup -m "not pty" --timeout=600 --timeout-method=signal` with `ci.yml`'s ignore list), 3 runs: 4054 passed / 142 skipped, exit 0 each. Local shape (`-n auto`, no ignore list), 3 runs: 4063 passed / 186 skipped, exit 0 each. Zero `Fatal Python error`, `INTERNALERROR`, `node down` or replaced worker in any of the six logs; the PVA path ran green rather than skipping. No worker cap is added. The untried shape is the whole-suite `-n auto` gate at `scripts/ci_check.sh:90`, where the p4p tests share a long-lived worker with ~16k others. **Stays open.**

## Polish, gating and retro-review

- **6 connectors off-loop** — `fix(connectors): offload the DOOCS and Tango limits read with the write`
- **7 limits shim** — `fix(control-system): import the limits validator instead of picking one at run time`
- **8 dotenv** — `refactor(connectors): derive the .env lock path in one place`
- **9 listing** — `test(mcp): list tools through the public API`
- **10 providers catalog** — `test(profiles): delete the skipped providers-catalog test`
- **11 scaffold** — `fix(web-terminal): open the scaffold editor with a single fetch`
- **12 hook diagnostics** — `feat(hooks): record why each control-context run ended` and `test(e2e): read hook attachments through one transcript reader`
- **13 gating** — `feat(workspace): auto-allow six lattice and artifact tools, ask before the three rail tools`. The same commit carries the explicit-config allowance lists and the lifecycle exemplar rows its preset change required; without them the preset-drift lint refused and `validate` printed its usage banner.
- **14 ingestion transport parity** — `fix(ariel): apply the ingestion transport settings on every logbook adapter`
- **15 config-drift extras** — `fix(hooks): keep the config-drift check answering on extra write tools`
- **16 limits parity remainder** — `fix(python-executor): bound the remaining Tango and caproto client writes`. Seven Tango spellings (`write_attribute_asynch`, `write_attributes_asynch`, `write_read_attribute`, `write_read_attributes` and `AttributeProxy.write`, `write_asynch`, `write_read`) and three caproto ones (`sync.client.read_write_read`, `threading.client.Batch.write`, `asyncio.client.PV.write`) are limits-checked in a `readwrite` run; `_LIMITS_NOT_YET_WRAPPED` is gone with them, so the partition is three buckets and no row can claim a bound the generated block does not install — a parametrized assertion over every `_LIMITS_WRAPPED` row proves the rebinding, and commenting one wrapper out fails that row alone. A Tango attribute handed over as an `AttributeInfo` or `DeviceAttribute` is checked under the channel its name addresses, and the `max_step` pre-read carries an explicit timeout on every caproto client. Tango `command_inout` stays refused: a command is an action, not a value to bound.

Found and fixed in passing, under the deflake-what-you-find rule:

- **facility-knowledge test order** — `fix(facility-knowledge): let a server clear the bundle it resolved at startup`; the startup outcome no longer stands for every test after it.
- **shared data root leak** — `test: keep the shared data root out of the checkout`. The creator is the auto-launch daemon thread of the server launcher, which starts the artifacts gallery, whose store watcher creates the directory under `var/`. The redirect is installed once for the process; the guard now names the first test seen with the directory present.
- **FSEvents arming** — `test(interfaces): re-apply the stimulus until the FSEvents observer delivers`, the item 2 mechanism above, shared by the bar-items, file-watcher and store-watcher modules. The store-watcher's two `flaky` markers are removed; the other two modules never carried one.

## Gate deflakes

Driving the full local gate green surfaced six more load-only failures. Each was
reproduced under load before it was touched, none was rerun away, and no assertion was
weakened.

- **the browser shell was driven before it stopped moving** — `test(interfaces): wait for
  the browser shell to settle before driving it`. The dock re-parents the terminal card
  twice on the way to its tile (adoption out of the source pool, then the boot layout
  applied over the default), while the chat console mounts independently of both. Playwright
  checks actionability and *then* writes, so a re-parent landing between those two steps
  takes focus off the element and the text is never inserted — the box reads empty, `submit`
  finds no prompt and returns, and the turn never starts. Instrumented rather than guessed:
  the failing run recorded the fill leaving an empty value and the Enter that followed
  reaching the right node with the app's handler running and nothing to send. `dock-workspace`
  now reports whether the boot layout has settled — the latch it already keeps for its own
  occupancy reporter — and the openers wait for that plus a frame in which the console does
  not move, because the announcement lands in the same frame as the last re-parent. Verified
  96/96 probe iterations and three full runs of the suite at load ~38, where the unfixed
  openers reproduced.
- **an audit fold measured against the host** — `test(auth-sidecar): hold the audit clock
  still across a folded flood`. The fold bound is a duration, not a count, so a loop that
  crossed the one-second window filed a second record. Both flood tests freeze the clock
  through the seam the module already uses; the assertions are untouched.
- **a graph suite holding a product timeout** — `test(integration): give the graph suite a
  query budget of its own`. Queries costing 0.25–1.34 s idle exceeded a 15 s budget under
  load. That 15 s sizes a query against the turn an agent has to act within — a deployed
  store on a machine of its own, not a container sharing a host with the suite. The fixture
  states its own budget; the case that covers the timeout path keeps its low one.
- **a handshake budget spent before the handshake** — `test(integration): read the MCP
  handshake budget from the server's own phases`. The budget started at spawn, so
  interpreter start and a long import were charged against it.
- **an interrupt capture inheriting its premise** — `test(cli): state the SIGINT disposition
  the interrupt capture relies on`. The capture rests on SIGINT being Python's own; a
  handler that merely records the signal absorbs it and the capture runs to completion with
  nothing to show.
- **an interrupt racing the child it interrupts** — `test(cli): wait for the child's output
  before interrupting the capture`. Making the SIGINT land reliably exposed the race it had
  been masking: the test armed the interrupt on a fixed 0.4 s timer, but its assertion needs
  the child to have written first, and the child completes two `fork`/`exec` pairs before
  `cat` writes a byte — tens of milliseconds idle, measured out to 334 ms across 300 samples
  under a fork-pressure model milder than the suite itself. An overrun leaves the spool empty
  and the assertion reads `'the-child-said-this' in ''`. The timer now polls for the spool
  having content and re-arms until it does, bounded so a child that never writes is
  interrupted anyway and the test fails on its own assertion rather than hanging.


## Follow-ups left open

- **Items 1b, 4 and 5** — none reproduced; each carries its run record and the shape to try next.
- Sibling web-terminal modules whose app fixture is module- or suite-scoped have the same fixture-ordering hole; a function-scoped audit-zone fixture cannot cover them.
- The repo-cleanliness guard keys on one shared path, so a concurrent foreign run in the same tree trips an innocent run's guard.
- `docs/source/how-to/web-terminal/panels.rst` still carries no enumerated panel-tool list; `docs/source/architecture/mcp-servers.rst` holds the only one.
- Eleven browser suites still seed the bare tour-dismissal key themselves, which the shared seam now both writes and answers; retire the copies in a sweep.
- `scripts/ci_check.sh` pipes `uvx twine check` into `grep -q PASSED`, so a `uvx` fetch failure reads as a twine failure with every diagnostic swallowed, and `dist/` is not cleared before the build, so twine can check stale artifacts.
- An Expert page writes the session pointer twice during boot, so on a slow tab the console and the terminal briefly disagree about which session the tab is on.
