### PR TITLE
refactor(registry): derive hand-kept enumerations from their producers and pin the deliberate mirrors

### DIFF
--- a/changelog.d/agent-model-table.changed.md
+++ b/changelog.d/agent-model-table.changed.md
@@ -1,0 +1,4 @@
+`osprey status --agents` now lists every agent the deployment can run, including
+`facility-knowledge` and `facility-knowledge-graph`, which were missing from the
+table. Both also gain an explicit default model tier instead of falling through
+to `sonnet` unstated.

--- a/changelog.d/approval-tools-panel.changed.md
+++ b/changelog.d/approval-tools-panel.changed.md
@@ -1,0 +1,3 @@
+The settings panel now offers a policy dropdown for every `approval.tools` key a
+deployment can set. Four of them — `entry_publish`, `add_panel_to_rail`,
+`remove_panel_from_rail` and `register_panel` — rendered as free-text boxes.

--- a/changelog.d/approval-tools-parity.internal.md
+++ b/changelog.d/approval-tools-parity.internal.md
@@ -1,0 +1,3 @@
+The shipped `approval.tools` rows are pinned against the tools each preset's
+resolved servers actually gate, and the approval hook drops a `tools:`
+frontmatter line nothing read.

--- a/changelog.d/ariel-module-reporting.changed.md
+++ b/changelog.d/ariel-module-reporting.changed.md
@@ -1,0 +1,5 @@
+`osprey ariel status` now reports every registered enhancement and search
+module, including `qmd_export` and any a deployment registered itself, instead of
+a fixed list of five. The per-module enhancement counts behind it are aggregated
+by module key rather than by name, so a module the framework does not ship is
+counted too.

--- a/changelog.d/ariel-registry-choices.changed.md
+++ b/changelog.d/ariel-registry-choices.changed.md
@@ -1,0 +1,8 @@
+`osprey ariel`'s `--adapter`, `--module` and `--mode` options now accept every
+name the registry carries, so an ingestion adapter, enhancement module or search
+module a deployment registered itself can be named on the command line. `osprey
+ariel ingest` no longer defaults `--adapter` to `generic_json`: with no flag it
+uses the `ariel.ingestion.adapter` from `config.yml`, the same rule `watch`
+follows. A project whose config names an adapter and previously relied on the
+`generic_json` default now ingests with the configured adapter; with neither, the
+run stops and says `ariel.ingestion.adapter` is required.

--- a/changelog.d/auth-method-set.internal.md
+++ b/changelog.d/auth-method-set.internal.md
@@ -1,0 +1,2 @@
+The auth sidecar's set of servable login methods has one definition instead of
+three, shared by the settings parser, the recheck route and the audit seam.

--- a/changelog.d/binary-artifact-type.fixed.md
+++ b/changelog.d/binary-artifact-type.fixed.md
@@ -1,0 +1,3 @@
+An artifact saved from raw bytes now shows a "Binary" badge in the gallery. Its
+`binary` type was missing from the type registry, so the badge rendered with the
+raw key and no colour.

--- a/changelog.d/bluesky-relay-routes.internal.md
+++ b/changelog.d/bluesky-relay-routes.internal.md
@@ -1,0 +1,2 @@
+The bluesky-web relay module docstrings list the three routes they serve but did
+not name.

--- a/changelog.d/builtin-panels-render-guard.fixed.md
+++ b/changelog.d/builtin-panels-render-guard.fixed.md
@@ -1,0 +1,3 @@
+A `config.yml` render that reaches the web-workspace block without the panel
+registry now stops and says so, instead of writing `panels: {}` and silently
+dropping every tab the profile selected.

--- a/changelog.d/preset-connector-prose.changed.md
+++ b/changelog.d/preset-connector-prose.changed.md
@@ -1,0 +1,5 @@
+The `control-assistant` preset's comments now name every shipped connector and
+archiver type, including `doocs`, `tango` and `doocs_archiver`, and `hello-world`
+points at `osprey config --defaults` for the ones it does not list — which now
+names them too, beside `control_system.type` and `archiver.type`. A test keeps
+both in step with the types the framework actually ships.

--- a/changelog.d/queue-manager-states.internal.md
+++ b/changelog.d/queue-manager-states.internal.md
@@ -1,0 +1,3 @@
+The halt path's set of "queue is draining" manager states is pinned to the
+bridge's own, along with the two browser copies, so a state added on one side
+cannot leave a moving lane un-haltable on another.

--- a/changelog.d/safety-notice-superset.fixed.md
+++ b/changelog.d/safety-notice-superset.fixed.md
@@ -1,0 +1,4 @@
+The safety notice a deployment gets when it lists no notices of its own now
+carries the same advice as the copy `osprey init` writes into a facility
+profile. Two sections had been added to the scaffolded copy only, so the
+deployment that made no choice read the shorter warning.

--- a/changelog.d/shared-constants-imported.internal.md
+++ b/changelog.d/shared-constants-imported.internal.md
@@ -1,0 +1,2 @@
+The ARIEL entry tools and the archiver recorder import the source-system and
+connector-type constants they had restated as string literals.

--- a/changelog.d/workspace-tool-classification.internal.md
+++ b/changelog.d/workspace-tool-classification.internal.md
@@ -1,0 +1,2 @@
+The `osprey_workspace` server's permission lists are pinned against the tools
+the package registers, so a new or renamed tool cannot silently lose its rule.

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -51,7 +51,7 @@ Adapters are discovered through Osprey's central registry. The built-in ones bel
 
 **Using a custom adapter:**
 
-An adapter written and registered as described in :doc:`/contributing/extending-osprey` is selected the same way as a built-in one: set ``ariel.ingestion.adapter`` to its registered name in ``config.yml``.
+An adapter written and registered as described in :doc:`/contributing/extending-osprey` is selected the same way as a built-in one: set ``ariel.ingestion.adapter`` to its registered name in ``config.yml``, or pass it as ``--adapter`` --- both accept every registered name, the framework's and your own.
 
 .. admonition:: Collaboration Welcome
    :class: outreach

--- a/scripts/check_config_keys.py
+++ b/scripts/check_config_keys.py
@@ -201,8 +201,15 @@ REQUIRED_DEFAULT_KEYS = POSTURE_FLOOR_KEYS | {"facility_knowledge.bundle_path"}
 #: carry a ``default_note:`` naming the derivation or the consequence. Without
 #: that rule the two would be an escape hatch from reading the code, which is
 #: the whole point of the column.
+#:
+#: ``required`` may carry one and need not: "no fallback exists" is a complete
+#: answer, but a key whose admissible values are a closed set has nowhere else
+#: to name them for a reader holding only the ledger. A literal default may
+#: not: the literal is the whole answer, so prose beside one is an excuse for
+#: it or a sign the sentinel is wrong.
 DEFAULT_SENTINELS = frozenset({"required", "n/a", "derived", "no-fallback"})
 DEFAULT_SENTINELS_NEEDING_NOTE = frozenset({"derived", "no-fallback"})
+DEFAULT_SENTINELS_ALLOWING_NOTE = DEFAULT_SENTINELS_NEEDING_NOTE | {"required"}
 
 
 def sentinel_lookalike(value: object) -> str | None:
@@ -684,10 +691,10 @@ class ConfigKeyGuard:
            refusal that no longer happens, and a floor key that loses
            ``required`` invites a fallback to be invented for something the
            build refuses to guess at;
-        3. ``derived`` and ``no-fallback`` carry a ``default_note:``, a literal
-           carries none, and a near-miss spelling of a sentinel
-           (``no_fallback``, ``Derived``) is refused rather than waved through
-           as the literal string it technically is.
+        3. ``derived`` and ``no-fallback`` carry a ``default_note:``,
+           ``required`` may carry one, a literal carries none, and a near-miss
+           spelling of a sentinel (``no_fallback``, ``Derived``) is refused
+           rather than waved through as the literal string it technically is.
         """
         keys = self.manifest["keys"]
         for key, spec in keys.items():
@@ -707,6 +714,7 @@ class ConfigKeyGuard:
                 )
                 continue
             needs_note = isinstance(value, str) and value in DEFAULT_SENTINELS_NEEDING_NOTE
+            may_note = isinstance(value, str) and value in DEFAULT_SENTINELS_ALLOWING_NOTE
             has_note = bool(str(spec.get("default_note") or "").strip())
             if needs_note and not has_note:
                 self.fail(
@@ -714,14 +722,14 @@ class ConfigKeyGuard:
                     f"{key} is {value!r} but carries no default_note naming the "
                     f"derivation or the consequence",
                 )
-            elif has_note and not needs_note:
+            elif has_note and not may_note:
                 # A note on a literal reads as an excuse for it. The literal is
                 # the whole answer, or it is the wrong sentinel.
                 self.fail(
                     "default",
                     f"{key} carries a default_note but its default is the literal "
                     f"{value!r}; a note belongs only on "
-                    f"{sorted(DEFAULT_SENTINELS_NEEDING_NOTE)}",
+                    f"{sorted(DEFAULT_SENTINELS_ALLOWING_NOTE)}",
                 )
 
         declared = {

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -121,6 +121,8 @@ AGENT_DEFAULT_TIERS: dict[str, str] = {
     "logbook-search": "sonnet",
     "logbook-deep-research": "opus",
     "data-visualizer": "sonnet",
+    "facility-knowledge": "sonnet",
+    "facility-knowledge-graph": "haiku",
     "pyat-specialist": "sonnet",
 }
 

--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -19,11 +19,8 @@ import click
 
 # Import get_config_value at module level for easier patching in tests
 from osprey.utils.config import get_config_value
-from osprey.utils.logger import get_logger
 
 from . import output
-
-logger = get_logger("ariel")
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -122,14 +119,6 @@ _ENHANCEMENT_MODULES_ATTR = "ariel_enhancement_modules"
 _INGESTION_ADAPTERS_ATTR = "ariel_ingestion_adapters"
 
 
-def _framework_registrations(attribute: str) -> tuple[str, ...]:
-    """Return the names the framework registers by default under *attribute*."""
-    from osprey.registry.builtins import FrameworkRegistryProvider
-
-    config = FrameworkRegistryProvider().get_registry_config()
-    return tuple(registration.name for registration in getattr(config, attribute))
-
-
 def _registered_names(attribute: str) -> tuple[str, ...]:
     """Return the names the registry knows about under *attribute*.
 
@@ -137,9 +126,16 @@ def _registered_names(attribute: str) -> tuple[str, ...]:
     own search module, enhancement module or ingestion adapter gets it as a
     CLI choice without a code change. Building that registry needs a project
     ``config.yml``; when there is none (``--help`` run outside a project
-    directory, say) the framework's own baseline registrations stand in. That
-    failure is expected here, so the registry loggers are muted while it is
-    probed — a help screen is not the place to report a missing project config.
+    directory, say) the framework's own baseline registrations stand in.
+
+    Which source answers is
+    :func:`osprey.services.ariel_search.config.registered_ariel_names`'s call to
+    make — one function owns that fallback, so ``osprey ariel status`` cannot
+    report a module that ``--module`` refuses, and the refusal a config raises
+    for a missing ``ariel.ingestion.adapter`` cannot advertise an adapter the
+    CLI would reject. What this wrapper adds is the muting: probing the registry
+    outside a project fails by design here, and a help screen is not the place
+    to report a missing project config.
 
     Args:
         attribute: Registry-config list attribute, e.g. ``ariel_search_modules``.
@@ -149,26 +145,17 @@ def _registered_names(attribute: str) -> tuple[str, ...]:
     """
     import logging
 
+    from osprey.services.ariel_search.config import registered_ariel_names
+
     muted = {name: logging.getLogger(name) for name in ("registry", "registry.loader")}
     previous_levels = {name: log.level for name, log in muted.items()}
+    for log in muted.values():
+        log.setLevel(logging.CRITICAL)
     try:
-        from osprey.registry import get_registry
-
-        for log in muted.values():
-            log.setLevel(logging.CRITICAL)
-        try:
-            names = tuple(
-                registration.name for registration in getattr(get_registry().config, attribute)
-            )
-        finally:
-            for name, log in muted.items():
-                log.setLevel(previous_levels[name])
-        if names:
-            return names
-    except Exception:
-        logger.debug("Registry unavailable; using framework %s", attribute, exc_info=True)
-
-    return _framework_registrations(attribute)
+        return tuple(registered_ariel_names(attribute))
+    finally:
+        for name, log in muted.items():
+            log.setLevel(previous_levels[name])
 
 
 class _RegistryChoice(click.Choice):

--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -113,27 +113,39 @@ def _handle_db_error(e: Exception) -> None:
         raise SystemExit(1) from None
 
 
-def _framework_search_modes() -> tuple[str, ...]:
-    """Return the search module names the framework registers by default."""
+#: Registry-config attributes behind the three ARIEL choice options. The
+#: attribute name is the whole parameter: the project registry's config and the
+#: framework's baseline config carry the same three lists, so one name reaches
+#: both the authoritative source and the fallback.
+_SEARCH_MODULES_ATTR = "ariel_search_modules"
+_ENHANCEMENT_MODULES_ATTR = "ariel_enhancement_modules"
+_INGESTION_ADAPTERS_ATTR = "ariel_ingestion_adapters"
+
+
+def _framework_registrations(attribute: str) -> tuple[str, ...]:
+    """Return the names the framework registers by default under *attribute*."""
     from osprey.registry.builtins import FrameworkRegistryProvider
 
     config = FrameworkRegistryProvider().get_registry_config()
-    return tuple(registration.name for registration in config.ariel_search_modules)
+    return tuple(registration.name for registration in getattr(config, attribute))
 
 
-def _registered_search_modes() -> tuple[str, ...]:
-    """Return the ARIEL search module names the registry knows about.
+def _registered_names(attribute: str) -> tuple[str, ...]:
+    """Return the names the registry knows about under *attribute*.
 
     The project registry is authoritative, so a deployment that registers its
-    own search module gets it as a ``--mode`` choice without a code change.
-    Building that registry needs a project ``config.yml``; when there is none
-    (``--help`` run outside a project directory, say) the framework's own
-    baseline registrations stand in. That failure is expected here, so the
-    registry loggers are muted while it is probed — a help screen is not the
-    place to report a missing project config.
+    own search module, enhancement module or ingestion adapter gets it as a
+    CLI choice without a code change. Building that registry needs a project
+    ``config.yml``; when there is none (``--help`` run outside a project
+    directory, say) the framework's own baseline registrations stand in. That
+    failure is expected here, so the registry loggers are muted while it is
+    probed — a help screen is not the place to report a missing project config.
+
+    Args:
+        attribute: Registry-config list attribute, e.g. ``ariel_search_modules``.
 
     Returns:
-        Search module names, in registry order.
+        Registered names, in registry order.
     """
     import logging
 
