### PR TITLE
chore: pre-b2 housekeeping and doc-sync fixes

### DIFF
--- a/changelog.d/nginx-front-proxy.changed.md
+++ b/changelog.d/nginx-front-proxy.changed.md
@@ -1,0 +1,3 @@
+The web-terminal front proxy image moves from `nginx:1.27-alpine` (end of
+life) to `nginx:1.31-alpine`; `modules.web_terminals.nginx_image` still
+overrides it.

--- a/changelog.d/pre-b2-sweep.fixed.md
+++ b/changelog.d/pre-b2-sweep.fixed.md
@@ -1,0 +1,5 @@
+Runtime remedies name `osprey init <dir> --preset <NAME>`, no shipped header,
+skill or message points at a `src/osprey/` path, both safety hooks list every
+tool they gate in their headers, setup-mode and demo-ui name the profile as the
+place to change protected keys, the hello-world README and tutorial carry the
+right hook counts, and the backup recipe names `.env.auth`.

--- a/docs/source/getting-started/hello-world-tutorial.rst
+++ b/docs/source/getting-started/hello-world-tutorial.rst
@@ -5,7 +5,7 @@ Hello World Tutorial
 Build and run your first OSPREY agent in about five minutes, with no containers
 and no hardware. The ``hello-world`` preset is the smallest deployment that
 still shows the whole write-safety chain: a mock control system that invents
-channel values, ten safety and bookkeeping hooks, and a browser interface.
+channel values, fourteen safety and bookkeeping hooks, and a browser interface.
 
 Three ``osprey`` commands take you from nothing to a running agent:
 
@@ -70,13 +70,13 @@ Step 2: Read profile.yml — It Is the Curriculum
 Open ``profile.yml``. This one file is the manifest for the whole deployment,
 and the preset deliberately leaves most of it unset — because every key it
 leaves unset is emitted into your copy as a **commented block** you can turn on
-later. The hello-world preset's minimalism yields exactly **13** such blocks,
+later. The hello-world preset's minimalism yields exactly **12** such blocks,
 covering everything from a channel database to event dispatch to a virtual
 accelerator. Growing this project into a production deployment is, quite
 literally, uncommenting one block at a time and rebuilding.
 
-The parts that *are* set are short. The agent's capabilities are lists of
-named artifacts from the OSPREY library — eleven hooks (three of which form the
+The parts that *are* set are short. The agent's capabilities are lists of named
+artifacts from the OSPREY library — fourteen hooks (three of which form the
 write-safety chain), three rules, and one output style:
 
 .. code-block:: yaml
@@ -85,7 +85,9 @@ write-safety chain), three rules, and one output style:
      - hook-log       # Append every tool call to a structured JSONL audit log
      ...
      # The next three are the write-safety chain, and no write reaches the control
-     # system until all three agree. Removing any one of them removes a guard.
+     # system until all three agree. Remove any one of them and `osprey build`
+     # refuses the render while writes are armed, naming the hook and the server
+     # whose write tools it guarded. Only a read-only deployment may drop them.
      - writes-check   # Kill switch: refuse every write while writes_enabled is false
      - approval       # Gate hardware-write tool calls on human approval prompt
      - limits         # Enforce per-channel min/max limits, from data/channel_limits.json
@@ -219,7 +221,9 @@ This is the first of **three guards** that every write must pass:
    for your explicit yes/no before anything is executed.
 
 Safety is not optional equipment here: the three hooks are declared in your
-``profile.yml``, and removing any one of them removes a guard.
+``profile.yml``. Remove any one of them and ``osprey build`` refuses the render
+while writes are armed, naming the hook and the server whose write tools it
+guarded. Only a read-only deployment may drop them.
 
 Step 7: Enable Writes — in profile.yml
 ---------------------------------------

--- a/docs/source/how-to/build-profiles.rst
+++ b/docs/source/how-to/build-profiles.rst
@@ -829,7 +829,7 @@ It never touches the source zone — only ``osprey init --force`` replaces that.
    osprey build
 
    # Change a setting, then carry it through to build/
-   osprey set model=claude-sonnet-4-6
+   osprey set model=claude-sonnet-5
    osprey build
 
    # Render another repository's build/ without cd-ing to it

--- a/docs/source/how-to/control-systems/use-connectors.rst
+++ b/docs/source/how-to/control-systems/use-connectors.rst
@@ -18,7 +18,9 @@ development and R&D default:
 
 .. code-block:: python
 
