### PR TITLE
docs(install): say how to install a pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Built for large scientific facilities, such as particle accelerators.
 ## Quick start
 
 ```bash
-# Install the framework as a standalone CLI tool (using uv, recommended)
+# Install the framework as a standalone CLI tool (using uv, recommended).
+# A pre-release needs the flag: uv tool install --prerelease allow osprey-framework
 uv tool install osprey-framework
 
 # Create a minimal deployment repo to verify your setup

--- a/changelog.d/prerelease-install.fixed.md
+++ b/changelog.d/prerelease-install.fixed.md
@@ -1,0 +1,4 @@
+The installation page says how to install a pre-release. `uv tool install
+osprey-framework` resolves to the newest stable release and skips betas, and a
+version pin alone fails on the matching `osprey-connectors` pre-release;
+`--prerelease allow` is the flag both need.

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -216,6 +216,24 @@ Step 5: Install OSPREY
 
          uv tool upgrade osprey-framework
 
+      **Pre-releases.** Both commands resolve to the newest *stable* release
+      and skip pre-releases (versions ending in ``b1``, ``rc1``, …), so a beta
+      announced for testing is not what they install. Ask for it explicitly:
+
+      .. code-block:: bash
+
+         # The newest version, pre-releases included
+         uv tool install --prerelease allow osprey-framework
+
+         # One specific pre-release
+         uv tool install --prerelease allow "osprey-framework==2026.9.0b2"
+
+      Pinning the version alone is not enough: ``osprey-connectors``, which
+      ships alongside the framework under the same number, is a pre-release
+      too, and ``--prerelease allow`` is what lets the resolver take it.
+      ``uv tool upgrade --prerelease allow osprey-framework`` moves an
+      installation on to the next pre-release.
+
    .. tab-item:: From source
 
       Clone the repository if you want to pin to a specific git ref, track

--- a/plugins/osprey/.claude-plugin/plugin.json
+++ b/plugins/osprey/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.6",
+  "version": "2026.9.7",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "author": {
     "name": "ALS Accelerator Physics Group",

--- a/plugins/osprey/.codex-plugin/plugin.json
+++ b/plugins/osprey/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.6",
+  "version": "2026.9.7",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/osprey/skills/install/SKILL.md
+++ b/plugins/osprey/skills/install/SKILL.md
@@ -123,16 +123,17 @@ deployment already exists, any generation; (2) a facility exists, but no OSPREY;
 nothing yet.
 
 **Second: is OSPREY installed here.** Run `osprey --version` first and say what it
-printed. Then AskUserQuestion with three options; the recommended one is whichever the
+printed. Then AskUserQuestion with these options; the recommended one is whichever the
 version output supports:
 
 | Option | What it does |
 | --- | --- |
 | Already installed | Keep the version `osprey --version` printed. Record it. |
 | Install the latest release | `uv tool install osprey-framework`. Upgrade later with `uv tool upgrade osprey-framework`. |
+| Install a pre-release | `uv tool install --prerelease allow osprey-framework` (newest, pre-releases included), or `uv tool install --prerelease allow "osprey-framework==<version>"` for one. The flag is what admits the matching `osprey-connectors` pre-release; a version pin alone fails. Upgrade later with `uv tool upgrade --prerelease allow osprey-framework`. |
 | Install the development version | `uv tool install git+https://github.com/als-apg/osprey.git@main`. Newest fixes, no checkout to manage; `uv tool upgrade` refreshes it. |
 
-Both installs put `osprey` on the PATH, so every command in this skill runs the same
+Every install puts `osprey` on the PATH, so every command in this skill runs the same
 way afterwards. The dev form also takes a branch: `@<branch>` instead of `@main` is how
 a deployment is built against an upstream fix branch (see `/osprey:upstream-scout`).
 If `uv` is missing, say so and point at the installation page rather than improvising an

--- a/plugins/osprey/skills/install/references/osprey-map.md
+++ b/plugins/osprey/skills/install/references/osprey-map.md
@@ -6,11 +6,12 @@ providers), run the command and read the live output instead of recalling one.
 
 ## Install OSPREY
 