@@ -145,19 +157,21 @@ def _registered_search_modes() -> tuple[str, ...]:
         for log in muted.values():
             log.setLevel(logging.CRITICAL)
         try:
-            names = tuple(module.name for module in get_registry().config.ariel_search_modules)
+            names = tuple(
+                registration.name for registration in getattr(get_registry().config, attribute)
+            )
         finally:
             for name, log in muted.items():
                 log.setLevel(previous_levels[name])
         if names:
             return names
     except Exception:
-        logger.debug("Registry unavailable; using framework search modules", exc_info=True)
+        logger.debug("Registry unavailable; using framework %s", attribute, exc_info=True)
 
-    return _framework_search_modes()
+    return _framework_registrations(attribute)
 
 
-class _SearchModeChoice(click.Choice):
+class _RegistryChoice(click.Choice):
     """Click choice type whose options come from the registry when parsed.
 
     ``click.Choice`` freezes its options when the decorator runs, which is
@@ -166,14 +180,19 @@ class _SearchModeChoice(click.Choice):
     parsing and help rendering.
     """
 
-    def __init__(self) -> None:
-        """Build a choice type with no fixed option list."""
+    def __init__(self, attribute: str) -> None:
+        """Build a choice type resolved from one registry-config attribute.
+
+        Args:
+            attribute: Registry-config list attribute the options come from.
+        """
+        self.attribute = attribute
         self.case_sensitive = True
 
     @property
     def choices(self) -> tuple[str, ...]:  # type: ignore[override]
-        """Registered search module names, resolved on each access."""
-        return _registered_search_modes()
+        """Registered names, resolved on each access."""
+        return _registered_names(self.attribute)
 
 
 def _handle_missing_tables(e: Exception) -> None:
@@ -361,16 +380,16 @@ def sync_command(limit: int | None, watch: bool) -> None:
 @click.option(
     "--adapter",
     "-a",
-    type=click.Choice(["als_logbook", "jlab_logbook", "ornl_logbook", "generic_json"]),
-    default="generic_json",
-    help="Adapter type",
+    type=_RegistryChoice(_INGESTION_ADAPTERS_ATTR),
+    default=None,
+    help="Adapter type (overrides config)",
 )
 @click.option("--since", type=click.DateTime(), help="Only ingest entries after this date")
 @click.option("--limit", type=int, help="Maximum entries to ingest")
 @click.option("--dry-run", is_flag=True, help="Parse entries without storing")
 def ingest_command(
     source: str,
-    adapter: str,
+    adapter: str | None,
     since: datetime | None,
     limit: int | None,
     dry_run: bool,
@@ -412,7 +431,7 @@ def ingest_command(
 @click.option(
     "--adapter",
     "-a",
-    type=click.Choice(["als_logbook", "jlab_logbook", "ornl_logbook", "generic_json"]),
+    type=_RegistryChoice(_INGESTION_ADAPTERS_ATTR),
     help="Adapter type (overrides config)",
 )
 @click.option("--once", is_flag=True, help="Run a single poll cycle and exit")
@@ -481,7 +500,7 @@ def watch_command(
 @click.option(
     "--module",
     "-m",
-    type=click.Choice(["text_embedding", "semantic_processor", "qmd_export"]),
+    type=_RegistryChoice(_ENHANCEMENT_MODULES_ATTR),
     help="Enhancement module to run",
 )
 @click.option("--force", is_flag=True, help="Re-process already enhanced entries")
@@ -530,7 +549,7 @@ def models_command() -> None:
 @click.argument("query")
 @click.option(
     "--mode",
-    type=_SearchModeChoice(),
+    type=_RegistryChoice(_SEARCH_MODULES_ATTR),
     default=None,
     help="Search module to use. Defaults to ariel.default_search_mode.",
 )

--- a/src/osprey/deployment/status_display.py
+++ b/src/osprey/deployment/status_display.py
@@ -1048,6 +1048,7 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
 
     from osprey.build.claude_code_resolver import AGENT_DEFAULT_TIERS, load_provider_spec
     from osprey.build.claude_code_telemetry import ObservabilityCredentialError
+    from osprey.registry.mcp import FRAMEWORK_AGENTS
     from osprey.utils.dotenv import ENV_CHAIN_FILENAMES
 
     rows: list[tuple[str, object]] = []
@@ -1142,11 +1143,19 @@ def _print_agent_section(repo_root, build_dir, config, *, show_agents):
             if show_agents:
                 rows.append(("agent models", ""))
                 agent_overrides = claude_code.get("agent_models") or {}
-                for agent_name, default_tier in sorted(AGENT_DEFAULT_TIERS.items()):
+                # Every agent this deployment could run, not only the ones the
+                # tier map happens to name: an agent missing from the map takes
+                # the resolver's sonnet fallback, and a status report that left
+                # it out would be the only place that went unsaid. `deployment`
+                # may import the registry; `osprey.build` may not, which is why
+                # the map lives there and the catalog here.
+                for agent_name in sorted(set(FRAMEWORK_AGENTS) | set(agent_overrides)):
                     if agent_name in agent_overrides:
                         origin = f"(override: {agent_overrides[agent_name]})"
+                    elif agent_name in AGENT_DEFAULT_TIERS:
+                        origin = f"({AGENT_DEFAULT_TIERS[agent_name]})"
                     else:
-                        origin = f"({default_tier})"
+                        origin = f"(default {spec.agent_tier(agent_name)})"
                     rows.append((agent_name, f"{spec.agent_model(agent_name)} {origin}"))
 
             conflicts = spec.detect_env_conflicts(dict(os.environ))

--- a/src/osprey/interfaces/bluesky_web/queue_relay.py
+++ b/src/osprey/interfaces/bluesky_web/queue_relay.py
@@ -17,6 +17,8 @@ The relayed surface mirrors the bridge's queue contract one-for-one:
 - ``POST /queue/stop`` -> stop after the running item (``cancel: true`` withdraws)
 - ``POST /queue/abort`` -> abort the plan already in motion
 - ``GET /queue/events`` -> the queue's Server-Sent-Events stream
+- ``DELETE /history`` -> drop every completed run from the manager's history
+- ``DELETE /runs/{run_id}`` -> drop one finished run from the history view
 
 **This sidecar holds no queue state and makes no queue policy.** It does not
 know which routes arm hardware, does not pre-check capability, and does not

--- a/src/osprey/interfaces/bluesky_web/read_proxy.py
+++ b/src/osprey/interfaces/bluesky_web/read_proxy.py
@@ -14,6 +14,7 @@ bridge-owned field. This mirrors the read side of the bridge contract at
 - ``GET /bridge/health`` -> the bridge's ``GET /health``
 - ``GET /plans``
 - ``GET /plans/{name}/source``
+- ``GET /devices``
 - ``GET /runs`` (``limit`` query param)
 - ``GET /runs/{run_id}``
 - ``GET /runs/{run_id}/data`` (``max_rows``/``offset``/``tail`` query params)

--- a/src/osprey/interfaces/web_terminal/static/js/settings.js
+++ b/src/osprey/interfaces/web_terminal/static/js/settings.js
@@ -52,17 +52,29 @@ const SETTINGS_WARNING_KEY_BASE = 'osprey-settings-warning-ack';
 // another. Guards against a rapid second click spawning a second dialog.
 let warningGatePending = false;
 
-// Known enum values for select dropdowns
+// Known enum values for select dropdowns. Every `approval.tools.<tool>` key a
+// deployment can set has a row here: the panel is the surface an operator
+// changes approval posture through, so a settable policy the drawer renders as
+// a free-text box is a policy they can only get wrong.
+// tests/profiles/test_approval_tools_parity.py holds this list to the same set
+// the presets ship and the config-key manifest documents.
+/** @type {string[]} */
+const APPROVAL_POLICIES = ['always', 'selective', 'skip'];
+
 /** @type {Record<string, string[]>} */
 const ENUM_FIELDS = {
   'claude_code.effort': ['low', 'medium', 'high', 'max'],
-  'approval.default_policy': ['always', 'selective', 'skip'],
-  'approval.tools.channel_write': ['always', 'selective', 'skip'],
-  'approval.tools.channel_read': ['always', 'selective', 'skip'],
-  'approval.tools.archiver_read': ['always', 'selective', 'skip'],
-  'approval.tools.execute': ['always', 'selective', 'skip'],
-  'approval.tools.setup_patch': ['always', 'selective', 'skip'],
-  'approval.tools.entry_create': ['always', 'selective', 'skip'],
+  'approval.default_policy': APPROVAL_POLICIES,
+  'approval.tools.channel_write': APPROVAL_POLICIES,
+  'approval.tools.channel_read': APPROVAL_POLICIES,
+  'approval.tools.archiver_read': APPROVAL_POLICIES,
+  'approval.tools.execute': APPROVAL_POLICIES,
+  'approval.tools.setup_patch': APPROVAL_POLICIES,
+  'approval.tools.entry_create': APPROVAL_POLICIES,
+  'approval.tools.entry_publish': APPROVAL_POLICIES,
+  'approval.tools.add_panel_to_rail': APPROVAL_POLICIES,
+  'approval.tools.remove_panel_from_rail': APPROVAL_POLICIES,
+  'approval.tools.register_panel': APPROVAL_POLICIES,
 };
 
 // Fields that should render as toggles even when the current value is null or

--- a/src/osprey/mcp_server/ariel/tools/entry.py
+++ b/src/osprey/mcp_server/ariel/tools/entry.py
@@ -15,7 +15,13 @@ from pathlib import Path
 
 from fastmcp.exceptions import ToolError
 
-from osprey.mcp_server.ariel.server import build_entry_url, make_error, mcp, serialize_entry
+from osprey.mcp_server.ariel.server import (
+    ARIEL_NATIVE_SOURCE_SYSTEM,
+    build_entry_url,
+    make_error,
+    mcp,
+    serialize_entry,
+)
 from osprey.mcp_server.ariel.server_context import get_ariel_context
 from osprey.mcp_server.http import notify_agent_activity_async
 
@@ -358,7 +364,7 @@ async def entry_create(
 
         entry = {
             "entry_id": entry_id,
-            "source_system": "ARIEL MCP",
+            "source_system": ARIEL_NATIVE_SOURCE_SYSTEM,
             "timestamp": now,
             "author": author or "Anonymous",
             "raw_text": f"{subject}\n\n{details}",
@@ -405,7 +411,7 @@ async def entry_create(
             {
                 "entry_id": entry_id,
                 "message": f"Entry {entry_id} created successfully",
-                "source_system": "ARIEL MCP",
+                "source_system": ARIEL_NATIVE_SOURCE_SYSTEM,
                 "attachment_count": attachment_count,
             },
             default=str,

--- a/src/osprey/mcp_server/bluesky/tools/queue.py
+++ b/src/osprey/mcp_server/bluesky/tools/queue.py
@@ -897,9 +897,11 @@ def _relay_refusal(
     return make_error(code, message, hints, details=detail)
 
 
-# Manager states that mean this lane's queue is draining toward hardware. From
-# the same vocabulary `queue_list` documents; a lane in one of these is a lane
-# with something to halt.
+# Manager states that mean this lane's queue is draining toward hardware. A copy
+# of `queue_backend.QUEUE_ACTIVE_MANAGER_STATES`, forced by this server's
+# no-bluesky-imports invariant and kept in step by name — the two JS clients
+# (`queue-client.js`, `bar-item-queue.js`) carry the same copy for the same
+# reason. A lane in one of these is a lane with something to halt.
 _MOVING_MANAGER_STATES = frozenset(
     {"executing_queue", "starting_queue", "executing_task", "paused"}
 )

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -801,7 +801,14 @@ keys:
   # ── Control system ──────────────────────────────────────────────────
     default: required
   control_system: {evidence: 'get_config_value\("control_system", \{\}\)', default: {}}
-  control_system.type: {evidence: 'get_config_value\("control_system\.type", "mock"\)', default: required}
+  control_system.type:
+    evidence: 'get_config_value\("control_system\.type", "mock"\)'
+    default: required
+    default_note: >-
+      The types a project can be built on are `mock`, `epics`,
+      `virtual_accelerator`, `doocs` and `tango`. `live_standin` is settable
+      on a deployment that has a stand-in, and `osprey init` never offers it,
+      so a fresh project cannot start there.
   control_system.writes_enabled:
     evidence: '"control_system\.writes_enabled"'
     note: >-
@@ -1227,7 +1234,12 @@ keys:
   # used to serve here and stopped describing the key the moment the
   # control-assistant default became mongodb_archiver — a matcher that tracks a
   # default is a matcher that goes quiet on the change it should have caught.
-  archiver.type: {evidence: 'archiver\.type is not set', default: required}
+  archiver.type:
+    evidence: 'archiver\.type is not set'
+    default: required
+    default_note: >-
+      The shipped archivers are `mock_archiver`, `epics_archiver`,
+      `mongodb_archiver` and `doocs_archiver`.
   # Point budget behind archiver_read's span-derived default bin (issue #117).
   archiver.auto_bin_points: {evidence: 'archiver\.auto_bin_points', default: 10000}
   archiver.epics_archiver:

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -155,9 +155,9 @@ keys:
       it. The ONLY enforcement anywhere is a non-emptiness lint
       (deployment/web_terminals/lint.py `_check_empty_facility_prefix`); no
       charset or length rule exists in code. See notes.prefix_rule_drift.
+    default: ''
 
   # ── Container runtime / deployment ──────────────────────────────────
-    default: ''
   container_runtime:
     all-templates: true
     evidence: 'config\.get\("container_runtime", "auto"\) if config else None'
@@ -513,6 +513,7 @@ keys:
       read from the same block but named on no page. There is deliberately no
       `password` key at any layer — the credential lives in the project .env as
       GRAPHDB_PASSWORD.
+    default: null
   # `services.graphdb.username` is read beside `uri` but documented nowhere, so
   # it stays out of the ledger.
 
@@ -524,7 +525,6 @@ keys:
   # config.yml — hence `rendered: false` on all of them, exactly as on
   # `images.registry`/`images.tag`. `services.graphdb.image` is the one member
   # of the family a template does render, so it keeps its entry above.
-    default: null
   services.postgresql.image:
     rendered: false
     evidence: '\(services\.postgresql \| default\(\{\}\)\)\.image'
@@ -1491,11 +1491,11 @@ keys:
     default: {}
   channel_finder.benchmark.dataset_path:
     evidence: 'No benchmark query set configured'
-
-  # ── ARIEL ───────────────────────────────────────────────────────────
     default: no-fallback
     default_note: >-
       the runner refuses a benchmark with no query set, naming this key and --queries-path
+
+  # ── ARIEL ───────────────────────────────────────────────────────────
   ariel: {evidence: 'get_config_value\("ariel", \{\}\)', default: {}}
   ariel.ingestion: {covered-by: ariel, default: n/a}
   ariel.ingestion.adapter:
@@ -1929,8 +1929,9 @@ keys:
     note: >-
       The block is never read as a mapping — its single leaf below carries the
       whole read, so the evidence anchors on the prefix they share and this
-      entry dies with that reader rather than outliving it. Rendered live in
-      the four templates that carry a `web:` block; hello_world has none, so
+      entry dies with that reader rather than outliving it. Rendered from the
+      root presets that carry a `web:` block — control-assistant,
+      ariel-standalone and channel-finder-standalone; hello-world has none, so
       this is deliberately not all-templates.
     default: {}
   web.config_panel.enabled:
@@ -1952,8 +1953,9 @@ keys:
     note: >-
       The block is never read as a mapping — its single leaf below carries the
       whole read, so the evidence anchors on the prefix they share and this
-      entry dies with that reader rather than outliving it. Rendered live in
-      the four templates that carry a `web:` block; hello_world has none, so
+      entry dies with that reader rather than outliving it. Rendered from the
+      root presets that carry a `web:` block — control-assistant,
+      ariel-standalone and channel-finder-standalone; hello-world has none, so
       this is deliberately not all-templates, same as `web.config_panel`.
     default: {}
   web.scaffold_gallery.write_enabled:

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -206,7 +206,9 @@ config:
   # above, so this deployment's baseline is a facility-shaped soft IOC that
   # behaves like hardware and moves nothing. "virtual_accelerator" is the
   # sandbox simulator, "epics" your own control system, "mock" needs no
-  # containers but cannot complete a plan.
+  # containers but cannot complete a plan. "doocs" and "tango" reach those
+  # control systems in place of Channel Access. Those five are every type
+  # `osprey init` will materialize; `osprey config --defaults` lists them too.
   # `control_target_set live` moves a session onto the machine authored under
   # `epics:`. The template ships that block unconfigured — author its
   # `gateways` and `probe_channel` first — then the switch probes that target,
@@ -359,8 +361,8 @@ config:
   # not turn it on; without this line you would deploy a store and not read it.
   # The store's coordinates (`archiver.mongodb_archiver.*`) are derived from
   # that block, so they are not written here. The alternatives are
-  # "mock_archiver" (synthesized history) and "epics_archiver" (an Archiver
-  # Appliance, configured below).
+  # "mock_archiver" (synthesized history), "epics_archiver" (an Archiver
+  # Appliance, configured below) and "doocs_archiver" (DOOCS local history).
   archiver.type: mongodb_archiver
   # When a read names no bin size, the bin is chosen so a continuously archived
   # channel returns about this many points. The agent is told which bin it got.

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -118,7 +118,8 @@ config:
   # ── Control system ─────────────────────────────────────────────────────────
   # Which control system to talk to. "mock" invents a value for ANY channel
   # name in-process, so reads work with no hardware and no containers behind
-  # them. The control-assistant preset shows the EPICS connector configuration.
+  # them. The control-assistant preset shows the EPICS connector configuration,
+  # and `osprey config --defaults` lists every shipped connector type.
   control_system.type: mock
   # The FIRST guard in the write-safety chain: while false, every hardware
   # write is refused before the limits check or the approval prompt is even
@@ -154,7 +155,8 @@ config:
   # Historical channel data behind the archiver_read tool. "mock_archiver"
   # synthesizes history, so "plot the beam current over the last hour" works
   # out of the box. A real deployment sets "epics_archiver" and adds
-  # `archiver.epics_archiver.url` — the control-assistant preset shows it.
+  # `archiver.epics_archiver.url` — the control-assistant preset shows it, and
+  # `osprey config --defaults` lists every shipped archiver type.
   archiver.type: mock_archiver
   # When a read names no bin size, the bin is chosen so a continuously archived
   # channel returns about this many points. The agent is told which bin it got.

--- a/src/osprey/services/archiver_recorder/recorder.py
+++ b/src/osprey/services/archiver_recorder/recorder.py
@@ -28,6 +28,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from osprey_connectors.standin import DEPLOYED_SERVICES_KEY, LIVE_STANDIN_PORT_KEY
+from osprey_connectors.types import VIRTUAL_ACCELERATOR
 
 from .config import RecorderConfigError, RecorderSettings, read_recording_facts
 from .store import ArchiveWriter
@@ -65,7 +66,7 @@ logger = logging.getLogger(__name__)
 #: the roster's label uses. It is the one predicate the recorder's compose entry
 #: and the deploy-time archive seed bind to as well, so a machine that is still
 #: the stand-in cannot be quietly dropped out of its own archive.
-RECORDING_CONTROL_SYSTEM = "virtual_accelerator"
+RECORDING_CONTROL_SYSTEM = VIRTUAL_ACCELERATOR
 
 #: Reads a set of addresses and returns the ones that answered.
 ChannelReader = Callable[[Sequence[str]], Awaitable[Mapping[str, float]]]

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -357,6 +357,7 @@ async def get_status(config_dict: dict, *, config_dir: Path | None = None) -> di
         store has never been ingested.
     """
     from osprey.services.ariel_search import create_ariel_service
+    from osprey.services.ariel_search.config import registered_ariel_names
 
     # Computed first and unconditionally: the vocabulary line must survive a
     # database that is down and a config that will not parse.
@@ -397,15 +398,12 @@ async def get_status(config_dict: dict, *, config_dir: Path | None = None) -> di
                     for t in tables
                 ],
                 "enhancement_modules": {
-                    "text_embedding": config.is_enhancement_module_enabled("text_embedding"),
-                    "semantic_processor": config.is_enhancement_module_enabled(
-                        "semantic_processor"
-                    ),
+                    name: config.is_enhancement_module_enabled(name)
+                    for name in registered_ariel_names("ariel_enhancement_modules")
                 },
                 "search_modules": {
-                    "keyword": config.is_search_module_enabled("keyword"),
-                    "semantic": config.is_search_module_enabled("semantic"),
-                    "hybrid": config.is_search_module_enabled("hybrid"),
+                    name: config.is_search_module_enabled(name)
+                    for name in registered_ariel_names("ariel_search_modules")
                 },
                 "vocabulary": vocabulary,
             }

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -530,13 +530,29 @@ async def run_sync(
 async def run_ingest(
     config_dict: dict,
     source: str,
-    adapter: str,
+    adapter: str | None,
     since: datetime | None,
     limit: int | None,
     dry_run: bool,
     progress: _ProgressCb = None,
 ) -> IngestResult:
-    """Ingest logbook entries from a source."""
+    """Ingest logbook entries from a source.
+
+    Args:
+        config_dict: Raw ARIEL configuration mapping.
+        source: Source file path or URL; always an override.
+        adapter: Override for ``ingestion.adapter``. ``None`` leaves the
+            configured adapter in place — the same rule ``run_watch`` follows,
+            so a project that names its adapter in config.yml does not have to
+            repeat it on every ingest.
+        since: Only ingest entries after this date.
+        limit: Maximum entries to ingest.
+        dry_run: Parse entries without storing them.
+        progress: Optional callback for human-readable progress lines.
+
+    Returns:
+        The run's counts.
+    """
     from osprey.services.ariel_search import create_ariel_service
     from osprey.services.ariel_search.enhancement import create_enhancers_from_config
     from osprey.services.ariel_search.ingestion import get_adapter
@@ -544,7 +560,8 @@ async def run_ingest(
     if "ingestion" not in config_dict:
         config_dict["ingestion"] = {}
     config_dict["ingestion"]["source_url"] = source
-    config_dict["ingestion"]["adapter"] = adapter
+    if adapter:
+        config_dict["ingestion"]["adapter"] = adapter
 
     config = _ariel_config(config_dict)
     adapter_instance = get_adapter(config)

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -367,33 +367,60 @@ class WriteConfig:
         )
 
 
-def _known_ingestion_adapters() -> list[str]:
-    """Adapter names to offer an operator who named none.
+def framework_ariel_names(attribute: str) -> list[str]:
+    """ARIEL names the framework itself registers under *attribute*.
 
-    The live registry first — a deployment that registered its own adapter must
-    see it here — and the framework's built-in registrations as the fallback,
-    since a config can be parsed outside a project, where there is no registry
-    to ask.
+    Args:
+        attribute: Registry-config list attribute, e.g. ``ariel_search_modules``.
 
     Returns:
-        Sorted adapter names, or an empty list if neither source can answer.
+        Registered names, in registration order.
+    """
+    from osprey.registry.builtins import FrameworkRegistryProvider
+
+    config = FrameworkRegistryProvider().get_registry_config()
+    return [registration.name for registration in getattr(config, attribute)]
+
+
+def registered_ariel_names(attribute: str) -> list[str]:
+    """ARIEL names registered under *attribute*, in registry order.
+
+    The one owner of this fallback. Every surface that has to name what is
+    registered goes through here — the ``--adapter``, ``--module`` and ``--mode``
+    choices, the status report's module table, and the refusal below that tells
+    an operator which adapters exist — so a name one of them accepts can never be
+    a name another does not know.
+
+    The live registry answers first, so a deployment that registered its own
+    adapter or module is reported without a code change. The framework's own
+    registrations are the fallback: a config can be parsed and ``--help`` can be
+    rendered outside a project, where there is no registry to ask, and a missing
+    project config must not turn either into an error.
+
+    Args:
+        attribute: Registry-config list attribute, e.g. ``ariel_search_modules``.
+
+    Returns:
+        Registered names, or an empty list if neither source can answer.
     """
     try:
-        from osprey.registry.manager import get_registry
+        from osprey.registry import get_registry
 
-        names = get_registry().list_ariel_ingestion_adapters()
+        names = [registration.name for registration in getattr(get_registry().config, attribute)]
         if names:
-            return sorted(names)
-    except Exception:  # noqa: BLE001 — the refusal matters more than the list
+            return names
+    except Exception:  # noqa: BLE001 — the caller's own job matters more than the list
         pass
 
     try:
-        from osprey.registry.builtins import FrameworkRegistryProvider
-
-        registrations = FrameworkRegistryProvider().get_registry_config()
-        return sorted(r.name for r in registrations.ariel_ingestion_adapters)
+        return framework_ariel_names(attribute)
     except Exception:  # noqa: BLE001 — same
         return []
+
+
+def _known_ingestion_adapters() -> list[str]:
+    """Adapter names to offer an operator who named none, sorted for the message."""
+    return sorted(registered_ariel_names("ariel_ingestion_adapters"))
 
 
 @dataclass

--- a/src/osprey/services/ariel_search/database/repository.py
+++ b/src/osprey/services/ariel_search/database/repository.py
@@ -537,55 +537,73 @@ class ARIELRepository:
     async def get_enhancement_stats(self) -> dict[str, Any]:
         """Get statistics about enhancement completion.
 
+        The per-module counts come from one grouped aggregate over
+        ``jsonb_each(enhancement_status)``, so the SQL text is fixed and no
+        module name is ever spliced into it. A module the store has never seen
+        simply has no rows; one a facility registered itself is reported the
+        moment its first entry lands, without a code change here.
+
+        ``pending`` keeps the meaning the two hand-written FILTER clauses gave
+        it: entries whose status for the module is ``pending``, PLUS entries
+        that carry no key for the module at all. The second half cannot be
+        counted per module by the aggregate — an entry without the key produces
+        no row for it — so it is derived from the total instead. That subtraction
+        is why the total rides along in the same statement: two statements on an
+        autocommit connection read two snapshots, and an ingest landing between
+        them would drive ``pending`` negative. The ``LEFT JOIN ... ON TRUE``
+        keeps one row even when no entry carries a status key, so the total is
+        still readable from a store that has nothing to group.
+
         Returns:
-            Dict with stats per module
+            ``total_entries`` plus, per module, a ``{complete, failed,
+            pending}`` count. An empty store returns ``total_entries`` alone.
         """
         try:
             async with self.pool.connection() as conn:
                 result = await conn.execute(
                     """
+                    WITH total AS (
+                        SELECT COUNT(*) AS entries FROM enhanced_entries
+                    ),
+                    per_module AS (
+                        SELECT
+                            status.key AS module,
+                            status.value->>'status' AS state,
+                            COUNT(*) AS entries
+                        FROM enhanced_entries
+                        CROSS JOIN LATERAL jsonb_each(enhancement_status) AS status
+                        GROUP BY status.key, status.value->>'status'
+                    )
                     SELECT
-                        COUNT(*) AS total_entries,
-                        COUNT(*) FILTER (
-                            WHERE enhancement_status->'text_embedding'->>'status' = 'complete'
-                        ) AS text_embedding_complete,
-                        COUNT(*) FILTER (
-                            WHERE enhancement_status->'text_embedding'->>'status' = 'failed'
-                        ) AS text_embedding_failed,
-                        COUNT(*) FILTER (
-                            WHERE enhancement_status->'text_embedding'->>'status' = 'pending'
-                            OR NOT enhancement_status ? 'text_embedding'
-                        ) AS text_embedding_pending,
-                        COUNT(*) FILTER (
-                            WHERE enhancement_status->'semantic_processor'->>'status' = 'complete'
-                        ) AS semantic_processor_complete,
-                        COUNT(*) FILTER (
-                            WHERE enhancement_status->'semantic_processor'->>'status' = 'failed'
-                        ) AS semantic_processor_failed,
-                        COUNT(*) FILTER (
-                            WHERE enhancement_status->'semantic_processor'->>'status' = 'pending'
-                            OR NOT enhancement_status ? 'semantic_processor'
-                        ) AS semantic_processor_pending
-                    FROM enhanced_entries
+                        total.entries AS total_entries,
+                        per_module.module,
+                        per_module.state,
+                        per_module.entries
+                    FROM total
+                    LEFT JOIN per_module ON TRUE
                     """
                 )
-                row = await result.fetchone()
-                if not row:
-                    return {"total_entries": 0}
+                rows = await result.fetchall()
 
-                return {
-                    "total_entries": row[0],
-                    "text_embedding": {
-                        "complete": row[1],
-                        "failed": row[2],
-                        "pending": row[3],
-                    },
-                    "semantic_processor": {
-                        "complete": row[4],
-                        "failed": row[5],
-                        "pending": row[6],
-                    },
-                }
+                total_entries = rows[0][0] if rows else 0
+
+                by_module: dict[str, dict[str, int]] = {}
+                seen: dict[str, int] = {}
+                for _total, module, state, entries in rows:
+                    if module is None:
+                        continue
+                    counts = by_module.setdefault(
+                        module, {"complete": 0, "failed": 0, "pending": 0}
+                    )
+                    if state in counts:
+                        counts[state] += entries
+                    seen[module] = seen.get(module, 0) + entries
+
+                stats: dict[str, Any] = {"total_entries": total_entries}
+                for module, counts in by_module.items():
+                    counts["pending"] += total_entries - seen[module]
+                    stats[module] = counts
+                return stats
         except Exception as e:
             raise DatabaseQueryError(
                 f"Failed to get enhancement stats: {e}",

--- a/src/osprey/services/auth_sidecar/app.py
+++ b/src/osprey/services/auth_sidecar/app.py
@@ -71,6 +71,7 @@ from osprey.deployment.web_terminals.personas import env_var_suffix, env_var_suf
 from osprey.interfaces.web_auth import DEFAULT_SESSION_LIFETIME
 
 from .identity_headers import same_domain, same_identity
+from .methods import METHOD_OIDC, SUPPORTED_METHODS
 from .revocation import RevocationStore
 from .sessions import SessionCodec
 from .throttle import AttemptThrottle
@@ -88,14 +89,12 @@ nginx never proxies it — it exists for the container healthcheck and for
 port directly.
 """
 
-SUPPORTED_METHODS = ("password", "oidc")
-"""Methods this process can actually serve.
-
-``none`` is a supported *deployment* posture (see ``render.py``'s
-``SUPPORTED_AUTH_METHODS``) but not a supported sidecar mode: with auth off
-there is no sidecar in the compose file at all, so a sidecar that finds
-``OSPREY_AUTH_METHOD=none`` has been mis-wired and refuses everything.
-"""
+# ``SUPPORTED_METHODS`` is imported above from ``methods.py``, the leaf module
+# the recheck route shares it with. ``none`` is a supported *deployment*
+# posture (see ``render.py``'s ``SUPPORTED_AUTH_METHODS``) but not a supported
+# sidecar mode: with auth off there is no sidecar in the compose file at all,
+# so a sidecar that finds ``OSPREY_AUTH_METHOD=none`` has been mis-wired and
+# refuses everything.
 
 # --- OIDC state cookie (Starlette SessionMiddleware) -------------------------
 # Pinned, never configurable: this cookie carries only the in-flight OIDC
@@ -576,7 +575,7 @@ class AuthSettings:
             missing.add(ENV_SESSION_SECRET)
         if self.session_lifetime <= 0:
             missing.add(ENV_SESSION_LIFETIME)
-        if self.method == "oidc":
+        if self.method == METHOD_OIDC:
             if not self.state_secret.strip():
                 missing.add(ENV_STATE_SECRET)
             if not self.oidc_issuer:

--- a/src/osprey/services/auth_sidecar/audit.py
+++ b/src/osprey/services/auth_sidecar/audit.py
@@ -71,6 +71,8 @@ from osprey.audit.envelope import (
 )
 from osprey.utils.identity import acting_identity
 
+from .methods import METHOD_OIDC, METHOD_PASSWORD
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
@@ -307,8 +309,8 @@ REASON_OIDC_LOGIN = "oidc_login"
 
 
 _SUCCESS_REASONS: dict[str, str] = {
-    "password": REASON_PASSWORD_LOGIN,
-    "oidc": REASON_OIDC_LOGIN,
+    METHOD_PASSWORD: REASON_PASSWORD_LOGIN,
+    METHOD_OIDC: REASON_OIDC_LOGIN,
 }
 """The reason each supported method's success is recorded under.
 

--- a/src/osprey/services/auth_sidecar/methods.py
+++ b/src/osprey/services/auth_sidecar/methods.py
@@ -1,0 +1,34 @@
+"""The auth methods this sidecar can actually serve.
+
+A leaf module with no sidecar imports of its own, so both layers that need the
+set can have it: :mod:`~osprey.services.auth_sidecar.app`, which refuses to
+serve a method outside it, and
+:mod:`~osprey.services.auth_sidecar.routes.recheck`, which refuses to mint a
+session for one. Those two cannot import each other — ``app`` builds the routes
+— so before this module the set was spelled twice, once as a tuple and once as
+a frozenset, and :mod:`~osprey.services.auth_sidecar.audit` keyed its success
+categories off a third copy written as bare strings.
+
+Distinct from :data:`~osprey.deployment.web_terminals.render.SUPPORTED_AUTH_METHODS`,
+which is a different fact: that one enumerates the deployment *postures* a
+render may declare, and includes ``none`` and ``token`` — postures under which
+no sidecar runs at all.
+"""
+
+from __future__ import annotations
+
+METHOD_PASSWORD = "password"
+"""The roster-credential posture: this service verifies the proof itself."""
+
+METHOD_OIDC = "oidc"
+"""The federated posture: an IdP proves the identity and may decide the role."""
+
+SUPPORTED_METHODS: frozenset[str] = frozenset({METHOD_PASSWORD, METHOD_OIDC})
+"""The methods a session may be minted for.
+
+Matched exactly, never case-folded: the value arrives from the environment
+through :class:`~osprey.services.auth_sidecar.app.AuthSettings`, which already
+lowercases it once. Folding again here would mean two components disagreeing
+about what counts as a match, and the one that is stricter should be the one
+handing out sessions.
+"""

--- a/src/osprey/services/auth_sidecar/routes/recheck.py
+++ b/src/osprey/services/auth_sidecar/routes/recheck.py
@@ -109,6 +109,7 @@ from osprey.deployment.web_terminals.personas import env_var_suffix
 
 from .. import audit
 from ..identity_headers import is_header_safe
+from ..methods import METHOD_OIDC, METHOD_PASSWORD, SUPPORTED_METHODS
 from ..sessions import UnlockedUser
 
 logger = logging.getLogger(__name__)
@@ -138,20 +139,9 @@ Pinned by a test against what the module actually defines, both ways: a new
 public helper has to be *looked at* rather than merely spelled unlike the two
 names an anti-lookup guard thought of. See the **Anti-lookup** note below."""
 
-METHOD_PASSWORD = "password"
-"""The roster-credential posture: this service verifies the proof itself."""
-
-METHOD_OIDC = "oidc"
-"""The federated posture: an IdP proves the identity and may decide the role."""
-
-SUPPORTED_METHODS: frozenset[str] = frozenset({METHOD_PASSWORD, METHOD_OIDC})
-"""The methods a session may be minted for.
-
-Matched exactly, never case-folded: the value arrives from the environment
-through :class:`~osprey.services.auth_sidecar.app.AuthSettings`, which already
-lowercases it once. Folding again here would mean two components disagreeing
-about what counts as a match, and the one that is stricter should be the one
-handing out sessions."""
+# METHOD_PASSWORD, METHOD_OIDC and SUPPORTED_METHODS are imported above from
+# ``methods.py``, and re-exported through this module's ``__all__``: a direct
+# import from ``app`` would cycle, since ``app`` is what builds these routes.
 
 ROLE_SOURCE_ROSTER = "roster"
 """The role came from the roster's ``role:`` entry — the one the render bound."""

--- a/src/osprey/stores/type_registry.py
+++ b/src/osprey/stores/type_registry.py
@@ -42,6 +42,12 @@ ARTIFACT_TYPES: dict[str, TypeDef] = {
     "image": TypeDef("image", "Image", "#a78bfa"),
     "text": TypeDef("text", "Text", "#8b9ab5"),
     "file": TypeDef("file", "File", "#506380"),
+    # What `serialize_object` stamps on raw bytes. Distinct from "file", which
+    # is a saved-from-disk artifact whose extension says what it holds: nothing
+    # can be inferred about these bytes, and the published `save_artifact()`
+    # contract names the type ("bytes -> binary file"), so remapping them onto
+    # "file" would break a promise the docstring makes.
+    "binary": TypeDef("binary", "Binary", "#64748b"),
     "notebook": TypeDef("notebook", "Notebook", "#e879f9"),
     "dashboard_html": TypeDef("dashboard_html", "Dashboard", "#06b6d4"),
 }

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -5,7 +5,6 @@ name: Human Approval Gate
 description: Requires human approval for dangerous operations based on per-tool policy
 summary: Requires human approval for dangerous operations
 event: PreToolUse
-tools: channel_write, execute, setup_patch, entry_create, entry_publish, queue_add, queue_start, queue_stop, queue_remove, stop_run, add_panel_to_rail, remove_panel_from_rail, register_panel
 safety_layer: 2
 ---
 

--- a/src/osprey/templates/modules/web_terminals/notices/working-safely.md
+++ b/src/osprey/templates/modules/web_terminals/notices/working-safely.md
@@ -26,12 +26,16 @@ lets you judge the next thing it proposes.
 - Notice which channels and sources it drew on.
 - Stop the session if it starts looping or heads somewhere you did not intend.
 
-## Know what this deployment covers
+## Agents are built to find you an answer
 
-Every deployment is set up for a particular set of systems and channels.
+These agents are biased toward producing a solution for whatever you ask them
+for. Ask for something this deployment cannot actually do and you are more likely
+to get an answer-shaped attempt than a refusal.
 
-- Know which subsystems and channels yours is configured for.
+- Know which subsystems and channels this deployment is configured for.
 - Narrow open-ended asks ("fix everything", "optimize the beam") yourself before
   handing them over.
+- Treat a confident answer about something outside that scope as a reason to
+  check, not as a result.
 
 When in doubt, stop the session and talk to your control system team.

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -197,7 +197,12 @@ ariel:
       model:
         model_id: {{ default_model }}
 {%- endif %}
-{%- set _builtin_panels = builtin_panels | default([]) %}
+{#- The registry, never a default: `builtin_panels` is set on every render
+    context the manager builds, so a render that reaches here without it is
+    a wiring fault. Defaulting to an empty list would swallow that and emit
+    `panels: {}` — every selected tab silently missing from the build. #}
+{%- set _builtin_panels = builtin_panels if builtin_panels is defined
+    else fail("builtin_panels missing from render context") %}
 {%- set _enabled_builtin_panels = selected_web_panels | default([]) | select("in", _builtin_panels) | list %}
 {%- set _has_default_panel = default_panel is defined and default_panel %}
 {%- set _has_presets = panel_presets is defined and panel_presets %}

--- a/tests/cli/data/json_keysets/ariel_status.json
+++ b/tests/cli/data/json_keysets/ariel_status.json
@@ -8,6 +8,7 @@
   "embedding_tables[].entries",
   "embedding_tables[].table",
   "enhancement_modules",
+  "enhancement_modules.qmd_export",
   "enhancement_modules.semantic_processor",
   "enhancement_modules.text_embedding",
   "entries",

--- a/tests/cli/test_ariel_registry_choices.py
+++ b/tests/cli/test_ariel_registry_choices.py
@@ -1,0 +1,127 @@
+"""``osprey ariel``'s choice options resolve from the registry, not a literal.
+
+``--adapter``, ``--module`` and ``--mode`` used to freeze the framework's own
+names into ``click.Choice`` at import time, so a deployment that registered its
+own ingestion adapter could not name it on the command line. Each option now
+resolves its options from the registry when the command is parsed.
+
+The second half covers the default that went with that literal: ``ingest``
+shipped ``--adapter generic_json``, which silently outranked an
+``ariel.ingestion.adapter`` the project had authored. Passing nothing now leaves
+the configured adapter in place, the rule ``watch`` already followed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from osprey.cli.ariel import (
+    _ENHANCEMENT_MODULES_ATTR,
+    _INGESTION_ADAPTERS_ATTR,
+    _SEARCH_MODULES_ATTR,
+    _framework_registrations,
+    _RegistryChoice,
+    ariel_group,
+)
+from osprey.services.ariel_search import cli_operations as ops
+
+_DB = {"database": {"uri": "postgresql://ariel:ariel@localhost:5432/ariel"}}
+
+
+@pytest.fixture
+def registered_ingest(monkeypatch) -> list[dict[str, Any]]:
+    """Stub ``osprey ariel ingest``'s work and record what it was called with."""
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_ingest(config_dict, source, adapter, since, limit, dry_run, progress=None):
+        calls.append({"config": config_dict, "adapter": adapter})
+        return ops.IngestResult(count=0, enhanced_count=0, failed_count=0, dry_run=True)
+
+    async def _no_resync(config_dict, progress=None):
+        return None
+
+    monkeypatch.setattr(ops, "run_ingest", _fake_ingest)
+    monkeypatch.setattr(ops, "resync_qmd_mirror_best_effort", _no_resync)
+    return calls
+
+
+class TestChoicesComeFromTheRegistry:
+    """Every option's option list is the registry's list."""
+
+    @pytest.mark.parametrize(
+        "attribute",
+        [_SEARCH_MODULES_ATTR, _ENHANCEMENT_MODULES_ATTR, _INGESTION_ADAPTERS_ATTR],
+    )
+    def test_choices_match_the_registered_names(self, attribute: str) -> None:
+        assert set(_RegistryChoice(attribute).choices) >= set(_framework_registrations(attribute))
+
+    def test_every_registered_adapter_parses(self, monkeypatch, registered_ingest) -> None:
+        """A name the registry carries is accepted, one it does not is refused."""
+        monkeypatch.setattr("osprey.cli.ariel.get_config_value", lambda key, default=None: _DB)
+
+        for name in _framework_registrations(_INGESTION_ADAPTERS_ATTR):
+            result = CliRunner().invoke(ariel_group, ["ingest", "-s", "entries.json", "-a", name])
+            assert result.exit_code == 0, result.output
+
+        refused = CliRunner().invoke(
+            ariel_group, ["ingest", "-s", "entries.json", "-a", "no_such_adapter"]
+        )
+        assert refused.exit_code != 0
+
+    def test_a_registry_added_adapter_is_accepted(self, monkeypatch, registered_ingest) -> None:
+        """The point of the change: a facility's own adapter needs no code edit."""
+        monkeypatch.setattr("osprey.cli.ariel.get_config_value", lambda key, default=None: _DB)
+        monkeypatch.setattr(
+            "osprey.cli.ariel._registered_names",
+            lambda attribute: ("facility_logbook",),
+        )
+
+        result = CliRunner().invoke(
+            ariel_group, ["ingest", "-s", "entries.json", "-a", "facility_logbook"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert registered_ingest[-1]["adapter"] == "facility_logbook"
+
+
+class TestIngestHonoursTheConfiguredAdapter:
+    """``--adapter`` is an override, not a value the CLI always supplies."""
+
+    def test_no_flag_passes_no_override(self, monkeypatch, registered_ingest) -> None:
+        monkeypatch.setattr("osprey.cli.ariel.get_config_value", lambda key, default=None: _DB)
+
+        result = CliRunner().invoke(ariel_group, ["ingest", "-s", "entries.json"])
+
+        assert result.exit_code == 0, result.output
+        assert registered_ingest[-1]["adapter"] is None
+
+    async def test_run_ingest_keeps_the_configured_adapter(self, monkeypatch) -> None:
+        """No override leaves ``ingestion.adapter`` as config.yml authored it."""
+        config_dict = {"ingestion": {"adapter": "als_logbook"}}
+        seen: list[str] = []
+
+        class _Adapter:
+            source_system_name = "als_logbook"
+
+            async def fetch_entries(self, since=None, limit=None):
+                return
+                yield  # pragma: no cover — makes this an async generator
+
+        def _fake_get_adapter(config):
+            seen.append(config.ingestion.adapter)
+            return _Adapter()
+
+        monkeypatch.setattr("osprey.services.ariel_search.ingestion.get_adapter", _fake_get_adapter)
+        monkeypatch.setattr(
+            "osprey.services.ariel_search.enhancement.create_enhancers_from_config",
+            lambda config: [],
+        )
+
+        result = await ops.run_ingest(config_dict, "entries.json", None, None, None, True)
+
+        assert result.dry_run
+        assert seen == ["als_logbook"]
+        assert config_dict["ingestion"]["adapter"] == "als_logbook"

--- a/tests/cli/test_ariel_registry_choices.py
+++ b/tests/cli/test_ariel_registry_choices.py
@@ -22,11 +22,11 @@ from osprey.cli.ariel import (
     _ENHANCEMENT_MODULES_ATTR,
     _INGESTION_ADAPTERS_ATTR,
     _SEARCH_MODULES_ATTR,
-    _framework_registrations,
     _RegistryChoice,
     ariel_group,
 )
 from osprey.services.ariel_search import cli_operations as ops
+from osprey.services.ariel_search.config import framework_ariel_names
 
 _DB = {"database": {"uri": "postgresql://ariel:ariel@localhost:5432/ariel"}}
 
@@ -56,13 +56,13 @@ class TestChoicesComeFromTheRegistry:
         [_SEARCH_MODULES_ATTR, _ENHANCEMENT_MODULES_ATTR, _INGESTION_ADAPTERS_ATTR],
     )
     def test_choices_match_the_registered_names(self, attribute: str) -> None:
-        assert set(_RegistryChoice(attribute).choices) >= set(_framework_registrations(attribute))
+        assert set(_RegistryChoice(attribute).choices) >= set(framework_ariel_names(attribute))
 
     def test_every_registered_adapter_parses(self, monkeypatch, registered_ingest) -> None:
         """A name the registry carries is accepted, one it does not is refused."""
         monkeypatch.setattr("osprey.cli.ariel.get_config_value", lambda key, default=None: _DB)
 
-        for name in _framework_registrations(_INGESTION_ADAPTERS_ATTR):
+        for name in framework_ariel_names(_INGESTION_ADAPTERS_ATTR):
             result = CliRunner().invoke(ariel_group, ["ingest", "-s", "entries.json", "-a", name])
             assert result.exit_code == 0, result.output
 

--- a/tests/cli/test_claude_code_resolver.py
+++ b/tests/cli/test_claude_code_resolver.py
@@ -536,6 +536,46 @@ class TestAgentDefaultTiersConsistency:
                 )
 
 
+class TestAgentDefaultTiersCoverFrameworkAgents:
+    """The tier map and the agent catalog are one list, not two.
+
+    ``AGENT_DEFAULT_TIERS`` lives in ``osprey.build`` and ``FRAMEWORK_AGENTS`` in
+    ``osprey.registry.mcp`` because the build must not import the registry — but
+    an agent missing from the map is not a build error, it silently takes the
+    ``sonnet`` fallback and disappears from ``osprey status``. So the two are
+    pinned equal here, and each agent template's own literal fallback is pinned
+    to the map entry it stands in for.
+    """
+
+    def test_the_map_covers_exactly_the_framework_agents(self):
+        from osprey.registry.mcp import FRAMEWORK_AGENTS
+
+        assert set(AGENT_DEFAULT_TIERS) == set(FRAMEWORK_AGENTS)
+
+    def test_each_template_fallback_matches_the_map(self):
+        """The ``else "<tier>"`` in a template renders when no spec is passed."""
+        import re
+        from pathlib import Path
+
+        agents_dir = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "osprey"
+            / "templates"
+            / "claude_code"
+            / "claude"
+            / "agents"
+        )
+        pattern = re.compile(r'agent_tier\("(?P<name>[^"]+)"\).*?else "(?P<tier>[a-z]+)"')
+        seen = {}
+        for path in sorted(agents_dir.glob("*.md.j2")):
+            match = pattern.search(path.read_text())
+            assert match, f"{path.name} declares no model line with a fallback tier"
+            seen[match.group("name")] = match.group("tier")
+
+        assert seen == AGENT_DEFAULT_TIERS
+
+
 class TestEnvBlockTierModels:
     """Env block contains ANTHROPIC_DEFAULT_*_MODEL vars for all providers."""
 

--- a/tests/cli/test_config_records_environment.py
+++ b/tests/cli/test_config_records_environment.py
@@ -36,6 +36,7 @@ from osprey.cli.build_cmd import build
 from osprey.cli.init_cmd import init
 from osprey.cli.templates.manager import TemplateManager
 from osprey.port_layout import DEFAULT_PORT_BASE, layout_ports
+from osprey.profiles.web_panels import BUILTIN_PANELS
 from osprey.utils.config import ConfigBuilder
 
 # The one bundled template that renders an ``execution:`` block. It is derived
@@ -120,12 +121,15 @@ class TestTemplatesRenderTheDeclaration:
     def jinja_env(self):
         return TemplateManager().jinja_env
 
-    #: The port table the real render builds in
+    #: The port table and panel registry the real render builds in
     #: TemplateManager._project_context. These tests reach the
-    #: environment directly, so they carry it themselves.
+    #: environment directly, so they carry them themselves. The template
+    #: refuses a render with no ``builtin_panels``, deliberately: it has no
+    #: other source for what a selected tab may name.
     PORTS = {
         "port_base": DEFAULT_PORT_BASE,
         "osprey_ports": layout_ports(DEFAULT_PORT_BASE),
+        "builtin_panels": sorted(BUILTIN_PANELS),
     }
 
     @pytest.mark.parametrize("template_name", CONFIG_TEMPLATES)

--- a/tests/cli/test_json_keyset_capture.py
+++ b/tests/cli/test_json_keyset_capture.py
@@ -23,8 +23,10 @@ so equality is a real contract rather than a fixture artifact:
 * ``query`` → ``tool_traces[]`` (a literal dict comprehension in
   ``_build_json_output``);
 * ``ariel status`` → ``database``, ``embedding_tables[]``,
-  ``enhancement_modules``, ``search_modules`` (all literal dicts in
-  ``get_status``);
+  ``enhancement_modules``, ``search_modules``. ``database`` is a literal dict
+  in ``get_status``; the two module maps are keyed by what the registry
+  carries, so this golden also records which modules the framework registers,
+  and a module added or renamed lands here.
 * ``ariel search`` → ``entries[]`` (``_entry_summary``'s fixed projection).
 
 Deliberately **not** nested: ``health``'s ``results[]`` rows, whose ``value`` /

--- a/tests/cli/test_templates.py
+++ b/tests/cli/test_templates.py
@@ -711,26 +711,26 @@ class TestBuiltinPanelRegistryDrift:
         assert "ariel" not in panels
 
     @pytest.mark.parametrize("template_path", PANEL_TEMPLATES)
-    def test_no_builtin_is_enabled_when_the_registry_is_absent(self, template_path):
-        """The registry is the only source: without it, no builtin is enabled.
+    def test_a_render_without_the_registry_refuses(self, template_path):
+        """The registry is the only source, and its absence is a wiring fault.
 
-        The template carries no inline list of its own to fall back to, so a
-        selection it cannot check against the registry enables nothing rather
-        than being waved through. Proves ``okf`` is enabled above because
-        ``BUILTIN_PANELS`` supplies it, not by accident of a literal that
-        happens to name it.
+        Every context the manager builds carries ``builtin_panels``, so a render
+        that reaches the panel block without it cannot check the selection
+        against anything. Degrading to an empty list would emit ``panels: {}``
+        and take every selected tab out of the build with nothing said; a render
+        error is the honest answer and the one a build surfaces.
         """
-        import yaml
+        from jinja2 import TemplateRuntimeError
 
         manager = TemplateManager()
         template = manager.jinja_env.get_template(template_path)
-        rendered = template.render(
-            selected_web_panels=["okf", "channel-finder"],
-            port_base=DEFAULT_PORT_BASE,
-            osprey_ports=layout_ports(DEFAULT_PORT_BASE),
-        )
 
-        assert yaml.safe_load(rendered).get("web") is None
+        with pytest.raises(TemplateRuntimeError, match="builtin_panels"):
+            template.render(
+                selected_web_panels=["okf", "channel-finder"],
+                port_base=DEFAULT_PORT_BASE,
+                osprey_ports=layout_ports(DEFAULT_PORT_BASE),
+            )
 
     def test_create_project_enables_okf_builtin_panel(self, tmp_path):
         """End-to-end: ``manager.py`` injects ``sorted(BUILTIN_PANELS)`` → template

--- a/tests/deployment/test_status_sections.py
+++ b/tests/deployment/test_status_sections.py
@@ -762,6 +762,23 @@ def test_the_per_agent_model_table_is_opt_in(lifecycle_repo, runtime):
     assert "model tiers" in default
 
 
+def test_the_agent_table_lists_every_framework_agent(lifecycle_repo, runtime):
+    """The table is the agent catalog, not the subset the tier map names.
+
+    An agent absent from ``AGENT_DEFAULT_TIERS`` still runs — it takes the
+    resolver's ``sonnet`` fallback — so leaving it out of the report would make
+    status the one place its model went unsaid.
+    """
+    from osprey.registry.mcp import FRAMEWORK_AGENTS
+
+    render_build(lifecycle_repo)
+
+    text = report(lifecycle_repo, show_agents=True)
+
+    for agent_name in FRAMEWORK_AGENTS:
+        assert agent_name in text, agent_name
+
+
 # ---------------------------------------------------------------------------
 # Status changes nothing
 # ---------------------------------------------------------------------------

--- a/tests/deployment/web_terminals/golden/landing.html
+++ b/tests/deployment/web_terminals/golden/landing.html
@@ -416,12 +416,16 @@ lets you judge the next thing it proposes.</p>
 <li>Notice which channels and sources it drew on.</li>
 <li>Stop the session if it starts looping or heads somewhere you did not intend.</li>
 </ul>
-<h2>Know what this deployment covers</h2>
-<p>Every deployment is set up for a particular set of systems and channels.</p>
+<h2>Agents are built to find you an answer</h2>
+<p>These agents are biased toward producing a solution for whatever you ask them
+for. Ask for something this deployment cannot actually do and you are more likely
+to get an answer-shaped attempt than a refusal.</p>
 <ul>
-<li>Know which subsystems and channels yours is configured for.</li>
+<li>Know which subsystems and channels this deployment is configured for.</li>
 <li>Narrow open-ended asks ("fix everything", "optimize the beam") yourself before
   handing them over.</li>
+<li>Treat a confident answer about something outside that scope as a reason to
+  check, not as a result.</li>
 </ul>
 <p>When in doubt, stop the session and talk to your control system team.</p></div>
     </details>

--- a/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
+++ b/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
@@ -110,6 +110,28 @@ unmasked: the frozen copy must still spell ports the layout cannot produce for
 this config, which is exactly what a copy regenerated from today's renderer
 could not do.
 
+**Notice prose is masked, not pinned**, for the same reason and on the same
+terms. The landing page renders each notice as a ``<details>`` section whose
+``<div class="landing-notice-body">`` holds the notice document turned into
+HTML. That prose is framework-shipped safety copy: no auth posture decides a
+word of it, it is written for operators rather than emitted by a template
+branch, and it is edited whenever the advice improves. Pinning it here would
+make every copy edit read as an SC6 violation and would say nothing about
+authentication. So both sides go through :func:`_mask_notice_bodies` too, which
+replaces the interior of each notice body with ``<notice body>`` and leaves the
+delimiters — and therefore the section's presence, count and ordering — in the
+diff.
+
+What that mask does NOT cover is everything SC6 is about. The ``<details>``
+wrapper, the ``id``, the ``<summary>`` label, every user card, badge, form,
+role and claim on the page sits outside a notice body and is still compared
+line for line; ``test_no_authorization_vocabulary_reaches_a_roles_off_render``
+reads the artifacts *unmasked*, so authorization vocabulary inside a notice
+body fails there. And a mask that stopped matching would hide the bodies'
+disappearance, so
+``test_the_frozen_baseline_really_predates_the_feature`` counts them on both
+sides.
+
 **When a hunk here fails**, the question is not "how do I widen the allowlist".
 It is: does the new line belong in a ``token``, roles-off render at all? If it
 carries authorization, a role, a claim or a login, the answer is no and the
@@ -233,6 +255,57 @@ def _ports_in(text: str) -> frozenset[int]:
     return frozenset(
         int(match.group("port")) for pattern in _PORT_SITES for match in pattern.finditer(text)
     )
+
+
+# --- The notice-body mask ----------------------------------------------------
+# See "Notice prose is masked, not pinned" in the module docstring.
+
+#: What a masked notice body reads as. Not prose, so a body the mask reaches can
+#: never compare equal to one it missed.
+_NOTICE_BODY_MASK = "<notice body>"
+
+#: One landing-page notice's rendered body: the markdown document as HTML,
+#: between the wrapper `<div>` the template emits and its close. Non-greedy, so
+#: a page with several notices masks each body separately and keeps every
+#: delimiter between them in the diff.
+_NOTICE_BODY = re.compile(
+    r'(?P<open><div class="landing-notice-body">)(?P<body>.*?)(?P<close></div>)',
+    re.DOTALL,
+)
+
+
+def _mask_notice_bodies(text: str) -> str:
+    """Blank out the prose inside every landing-page notice in one artifact.
+
+    Args:
+        text: A rendered or frozen artifact. The two that carry no notices are
+            returned unchanged.
+
+    Returns:
+        The same text with each notice body replaced by
+        :data:`_NOTICE_BODY_MASK`, so a render whose safety copy has been
+        reworded compares equal to the frozen baseline's — while the notice's
+        wrapper, id and ``<summary>`` label stay in the comparison.
+    """
+    return _NOTICE_BODY.sub(
+        lambda match: f"{match.group('open')}{_NOTICE_BODY_MASK}{match.group('close')}", text
+    )
+
+
+def _notice_bodies(text: str) -> list[str]:
+    """Every notice body one artifact carries, in order.
+
+    The inverse of :func:`_mask_notice_bodies` over the same pattern, so what is
+    read back here is exactly what the diffs below stop seeing.
+
+    Args:
+        text: A rendered or frozen artifact.
+
+    Returns:
+        The bodies found, as HTML — empty for the two artifacts that are not the
+        landing page.
+    """
+    return [match.group("body") for match in _NOTICE_BODY.finditer(text)]
 
 
 #: The registry port families `EXAMPLE_CONFIG`'s roster renders, one port per
@@ -479,16 +552,22 @@ def _opcodes(
 ) -> tuple[list[str], list[str], list[tuple]]:
     """Baseline lines, current lines, and the line-level edit script between them.
 
-    Both sides are port-masked first (see the module docstring), so the edit
-    script reports structure and never renumbering.
+    Both sides are port-masked and notice-body-masked first (see the module
+    docstring), so the edit script reports structure and never renumbering or a
+    reworded safety notice.
 
     ``artifacts`` defaults to the absent-stanza render; pass the explicit-token
     render to hold that spelling to the same frozen baseline.
     """
     rendered = _token_render() if artifacts is None else artifacts
-    old = _mask_ports(_baseline(name)).splitlines()
-    new = _mask_ports(rendered[_ARTIFACTS[name]]).splitlines()
+    old = _masked(_baseline(name)).splitlines()
+    new = _masked(rendered[_ARTIFACTS[name]]).splitlines()
     return old, new, difflib.SequenceMatcher(a=old, b=new, autojunk=False).get_opcodes()
+
+
+def _masked(text: str) -> str:
+    """One artifact with both masks applied, in the order the diffs see them."""
+    return _mask_notice_bodies(_mask_ports(text))
 
 
 def test_the_frozen_baseline_really_predates_the_feature() -> None:
@@ -526,6 +605,30 @@ def test_the_frozen_baseline_really_predates_the_feature() -> None:
     assert "X-Osprey-Auth-Role" not in nginx
 
     _assert_the_frozen_ports_predate_the_layout()
+    _assert_the_notice_body_mask_still_matches()
+
+
+def _assert_the_notice_body_mask_still_matches() -> None:
+    """The notice-body mask hides prose only while it is finding prose to hide.
+
+    A mask that stopped matching — a renamed wrapper class, a notice the page no
+    longer renders — would let the bodies vanish from BOTH sides of every diff
+    and report nothing, so the count is asserted equal here instead. The bodies
+    themselves stay outside the comparison; how many sections the page carries
+    does not.
+    """
+    frozen = _notice_bodies(_baseline("landing.html"))
+    live = _notice_bodies(_token_render()[_ARTIFACTS["landing.html"]])
+
+    assert frozen, (
+        "the frozen landing baseline carries no notice body — the mask's wrapper "
+        "spelling no longer matches the artifact it was written for"
+    )
+    assert len(live) == len(frozen), (
+        f"the `token` landing page renders {len(live)} notice section(s) where the "
+        f"pre-feature render had {len(frozen)}. The mask hides a notice's PROSE, "
+        f"never whether the section is there."
+    )
 
 
 def _assert_the_frozen_ports_predate_the_layout() -> None:

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -346,7 +346,9 @@ config:
   # above, so this deployment's baseline is a facility-shaped soft IOC that
   # behaves like hardware and moves nothing. "virtual_accelerator" is the
   # sandbox simulator, "epics" your own control system, "mock" needs no
-  # containers but cannot complete a plan.
+  # containers but cannot complete a plan. "doocs" and "tango" reach those
+  # control systems in place of Channel Access. Those five are every type
+  # `osprey init` will materialize; `osprey config --defaults` lists them too.
   # `control_target_set live` moves a session onto the machine authored under
   # `epics:`. The template ships that block unconfigured — author its
   # `gateways` and `probe_channel` first — then the switch probes that target,
@@ -499,8 +501,8 @@ config:
   # not turn it on; without this line you would deploy a store and not read it.
   # The store's coordinates (`archiver.mongodb_archiver.*`) are derived from
   # that block, so they are not written here. The alternatives are
-  # "mock_archiver" (synthesized history) and "epics_archiver" (an Archiver
-  # Appliance, configured below).
+  # "mock_archiver" (synthesized history), "epics_archiver" (an Archiver
+  # Appliance, configured below) and "doocs_archiver" (DOOCS local history).
   archiver.type: mongodb_archiver
   # When a read names no bin size, the bin is chosen so a continuously archived
   # channel returns about this many points. The agent is told which bin it got.

--- a/tests/integration/test_qmd_ariel_resync_paths.py
+++ b/tests/integration/test_qmd_ariel_resync_paths.py
@@ -53,6 +53,7 @@ from typing import Any
 
 import pytest
 
+from osprey.mcp_server.ariel.server import ARIEL_NATIVE_SOURCE_SYSTEM
 from tests.integration._qmd_ariel_support import open_migrated_repository, qmd_ariel_config_dict
 
 pytestmark = [
@@ -362,7 +363,7 @@ class TestMcpEntryCreatePath:
         )
         entry_id = payload["entry_id"]
 
-        assert payload["source_system"] == "ARIEL MCP"
+        assert payload["source_system"] == ARIEL_NATIVE_SOURCE_SYSTEM
         assert lane.mirrored_ids() == set(), "the MCP write must bypass the enhancers"
 
         result = await lane.resync()

--- a/tests/mcp_server/ariel/test_entry.py
+++ b/tests/mcp_server/ariel/test_entry.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from osprey.mcp_server.ariel.server import ARIEL_NATIVE_SOURCE_SYSTEM
 from osprey.mcp_server.ariel.server_context import initialize_ariel_context
 from osprey.port_layout import default_port
 from tests.mcp_server.ariel.conftest import get_tool_fn, make_mock_entry
@@ -118,12 +119,12 @@ async def test_entry_create_all_fields(tmp_path, monkeypatch):
 
     data = json.loads(result)
     assert data["entry_id"].startswith("ariel-")
-    assert data["source_system"] == "ARIEL MCP"
+    assert data["source_system"] == ARIEL_NATIVE_SOURCE_SYSTEM
     assert "created successfully" in data["message"]
 
     # Verify the upsert was called with correct data
     call_args = mock_service.repository.upsert_entry.call_args[0][0]
-    assert call_args["source_system"] == "ARIEL MCP"
+    assert call_args["source_system"] == ARIEL_NATIVE_SOURCE_SYSTEM
     assert call_args["author"] == "Bob"
     assert call_args["metadata"]["logbook"] == "Operations"
     assert call_args["metadata"]["shift"] == "Day"

--- a/tests/mcp_server/test_type_registry.py
+++ b/tests/mcp_server/test_type_registry.py
@@ -36,6 +36,43 @@ class TestTypeDefs:
         assert HEX_RE.match(td.color), f"tool type {key!r} has invalid colour {td.color!r}"
 
 
+class TestSerializerCoverage:
+    """Every type ``serialize_object`` can stamp is a registered one.
+
+    The gallery reads its badge label and colour from this registry, so an
+    artifact stamped with a type the registry does not carry renders with the
+    raw key as its label and no colour at all — silently, in the UI only.
+    """
+
+    def test_every_emitted_artifact_type_is_registered(self):
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[2] / "src" / "osprey" / "stores" / "artifact_store.py"
+        ).read_text()
+        tree = ast.parse(source)
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "serialize_object"
+        )
+
+        # (content, artifact_type, filename, mime) — the second element of every
+        # tuple this function returns.
+        emitted = {
+            node.value.elts[1].value
+            for node in ast.walk(function)
+            if isinstance(node, ast.Return)
+            and isinstance(node.value, ast.Tuple)
+            and len(node.value.elts) == 4
+            and isinstance(node.value.elts[1], ast.Constant)
+        }
+
+        assert emitted, "the AST scan found no artifact types — the scan is broken"
+        assert emitted <= set(ARTIFACT_TYPES)
+
+
 class TestPublicAPI:
     def test_get_artifact_types_returns_copy(self):
         a = get_artifact_types()

--- a/tests/profiles/test_approval_tools_parity.py
+++ b/tests/profiles/test_approval_tools_parity.py
@@ -1,0 +1,164 @@
+"""The ``approval.tools.<tool>`` rows the root presets ship, against the registry.
+
+Every row is a hand-written policy for one tool. The set is deliberately SMALLER
+than the set of tools the approval hook governs — a curated starter subset under
+a fail-closed ``approval.default_policy: always``, so a governed tool with no row
+prompts every time rather than slipping through. The manifest states that
+asymmetry outright and says not to "fix" one side to match the other, and
+``scripts/check_config_keys.py``'s own governed-set checks already go red when a
+newly gated tool appears.
+
+What is NOT protected by any of that is the other direction: a row naming a tool
+the preset's resolved servers do not gate. Such a row governs nothing, reads as
+posture the deployment does not have, and nothing errors. That is what these
+tests pin, plus the two other surfaces the same set has to appear on: the
+manifest documents every shipped row, and the settings panel's ``ENUM_FIELDS``
+offers each one as a policy dropdown. A key the panel does not know renders as a
+free-text box, which is an approval policy an operator can only get wrong, so
+the panel is held to the whole set rather than to a subset of it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRESET_DIR = REPO_ROOT / "src" / "osprey" / "profiles" / "presets"
+MANIFEST_PATH = REPO_ROOT / "src" / "osprey" / "profiles" / "config_key_manifest.yml"
+GUARD_PATH = REPO_ROOT / "scripts" / "check_config_keys.py"
+SETTINGS_JS = (
+    REPO_ROOT / "src" / "osprey" / "interfaces" / "web_terminal" / "static" / "js" / "settings.js"
+)
+
+#: The four documents an operator starts from. Persona presets extend
+#: control-assistant and carry deltas, not blocks of their own.
+ROOT_PRESETS = ("control-assistant", "hello-world", "ariel-standalone", "channel-finder-standalone")
+
+#: Rows that name a tool their preset's servers do not gate, and the reason.
+#: Quoted from the manifest's own entry for these keys: "Inert in hello_world:
+#: that template disables the ariel server, so the tool never exists. Harmless
+#: (fail-closed either way); recorded so it is not mistaken for drift." The
+#: manifest is pinned to this set below, so the two cannot part company.
+_INERT_ROWS = {("hello-world", "entry_create"), ("hello-world", "entry_publish")}
+
+#: The manifest phrase that records the exemption above. Matched on the shape
+#: rather than the exact spelling: the manifest writes the preset's name both
+#: ways ("hello_world" beside "hello-world"), and which separator a note happens
+#: to use is not the fact being pinned.
+_INERT_NOTE_RE = re.compile(r"inert in hello[-_]world", re.IGNORECASE)
+
+_ROW_RE = re.compile(r"^\s*approval\.tools\.([a-z_]+):", re.MULTILINE)
+
+#: The same key in the settings panel's `ENUM_FIELDS` map, where it is a
+#: quoted JS string rather than a YAML key.
+_ENUM_FIELD_RE = re.compile(r"""['"]approval\.tools\.([a-z_]+)['"]\s*:""")
+
+pytestmark = pytest.mark.unit
+
+
+def _load_guard():
+    """Import ``scripts/check_config_keys.py`` by path, as its own suite does."""
+    spec = importlib.util.spec_from_file_location("check_config_keys", GUARD_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def guard():
+    module = _load_guard()
+    return module.ConfigKeyGuard(REPO_ROOT, module.load_manifest(module.DEFAULT_MANIFEST))
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return yaml.safe_load(MANIFEST_PATH.read_text())
+
+
+def _preset_rows(preset: str) -> set[str]:
+    """The tool short names ``approval.tools.<name>`` names in *preset*."""
+    return set(_ROW_RE.findall((PRESET_DIR / f"{preset}.yml").read_text()))
+
+
+@pytest.mark.parametrize("preset", ROOT_PRESETS)
+def test_no_row_names_a_tool_the_preset_does_not_gate(preset: str, guard) -> None:
+    """A policy for an ungated tool is posture the deployment does not have."""
+    governed = guard.governed_tools(preset)
+    unexplained = {
+        tool for tool in _preset_rows(preset) - governed if (preset, tool) not in _INERT_ROWS
+    }
+
+    assert not unexplained, (
+        f"{preset}: approval.tools names {sorted(unexplained)}, which its resolved "
+        f"servers do not attach the approval hook to"
+    )
+
+
+def test_the_inert_rows_are_still_recorded_in_the_manifest(manifest) -> None:
+    """The exemption above is the manifest's, not this test's."""
+    keys = manifest["keys"]
+    for _preset, tool in _INERT_ROWS:
+        note = keys[f"approval.tools.{tool}"].get("note", "")
+        assert _INERT_NOTE_RE.search(note), tool
+
+
+def test_the_manifest_rows_are_the_union_of_what_the_presets_ship(manifest) -> None:
+    """Every shipped row is documented, and no documented row is unshipped."""
+    documented = {
+        key.removeprefix("approval.tools.")
+        for key in manifest["keys"]
+        if key.startswith("approval.tools.")
+    }
+    shipped: set[str] = set()
+    for preset in ROOT_PRESETS:
+        shipped |= _preset_rows(preset)
+
+    assert documented == shipped
+
+
+def _settings_panel_rows() -> set[str]:
+    """The tool short names the settings panel offers a policy dropdown for."""
+    return set(_ENUM_FIELD_RE.findall(SETTINGS_JS.read_text()))
+
+
+def test_the_settings_panel_offers_every_shipped_row() -> None:
+    """A settable approval policy the panel does not know is a free-text box.
+
+    The drawer is where an operator changes posture at runtime, and
+    ``ENUM_FIELDS`` decides which keys it renders as a dropdown over the three
+    policies. A key missing from it is offered as prose the operator has to
+    spell correctly, for a value the hook reads fail-closed.
+    """
+    shipped: set[str] = set()
+    for preset in ROOT_PRESETS:
+        shipped |= _preset_rows(preset)
+
+    offered = _settings_panel_rows()
+
+    assert offered == shipped, (
+        "the settings panel and the shipped presets name different approval.tools "
+        f"keys: panel-only {sorted(offered - shipped)}, preset-only "
+        f"{sorted(shipped - offered)}. Every settable policy gets a dropdown."
+    )
+
+
+def test_the_panel_offers_no_policy_the_servers_do_not_gate(guard) -> None:
+    """The panel's own rows, read against the registry rather than via a preset."""
+    governed: set[str] = set()
+    for preset in ROOT_PRESETS:
+        governed |= guard.governed_tools(preset)
+
+    ungated = {tool for tool in _settings_panel_rows() if tool not in governed}
+
+    assert not ungated, (
+        f"the settings panel offers approval policies for {sorted(ungated)}, which "
+        f"no root preset's resolved servers attach the approval hook to"
+    )

--- a/tests/profiles/test_preset_connector_prose.py
+++ b/tests/profiles/test_preset_connector_prose.py
@@ -1,0 +1,156 @@
+"""The connector and archiver types the root presets name in prose.
+
+A preset is a static document: it cannot render its "the alternatives are ..."
+comment from :mod:`osprey_connectors.types`, so the enumeration is hand-kept and
+goes stale silently the moment a connector is added or removed. These tests are
+the pin that makes that loud.
+
+What is read is narrow on purpose: the value of ``control_system.type`` /
+``archiver.type`` plus the comment block directly above it — the prose that
+introduces the key and lists its alternatives. Inside that block every
+double-quoted lower_snake token is a type name; elsewhere in the file a quoted
+token is as likely to be an approval policy or a persona id.
+
+Three rules, and the third is what keeps a partial list honest:
+
+1. every type name the block mentions is a type the framework actually ships —
+   a renamed or deleted connector cannot be left behind in the copy;
+2. ``control-assistant``, the reference document, mentions every shipped type —
+   a new connector nobody documented fails here;
+3. a block that mentions only some of them points the reader at
+   ``osprey config --defaults``, so a short list never reads as a complete one,
+   and that ledger really does name every type — a pointer at a surface that
+   enumerates nothing is worse than the short list it excuses.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from osprey_connectors.types import (
+    CLI_ARCHIVER_TYPES,
+    CLI_CONTROL_SYSTEM_TYPES,
+    SET_CONTROL_SYSTEM_TYPES,
+)
+
+PRESET_DIR = Path(__file__).resolve().parents[2] / "src" / "osprey" / "profiles" / "presets"
+
+#: The four documents an operator starts from.
+ROOT_PRESETS = ("control-assistant", "hello-world", "ariel-standalone", "channel-finder-standalone")
+
+#: The preset that enumerates the alternatives, and is therefore held to the
+#: complete list. The other three describe only the one type they set.
+REFERENCE_PRESET = "control-assistant"
+
+#: Where a block sends a reader whose type it does not name.
+FULL_LIST_POINTER = "osprey config --defaults"
+
+#: ``live_standin`` is settable but not initable, so prose may name it while the
+#: CLI choice list does not carry it.
+SHIPPED = {
+    "control_system.type": frozenset(SET_CONTROL_SYSTEM_TYPES),
+    "archiver.type": frozenset(CLI_ARCHIVER_TYPES),
+}
+
+#: The complete list each block is measured against — what ``osprey init`` will
+#: actually materialize, which is the narrower of the two control-system lists.
+ADVERTISED = {
+    "control_system.type": frozenset(CLI_CONTROL_SYSTEM_TYPES),
+    "archiver.type": frozenset(CLI_ARCHIVER_TYPES),
+}
+
+_QUOTED_TOKEN_RE = re.compile(r'"([a-z][a-z0-9_]*)"')
+#: The ledger writes prose, and prose quotes a name in backticks.
+_BACKTICK_TOKEN_RE = re.compile(r"`([a-z][a-z0-9_]*)`")
+
+
+def _type_block(preset: str, key: str) -> tuple[set[str], str] | None:
+    """The names *key*'s block in *preset* mentions, and the block's text.
+
+    Returns ``None`` when the preset does not set *key* at all — the two
+    standalone presets set neither, and a preset that stays silent makes no
+    claim to check.
+    """
+    lines = (PRESET_DIR / f"{preset}.yml").read_text().splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip().startswith(f"{key}:"):
+            continue
+        value = line.split(":", 1)[1].strip()
+        comments: list[str] = []
+        cursor = index - 1
+        while cursor >= 0 and lines[cursor].strip().startswith("#"):
+            comments.append(lines[cursor])
+            cursor -= 1
+        names = {value} if value else set()
+        for comment in comments:
+            names.update(_QUOTED_TOKEN_RE.findall(comment))
+        return names, "\n".join(reversed(comments))
+    return None
+
+
+_CASES = [(preset, key) for preset in ROOT_PRESETS for key in SHIPPED]
+
+
+@pytest.mark.parametrize(("preset", "key"), _CASES)
+def test_prose_names_only_shipped_types(preset: str, key: str) -> None:
+    """No preset advertises a connector or archiver the framework does not have."""
+    block = _type_block(preset, key)
+    if block is None:
+        pytest.skip(f"{preset} does not set {key}")
+    assert block[0] <= SHIPPED[key]
+
+
+@pytest.mark.parametrize("key", sorted(ADVERTISED))
+def test_the_reference_preset_names_every_shipped_type(key: str) -> None:
+    """A connector added without a line in the reference document fails here."""
+    block = _type_block(REFERENCE_PRESET, key)
+    assert block is not None
+    assert ADVERTISED[key] <= block[0]
+
+
+@pytest.mark.parametrize(("preset", "key"), _CASES)
+def test_a_partial_list_points_at_the_full_one(preset: str, key: str) -> None:
+    """Prose that names some of the types must say where the rest are.
+
+    A block naming all of them passes on its own; the failure is the middle
+    case, which reads as a complete list and is not one.
+    """
+    block = _type_block(preset, key)
+    if block is None:
+        pytest.skip(f"{preset} does not set {key}")
+    names, comment_text = block
+    if ADVERTISED[key] <= names:
+        return
+    assert FULL_LIST_POINTER in comment_text
+
+
+def _ledger_note(key: str) -> str:
+    """The comment block ``osprey config --defaults`` prints above *key*."""
+    from osprey.cli.config_cmd import _render_defaults_ledger
+
+    lines = _render_defaults_ledger().splitlines()
+    index = next(i for i, line in enumerate(lines) if line.startswith(f"{key}: "))
+    note: list[str] = []
+    cursor = index - 1
+    while cursor >= 0 and lines[cursor].startswith("# ") and not lines[cursor].startswith("# ──"):
+        note.append(lines[cursor])
+        cursor -= 1
+    return "\n".join(reversed(note))
+
+
+@pytest.mark.parametrize("key", sorted(ADVERTISED))
+def test_the_pointed_at_ledger_names_every_type(key: str) -> None:
+    """The surface a partial list sends the reader to lists the whole set.
+
+    ``control_system.type`` and ``archiver.type`` have no fallback, so the
+    ledger's ``default:`` column prints ``<required>`` and nothing else. Their
+    admissible values are a closed set with nowhere else to appear for a reader
+    holding only the ledger, so the manifest's ``default_note`` names them and
+    this is the pin that keeps that list whole.
+    """
+    named = set(_BACKTICK_TOKEN_RE.findall(_ledger_note(key)))
+    assert ADVERTISED[key] <= named
+    assert named <= SHIPPED[key]

--- a/tests/registry/test_workspace_registration.py
+++ b/tests/registry/test_workspace_registration.py
@@ -1,0 +1,86 @@
+"""Every ``osprey_workspace`` tool is classified, and the list matches the package.
+
+``permissions_allow`` and ``permissions_ask`` are hand-kept lists of tool short
+names. Nothing errors when one drifts from what the package registers: a name
+that no longer exists renders a rule for nothing, and a tool that reaches the
+render without a rule falls through to a prompt. Both are silent, and both are a
+posture change nobody chose.
+
+So the vocabulary is pinned from both ends. Every registered tool is either
+auto-allowed, approval-gated, or named in :data:`_DELIBERATELY_PROMPTED` with
+the reason quoted from the registration; and every listed name is a tool the
+package actually registers.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from osprey.registry.mcp import FRAMEWORK_SERVERS
+
+_TOOLS_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "osprey" / "mcp_server" / "workspace" / "tools"
+)
+
+#: The rail axis: the three verbs that change what an operator can launch at
+#: all, rather than what is on screen right now. Quoted from the registration:
+#: "remove_panel_from_rail costs them the ability to launch the panel back,
+#: add_panel_to_rail puts an entry in front of them, and register_panel adds a
+#: proxied upstream." ``setup_patch`` is gated for a different reason — it
+#: rewrites the deployment's own config — and is therefore checked separately.
+#:
+#: ``register_panel`` belongs here for the strongest of the three reasons:
+#: registering a proxied upstream is a network reach beyond the workspace, so it
+#: is asked for even in a deployment that auto-allows the rest of the package.
+_DELIBERATELY_PROMPTED = {"add_panel_to_rail", "remove_panel_from_rail", "register_panel"}
+
+
+def _registered_tool_names() -> set[str]:
+    """Short names of every ``@mcp.tool()`` under the workspace tools package."""
+    names: set[str] = set()
+    for path in sorted(_TOOLS_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if any("mcp.tool" in ast.unparse(dec) for dec in node.decorator_list):
+                names.add(node.name)
+    return names
+
+
+@pytest.fixture(scope="module")
+def sdef():
+    assert "osprey_workspace" in FRAMEWORK_SERVERS
+    return FRAMEWORK_SERVERS["osprey_workspace"]
+
+
+@pytest.fixture(scope="module")
+def registered() -> set[str]:
+    tools = _registered_tool_names()
+    assert tools, "the AST scan found no @mcp.tool() functions — the scan is broken"
+    return tools
+
+
+def test_every_registered_tool_is_classified(sdef, registered) -> None:
+    """A new tool must be allowed or gated, never left to fall through."""
+    classified = set(sdef.permissions_allow) | set(sdef.permissions_ask)
+    assert registered <= classified
+
+
+def test_no_listed_name_is_a_tool_the_package_does_not_have(sdef, registered) -> None:
+    """A rule for a tool that no longer exists gates nothing."""
+    assert set(sdef.permissions_allow) | set(sdef.permissions_ask) <= registered
+
+
+def test_the_prompted_set_is_exactly_the_declared_one(sdef) -> None:
+    """``permissions_ask`` holds the rail verbs plus the config editor, nothing else."""
+    assert set(sdef.permissions_ask) == _DELIBERATELY_PROMPTED | {"setup_patch"}
+
+
+def test_every_prompted_tool_has_its_approval_hook(sdef) -> None:
+    """A tool in ``ask`` with no PreToolUse rule asks nothing at run time."""
+    gated = {rule.matcher.removeprefix("mcp__osprey_workspace__") for rule in sdef.hooks_pre}
+    assert gated == set(sdef.permissions_ask)

--- a/tests/scripts/test_config_key_guard.py
+++ b/tests/scripts/test_config_key_guard.py
@@ -775,6 +775,22 @@ def test_near_miss_sentinel_goes_red(misspelling):
     assert "cli.theme" in details(guard)
 
 
+def test_note_on_a_required_default_stays_green():
+    """`required` says no fallback exists; the note says which values are legal.
+
+    A key whose admissible values are a closed set has nowhere else to name
+    them for a reader holding only `osprey config --defaults`, so the note is
+    the answer rather than an excuse for a missing one.
+    """
+
+    def name_the_legal_values(manifest):
+        manifest["keys"]["hooks.debug"]["default_note"] = "true or false, nothing else"
+
+    guard = make_guard(name_the_legal_values)
+    guard.check_defaults()
+    assert modes(guard) == []
+
+
 def test_note_on_a_literal_default_goes_red():
     """A literal is the whole answer; a note beside one means the wrong sentinel."""
 

--- a/tests/services/ariel_search/test_repository_unit.py
+++ b/tests/services/ariel_search/test_repository_unit.py
@@ -721,14 +721,23 @@ class TestEnhancementStatus:
         assert "ORDER BY created_at ASC LIMIT %s" in body
         assert params == [7]
 
-    async def test_get_enhancement_stats_maps_row_positions(self, fake_pool_factory) -> None:
-        """The seven aggregate columns are unpacked positionally.
+    async def test_get_enhancement_stats_groups_by_module_key(self, fake_pool_factory) -> None:
+        """Whatever modules the store carries are reported, none of them named in SQL.
 
-        Hazard: the SELECT list order and this mapping are one contract with no
-        column names between them -- reordering the FILTER clauses without
-        reordering the indices would silently swap 'failed' and 'pending'.
+        The aggregate returns one row per (module, status) pair, so a module a
+        facility registered itself is counted the moment its first entry lands.
         """
-        pool = fake_pool_factory(results=[[(100, 90, 5, 5, 80, 10, 10)]])
+        pool = fake_pool_factory(
+            rows_for={
+                "jsonb_each(enhancement_status)": [
+                    (100, "text_embedding", "complete", 90),
+                    (100, "text_embedding", "failed", 5),
+                    (100, "text_embedding", "pending", 5),
+                    (100, "facility_tagger", "complete", 80),
+                    (100, "facility_tagger", "failed", 10),
+                ],
+            }
+        )
         repo = ARIELRepository(pool, _make_config())
 
         stats = await repo.get_enhancement_stats()
@@ -736,8 +745,54 @@ class TestEnhancementStatus:
         assert stats == {
             "total_entries": 100,
             "text_embedding": {"complete": 90, "failed": 5, "pending": 5},
-            "semantic_processor": {"complete": 80, "failed": 10, "pending": 10},
+            # 10 entries never reached this module at all: no key, so no row.
+            "facility_tagger": {"complete": 80, "failed": 10, "pending": 10},
         }
+
+    async def test_get_enhancement_stats_reads_one_snapshot(self, fake_pool_factory) -> None:
+        """Total and per-module counts come from a single statement.
+
+        ``pending`` is derived by subtracting the module's seen rows from the
+        total, so the two counts must describe the same snapshot. Split across
+        two statements on an autocommit connection, an ingest landing in between
+        would make the subtraction negative.
+        """
+        pool = fake_pool_factory(
+            rows_for={"jsonb_each(enhancement_status)": [(4, "text_embedding", "complete", 4)]}
+        )
+        repo = ARIELRepository(pool, _make_config())
+
+        await repo.get_enhancement_stats()
+
+        assert len(pool.calls) == 1
+        body = _sql_body(pool.calls[0][0])
+        assert "COUNT(*) AS entries FROM enhanced_entries" in body
+        assert "jsonb_each(enhancement_status)" in body
+
+    async def test_get_enhancement_stats_names_no_module_in_sql(self, fake_pool_factory) -> None:
+        """Fixed SQL text: a module name never reaches the statement."""
+        pool = fake_pool_factory(
+            rows_for={"jsonb_each(enhancement_status)": [(1, None, None, None)]}
+        )
+        repo = ARIELRepository(pool, _make_config())
+
+        await repo.get_enhancement_stats()
+
+        aggregate = [sql for sql, _ in pool.calls if "jsonb_each" in sql]
+        assert len(aggregate) == 1
+        assert "text_embedding" not in aggregate[0]
+        assert "semantic_processor" not in aggregate[0]
+
+    async def test_get_enhancement_stats_reports_a_total_with_no_status_keys(
+        self, fake_pool_factory
+    ) -> None:
+        """A store whose entries carry no status key still reports its total."""
+        pool = fake_pool_factory(
+            rows_for={"jsonb_each(enhancement_status)": [(7, None, None, None)]}
+        )
+        repo = ARIELRepository(pool, _make_config())
+
+        assert await repo.get_enhancement_stats() == {"total_entries": 7}
 
     async def test_get_enhancement_stats_on_empty_database(self, fake_pool) -> None:
         """No aggregate row degrades to a zero total rather than raising."""

--- a/tests/services/auth_sidecar/test_methods_parity.py
+++ b/tests/services/auth_sidecar/test_methods_parity.py
@@ -1,0 +1,44 @@
+"""The servable auth-method set has one producer, and everything keyed by it agrees.
+
+``methods.py`` is a leaf: ``app`` refuses to serve a method outside the set,
+``routes.recheck`` refuses to mint a session for one, and ``audit`` keys the
+category each success is recorded under by the same constants. Those three
+cannot reach each other — ``app`` builds the routes — so before the leaf module
+the set was written out three times, twice with different container types.
+
+The last test is the seam to the *other* method vocabulary: ``render.py``
+enumerates deployment postures, which is a different fact and deliberately
+larger. What must hold is containment — a sidecar method a render cannot even
+declare would be unreachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.deployment.web_terminals import render
+from osprey.services.auth_sidecar import app, audit
+from osprey.services.auth_sidecar.methods import METHOD_OIDC, METHOD_PASSWORD, SUPPORTED_METHODS
+from osprey.services.auth_sidecar.routes import recheck
+
+pytestmark = pytest.mark.unit
+
+
+def test_the_set_is_the_two_named_constants() -> None:
+    assert SUPPORTED_METHODS == frozenset({METHOD_PASSWORD, METHOD_OIDC})
+
+
+def test_both_consumers_read_the_one_producer() -> None:
+    """A second definition anywhere makes this fail rather than drift."""
+    assert app.SUPPORTED_METHODS is SUPPORTED_METHODS
+    assert recheck.SUPPORTED_METHODS is SUPPORTED_METHODS
+
+
+def test_every_servable_method_has_an_audit_category() -> None:
+    """A method with no success reason would be recorded as a generic login."""
+    assert set(audit._SUCCESS_REASONS) == set(SUPPORTED_METHODS)
+
+
+def test_the_servable_set_is_within_the_declarable_postures() -> None:
+    """``none`` and ``token`` are postures under which no sidecar runs at all."""
+    assert SUPPORTED_METHODS <= set(render.SUPPORTED_AUTH_METHODS) - {"none", "token"}

--- a/tests/services/test_single_lane_switch_refusal.py
+++ b/tests/services/test_single_lane_switch_refusal.py
@@ -368,6 +368,43 @@ def test_the_tool_modules_reason_code_is_the_queue_backend_constant():
     assert queue.REASON_CONTROL_TARGET_MISMATCH == qb.REASON_CONTROL_TARGET_MISMATCH
 
 
+def test_the_halt_paths_manager_states_are_the_queue_backends():
+    """The other copy the no-bluesky-imports invariant forces apart.
+
+    ``queue.py`` may not import ``queue_backend`` (it pulls in
+    ``bluesky-queueserver-api``), so the set of states that mean "this lane is
+    draining toward hardware" is spelled twice. A state added on the bridge and
+    not here would leave a moving lane un-haltable, which nothing else would
+    report.
+    """
+    assert queue._MOVING_MANAGER_STATES == qb.QUEUE_ACTIVE_MANAGER_STATES
+
+
+def test_the_js_queue_clients_carry_the_same_manager_states():
+    """The two browser copies of the same set, pinned by regex.
+
+    Neither can import the Python constant either, and a panel that thinks a
+    lane is idle offers no stop button for a plan that is running.
+    """
+    import re
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    sources = [
+        repo_root / "src/osprey/interfaces/bluesky_web/panels/bluesky/queue-client.js",
+        repo_root / "src/osprey/interfaces/web_terminal/static/js/bar-item-queue.js",
+    ]
+    pattern = re.compile(
+        r"QUEUE_ACTIVE_MANAGER_STATES\s*=\s*Object\.freeze\(\[(?P<body>[^\]]*)\]\)"
+    )
+
+    for source in sources:
+        match = pattern.search(source.read_text())
+        assert match, f"{source.name} no longer declares QUEUE_ACTIVE_MANAGER_STATES"
+        states = set(re.findall(r"'([a-z_]+)'", match.group("body")))
+        assert states == set(qb.QUEUE_ACTIVE_MANAGER_STATES), source.name
+
+
 def test_the_reason_has_an_entry_in_the_shared_refusal_hint_table():
     """So a lane-aware bridge relaying the same code answers the same way."""
     hints = queue._REFUSAL_HINTS[qb.REASON_CONTROL_TARGET_MISMATCH]

--- a/tests/templates/test_safety_notice_superset.py
+++ b/tests/templates/test_safety_notice_superset.py
@@ -1,0 +1,77 @@
+"""The packaged safety notice is the superset; the scaffolded copy adds only its
+"this file is yours to edit" preamble.
+
+Two files carry the same safety copy for two different readers. The packaged one
+(``templates/modules/web_terminals/notices/working-safely.md``) is what a landing
+page renders when a deployment lists no notices of its own, so it is the copy an
+operator sees when nobody made a choice. The other
+(``templates/apps/control_assistant/data/landing/working-safely.md``) is written
+into a facility's profile by ``osprey init`` as a seed the facility then owns and
+edits, which is why it cannot be generated at render time.
+
+Two hand-kept copies drift, and this one had: the seed grew a section the
+packaged copy never got, so the deployment that made no choice got the shorter
+warning. The invariant that keeps them together is stated here rather than left
+to whoever edits one of them next — the seed is the packaged text with the
+preamble paragraph inserted, and nothing else.
+
+Editing either file means editing both. The failure below names the paragraph
+that differs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import osprey
+
+_TEMPLATES = Path(osprey.__file__).resolve().parent / "templates"
+
+#: Shipped in the wheel, rendered by `_packaged_notice()` when a config lists no
+#: `landing.notices` of its own.
+PACKAGED_NOTICE = _TEMPLATES / "modules" / "web_terminals" / "notices" / "working-safely.md"
+
+#: Copied verbatim into a facility's profile by `osprey init`, then owned by the
+#: facility.
+SEED_NOTICE = _TEMPLATES / "apps" / "control_assistant" / "data" / "landing" / "working-safely.md"
+
+#: The one paragraph the seed carries and the packaged copy must not: it tells a
+#: facility how to add notices of its own, which is advice for whoever edits the
+#: profile, not for the operator reading the rendered page.
+PREAMBLE_OPENER = "This file is yours to edit."
+
+
+def _paragraphs(path: Path) -> list[str]:
+    """One entry per blank-line-separated block of *path*, in order.
+
+    Comparing blocks rather than lines means a failure names the paragraph that
+    diverged instead of the first line that did, which is the difference between
+    a diff a reader can act on and one they have to reconstruct.
+    """
+    text = path.read_text(encoding="utf-8")
+    assert text.strip(), f"empty notice: {path}"
+    return [block for block in text.split("\n\n") if block.strip()]
+
+
+def test_the_seed_is_the_packaged_notice_plus_its_preamble() -> None:
+    """The whole invariant, in one comparison."""
+    packaged = _paragraphs(PACKAGED_NOTICE)
+    seed = _paragraphs(SEED_NOTICE)
+
+    preambles = [block for block in seed if block.startswith(PREAMBLE_OPENER)]
+    assert len(preambles) == 1, (
+        f"expected exactly one {PREAMBLE_OPENER!r} paragraph in {SEED_NOTICE.name}, "
+        f"found {len(preambles)}"
+    )
+
+    assert [block for block in seed if not block.startswith(PREAMBLE_OPENER)] == packaged, (
+        "the scaffolded seed and the packaged notice have drifted apart. They carry "
+        "the same safety copy for two readers, and the seed may add nothing to it "
+        "but its editing preamble — fold the change into both."
+    )
+
+
+def test_the_packaged_notice_carries_no_editing_preamble() -> None:
+    """The packaged copy is not a file anyone edits: it is read out of the wheel,
+    and a deployment that wants its own notices lists them instead."""
+    assert PREAMBLE_OPENER not in PACKAGED_NOTICE.read_text(encoding="utf-8")


### PR DESCRIPTION
Thirteen hand-kept enumerations now derive from, or are pinned to, the registry or constants module that already produces them.

Commits, in order:

1. `test(profiles): pin the connector and archiver types the root presets name`
2. `fix(cli): resolve --adapter and --module choices from the ARIEL registry`
3. `test(registry): pin every osprey_workspace tool to its permission classification`
4. `fix(build): give every framework agent a default tier and show every agent in osprey status`
5. `fix(ariel): report enhancement and search modules from the registry`
6. `test(bluesky): pin the halt path's manager-state set to queue_backend`
7. `refactor(auth-sidecar): one producer for the servable auth-method set`
8. `refactor: import the constants ariel entry and the recorder restate`
9. `fix(stores): register the binary artifact type the serializer emits`
10. `fix(templates): fail the render when builtin_panels is missing from the context`
11. `fix(templates): make the packaged safety notice the superset`
12. `test(approval): pin the shipped approval.tools keys to the registry's gated tools`
13. `docs(bluesky-web): list the routes the relays actually serve`

## Why

Each of these was a literal restating a fact something else already produced, and most had already drifted: two of seven framework agents had no default model tier and appeared in no status report, five ARIEL modules were named by hand so a facility's own module went unreported and could not be passed on the command line, the artifact type the serializer stamps on raw bytes was not in the type registry, the auth sidecar spelled its servable method set three times, and the packaged safety notice had fallen a section and a bullet behind the scaffolded seed — so the deployment that made no choice read the weaker warning. The house pattern for each fix already existed elsewhere in the tree; this applies it to the holdouts.

What a deployer can now do that they could not: register an ingestion adapter, enhancement module or search module and name it on the command line and see it in `osprey ariel status`, without editing framework code. A `config.yml` render that loses the panel registry now stops instead of silently dropping every selected tab, `osprey status --agents` reports every agent the deployment can run rather than the subset one map happened to name, and the settings panel offers a dropdown for every `approval.tools` key a deployment can set rather than six of them.

The auth-off baseline pin now masks notice bodies the way it already masks ports: the prose is framework safety copy no auth posture decides, so an edit to it no longer reads as a posture change. The section's presence, count, wrapper, id and summary stay in the comparison, and a guard asserts the mask is still finding bodies to hide.

## Not in this PR

- Per-type commented `connector.<type>` stanzas for `doocs` / `tango` / `mongodb_archiver` / `doocs_archiver` — the misleading part was the Options comment, and that is what this fixes.
- Rendering the full `approval.tools` block from the registry: the shipped rows are a curated starter subset under a fail-closed `default_policy`, and growing them would change what a deployment does. The pin is the one direction that is safe — no row may name a tool its servers do not gate.
- Whether an *unrecognised* bluesky manager state should count as motion — a separate fail-closed question.
- Moving the agent tier onto `AgentDefinition` — later polish; the map stays where the import direction allows it.
