### PR TITLE
Allow provider extra_body passthrough for LiteLLM gateways

### DIFF
--- a/changelog.d/provider-extra-body.added.md
+++ b/changelog.d/provider-extra-body.added.md
@@ -1,0 +1,4 @@
+A provider entry in `providers.yml` may carry an `extra_body` mapping. The
+mapping is sent in the request body of every completion, which is how a
+LiteLLM gateway that uses client-side auth receives a per-user upstream key
+alongside the gateway key in `api_key`. (#930)

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -213,6 +213,11 @@ Anthropic's own API. Keep the trailing
 ``/v1`` on OpenAI-compatible gateways — the translation proxy needs it, and the
 agent's own requests have it stripped automatically.
 
+``extra_body`` is an optional mapping sent in the request body of every
+completion. A LiteLLM gateway that uses client-side auth reads a per-user
+upstream key from it, so ``api_key`` stays the gateway credential while
+``extra_body: {api_key: ${UPSTREAM_KEY}}`` carries the user's own.
+
 **Select the active provider** with the profile's two top-level fields:
 
 .. code-block:: yaml

--- a/src/osprey/models/completion.py
+++ b/src/osprey/models/completion.py
@@ -94,7 +94,8 @@ def get_chat_completion(
     :param enable_thinking: Enable extended thinking capabilities where supported
     :param output_model: Pydantic model or TypedDict for structured output validation
     :param base_url: Custom API endpoint, required for Ollama and CBORG providers
-    :param provider_config: Optional provider configuration dict with api_key, base_url, etc.
+    :param provider_config: Optional provider configuration dict with api_key, base_url,
+        extra_body, etc.
     :param temperature: Sampling temperature (0.0-2.0)
     :raises ValueError: If required provider, model_id, api_key, or base_url are missing
     :return: Model response (str, Pydantic model, or list of content blocks for thinking)
@@ -195,6 +196,8 @@ def get_chat_completion(
         "tools": tools,
         "tool_choice": tool_choice,
     }
+    if provider_config and isinstance(provider_config.get("extra_body"), dict):
+        completion_kwargs["extra_body"] = dict(provider_config["extra_body"])
 
     result = provider_instance.execute_completion(
         message=message,

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -202,6 +202,10 @@ def execute_litellm_completion(
         "temperature": temperature,
     }
 
+    extra_body = kwargs.get("extra_body")
+    if isinstance(extra_body, dict) and extra_body:
+        completion_kwargs["extra_body"] = dict(extra_body)
+
     # Set API key
     if api_key:
         completion_kwargs["api_key"] = api_key

--- a/tests/models/test_completion.py
+++ b/tests/models/test_completion.py
@@ -306,3 +306,44 @@ class TestGetChatCompletionAcceptsAProviderDefault:
 
         with pytest.raises(ValueError, match="Base URL required for als-apg"):
             completion_module.get_chat_completion(message="ping", provider="als-apg", max_tokens=4)
+
+    def test_provider_config_extra_body_reaches_provider(self, monkeypatch):
+        """Provider catalog entries may carry LiteLLM request-body extensions.
+
+        This is the shape needed for a Delphi-fronted BYOK provider: the normal
+        provider api_key authenticates to Delphi, while extra_body.api_key is
+        the user's upstream key forwarded by LiteLLM clientside auth.
+        """
+        from osprey.models import completion as completion_module
+        from osprey.models.provider_registry import get_provider_registry
+
+        seen: dict = {}
+
+        def fake_execute(self, **kwargs):
+            seen.update(kwargs)
+            return "ok"
+
+        monkeypatch.setattr(
+            completion_module,
+            "get_provider_config",
+            lambda provider: {
+                "api_key": "delphi-key",
+                "base_url": "http://127.0.0.1:4000/v1",
+                "default_model_id": "amsc/gpt-oss-120b-safeguard",
+                "extra_body": {"api_key": "upstream-amsc-key"},
+            },
+        )
+        provider_class = get_provider_registry().get_provider("amsc-i2")
+        monkeypatch.setattr(provider_class, "execute_completion", fake_execute)
+
+        result = completion_module.get_chat_completion(
+            message="ping",
+            provider="amsc-i2",
+            max_tokens=4,
+        )
+
+        assert result == "ok"
+        assert seen["api_key"] == "delphi-key"
+        assert seen["base_url"] == "http://127.0.0.1:4000/v1"
+        assert seen["model_id"] == "amsc/gpt-oss-120b-safeguard"
+        assert seen["extra_body"] == {"api_key": "upstream-amsc-key"}

--- a/tests/models/test_litellm_adapter.py
+++ b/tests/models/test_litellm_adapter.py
@@ -586,6 +586,30 @@ class TestExecuteLitellmCompletionResponses:
         assert "api_key" not in mock_completion.call_args.kwargs
 
     @patch("litellm.completion")
+    def test_extra_body_is_forwarded_to_litellm(self, mock_completion):
+        """LiteLLM clientside-auth fields can be sent in the request body."""
+        message = MagicMock()
+        message.tool_calls = None
+        message.content = "ok"
+        response = MagicMock()
+        response.choices = [MagicMock(message=message)]
+        mock_completion.return_value = response
+
+        execute_litellm_completion(
+            provider="amsc-i2",
+            message="hi",
+            model_id="amsc/gpt-oss-120b-safeguard",
+            api_key="delphi-key",
+            base_url="http://127.0.0.1:4000/v1",
+            extra_body={"api_key": "upstream-amsc-key"},
+        )
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["api_key"] == "delphi-key"
+        assert kwargs["api_base"] == "http://127.0.0.1:4000/v1"
+        assert kwargs["extra_body"] == {"api_key": "upstream-amsc-key"}
+
+    @patch("litellm.completion")
     def test_empty_choices_returns_empty_string(self, mock_completion):
         """A response with no choices yields '' rather than raising an IndexError."""
         response = MagicMock()


### PR DESCRIPTION
## Summary
- Forward `provider_config.extra_body` through `get_chat_completion` into provider adapters.
- Pass dictionary `extra_body` through to `litellm.completion`.
- Add focused tests for provider config forwarding and the LiteLLM adapter payload.

## Use case
Osprey can point an OpenAI-compatible provider at an institutional LiteLLM gateway such as Delphi. In that setup, `api.providers.<provider>.api_key` authenticates the user to the gateway, while LiteLLM client-side auth providers may require a second request-body credential, such as `extra_body.api_key`, for the user's upstream provider key.

That gives deployments a clean BYOK path for upstream services such as AMSC:

```yaml
api:
  providers:
    amsc-i2:
      api_key: ${DELPHI_LITELLM_API_KEY}
      base_url: https://api.delphi.jlab.org/v1
      default_model_id: amsc/gpt-oss-120b-safeguard
      extra_body:
        api_key: ${AMSC_I2_API_KEY}
```

The Delphi/LiteLLM key remains the proxy authorization and accounting identity. The user-owned AMSC key is carried only as request body metadata for LiteLLM's upstream client-side-auth flow. This lets an institution keep centralized logging, guardrails, accounting, and routing while still allowing users to bring their own upstream API key.

The implementation is intentionally generic: Osprey forwards `extra_body` when configured, without adding any AMSC-specific behavior.

## Validation
- `uv run --with pytest --with pytest-xdist pytest tests/models/test_completion.py::TestGetChatCompletionAcceptsAProviderDefault::test_provider_config_extra_body_reaches_provider tests/models/test_litellm_adapter.py::TestExecuteLitellmCompletionResponses::test_extra_body_is_forwarded_to_litellm`
- `python3 -m py_compile src/osprey/models/completion.py src/osprey/models/providers/litellm_adapter.py`
- `git diff --check`