-Three forms, all of which put `osprey` on the PATH so every verb below runs the same way:
+Four forms, all of which put `osprey` on the PATH so every verb below runs the same way:
 
 | Form | Command | Upgrade |
 | --- | --- | --- |
 | Latest release | `uv tool install osprey-framework` | `uv tool upgrade osprey-framework` |
+| A pre-release | `uv tool install --prerelease allow osprey-framework`, or `--prerelease allow "osprey-framework==<version>"` for one — the flag admits the matching `osprey-connectors` pre-release, a pin alone fails | `uv tool upgrade --prerelease allow osprey-framework` |
 | Development version, `main` | `uv tool install git+https://github.com/als-apg/osprey.git@main` | `uv tool upgrade osprey-framework` |
 | A branch (an upstream fix in flight) | `uv tool install git+https://github.com/<owner>/osprey.git@<branch>`, or `uv tool install --editable <clone>` | re-run the same command |
 

--- a/plugins/osprey/skills/release/SKILL.md
+++ b/plugins/osprey/skills/release/SKILL.md
@@ -74,16 +74,22 @@ differences, each load-bearing:
   `osprey-connectors>=<last-stable>,!=<last-stable>a0`: the `!=` clause names
   a pre-release, which under PEP 440 admits pre-release candidates to the
   whole set, so pip pairs beta with beta while dev wheels still satisfy the
-  floor. uv resolves transitive pre-releases only with `--prerelease=allow`
-  and fails loudly with that hint — put the flag in the release notes. Run
-  `uv lock --check` after the edit. The final release afterwards restores
+  floor. uv admits transitive pre-releases only with `--prerelease allow`:
+  even an exact `==` pin on the framework fails without it, with a hint that
+  names the flag. The installation page carries the command under
+  *Pre-releases*; repeat the exact command at the top of the GitHub Release
+  body, because a reader who follows the stable instructions from the
+  pre-release's own docs directory gets the last stable release and not the
+  beta. Run `uv lock --check` after the edit. The final release afterwards restores
   the plain floor at its own stable version.
 - **The GitHub Release is marked pre-release automatically.** `release.yml`
   classifies the tag (exactly `X.Y.Z` = stable, anything else = pre-release)
   and sets the flag, so the beta never shows as "Latest".
-- **Docs do not publish.** `docs.yml` builds a pre-release tag but refuses to
-  deploy it: the site root and the version switcher stay on the last stable
-  release, and beta users read `/latest/`. Deliberate — do not "fix" it.
+- **Docs publish into the tag's own directory.** `docs.yml` deploys a
+  pre-release tag to `/vX.Y.Z{a|b|rc}N/` with its own switcher entry; the site
+  root and the switcher's preferred entry stay on the last stable release.
+  Nothing to do here — but it is why the release body must carry the install
+  command: that directory is where beta testers land.
 - **The version module keeps the segment.** A clean checkout of the tag
   reports `is_release()` true and pins `osprey-framework==YYYY.M.PbN`;
   `tests/test_version.py::TestPreReleaseChannel` pins this. `base_version`

--- a/tests/e2e/test_jupyter_panel_lifecycle.py
+++ b/tests/e2e/test_jupyter_panel_lifecycle.py
@@ -517,6 +517,52 @@ def _wait_for_ready(terminal: Terminal, timeout: float) -> None:
     )
 
 