-   from osprey.connectors.factory import ConnectorFactory
+   from osprey.connectors.factory import ConnectorFactory, register_builtin_connectors
+
+   register_builtin_connectors()   # registers the built-in names; idempotent
 
    # Create mock connector - works with ANY channel names
    connector = await ConnectorFactory.create_control_system_connector({

--- a/docs/source/how-to/deploy-project/compose-templates.rst
+++ b/docs/source/how-to/deploy-project/compose-templates.rst
@@ -180,7 +180,7 @@ fails at ``up`` on the image it forgot:
    modules:
      web_terminals:
        image_tag: "2026.08.1"
-       nginx_image: registry.example.org/mirror/nginx:1.27-alpine
+       nginx_image: registry.example.org/mirror/nginx:1.31-alpine
        auth:
          image: registry.example.org/accelerator/demo-assistant-auth:2026.08.1
 

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -131,8 +131,8 @@ A gateway that OSPREY does not ship is an entry appended to ``providers.yml``:
        base_url: https://my-gateway.example.com/v1
        models:
          haiku: claude-haiku-4-5
-         sonnet: claude-sonnet-4-6
-         opus: claude-opus-4-6
+         sonnet: claude-sonnet-5
+         opus: claude-opus-5
 
 and one line in ``profile.yml`` naming it:
 
@@ -174,9 +174,9 @@ see what the two source files become. The whole catalog appears under
          api_key: ${ANTHROPIC_API_KEY}
          base_url: https://api.anthropic.com
          models:
-           haiku: claude-haiku-4-5-20251001
-           sonnet: claude-sonnet-4-5-20250929
-           opus: claude-opus-4-6
+           haiku: claude-haiku-4-5
+           sonnet: claude-sonnet-5
+           opus: claude-opus-5
 
        cborg:
          api_key: ${CBORG_API_KEY}
@@ -276,7 +276,7 @@ deployment's ``profile.yml``:
    model: sonnet
    config:
      # use sonnet even for opus-tier agents
-     claude_code.models.opus: claude-sonnet-4-6
+     claude_code.models.opus: claude-sonnet-5
 
 Agents can also be pinned to specific tiers:
 
@@ -400,7 +400,10 @@ The framework automatically:
 
 - Detects that ``my-provider`` is not a built-in Anthropic-native provider.
 - Starts the translation proxy to bridge Anthropic → OpenAI protocols.
-- Maps ``${MY_PROVIDER_API_KEY}`` to the auth token the Osprey agent expects.
+- Reads the Osprey agent's auth token from ``MY_PROVIDER_API_KEY``. The launcher
+  derives that variable name from the provider's own name — uppercased, dashes to
+  underscores — and never reads the entry's ``api_key`` value, so the name here
+  lines up only because the provider is called ``my-provider``.
 - Injects the resolved model IDs into the Osprey agent's environment.
 
 .. note::

--- a/docs/source/how-to/llm-providers/run-open-models.rst
+++ b/docs/source/how-to/llm-providers/run-open-models.rst
@@ -37,7 +37,7 @@ In ``providers.yml``, beside the deployment's ``profile.yml``:
 
    providers:
      cborg-open:
-       api_key: ${CBORG_API_KEY}
+       api_key: ${CBORG_OPEN_API_KEY}
        base_url: https://api.cborg.lbl.gov/v1   # keep the /v1
        models:
          haiku: gpt-oss-120b
@@ -50,6 +50,11 @@ and in ``profile.yml``:
 
    provider: cborg-open
    model: sonnet
+
+A provider you add yourself takes its key from ``<NAME>_API_KEY`` — uppercased,
+dashes to underscores — so ``cborg-open`` reads ``CBORG_OPEN_API_KEY``. Put
+``CBORG_OPEN_API_KEY=<your CBORG key>`` in the repo's ``.env``; the same CBORG
+key serves both entries.
 
 Any model ID from CBORG's catalogue works in the ``models`` block — the
 *Benchmark snapshot* box on this page shows which ones hold up in practice. The

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -114,6 +114,11 @@ so far already in the log. Nothing is ended on a clock: only the turn
 finishing, closing the page, or that button ends it. The button interrupts the
 agent, and stops it outright if it has not yielded within five seconds.
 
+Flip views while the other side's agent is idle and there is nothing to wait
+for: the view you arrive in reads *Restarting the agent in this view…*, with no
+clock and no stop button. A restart that runs past about four seconds turns
+into the wait above.
+
 A refusal can meet you instead of the wait. *This session is in use in
 another tab or view.* means another browser tab holds it, so close that tab or
 work there instead. *The previous agent is still shutting down.* is the one

--- a/docs/source/reference/configuration/profile.rst
+++ b/docs/source/reference/configuration/profile.rst
@@ -346,8 +346,8 @@ top-level ``provider:`` field picks one entry by name.
        base_url: https://my-gateway.example.org/v1
        models:
          haiku: claude-haiku-4-5
-         sonnet: claude-sonnet-4-6
-         opus: claude-opus-4-6
+         sonnet: claude-sonnet-5
+         opus: claude-opus-5
 
 ``base_url`` is required. ``api_key`` is optional and is normally an
 ``${ENV_VAR}`` reference resolved at run time from the repository's ``.env`` —

--- a/plugins/osprey/.claude-plugin/plugin.json
+++ b/plugins/osprey/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.7",
+  "version": "2026.9.8",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "author": {
     "name": "ALS Accelerator Physics Group",

--- a/plugins/osprey/.codex-plugin/plugin.json
+++ b/plugins/osprey/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "osprey",
-  "version": "2026.9.7",
+  "version": "2026.9.8",
   "description": "Agent skills for developing and deploying OSPREY, the agentic control-room interface for accelerators and beamlines.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/osprey/skills/panel/SKILL.md
+++ b/plugins/osprey/skills/panel/SKILL.md
@@ -20,10 +20,12 @@ literal).
 Follow these steps in order. The panel is done when the validator (Step 5)
 raises nothing. Do not skip the self-check.
 
-The canonical exemplar every panel is copied from lives in the OSPREY source at
-`src/osprey/interfaces/design_system/panels/reference/` (`index.html` +
-`manifest.json`). This skill inlines everything you need, but that reference is
-the source of truth if anything here is ambiguous.
+The canonical exemplar every panel is copied from ships with OSPREY at
+`interfaces/design_system/panels/reference/` (`index.html` + `manifest.json`),
+under the package root that
+`python3 -c "import osprey, pathlib; print(pathlib.Path(osprey.__file__).parent)"`
+prints. This skill inlines everything you need, but that reference is the source
+of truth if anything here is ambiguous.
 
 ---
 
@@ -112,8 +114,8 @@ Use these real token names (verified against `tokens.css`):
 | Monospace font family | `var(--font-mono)` |
 
 If you need a color that isn't in this list, look it up in
-`src/osprey/interfaces/design_system/static/css/tokens.css` — never invent a hex
-value. A `--…-tint-NN` token is a low-opacity fill of the base color (e.g.
+`interfaces/design_system/static/css/tokens.css` under that same package root —
+never invent a hex value. A `--…-tint-NN` token is a low-opacity fill of the base color (e.g.
 `--success-tint-08`), useful for badge/pill backgrounds.
 
 ---

--- a/src/osprey/cli/deploy_scaffold.py
+++ b/src/osprey/cli/deploy_scaffold.py
@@ -418,7 +418,8 @@ def _load_profile(profile_file: Path, *, command: str) -> tuple[dict[str, Any], 
         raise ConfigurationError(
             f"No profile at {profile_file}. '{command}' renders from a "
             f"deployment repo's profile — run it from a repo holding "
-            f"{PROFILE_FILENAME}, or create one with 'osprey init'."
+            f"{PROFILE_FILENAME}, or create one with "
+            f"'osprey init <dir> --preset <NAME>'."
         )
 
     raw = _read_profile_document(profile_file)

--- a/src/osprey/cli/init_cmd.py
+++ b/src/osprey/cli/init_cmd.py
@@ -151,7 +151,7 @@ __pycache__/
 """
 
 
-def _repo_env_shared(name: str, seeded: tuple[str, ...] = ()) -> str:
+def _repo_env_shared(name: str, seeded: tuple[str, ...] = (), facility_rule: bool = False) -> str:
     """The committed half of the deployment's environment, as a commented starter.
 
     Every line is commented out, because a deployment needs no shared defaults
@@ -204,7 +204,7 @@ def _repo_env_shared(name: str, seeded: tuple[str, ...] = ()) -> str:
 """
 
 
-def _repo_readme(name: str, seeded: tuple[str, ...] = ()) -> str:
+def _repo_readme(name: str, seeded: tuple[str, ...] = (), facility_rule: bool = False) -> str:
     """The README an operator meets this layout through.
 
     Its subject is the repo, not the profile: which zone survives what, and the
@@ -226,7 +226,7 @@ the folder name is the assistant's name.
 | Generated files | `{BUILD_OUTPUT_DIR}/` | no | no, safe to delete |
 | The agent's memory and audit log | `{STATE_DIR}/agent_data/`, `{STATE_DIR}/audit/` | no | yes |
 
-In full, the first row is: {_source_zone_prose(seeded)}.
+In full, the first row is: {_source_zone_prose(seeded, facility_rule)}.
 
 `{BUILD_OUTPUT_DIR}/` is generated from your settings every time you run `osprey build`.
 Deleting it is always safe: no settings, no keys and no agent memory live there.
@@ -308,8 +308,10 @@ deletes the audit log as well; that plus deleting this folder removes it all.
 
 ## Backups
 
-Git covers your settings. `{STATE_DIR}/` and `.env` are everything else, so a backup
-is a copy of those two, and a restore is:
+Git covers your settings. `{STATE_DIR}/` and the root's `.env` files are everything
+else — `.env`, and on a deployment with web terminals the deploy-written `.env.auth`,
+which holds the password hashes and cannot be regenerated: without it `osprey up`
+mints a new password for every user. A backup is a copy of those, and a restore is:
 
 ```bash
 git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d
@@ -374,7 +376,7 @@ Every key named here is written up in full at https://als-apg.github.io/osprey/.
 """
 
 
-def _ci_extra_text(name: str, seeded: tuple[str, ...] = ()) -> str:
+def _ci_extra_text(name: str, seeded: tuple[str, ...] = (), facility_rule: bool = False) -> str:
     """The starter ``ci-extra.yml`` — an include point with nothing in it yet.
 
     Written by this command and by nothing else, ever: the pipeline beside it
@@ -453,7 +455,9 @@ _NOT_A_DIRECTORY = "Not a directory: {target}. `osprey init` creates a deploymen
 # than by a promise anybody has to maintain.
 
 
-def _repo_gitignore_for(name: str, seeded: tuple[str, ...] = ()) -> str:
+def _repo_gitignore_for(
+    name: str, seeded: tuple[str, ...] = (), facility_rule: bool = False
+) -> str:
     """:func:`_repo_gitignore`, with the uniform signature the table needs.
 
     The zone paths are the layout's, not the deployment's, so this is the one
@@ -468,11 +472,12 @@ def _repo_gitignore_for(name: str, seeded: tuple[str, ...] = ()) -> str:
 #: its text. This mapping DRIVES the writing — ``init`` loops over it rather
 #: than naming the four files again — so a file that is written is a file that
 #: is listed, and the ``--force`` promise below cannot describe a set the code
-#: does not implement. Every builder takes the same pair — the deployment's
-#: name, and the directories :data:`WRITE_ONCE_DIRS` actually seeded into this
-#: repo — so that a builder may start describing a seeded directory without the
-#: loop that calls it having to learn which builders care.
-WRITE_ONCE_FILES: Mapping[str, Callable[[str, tuple[str, ...]], str]] = {
+#: does not implement. Every builder takes the same triple — the deployment's
+#: name, the directories :data:`WRITE_ONCE_DIRS` actually seeded into this repo,
+#: and whether the resolved profile selects the facility rule — so that a builder
+#: may start describing either conditional directory without the loop that calls
+#: it having to learn which builders care.
+WRITE_ONCE_FILES: Mapping[str, Callable[[str, tuple[str, ...], bool], str]] = {
     ".gitignore": _repo_gitignore_for,
     ENV_SHARED_FILENAME: _repo_env_shared,
     "README.md": _repo_readme,
@@ -511,7 +516,7 @@ WRITE_ONCE_DIRS: Mapping[str, str] = {MCP_SERVER_SOURCE_DIR: "mcp_servers"}
 FACILITY_RULE_DIR: str = "rules"
 
 
-def _source_zone_prose(seeded: tuple[str, ...] = ()) -> str:
+def _source_zone_prose(seeded: tuple[str, ...] = (), facility_rule: bool = False) -> str:
     """The SOURCE row of the README's zone table, derived from the categories above.
 
     The source zone is exactly what a materialization owns
@@ -534,6 +539,12 @@ def _source_zone_prose(seeded: tuple[str, ...] = ()) -> str:
     not name a directory the operator will not find. The names arrive already
     filtered, so the row grows only where the directory does.
 
+    ``facility_rule`` carries the same rule for :data:`FACILITY_RULE_DIR`, which
+    is written only where the resolved profile selects the facility rule — the
+    gate ``profile_cmd`` makes before it seeds the directory. A deployment whose
+    rule selection leaves the facility rule out has no such directory, so its
+    README does not name one.
+
     Imported inside the body rather than at module scope: ``profile_cmd`` pulls
     the build-profile chain in with it, which ``osprey --help`` must stay off
     (TR-2), and this is only ever called while a repo is being written.
@@ -544,7 +555,8 @@ def _source_zone_prose(seeded: tuple[str, ...] = ()) -> str:
         f"{name}/" if not Path(name).suffix else name for name in MATERIALIZED_SOURCE_ENTRIES
     ]
     entries.extend(f"{name}/" for name in seeded)
-    entries.append(f"{FACILITY_RULE_DIR}/")
+    if facility_rule:
+        entries.append(f"{FACILITY_RULE_DIR}/")
     entries.extend(WRITE_ONCE_FILES)
     entries.extend(CI_EMITTED_PATHS)
     return ", ".join(f"`{name}`" for name in entries)
@@ -1374,11 +1386,22 @@ def init(
             phase.step(f"settings and data from preset {preset}")
 
             name = materialized.profile_name
+            # Read from the profile that was written rather than from the preset
+            # name, and read through the same test `profile_cmd` seeds the
+            # directory on, so the README names `rules/` exactly where a repo has
+            # one. Imported here, not at module scope: `osprey --help` must not
+            # pull in the build pipeline (TR-2).
+            from .build_persistence import FACILITY_RULE_NAME
+
+            facility_rule = FACILITY_RULE_NAME in materialized.resolved.rules
             # Driven off the table rather than four calls written out: the set of
             # files this command authors and the set the --force promise names are
             # then the same object, not two lists that agree today.
             for filename, build_text in WRITE_ONCE_FILES.items():
-                _write_if_absent(target / filename, build_text(name, materialized.seeded))
+                _write_if_absent(
+                    target / filename,
+                    build_text(name, materialized.seeded, facility_rule),
+                )
             for relative in _STATE_DIRS:
                 (target / relative).mkdir(parents=True, exist_ok=True)
 

--- a/src/osprey/cli/repo_resolver.py
+++ b/src/osprey/cli/repo_resolver.py
@@ -220,7 +220,8 @@ def find_repo_root(start: Path | None = None) -> Path:
         f"No OSPREY deployment repo found: no {PROFILE_FILENAME} in {searched_from} "
         "or any parent directory.\n\n"
         "A deployment repo is the directory holding its profile.yml. Either cd into "
-        "one, point at one with --repo PATH, or create one with 'osprey init <name>'.",
+        "one, point at one with --repo PATH, or create one with "
+        "'osprey init <name> --preset <NAME>'. 'osprey init --list-presets' lists them.",
         searched_from=searched_from,
     )
 

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -2606,7 +2606,7 @@ def _check_nginx_image(web_terminals: dict[str, Any]) -> list[Finding]:
                 message=(
                     f"modules.web_terminals.nginx_image {value!r} is not a string; "
                     "it must be an image reference, e.g. "
-                    "'registry.example.com:5050/mirrors/nginx:1.27-alpine'"
+                    "'registry.example.com:5050/mirrors/nginx:1.31-alpine'"
                 ),
             )
         ]

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -93,7 +93,7 @@ _LOOPBACK_BIND_HOST = "127.0.0.1"
 # Default nginx image when `modules.web_terminals.nginx_image` is unset. Kept
 # byte-identical to docker-compose.web.yml.j2's own `| default(...)` fallback so
 # an absent config value renders the same image from either side.
-_DEFAULT_NGINX_IMAGE = "nginx:1.27-alpine"
+_DEFAULT_NGINX_IMAGE = "nginx:1.31-alpine"
 
 #: The TLS seam's listener port when ``modules.web_terminals.tls.port`` is
 #: unset: HTTPS's own default rather than a slot in this deployment's port

--- a/src/osprey/interfaces/design_system/generator/emit_css.py
+++ b/src/osprey/interfaces/design_system/generator/emit_css.py
@@ -41,7 +41,7 @@ __all__ = ["css_variable_name", "emit_css"]
 
 _HEADER = (
     "/* AUTO-GENERATED — DO NOT EDIT.\n"
-    " * Source: src/osprey/interfaces/design_system/tokens/\n"
+    " * Source: osprey/interfaces/design_system/tokens/ (src/osprey/... in a source checkout)\n"
     " * Regenerate with: python -m osprey.interfaces.design_system.generator.build\n"
     " */"
 )

--- a/src/osprey/interfaces/design_system/generator/emit_js.py
+++ b/src/osprey/interfaces/design_system/generator/emit_js.py
@@ -100,7 +100,7 @@ SCOPE_ATTRIBUTE = "data-osprey-storage-scope"
 #: freshness is verified by content diff, not by date.
 GENERATED_HEADER_LINES: tuple[str, ...] = (
     "// AUTO-GENERATED — DO NOT EDIT.",
-    "// Source: src/osprey/interfaces/design_system/tokens/",
+    "// Source: osprey/interfaces/design_system/tokens/ (src/osprey/... in a source checkout)",
     "// Regenerate with: python -m osprey.interfaces.design_system.generator.build",
 )
 

--- a/src/osprey/interfaces/design_system/static/css/tokens.css
+++ b/src/osprey/interfaces/design_system/static/css/tokens.css
@@ -1,5 +1,5 @@
 /* AUTO-GENERATED — DO NOT EDIT.
- * Source: src/osprey/interfaces/design_system/tokens/
+ * Source: osprey/interfaces/design_system/tokens/ (src/osprey/... in a source checkout)
  * Regenerate with: python -m osprey.interfaces.design_system.generator.build
  */
 

--- a/src/osprey/interfaces/design_system/static/js/theme-boot.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-boot.js
@@ -1,6 +1,6 @@
 // @ts-check
 // AUTO-GENERATED — DO NOT EDIT.
-// Source: src/osprey/interfaces/design_system/tokens/
+// Source: osprey/interfaces/design_system/tokens/ (src/osprey/... in a source checkout)
 // Regenerate with: python -m osprey.interfaces.design_system.generator.build
 
 // Applies data-theme before first paint. Deliberately NOT an ES module —

--- a/src/osprey/interfaces/design_system/static/js/tokens.js
+++ b/src/osprey/interfaces/design_system/static/js/tokens.js
@@ -1,5 +1,5 @@
 // AUTO-GENERATED — DO NOT EDIT.
-// Source: src/osprey/interfaces/design_system/tokens/
+// Source: osprey/interfaces/design_system/tokens/ (src/osprey/... in a source checkout)
 // Regenerate with: python -m osprey.interfaces.design_system.generator.build
 
 // Theme registry only: no color palettes here (see module docstring

--- a/src/osprey/interfaces/vendor.py
+++ b/src/osprey/interfaces/vendor.py
@@ -280,8 +280,7 @@ def asset_cdn_url(name: str) -> str:
         if asset.get("name") == name:
             return asset["url"]
     raise KeyError(
-        f"Unknown vendor asset name: {name!r}. Check the 'name' fields in "
-        "src/osprey/interfaces/vendor_manifest.json."
+        f"Unknown vendor asset name: {name!r}. Check the 'name' fields in {MANIFEST_PATH}."
     )
 
 

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1076,14 +1076,27 @@ keys:
     default: no-fallback
     default_note: an unstated leaf is not False — the write paths fail closed
   control_system.target_switch:
-    forward-declared: true
+    evidence: 'section\.get\("target_switch"\)'
     note: >-
       Tuning + acknowledgment block for the running-session control-system
-      target switch. Rendered ahead of its readers on this branch.
+      target switch. Consumed by descent: the host manager and the endpoint
+      prober each read their own leaf out of it.
     default: no-fallback
-    default_note: 'forward-declared: written by the presets, read by nothing today'
-  control_system.target_switch.drain_timeout_s: {forward-declared: true, default: no-fallback, default_note: 'forward-declared: written by the presets, read by nothing today'}
-  control_system.target_switch.probe_interval_s: {forward-declared: true, default: no-fallback, default_note: 'forward-declared: written by the presets, read by nothing today'}
+    default_note: >-
+      no-fallback: an absent block leaves each leaf at the default its own
+      reader supplies
+  control_system.target_switch.drain_timeout_s:
+    evidence: 'DRAIN_TIMEOUT_KEY = "drain_timeout_s"'
+    note: >-
+      How long a target switch waits for the outgoing connector host to drain
+      before it is killed. Read by the connector host manager.
+    default: 5.0
+  control_system.target_switch.probe_interval_s:
+    evidence: 'PROBE_INTERVAL_KEY = "control_system\.target_switch\.probe_interval_s"'
+    note: >-
+      Sweep period for the endpoint prober's reachability probe of every target
+      this deployment has.
+    default: 30.0
   control_system.target_switch.live_gateway_acknowledged:
     rendered: false
     evidence: 'ACK_KEY = "control_system\.target_switch\.live_gateway_acknowledged"'

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -1,6 +1,6 @@
 # hello-world.yml
 # The onboarding preset: the smallest agent that still shows the whole
-# write-safety chain. A mock control system, twelve hooks, and one container (the
+# write-safety chain. A mock control system, fourteen hooks, and one container (the
 # telemetry store), so `osprey init` → `osprey build` → `osprey web` is the entire
 # first session.
 #
@@ -43,7 +43,9 @@ hooks:
   - hook-config    # Inject project config.yml path into every tool call env
   - error-guidance # Post-error hook that surfaces remediation hints
   # The next three are the write-safety chain, and no write reaches the control
-  # system until all three agree. Removing any one of them removes a guard.
+  # system until all three agree. Remove any one of them and `osprey build`
+  # refuses the render while writes are armed, naming the hook and the server
+  # whose write tools it guarded. Only a read-only deployment may drop them.
   - writes-check   # Kill switch: refuse every write while writes_enabled is false
   - approval       # Gate hardware-write tool calls on human approval prompt
   - limits         # Enforce per-channel min/max limits, from data/channel_limits.json

--- a/src/osprey/services/ariel_search/ingestion/base.py
+++ b/src/osprey/services/ariel_search/ingestion/base.py
@@ -95,7 +95,7 @@ class FacilityAdapter(ABC):
             aiohttp connector (with proxy if configured)
 
         Raises:
-            IngestionError: If proxy is configured but aiohttp-socks is not installed
+            IngestionError: If a proxy is configured but aiohttp-socks cannot be imported
         """
         if not self.proxy_url:
             return aiohttp.TCPConnector()
@@ -104,8 +104,9 @@ class FacilityAdapter(ABC):
             from aiohttp_socks import ProxyConnector
         except ImportError as e:
             raise IngestionError(
-                "SOCKS proxy configured but aiohttp-socks is not installed. "
-                "Install with: pip install osprey-framework",
+                "SOCKS proxy support needs aiohttp-socks, a core osprey "
+                "dependency, so a missing module means a broken install — "
+                "repair it with: pip install --force-reinstall aiohttp-socks",
                 source_system=self.source_system_name,
             ) from e
 

--- a/src/osprey/services/virtual_accelerator/entrypoint.py
+++ b/src/osprey/services/virtual_accelerator/entrypoint.py
@@ -240,8 +240,7 @@ def _resolve_channels_file(data_dir: Path) -> Path:
             "VA_CHANNELS_FILE into its .env.\n"
             "  Standalone demo: ask for the packaged demo manifest by name --\n"
             f"    -e VA_CHANNELS_FILE={MANIFEST_OUTPUT} -e VA_LATTICE={LATTICE_BUILTIN}\n"
-            "  (that path is where this installation carries it; "
-            "scripts/va/run_va.sh arranges the same demo)."
+            "  (that path is where this installation carries it)."
         )
     path = Path(raw)
     return path if path.is_absolute() else data_dir / path

--- a/src/osprey/templates/claude_code/CLAUDE.md.j2
+++ b/src/osprey/templates/claude_code/CLAUDE.md.j2
@@ -28,7 +28,7 @@ do not attempt their work with your own tools.
 
 {% if channel_finder_enabled -%}
 - **channel-finder** — Finds channel/PV addresses. You do NOT have channel-finding tools.
-  For ANY channel/PV/signal lookup — even a single name — delegate to **channel-finder**. Do NOT call `list_systems`, `list_families`, `list_channels`, `run_sql`, `ask_channels`, `mcp__python__execute`, `mcp__python__execute_file`, or `Write` yourself; only the subagent has the indexed hierarchy traversal needed to resolve user descriptions to real addresses. Channel-finder returns *addresses*, not values — feed them into the appropriate archiver or live-read tool yourself{% if data_visualizer_enabled %}, then to **data-visualizer** if a plot is needed{% endif %}.
+  For ANY channel/PV/signal lookup — even a single name — delegate to **channel-finder**. Do NOT call {% for t in channel_finder_tools | default([]) %}`{{ t }}`, {% endfor %}`mcp__python__execute`, `mcp__python__execute_file`, or `Write` yourself; only the subagent has the indexed hierarchy traversal needed to resolve user descriptions to real addresses. Channel-finder returns *addresses*, not values — feed them into the appropriate archiver or live-read tool yourself{% if data_visualizer_enabled %}, then to **data-visualizer** if a plot is needed{% endif %}.
 {% endif -%}
 {%- if logbook_search_enabled %}
 - **logbook-search** — Searches the facility logbook for entries and events. Use for simple lookups.

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_approval.py
@@ -5,7 +5,7 @@ name: Human Approval Gate
 description: Requires human approval for dangerous operations based on per-tool policy
 summary: Requires human approval for dangerous operations
 event: PreToolUse
-tools: channel_write, execute, setup_patch, entry_create, entry_publish, queue_add, queue_start, queue_stop, queue_remove, stop_run, add_panel_to_rail, remove_panel_from_rail, register_panel
+tools: channel_write, control_target_set, channel_read, archiver_read, phoebus_drive, execute, execute_file, setup_patch, add_panel_to_rail, remove_panel_from_rail, register_panel, entry_create, entry_publish, draft_concept, queue_add, queue_start, queue_stop, queue_remove, stop_run, write_plan, validate_plan
 safety_layer: 2
 ---
 

--- a/src/osprey/templates/claude_code/claude/hooks/osprey_writes_check.py
+++ b/src/osprey/templates/claude_code/claude/hooks/osprey_writes_check.py
@@ -5,7 +5,7 @@ name: Writes Kill Switch
 description: Blocks ALL write operations under a readonly write posture or an unarmed target
 summary: Blocks write operations when the deployment is sandboxed or the target is not armed
 event: PreToolUse
-tools: channel_write, execute
+tools: channel_write, phoebus_drive, execute, execute_file, queue_add, queue_start
 safety_layer: 1
 ---
 

--- a/src/osprey/templates/claude_code/claude/skills/demo-ui/SKILL.md
+++ b/src/osprey/templates/claude_code/claude/skills/demo-ui/SKILL.md
@@ -48,9 +48,11 @@ same gate the audience is there to see — and let the operator answer it. The
 on-screen verbs `open_panel` and `close_panel` do not ask on a stock build.
 
 A deployment that wants those beats to run uninterrupted sets
-`approval.tools.add_panel_to_rail: skip` in its `config.yml`, and the same for
-the other two. `skip` is the only value that silences a prompt: the policies are
-`skip`, `always` and `selective`, and there is no `never`.
+`config.approval.tools.add_panel_to_rail: skip` in its profile's `config:` block —
+`osprey set config.approval.tools.add_panel_to_rail=skip`, then `osprey build` — and
+the same for the other two. `approval.*` is protected, so `setup_patch` cannot do it.
+`skip` is the only value that silences a prompt: the policies are `skip`, `always`
+and `selective`, and there is no `never`.
 
 ## Pick a workflow
 
@@ -163,8 +165,8 @@ different surfaces on the rail.
    that layout resolves to — same primitive, same result, just reached by asking.
 3. **If it defines none** — compose a plausible one from the panels that exist
    (e.g. logbook review = the logbook panel plus the workspace) and mention the
-   deployment can name it in `config.yml` under `web.presets` so it becomes one
-   click for everyone.
+   deployment can name it in the profile's `config:` block under `config.web.presets`,
+   then `osprey build`, so it becomes one click for everyone.
 4. **Restore** the starting rail membership and active panel.
 
 ## 4. Grand tour

--- a/src/osprey/templates/claude_code/claude/skills/setup-mode/SKILL.md.j2
+++ b/src/osprey/templates/claude_code/claude/skills/setup-mode/SKILL.md.j2
@@ -65,6 +65,8 @@ For each issue found, propose a specific fix. Classify each as:
 - **Manual**: Requires operator action (e.g., setting environment variables, restarting services)
 - **Rebuild**: Requires `osprey build` to re-render the artifact from its template
 
+`setup_patch` refuses every protected key and records the refusal, so nothing under `control_system.`, `approval.`, `hooks.` (except `hooks.debug`), `claude_code.permissions.`, `claude_code.hooks.`, `claude_code.servers.`, `agent_data.`, `artifacts.`, `file_paths.` or `dangerously_allow_bash` is Auto-fixable: those belong to the deployment repo's profile, so they are Rebuild items — `osprey set config.<key>=<value>`, then `osprey build`.
+
 Ask the operator which fixes to apply before proceeding.
 
 ### Step 5 — Apply & Verify
@@ -100,6 +102,10 @@ Then re-enter `/setup-mode` to verify the fix.
 | `ariel` | ARIEL logbook search and entry creation | {% if "ariel" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
 {% if channel_finder_pipeline is defined %}| `channel-finder` | Channel finder pipeline ({{ channel_finder_pipeline }}) | {% if "channel-finder" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
 {% endif %}| `graph` | Facility knowledge-graph queries (read-only Cypher against the graphdb store) | {% if "graph" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
+| `osprey_facility_knowledge` | Facility knowledge bundle: concept index, concept read, full-text search, concept drafting | {% if "osprey_facility_knowledge" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
+| `bluesky` | Bluesky plan authoring, queue control and run data | {% if "bluesky" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
+| `phoebus` | Phoebus display bridge: open, perceive, drive | {% if "phoebus" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
+| `health` | Deployment health checks | {% if "health" in enabled_servers %}Enabled{% else %}Disabled{% endif %} |
 
 ### Required Environment Variables
 
@@ -156,7 +162,7 @@ Switching control target is not a config change: `control_system.type` only sets
 ### 2. Writes Blocked
 **Symptoms**: `channel_write` rejected.
 **Check**: `setup_inspect` → `config.control_system.writes_enabled`, and `config.control_system.connector.<type>.writes_enabled` for the type the control target resolves to. The per-type key answers on its own where it is set: a type that carries one never falls back to the deployment-wide key, so writes can be armed on the virtual accelerator and refused on the live machine in the same project.
-**Fix**: `setup_patch config.yml control_system.writes_enabled true` to arm every type that says nothing, or `setup_patch config.yml control_system.connector.virtual_accelerator.writes_enabled true` to arm that one type. Then `osprey build` and restart the agent. The patch alone only un-gates the hook — the connector and the enforced `permissions.deny` list still refuse writes until the rebuild and restart (cold change). Only a literal `true` arms writes; the string `"true"` and `1` do not.
+**Fix**: `control_system.*` is a protected key — `setup_patch` refuses it and records the refusal. The change belongs to the deployment repo's profile: run `osprey set config.control_system.writes_enabled=true` to arm every type that says nothing, or `osprey set config.control_system.connector.virtual_accelerator.writes_enabled=true` to arm one type. Then `osprey build` and restart the agent (cold change: the connector and the enforced `permissions.deny` list still refuse writes until then). Only a literal `true` arms writes; the string `"true"` and `1` do not.
 
 ### 3. Missing Safety Hooks
 **Symptoms**: Writes proceed without approval prompts.

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -189,7 +189,7 @@
       render.py must resolve it once, typically from `deploy.host` + this
       same `nginx_port`.
 
-    nginx_image: str, optional, default "nginx:1.27-alpine"
+    nginx_image: str, optional, default "nginx:1.31-alpine"
     facility_timezone: str, optional, default "UTC" -> TZ
 
     tls_host_cert_dir: str | None, tls_mount_target: str | None
@@ -514,7 +514,7 @@
 services:
 
   nginx:
-    image: {{ nginx_image | default("nginx:1.27-alpine") }}
+    image: {{ nginx_image | default("nginx:1.31-alpine") }}
     container_name: {{ facility_prefix }}-nginx
     restart: unless-stopped
     network_mode: host

--- a/src/osprey/templates/project/Dockerfile.j2
+++ b/src/osprey/templates/project/Dockerfile.j2
@@ -9,11 +9,12 @@
 #   docker run --rm -p {{ osprey_ports.web }}:{{ osprey_ports.web }} --env-file .env {{ project_name }}
 #
 # The container starts as ROOT and does not stay there. `build/entrypoint.sh`
-# re-renders any drifted Claude Code artifact and restores the operator's owned
+# re-renders any drifted Claude Code artifact, restores the operator's owned
 # scaffold bodies — both writes into a render this image deliberately leaves
-# root-owned — and only then drops to the unprivileged `osprey` user with
-# `gosu` for the actual command. Running the image with `--user` skips the two
-# startup steps and says so in the log rather than failing halfway through.
+# root-owned — and seeds Claude Code's missing first-run state, and only then
+# drops to the unprivileged `osprey` user with `gosu` for the actual command.
+# Running the image with `--user` skips the three startup steps and says so in
+# the log rather than failing halfway through.
 #
 # Build args:
 #   OSPREY_PIP_SPEC     pip requirement for OSPREY (default: PyPI release;

--- a/src/osprey/templates/project/dockerignore
+++ b/src/osprey/templates/project/dockerignore
@@ -73,9 +73,9 @@ Dockerfile
 # never from an image — gigabytes of GGUF that this image would carry for no
 # reader.
 #
-# The one `**/`-anchored entry in this file, deliberately: the staged directory
-# sits beside the qmd service's Dockerfile deep in the render, not at the
-# project root, so the root-anchored spelling the rest of the list uses would
-# match nothing here. The derivation described above prefixes another `**/`,
-# which is redundant but harmless.
+# The one `**/`-anchored entry in this file, deliberately: `services.qmd.models_dir`
+# is an absolute host path, so the staging directory can sit anywhere — this tree
+# included — and a root-anchored pattern would miss it. The files reach the sidecar
+# over that read-only mount, never through a build context. The derivation
+# described above prefixes another `**/`, which is redundant but harmless.
 **/prefetched-models/

--- a/src/osprey/templates/project/entrypoint.sh
+++ b/src/osprey/templates/project/entrypoint.sh
@@ -29,11 +29,11 @@
 # files that decide what the agent is allowed to do. Only root can perform
 # them, and only before the server starts — so they happen here, once, and the
 # process that serves requests never has the privilege to repeat them. A
-# container started with `--user osprey` skips both and says so, rather than
-# failing halfway through a partial write.
+# container started with `--user osprey` skips every maintenance step and says so,
+# rather than failing halfway through a partial write.
 #
-# Both steps fail open: a regen or restore that raises is reported and the
-# container still starts. A container that will not boot because an artifact
+# All three steps fail open: a regen, restore or seed that raises is reported and
+# the container still starts. A container that will not boot because an artifact
 # could not be re-rendered is strictly worse than one running slightly stale
 # artifacts and saying so in its logs. The privilege drop is the opposite —
 # a missing `gosu` is fatal, because continuing would run the agent as root,
@@ -86,7 +86,7 @@ die() {
 # run in one interpreter rather than two: importing osprey is the expensive part
 # and doing it twice would add seconds to every container start for nothing.
 # Each step carries its own try/except — including its import — so a step that
-# cannot even load does not take the other one down with it.
+# cannot even load does not take the others down with it.
 #
 # The restore is deliberately the shared `restore_scaffold_bodies`, not a
 # reimplementation. Its refusal to install a reserved path lives in that
@@ -438,14 +438,15 @@ main() {
 
     log "starting: render $RENDER_DIR, command: $*"
 
-    # Already unprivileged — someone ran the image with `--user`. Neither
+    # Already unprivileged — someone ran the image with `--user`. No
     # maintenance step can write a root-owned render, and gosu cannot drop to a
     # user it is not root to become, so do the one useful thing left: run the
     # command. Loud, because the artifacts this would have refreshed are now
     # whatever the image happens to carry.
     if [ "$(id -u)" -ne 0 ]; then
-        log "WARNING: running as uid $(id -u), not root; skipping the startup regen"
-        log "         and scaffold restore, and running the command directly."
+        log "WARNING: running as uid $(id -u), not root; skipping the startup regen,"
+        log "         scaffold restore and first-run state seed, and running the command"
+        log "         directly."
         log "         Derived artifacts will be whatever this image was built with."
         exec "$@"
     fi
@@ -462,7 +463,7 @@ main() {
     if command -v "$PYTHON" > /dev/null 2>&1; then
         run_maintenance || log "WARNING: startup maintenance exited non-zero; continuing to the privilege drop"
     else
-        log "WARNING: no '$PYTHON' interpreter on PATH; skipping the startup regen and scaffold restore"
+        log "WARNING: no '$PYTHON' interpreter on PATH; skipping the startup regen, scaffold restore and first-run state seed"
     fi
 
     # Groups before the drop, because `gosu` reads /etc/group and not this

--- a/src/osprey/templates/project/env.example.j2
+++ b/src/osprey/templates/project/env.example.j2
@@ -1,12 +1,12 @@
 # {{ project_name }} Environment Configuration
 #
-# Every variable this agent reads, listed in one place. Copy this file to `.env`
-# beside it and fill in what you need. That one file holds all your secrets, and
-# a value in it survives every rebuild.
+# Every variable this agent reads, listed in one place. Copy it to `.env` at the
+# repository root, beside `profile.yml`, and fill in what you need. That one file
+# holds all your secrets, and a value in it survives every rebuild.
 #
 # This file has no secrets in it and is safe to commit.
 #
-# The `.env` files, and which one to edit:
+# The `.env` files at the repository root, and which one to edit:
 #
 #   .env.shared    the settings that are the same on every host; committed
 #   .env           this host's own values and every key; wins over

--- a/tests/cli/test_dockerfile_template.py
+++ b/tests/cli/test_dockerfile_template.py
@@ -655,10 +655,10 @@ class TestDockerignore:
         """Model files staged by hand are qmd build inputs, not image content.
 
         Pinned with its ``**/`` prefix, which is the one deviation from the
-        root-anchored spelling the rest of the list uses: the staged directory
-        sits beside the qmd service's Dockerfile inside the render, so a
-        root-anchored pattern would name nothing and gigabytes of GGUF would
-        ride into the project image.
+        root-anchored spelling the rest of the list uses: ``services.qmd.models_dir``
+        is an absolute host path, so the staging directory can sit anywhere — this
+        tree included — and a root-anchored pattern would name nothing while
+        gigabytes of GGUF rode into the project image.
         """
         assert "**/prefetched-models/" in self._entries(hello_project)
 

--- a/tests/cli/test_lifecycle_phases.py
+++ b/tests/cli/test_lifecycle_phases.py
@@ -497,6 +497,7 @@ def init_stubs(monkeypatch, seen):
 
     class _Resolved:
         mcp_servers: dict = {}
+        rules: tuple = ()
 
     class _Materialized:
         profile_name = "probe"

--- a/tests/deployment/web_terminals/golden/docker-compose.web.yml
+++ b/tests/deployment/web_terminals/golden/docker-compose.web.yml
@@ -2,7 +2,7 @@
 services:
 
   nginx:
-    image: nginx:1.27-alpine
+    image: nginx:1.31-alpine
     container_name: dls-nginx
     restart: unless-stopped
     network_mode: host

--- a/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
+++ b/tests/deployment/web_terminals/test_auth_off_baseline_pin.py
@@ -110,6 +110,14 @@ unmasked: the frozen copy must still spell ports the layout cannot produce for
 this config, which is exactly what a copy regenerated from today's renderer
 could not do.
 
+**The front proxy's image tag is masked too.** The baseline was frozen against
+one nginx release, and the front proxy tracks the supported mainline, so the
+``image:`` line moves for reasons SC6 has no opinion about. :func:`_mask_image_tag`
+blanks the tag on both sides; the image NAME still compares byte for byte, and the
+tag itself is pinned by ``test_golden_render.py`` for today's output and by the
+renderer's own default. ``_assert_the_frozen_image_tag_predates_the_current_default``
+reads it back unmasked, on the same argument the ports use.
+
 **When a hunk here fails**, the question is not "how do I widen the allowlist".
 It is: does the new line belong in a ``token``, roles-off render at all? If it
 carries authorization, a role, a claim or a login, the answer is no and the
@@ -132,7 +140,10 @@ from pathlib import Path
 import pytest
 import yaml
 
-from osprey.deployment.web_terminals.render import render_web_terminals
+from osprey.deployment.web_terminals.render import (
+    _DEFAULT_NGINX_IMAGE,
+    render_web_terminals,
+)
 from osprey.port_layout import default_port, resolve_port_base
 from osprey.services.auth_sidecar.app import ENV_ROSTER_ACCESS_PREFIX
 from osprey.services.auth_sidecar.routes.recheck import ENV_ROSTER_ROLE_PREFIX
@@ -233,6 +244,49 @@ def _ports_in(text: str) -> frozenset[int]:
     return frozenset(
         int(match.group("port")) for pattern in _PORT_SITES for match in pattern.finditer(text)
     )
+
+
+# --- The front-proxy image-tag mask ------------------------------------------
+# See "The front proxy's image tag is masked" in the module docstring. Only the
+# tag is replaced: the image NAME stays in the diff, so swapping the front proxy
+# for a different image is still a difference this pin reports.
+
+#: What a masked image tag reads as, in the same shape as :data:`_PORT_MASK`.
+_IMAGE_TAG_MASK = "<tag>"
+
+#: The front proxy's own `image:` line, and nothing else that carries a tag.
+_IMAGE_TAG_SITE = re.compile(r"^(?P<lead>\s*image:\s*nginx):(?P<tag>\S+)$", re.MULTILINE)
+
+
+def _mask_image_tag(text: str) -> str:
+    """Blank out the front proxy's image tag in one artifact.
+
+    Args:
+        text: A rendered or frozen artifact.
+
+    Returns:
+        The same text with the tag on the nginx ``image:`` line replaced by
+        :data:`_IMAGE_TAG_MASK`, so an artifact rendered against one nginx
+        release compares equal to the same artifact rendered against another.
+    """
+    return _IMAGE_TAG_SITE.sub(rf"\g<lead>:{_IMAGE_TAG_MASK}", text)
+
+
+def _image_tag_in(text: str) -> str | None:
+    """The front proxy's image tag as one artifact spells it, or ``None``.
+
+    The inverse of :func:`_mask_image_tag`, so the tag read back here is exactly
+    the one the diffs below stop seeing.
+
+    Args:
+        text: A rendered or frozen artifact.
+
+    Returns:
+        The tag, or ``None`` for an artifact that carries no nginx ``image:``
+        line -- ``nginx.conf`` and ``landing.html`` carry none.
+    """
+    match = _IMAGE_TAG_SITE.search(text)
+    return match.group("tag") if match else None
 
 
 #: The registry port families `EXAMPLE_CONFIG`'s roster renders, one port per
@@ -468,15 +522,16 @@ def _opcodes(
 ) -> tuple[list[str], list[str], list[tuple]]:
     """Baseline lines, current lines, and the line-level edit script between them.
 
-    Both sides are port-masked first (see the module docstring), so the edit
-    script reports structure and never renumbering.
+    Both sides are port-masked and image-tag-masked first (see the module
+    docstring), so the edit script reports structure and never renumbering or a
+    base-image release.
 
     ``artifacts`` defaults to the absent-stanza render; pass the explicit-token
     render to hold that spelling to the same frozen baseline.
     """
     rendered = _token_render() if artifacts is None else artifacts
-    old = _mask_ports(_baseline(name)).splitlines()
-    new = _mask_ports(rendered[_ARTIFACTS[name]]).splitlines()
+    old = _mask_image_tag(_mask_ports(_baseline(name))).splitlines()
+    new = _mask_image_tag(_mask_ports(rendered[_ARTIFACTS[name]])).splitlines()
     return old, new, difflib.SequenceMatcher(a=old, b=new, autojunk=False).get_opcodes()
 
 
@@ -515,6 +570,7 @@ def test_the_frozen_baseline_really_predates_the_feature() -> None:
     assert "X-Osprey-Auth-Role" not in nginx
 
     _assert_the_frozen_ports_predate_the_layout()
+    _assert_the_frozen_image_tag_predates_the_current_default()
 
 
 def _assert_the_frozen_ports_predate_the_layout() -> None:
@@ -546,6 +602,32 @@ def _assert_the_frozen_ports_predate_the_layout() -> None:
         f"{sorted(frozen & _LAYOUT_PORTS)}. `golden/pre_audit_roles/` predates the "
         f"layout and must never be regenerated from the current renderer — see the "
         f"module docstring."
+    )
+
+
+def _assert_the_frozen_image_tag_predates_the_current_default() -> None:
+    """The same anti-tamper argument, for the other axis a mask hides.
+
+    :func:`_mask_image_tag` blanks the front proxy's tag on both sides, so a
+    refreshed baseline's tag would slip through every comparison in this module.
+    It is therefore read back unmasked here: the frozen copy must spell a tag
+    the renderer's current default does not, which a copy regenerated from the
+    current renderer cannot do.
+    """
+    live = _image_tag_in(_token_render()["docker-compose.web.yml"])
+    assert live, "today's render spells no front-proxy image tag — the mask has stopped matching"
+    assert live == _DEFAULT_NGINX_IMAGE.split(":", 1)[1], (
+        f"today's `token` render spells front-proxy tag {live!r}, which is not the "
+        f"renderer's default {_DEFAULT_NGINX_IMAGE!r} — the mask is watching a line "
+        f"the renderer no longer owns."
+    )
+
+    frozen = _image_tag_in((_BASELINE_DIR / "docker-compose.web.yml").read_text())
+    assert frozen, "the frozen baseline spells no front-proxy image tag"
+    assert frozen != live, (
+        f"the frozen baseline spells the same front-proxy tag as today's render "
+        f"({frozen!r}), so it can no longer be shown to predate the current "
+        f"default. Restore `golden/pre_audit_roles/` from the commit that froze it."
     )
 
 

--- a/tests/deployment/web_terminals/test_env_digest_recreate_proof.py
+++ b/tests/deployment/web_terminals/test_env_digest_recreate_proof.py
@@ -44,7 +44,7 @@ pytestmark = [
 # Already pulled by this directory's other dockerbuild tests, so no extra image
 # cost; `sleep` exists in the alpine base and keeps the container running with
 # no ports and no config of its own.
-_IMAGE = "nginx:1.27-alpine"
+_IMAGE = "nginx:1.31-alpine"
 
 _ENV_VAR = "OSPREY_AUTH_SESSION_SECRET"  # variable NAME only; test values are dummies
 

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -2501,7 +2501,7 @@ def test_lint_valid_nginx_image_string_reports_nothing() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["nginx_image"] = (
-        "registry.example.com:5050/mirrors/nginx:1.27-alpine"
+        "registry.example.com:5050/mirrors/nginx:1.31-alpine"
     )
 
     # Act

--- a/tests/deployment/web_terminals/test_nginx_auth_surface.py
+++ b/tests/deployment/web_terminals/test_nginx_auth_surface.py
@@ -719,7 +719,7 @@ def test_the_open_render_holds_no_login_surface_anywhere() -> None:
 # --------------------------------------------------------------------------
 
 #: The base image the deployed stack runs, matching `test_nginx_validate.py`.
-_NGINX_IMAGE = "nginx:1.27-alpine"
+_NGINX_IMAGE = "nginx:1.31-alpine"
 #: Where the compose overlay's entrypoint writes the per-user secret snippets
 #: each gated location `include`s. `nginx -t` reads the include, so the file has
 #: to exist — but nothing here cares about the envsubst chain that normally

--- a/tests/deployment/web_terminals/test_nginx_validate.py
+++ b/tests/deployment/web_terminals/test_nginx_validate.py
@@ -3,7 +3,7 @@
 `test_render.py`'s and `test_auth_tls_seams.py`'s assertions are string matches
 on the Jinja output — cheap and fast, but they can't catch an nginx syntax error
 the strings happen to satisfy. This module closes that gap for real by actually
-invoking `nginx -t` inside `nginx:1.27-alpine` (the base image the deployed stack
+invoking `nginx -t` inside `nginx:1.31-alpine` (the base image the deployed stack
 uses) against each render shape the auth/TLS seams can produce:
 
 - the default render (`auth.method` unset -> "token", `tls.enabled` unset ->
@@ -58,7 +58,7 @@ from tests._container_support import docker_cli_unavailable_reason
 #: moves them, so they are the layout's own — derived here so a cookie name or a
 #: proxy_pass target asserted further down follows a slot that moves.
 _BASE_PORTS = {slot: default_port(slot) for slot in ("web", "artifact", "ariel", "lattice")}
-_NGINX_IMAGE = "nginx:1.27-alpine"
+_NGINX_IMAGE = "nginx:1.31-alpine"
 
 #: The `tls.port` a rootless deployment names: above 1024, so an unprivileged
 #: nginx can bind it, and pointedly not `TLS_LISTEN_PORT` — the whole point of
@@ -213,7 +213,7 @@ def _run_nginx_t(
     command: tuple[str, ...] = ("nginx", "-t"),
     entrypoint: str | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run *command* (default ``nginx -t``) in ``nginx:1.27-alpine`` against the
+    """Run *command* (default ``nginx -t``) in ``nginx:1.31-alpine`` against the
     rendered fragment.
 
     When *templates_dir* is given, the base image's entrypoint is driven exactly

--- a/tests/deployment/web_terminals/test_provision.py
+++ b/tests/deployment/web_terminals/test_provision.py
@@ -120,7 +120,7 @@ def test_deploy_down_web_terminals_noop_without_web_file(monkeypatch, tmp_path):
 _WEB_COMPOSE = (
     "services:\n"
     "  nginx:\n"
-    "    image: nginx:1.27-alpine\n"
+    "    image: nginx:1.31-alpine\n"
     "    container_name: als-nginx\n"
     "  web-alice:\n"
     "    image: reg/web-terminal:latest\n"
@@ -162,7 +162,7 @@ def test_reconcile_force_recreates_only_drifted_services(monkeypatch, tmp_path):
     _patch_ids(
         monkeypatch,
         image_ids={
-            "nginx:1.27-alpine": "idnginx",
+            "nginx:1.31-alpine": "idnginx",
             "reg/web-terminal:latest": "idNEW",
             "reg/web-terminal-analysis:latest": "idbob",
         },
@@ -203,7 +203,7 @@ def test_reconcile_noop_when_all_images_match(monkeypatch, tmp_path):
     _write_web_compose(tmp_path)
     monkeypatch.setattr(provision, "get_runtime_command", lambda config=None: ["podman", "compose"])
     ids = {
-        "nginx:1.27-alpine": "idnginx",
+        "nginx:1.31-alpine": "idnginx",
         "reg/web-terminal:latest": "idalice",
         "reg/web-terminal-analysis:latest": "idbob",
     }
@@ -247,7 +247,7 @@ def test_reconcile_skips_service_on_inspect_error_without_raising(monkeypatch, t
     _patch_ids(
         monkeypatch,
         image_ids={
-            "nginx:1.27-alpine": "idnginx",
+            "nginx:1.31-alpine": "idnginx",
             "reg/web-terminal:latest": None,  # image inspect failed / never pulled
             "reg/web-terminal-analysis:latest": "idbob",
         },

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -182,7 +182,7 @@ def test_nginx_image_defaults_when_config_omits_it() -> None:
     compose = yaml.safe_load(artifacts["docker-compose.web.yml"])
 
     # Assert
-    assert compose["services"]["nginx"]["image"] == "nginx:1.27-alpine"
+    assert compose["services"]["nginx"]["image"] == "nginx:1.31-alpine"
 
 
 def test_nginx_image_custom_value_lands_on_the_nginx_service() -> None:
@@ -190,7 +190,7 @@ def test_nginx_image_custom_value_lands_on_the_nginx_service() -> None:
     only from a private mirror point it at their own registry."""
     # Arrange
     config = copy.deepcopy(_MULTI_USER_CONFIG)
-    custom = "registry.example.com:5050/mirrors/nginx:1.27-alpine"
+    custom = "registry.example.com:5050/mirrors/nginx:1.31-alpine"
     config["modules"]["web_terminals"]["nginx_image"] = custom
 
     # Act

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -1974,13 +1974,13 @@ __pycache__/
 ENV_EXAMPLE = """\
 # Als Exemplar Environment Configuration
 #
-# Every variable this agent reads, listed in one place. Copy this file to `.env`
-# beside it and fill in what you need. That one file holds all your secrets, and
-# a value in it survives every rebuild.
+# Every variable this agent reads, listed in one place. Copy it to `.env` at the
+# repository root, beside `profile.yml`, and fill in what you need. That one file
+# holds all your secrets, and a value in it survives every rebuild.
 #
 # This file has no secrets in it and is safe to commit.
 #
-# The `.env` files, and which one to edit:
+# The `.env` files at the repository root, and which one to edit:
 #
 #   .env.shared    the settings that are the same on every host; committed
 #   .env           this host's own values and every key; wins over
@@ -2181,8 +2181,10 @@ deletes the audit log as well; that plus deleting this folder removes it all.
 
 ## Backups
 
-Git covers your settings. `var/` and `.env` are everything else, so a backup
-is a copy of those two, and a restore is:
+Git covers your settings. `var/` and the root's `.env` files are everything
+else — `.env`, and on a deployment with web terminals the deploy-written `.env.auth`,
+which holds the password hashes and cannot be regenerated: without it `osprey up`
+mints a new password for every user. A backup is a copy of those, and a restore is:
 
 ```bash
 git clone <this repo> && tar xf state.tar.gz && osprey build && osprey up -d

--- a/tests/interfaces/fsevents_wait.py
+++ b/tests/interfaces/fsevents_wait.py
@@ -144,7 +144,8 @@ def drain(pump: Callable[[], bool]) -> None:
 def collect_frames(
     queue: asyncio.Queue,
     *,
-    until: str,
+    until: str | None = None,
+    until_under: str | None = None,
     poke: Callable[[], Any],
     until_type: str | None = None,
     budget: float = ARM_BUDGET,
@@ -154,6 +155,14 @@ def collect_frames(
     The frame-queue shape of :func:`poke_until` plus :func:`drain`, shared by the
     workspace-watcher tests: wait for the sentinel frame, re-applying the change
     that produces it until it arrives, then take the coalesced tail behind it.
+
+    A sentinel proves the observer is live and delivering. It does not prove
+    that every event before it was delivered: a loaded FSEvents daemon hands a
+    stream its events in sparse batches, and a later write's frame can land
+    while an earlier write's frames are still pending. So a test that requires
+    a frame to be *present* waits for that frame — or, with *until_under*, for
+    any frame at or below a directory — and pokes with the stimulus that
+    produces it, never with a bystander write.
 
     Frames are returned whole rather than flattened to paths, because a poke
     only proves what it reproduces: a test whose subject is a *creation* has to
@@ -165,13 +174,20 @@ def collect_frames(
     Args:
         queue: A ``FileEventBroadcaster`` subscription.
         until: The workspace-relative path whose frame ends the wait.
-        poke: Re-applies the change that produces the *until* frame.
+        until_under: A workspace-relative directory instead of a path: the
+            first frame at or below it ends the wait. For a store whose write
+            lands at a random temp name and a rename, no single path can be
+            named in advance, but the store directory can. Exactly one of
+            *until* and *until_under* is given.
+        poke: Re-applies the change that produces the awaited frame.
         until_type: When given, only a frame of this ``type`` ends the wait.
         budget: Seconds of repeated stimulus before failing.
 
     Returns:
         Every frame delivered, in arrival order, sentinel included.
     """
+    if (until is None) == (until_under is None):
+        raise ValueError("pass exactly one of until= and until_under=")
     frames: list[dict] = []
 
     def pump() -> bool:
@@ -183,14 +199,21 @@ def collect_frames(
                 return took
             took = True
 
+    def at_target(path: str) -> bool:
+        if until is not None:
+            return path == until
+        prefix = until_under.rstrip("/")  # type: ignore[union-attr]
+        return path == prefix or path.startswith(prefix + "/")
+
     def matched(frame: dict) -> bool:
-        return frame["path"] == until and (until_type is None or frame["type"] == until_type)
+        return at_target(frame["path"]) and (until_type is None or frame["type"] == until_type)
 
     def arrived() -> bool:
         pump()
         return any(matched(frame) for frame in frames)
 
-    wanted = f"a {until_type!r} frame for {until!r}" if until_type else f"a frame for {until!r}"
+    where = f"for {until!r}" if until is not None else f"under {until_under!r}"
+    wanted = f"a {until_type!r} frame {where}" if until_type else f"a frame {where}"
     poke_until(arrived, poke, what=wanted, budget=budget)
     drain(pump)
     return frames
@@ -199,7 +222,8 @@ def collect_frames(
 def collect_paths(
     queue: asyncio.Queue,
     *,
-    until: str,
+    until: str | None = None,
+    until_under: str | None = None,
     poke: Callable[[], Any],
     budget: float = ARM_BUDGET,
 ) -> list[str]:
@@ -208,4 +232,5 @@ def collect_paths(
     Only for tests whose subject is *which* paths reached the panel, never
     whether a particular kind of change did — those must read the frames.
     """
-    return [frame["path"] for frame in collect_frames(queue, until=until, poke=poke, budget=budget)]
+    frames = collect_frames(queue, until=until, until_under=until_under, poke=poke, budget=budget)
+    return [frame["path"] for frame in frames]

--- a/tests/interfaces/web_terminal/test_bar_items_routes.py
+++ b/tests/interfaces/web_terminal/test_bar_items_routes.py
@@ -677,27 +677,37 @@ class TestAStoredDocumentThisBuildCannotRead:
 # ── the watcher does not announce a save ───────────────────────────────────
 
 
-def _broadcast_paths(queue, *, until: str, poke) -> list[str]:
-    """Every path broadcast up to and shortly after *until* arrives.
+def _broadcast_paths(
+    queue, *, until: str | None = None, until_under: str | None = None, poke
+) -> list[str]:
+    """Every path broadcast up to and shortly after the awaited frame arrives.
 
-    The control write is made **after** the save, so its frame arriving is
-    proof the observer has caught up past the save — the ordering that makes an
-    assertion about the save's *absence* a real one rather than a race.
+    *until* names a control note whose frame ends the wait; *until_under* names
+    the store directory instead, for the one test whose subject is the save's
+    own frames.
 
-    *poke* rewrites the file *until* names, and it is what makes that proof
-    obtainable rather than hoped for. A watchdog observer is not delivering the
-    moment the lifespan's ``start()`` returns; a control write made while its
-    stream is still arming is delivered late or not at all, and waiting longer
-    cannot recover a stimulus the stream never saw. So the wait re-applies the
-    stimulus instead of extending — see ``tests/interfaces/fsevents_wait.py``,
-    which also owns the trailing drain that catches a coalesced frame arriving a
-    beat behind the sentinel.
+    The control write is made **after** the save. Its frame arriving proves the
+    observer is live and delivering; it does not prove that the save's frames
+    were delivered first — a loaded FSEvents daemon hands a stream its events in
+    sparse batches, and a later write's frame can land while an earlier write's
+    frames are still pending. That is enough for an *absence* assertion, which
+    waiting longer can only strengthen, and not enough for a *presence* one:
+    the test that requires the save to be seen waits under the store and pokes
+    with the save itself.
+
+    *poke* re-applies the stimulus, and it is what makes the wait converge
+    rather than expire. A watchdog observer is not delivering the moment the
+    lifespan's ``start()`` returns; a write made while its stream is still
+    arming is delivered late or not at all, and waiting longer cannot recover a
+    stimulus the stream never saw — see ``tests/interfaces/fsevents_wait.py``,
+    which also owns the trailing drain that catches a coalesced frame arriving
+    a beat behind the sentinel.
 
     Rewriting an ordinary workspace note can only add more of the frames these
     tests require to be *present*. It cannot manufacture one they require to be
-    absent, so the assertions below keep their full strength.
+    absent, so the absence assertions below keep their full strength.
     """
-    return collect_paths(queue, until=until, poke=poke)
+    return collect_paths(queue, until=until, until_under=until_under, poke=poke)
 
 
 def _arm(queue, workspace) -> None:
@@ -798,7 +808,14 @@ class TestALayoutSaveIsNotAFileChange:
         watcher an empty ``concealed`` collection and the identical save
         broadcasts the document it wrote. This is what stops the narrowed
         ``agent_data/`` prefix from being an assertion that can no longer fail.
+
+        The wait targets the store rather than a control note: a note's frame
+        can arrive while the save's own frames are still pending, so it proves
+        nothing about their presence. The poke re-applies the save through the
+        store's own atomic write — the temp file and rename the route performs —
+        which is the one stimulus that reproduces the frames this test requires.
         """
+        store_dir = watched_workspace / "agent_data" / "bar_items"
         with patch(
             "osprey.interfaces.web_terminal.app.resolve_store_rel",
             return_value=None,
@@ -814,16 +831,18 @@ class TestALayoutSaveIsNotAFileChange:
                 _arm(queue, watched_workspace)
 
                 unconcealed.put("/api/bar-items", json=document(0))
-                control_note = watched_workspace / "control-note.txt"
-                control_note.write_text("ordinary content")
+                stored = bar_items_store.read_json_object(bar_items_store.layout_path(store_dir))
+                assert stored is not None, "the save landed in the store the watcher sees"
 
                 paths = _broadcast_paths(
                     queue,
-                    until="control-note.txt",
-                    poke=lambda: control_note.write_text("ordinary content"),
+                    until_under="agent_data/bar_items",
+                    poke=lambda: bar_items_store.write_json_atomic(
+                        bar_items_store.layout_path(store_dir), stored
+                    ),
                 )
 
-        assert [path for path in paths if path.startswith("agent_data/")] != []
+        assert [path for path in paths if path.startswith("agent_data/bar_items")] != []
 
     def test_the_first_ever_save_never_names_the_store_or_the_document(
         self, watched_client, watched_workspace

--- a/tests/registry/test_gate_wiring.py
+++ b/tests/registry/test_gate_wiring.py
@@ -35,9 +35,11 @@ import asyncio
 import json
 from pathlib import Path
 
+import yaml
+
 import osprey
 from osprey import bluesky_tool_names as bsky
-from osprey.registry.mcp import resolve_agents, resolve_servers
+from osprey.registry.mcp import FRAMEWORK_SERVERS, HOOK_PRESETS, resolve_agents, resolve_servers
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -82,6 +84,37 @@ def _hook_source(filename: str) -> str:
     path = _HOOKS_DIR / filename
     assert path.exists(), f"hook template source not found: {path}"
     return path.read_text(encoding="utf-8")
+
+
+def _hook_docstring_and_body(filename: str) -> tuple[str, str]:
+    """A hook template split at its module docstring: (docstring, everything after).
+
+    The docstring carries the frontmatter header — what the hook is called,
+    which event it answers and which tools it gates — and the body is the code
+    that runs. Guards that pin a *header* against the registry read the first;
+    guards that forbid a literal in the *code* read the second.
+    """
+    src = _hook_source(filename)
+    start = src.find('"""')
+    end = src.find('"""', start + 3)
+    assert start >= 0 and end > start, f"{filename} has no module docstring"
+    return src[start + 3 : end], src[end + 3 :]
+
+
+def _hook_header_tools(filename: str) -> set[str]:
+    """The short tool names a hook's frontmatter ``tools:`` line declares."""
+    docstring, _ = _hook_docstring_and_body(filename)
+    parts = docstring.split("---")
+    assert len(parts) >= 3, f"{filename} has no frontmatter block"
+    meta = yaml.safe_load(parts[1])
+    return {tool.strip() for tool in str(meta["tools"]).split(",") if tool.strip()}
+
+
+def _short_name(matcher: str) -> str:
+    """``mcp__<server>__<tool>`` → ``<tool>``; any other matcher as it is."""
+    if matcher.startswith("mcp__") and matcher.count("__") >= 2:
+        return matcher.split("__", 2)[2]
+    return matcher
 
 
 # ---------------------------------------------------------------------------
@@ -229,20 +262,50 @@ def test_approval_template_source_carries_the_queue_control_constants() -> None:
     )
 
 
+def test_hook_headers_list_exactly_the_tools_the_registry_attaches() -> None:
+    """Every safety hook's frontmatter ``tools:`` line equals its registry matchers.
+
+    The header is what an operator reads to learn what a hook gates, and the
+    registry's ``HookRule``s are what actually attach it — so the two are
+    pinned to each other, as sets, across every ``FRAMEWORK_SERVERS`` entry.
+    A tool gated in the registry and missing from the header under-reports the
+    hook; a tool named in the header and gated nowhere over-reports it. This
+    is also what lets a header carry a Bluesky tool name at all: a rename that
+    updates the constant moves the registry's matcher, and this guard then
+    names the header that still spells the old name.
+    """
+    for key, entry in HOOK_PRESETS.items():
+        filename = entry.command.rsplit("/", 1)[-1].rstrip('"')
+        attached = {
+            _short_name(rule.matcher)
+            for template in FRAMEWORK_SERVERS.values()
+            for rule in template.hooks_pre
+            if entry in rule.hooks
+        }
+        declared = _hook_header_tools(filename)
+        assert declared == attached, (
+            f"{filename} header tools: {sorted(declared)} != registry matchers for the "
+            f"{key!r} hook {sorted(attached)} — under-reported: "
+            f"{sorted(attached - declared)}, over-reported: {sorted(declared - attached)}"
+        )
+
+
 def test_writes_check_template_carries_no_bluesky_tool_literal() -> None:
     """The kill switch stays data-driven — no Bluesky tool name is hardcoded.
 
     Both of the hook's tool-keyed decisions arrive as rendered data, never as a
-    literal here: which tools it gates at all flows registry HookRule →
+    literal in its code: which tools it gates at all flows registry HookRule →
     ``hook_config.json`` → its runtime ``write_tools`` load, and which of them
     skip the per-target stage because a plan lane addresses them flows
     ``QUEUE_CONTROL_TOOLS`` → ``hook_config.json`` → its ``lane_addressed_tools``
-    load. Pinning the ABSENCE documents why a Bluesky tool rename never needs to
-    touch this standalone source (and flags anyone who reintroduces a literal
-    that would then silently drift on the next rename).
+    load. Pinning the ABSENCE flags anyone who reintroduces a literal that
+    would then silently drift on the next rename. The frontmatter header is
+    the one place the names may appear: it is pinned against the registry by
+    ``test_hook_headers_list_exactly_the_tools_the_registry_attaches``, so a
+    rename that leaves it stale fails there rather than drifting.
     """
-    src = _hook_source("osprey_writes_check.py")
-    present = [t for t in bsky.ALL_TOOLS if t in src]
+    _, body = _hook_docstring_and_body("osprey_writes_check.py")
+    present = [t for t in bsky.ALL_TOOLS if t in body]
     assert present == [], (
         f"osprey_writes_check.py hardcodes Bluesky tool name(s) {present} — the "
         f"writes kill switch must stay data-driven (write_tools loaded from "

--- a/tests/services/ariel_search/test_ingestion.py
+++ b/tests/services/ariel_search/test_ingestion.py
@@ -1125,8 +1125,10 @@ class TestALSLogbookAdapterHTTPMocked:
                             raise ImportError("No module named 'aiohttp_socks'")
                         except ImportError as e:
                             raise IngestionError(
-                                "SOCKS proxy configured but aiohttp-socks is not installed. "
-                                "Install with: pip install osprey-framework",
+                                "SOCKS proxy support needs aiohttp-socks, a core "
+                                "osprey dependency, so a missing module means a "
+                                "broken install — repair it with: pip install "
+                                "--force-reinstall aiohttp-socks",
                                 source_system=adapter.source_system_name,
                             ) from e
                     return original_method()

--- a/tests/services/ariel_search/test_ingestion_branches.py
+++ b/tests/services/ariel_search/test_ingestion_branches.py
@@ -812,14 +812,14 @@ class TestALSConnector:
             await connector.close()
 
     def test_proxy_without_aiohttp_socks_raises(self, monkeypatch):
-        """A proxy without the optional dependency installed fails with an install hint."""
+        """A proxy whose transport module will not import fails with a repair hint."""
         adapter = _als_adapter(proxy_url="socks5://127.0.0.1:9095")
         monkeypatch.setitem(sys.modules, "aiohttp_socks", None)
 
         with pytest.raises(IngestionError) as exc_info:
             adapter._create_connector()
 
-        assert "aiohttp-socks is not installed" in str(exc_info.value)
+        assert "pip install --force-reinstall aiohttp-socks" in str(exc_info.value)
 
 
 class TestFacilityAdapterTransportDefaults:
@@ -998,7 +998,7 @@ class TestJSONAdapterTransport:
         """A proxy that cannot be built stops the fetch instead of going direct.
 
         The connector is created inside the same ``try`` that maps a missing
-        aiohttp to an install hint, so this also pins that the proxy failure
+        aiohttp to a repair hint, so this also pins that the proxy failure
         keeps its own message rather than being reported as a missing aiohttp.
         """
         adapter = GenericJSONAdapter(
@@ -1009,7 +1009,7 @@ class TestJSONAdapterTransport:
         with pytest.raises(IngestionError) as exc_info:
             await adapter._load_data()
 
-        assert "aiohttp-socks is not installed" in str(exc_info.value)
+        assert "pip install --force-reinstall aiohttp-socks" in str(exc_info.value)
 
 
 class TestALSConvertEntry:


### PR DESCRIPTION
## Problem

The pre-b2 housekeeping and doc-sync sweeps (baseline v2026.9.0b1) found 22 housekeeping findings and 6 doc-sync findings where what OSPREY ships, prints or documents had drifted from what it does. Four were new since b1: the init README lists `rules/` for a hello-world repo that has none, the approval and writes-check hook headers name 13 of 21 and 2 of 6 gated tools, the demo-ui skill sends operators to edit the rendered `config.yml`, and the SOCKS proxy remedy names an install step that cannot fix the error.

## What changes

- **CLI remedies** name `osprey init <dir> --preset <NAME>`; the init README lists `rules/` only where the resolved profile selects the facility rule, and its backup recipe names `.env.auth`.
- **Shipped prompts and headers**: both safety hooks list every tool they gate; setup-mode and demo-ui route protected keys to the profile via `osprey set`; the persona template renders the channel-finder do-not-call list from the pipeline's tool names; setup-mode's server table has one row per framework server; no shipped header, skill or message points at a `src/osprey/` path.
- **Runtime messages**: the vendor manifest error interpolates the resolved path; the SOCKS remedy names a repair that works; the VA entrypoint hint drops a script the wheel does not ship.
- **Pins**: the web-terminal front proxy moves from `nginx:1.27-alpine` (end of life) to `nginx:1.31-alpine`. The frozen auth-off baseline pin masks the image tag the way it masks ports, so future base-image bumps never require regenerating the frozen copy.
- **Manifest and preset**: `control_system.target_switch.{drain_timeout_s,probe_interval_s}` carry evidence and their real defaults (5.0 s, 30.0 s) instead of "forward-declared"; hello-world states fourteen hooks and that dropping a write-safety hook while writes are armed makes `osprey build` refuse the render.
- **Docs**: provider pages name the shipping model ids and state the `<NAME>_API_KEY` derivation rule; hello-world tutorial counts and write-safety note match the preset; the connector how-to registers built-in connectors before creating one; the operate page describes the idle restart state.
- Plugin 2026.9.8.

Deferred to the release after the facility-agnostic train by owner ruling: openobserve, tiled, model-id and CLI-version pins.

## Guard interaction found by the local gate

Listing `queue_add` and `queue_start` in the writes-check hook's header tripped `test_writes_check_template_carries_no_bluesky_tool_literal`, which forbade any Bluesky tool name in that file so a rename never has to touch the deployed source. Resolution: that guard now scans the code body only, where a literal would bypass the data-driven gate, and a new guard pins every safety hook's `tools:` header to the union of the registry's matchers for that hook (the guard the housekeeping report proposed). A header that goes stale on a rename now fails by name instead of drifting.

## Deflake found by the local gate

`TestALayoutSaveIsNotAFileChange::test_without_concealment_the_same_save_does_reach_the_file_panel` failed on a loaded machine (fseventsd saturated). A standalone watchdog reproduction lost the save's frames in 17 of 20 runs while the control note's poke still got through: a later write's frame can land while an earlier write's frames are still pending, so a sentinel written after the save proves nothing about the save's presence. The test now waits for the first frame under the store and pokes by re-applying the save through the store's own atomic write; the wait helper gains `until_under=`. Under the same load, 10 of 10 reproduction runs and 6 of 6 test runs converge.

## Verification

Sphinx `-W` build clean; `tests/docs` 225 passed; targeted suites across CLI, templates, hooks, web terminals, ARIEL ingestion and design system 3100 passed; full fast unit suite on the final tree 41169 passed, 0 failed.