+def _fleet_settled(posture: dict[str, Any], target: str) -> bool:
+    """Whether every controls server has landed *target* at the record's generation.
+
+    The condition the kernel's cell gate checks, read off the roster the chip
+    reads: a server still ``applying`` the record's generation refuses every
+    cell, and a server with children that reports an older binding has not got
+    there yet. A server serving nothing is passed over, as ``converged()``
+    passes over it.
+    """
+    generation = posture.get("generation")
+    if posture.get("control_target") != target or generation is None:
+        return False
+    for row in posture.get("servers", []):
+        block = row.get("last_switch") or {}
+        if block.get("generation") == generation and block.get("status") == "applying":
+            return False
+        bound = (row.get("applied_target"), row.get("applied_generation"))
+        if row.get("children") and bound != (target, generation):
+            return False
+    return True
+
+
+def _wait_for_switch_to_settle(terminal: Terminal, target: str) -> dict[str, Any]:
+    """Poll until the deployment has switched to *target* and the fleet has followed.
+
+    The record moving is the first half of a switch. Each live controls server
+    then reports ``applying`` at the new generation and ``applied`` once its
+    connector is up, and until the last of them has, ``pre_run_cell`` stamps a
+    kernel with a refusal instead of a target — so a cell admitted on the
+    record alone can meet either a missing ``OSPREY_CONTROL_TARGET`` or a
+    ``SwitchInProgressError``, depending on which server ticks first.
+    """
+    deadline = time.monotonic() + SWITCH_TIMEOUT_SEC
+    posture = terminal.posture()
+    while not _fleet_settled(posture, target) and time.monotonic() < deadline:
+        time.sleep(1.0)
+        posture = terminal.posture()
+    assert _fleet_settled(posture, target), (
+        f"the switch to {target!r} did not settle within {SWITCH_TIMEOUT_SEC:.0f}s: "
+        f"control_target={posture.get('control_target')!r} "
+        f"generation={posture.get('generation')} last_switch={posture.get('last_switch')} "
+        f"servers={posture.get('servers')}"
+    )
+    return posture
+
+
 # ---------------------------------------------------------------------------
 # Talking to a kernel over the proxied channels socket
 # ---------------------------------------------------------------------------
@@ -844,14 +890,7 @@ def test_the_next_cell_follows_a_chip_target_switch(terminal: Terminal) -> None:
     )
     assert switched.status_code == 202, switched.text
 
-    deadline = time.monotonic() + SWITCH_TIMEOUT_SEC
-    posture = terminal.posture()
-    while posture.get("control_target") != other and time.monotonic() < deadline:
-        time.sleep(1.0)
-        posture = terminal.posture()
-    assert posture.get("control_target") == other, (
-        f"the session never moved to {other!r}: {posture.get('last_switch')}"
-    )
+    _wait_for_switch_to_settle(terminal, other)
 
     channel_session = uuid.uuid4().hex
     try:


### PR DESCRIPTION
## Why

\`uv tool install osprey-framework\` resolves to the newest stable release, so anyone following the installation page for v2026.9.0b1 gets 2026.6.2. Pinning the version alone (\`osprey-framework==2026.9.0b1\`) fails too: \`osprey-connectors\` ships as a pre-release under the same number, and uv only admits it with \`--prerelease allow\`. Neither fact was written down anywhere.

## What

- **Installation page**, PyPI tab: a *Pre-releases* block with the two working forms (newest-including-pre-releases, and one exact version), why the pin alone fails, and the upgrade form. The blocks live inside the PyPI tab, which \`extract_doc_bash.py\` already skips, so the install-docs validator is unchanged (verified: 0 \`prerelease\` lines in its output).
- **README** quick start: one comment line.
- **Install skill** (\`SKILL.md\`, \`osprey-map.md\`): a pre-release row; plugin bumped 2026.9.6 → 2026.9.7.
- **Release skill**: the bullet claiming pre-release docs do not publish was wrong — \`docs_publish.py\` deploys them into \`/vX.Y.ZbN/\` — and that directory is where testers read the stable instructions, so the install command now belongs at the top of the release body.

## Verified

- \`uv pip compile\`: plain → 2026.6.2; \`==2026.9.0b1\` → unsatisfiable (connectors hint); \`--prerelease allow\` → both packages at 2026.9.0b1.
- \`uv tool install --prerelease allow "osprey-framework==2026.9.0b1"\` into a clean tool dir → \`osprey, version 2026.9.0b1\`.
- pip pairs the pinned beta with connectors 2026.9.0b1 on its own (the \`!=a0\` floor), so the service Dockerfiles are unaffected; this is a uv-only trap.
- Sphinx build clean; pre-commit clean.