### PR TITLE
fix: one producer for operator identity, browse filters and dispatcher limits

### DIFF
--- a/changelog.d/ariel-browse-filters.fixed.md
+++ b/changelog.d/ariel-browse-filters.fixed.md
@@ -1,0 +1,4 @@
+The ARIEL `browse` tool filters by author and source system in the database
+query instead of over the page it just fetched, so a filter on a logbook larger
+than one page no longer silently drops matching entries or reports a total that
+counts the whole table.

--- a/changelog.d/ariel-entries-sort-order.removed.md
+++ b/changelog.d/ariel-entries-sort-order.removed.md
@@ -1,0 +1,2 @@
+The ARIEL entries API no longer advertises `sort_order`; ordering was and is
+newest-first.

--- a/changelog.d/dispatcher-pool-defaults.changed.md
+++ b/changelog.d/dispatcher-pool-defaults.changed.md
@@ -1,0 +1,5 @@
+A dispatcher run by hand from a `triggers.yml` that omits `max_concurrent_runs`
+and `max_queue_depth` now starts at 2 concurrent runs and a queue of 50 — the
+pair the documentation describes and the pair a built deployment already
+writes. A deployment built by `osprey build` is unaffected; it writes both keys
+from the profile.

--- a/changelog.d/logbook-operator-identity.fixed.md
+++ b/changelog.d/logbook-operator-identity.fixed.md
@@ -1,0 +1,5 @@
+Logbook entries name the operator the audit ledger names. The session metadata
+attached to an entry resolved the operator from the process account, which in a
+per-user terminal container is a service account rather than the person at the
+keyboard; it now climbs the same identity ladder every audit record uses, and
+falls back to `unknown` rather than to no name at all.

--- a/docs/source/how-to/agent-interfaces/event-dispatch.rst
+++ b/docs/source/how-to/agent-interfaces/event-dispatch.rst
@@ -244,6 +244,11 @@ Authoring Triggers
 
    Each webhook trigger is reachable at ``POST /webhook/<name>``.
 
+   ``max_concurrent_runs`` and ``max_queue_depth`` are shown with their
+   defaults: leave them out and the dispatcher carries two runs at once and
+   holds fifty events waiting for a slot. A build writes both keys from the
+   profile's ``dispatch:`` block, which starts at the same pair.
+
    **Turn ceiling.** How many agentic turns one dispatched run may take is
    ``dispatch.max_turns`` in the build profile (default 25) — the third budget
    beside ``dispatch.timeout_sec`` and ``dispatch.inactivity_sec``, and the one

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
+from osprey.dispatch_pool_defaults import DEFAULT_MAX_CONCURRENT_RUNS, DEFAULT_MAX_QUEUE_DEPTH
 from osprey.errors import BuildProfileError
 from osprey.port_layout import (
     DEFAULT_PORT_BASE,
@@ -974,8 +975,10 @@ def _parse_profile(raw: dict[str, Any]) -> BuildProfile:
             triggers=dispatch_raw.get("triggers", ""),
             worker_count=dispatch_raw.get("worker_count", 1),
             workspace_mode=dispatch_raw.get("workspace_mode", "isolated"),
-            max_concurrent_runs=dispatch_raw.get("max_concurrent_runs", 2),
-            max_queue_depth=dispatch_raw.get("max_queue_depth", 50),
+            max_concurrent_runs=dispatch_raw.get(
+                "max_concurrent_runs", DEFAULT_MAX_CONCURRENT_RUNS
+            ),
+            max_queue_depth=dispatch_raw.get("max_queue_depth", DEFAULT_MAX_QUEUE_DEPTH),
             dispatcher_port=dispatch_raw.get(
                 "dispatcher_port", default_port("dispatcher", base=port_base)
             ),

--- a/src/osprey/cli/build_profile_schema.py
+++ b/src/osprey/cli/build_profile_schema.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from osprey.dispatch_pool_defaults import DEFAULT_MAX_CONCURRENT_RUNS, DEFAULT_MAX_QUEUE_DEPTH
 from osprey.port_layout import DEFAULT_PORT_BASE, SLOTS_BY_NAME, default_port, layout_ports
 
 #: The shape of an environment-variable NAME wherever a profile names one
@@ -407,8 +408,8 @@ class DispatchConfig:
     triggers: str
     worker_count: int = 1
     workspace_mode: Literal["isolated", "shared"] = "isolated"
-    max_concurrent_runs: int = 2
-    max_queue_depth: int = 50
+    max_concurrent_runs: int = DEFAULT_MAX_CONCURRENT_RUNS
+    max_queue_depth: int = DEFAULT_MAX_QUEUE_DEPTH
     dispatcher_port: int = default_port("dispatcher")
     """Host port the event dispatcher publishes, at the layout's ``dispatcher``
     slot.

--- a/src/osprey/dispatch/trigger_config.py
+++ b/src/osprey/dispatch/trigger_config.py
@@ -1,4 +1,8 @@
-"""Trigger configuration dataclasses and YAML loader for the event dispatcher."""
+"""Trigger configuration dataclasses and YAML loader for the event dispatcher.
+
+The pool limits are re-exported from :mod:`osprey.dispatch_pool_defaults`, the
+stdlib-only leaf the build profile reads them from as well.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +10,16 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import yaml
+
+from osprey.dispatch_pool_defaults import DEFAULT_MAX_CONCURRENT_RUNS, DEFAULT_MAX_QUEUE_DEPTH
+
+__all__ = [
+    "DEFAULT_MAX_CONCURRENT_RUNS",
+    "DEFAULT_MAX_QUEUE_DEPTH",
+    "DispatcherConfig",
+    "TriggerConfig",
+    "load_triggers",
+]
 
 _DEFAULT_ON_ERROR: dict[str, Any] = {
     "action": "drop",
@@ -49,8 +63,8 @@ class TriggerConfig:
 @dataclass
 class DispatcherConfig:
     dispatch_target: str
-    max_concurrent_runs: int = 5
-    max_queue_depth: int = 100
+    max_concurrent_runs: int = DEFAULT_MAX_CONCURRENT_RUNS
+    max_queue_depth: int = DEFAULT_MAX_QUEUE_DEPTH
 
 
 def _parse_trigger(raw: dict[str, Any], index: int) -> TriggerConfig:
@@ -126,8 +140,8 @@ def load_triggers(path: str) -> tuple[DispatcherConfig, list[TriggerConfig]]:
     dispatcher_raw = doc.get("dispatcher", {})
     dispatcher_cfg = DispatcherConfig(
         dispatch_target=dispatcher_raw.get("dispatch_target", ""),
-        max_concurrent_runs=dispatcher_raw.get("max_concurrent_runs", 5),
-        max_queue_depth=dispatcher_raw.get("max_queue_depth", 100),
+        max_concurrent_runs=dispatcher_raw.get("max_concurrent_runs", DEFAULT_MAX_CONCURRENT_RUNS),
+        max_queue_depth=dispatcher_raw.get("max_queue_depth", DEFAULT_MAX_QUEUE_DEPTH),
     )
 
     raw_triggers = doc.get("triggers") or []

--- a/src/osprey/dispatch_pool_defaults.py
+++ b/src/osprey/dispatch_pool_defaults.py
@@ -1,0 +1,19 @@
+"""Single source of truth for the event dispatcher's pool limits.
+
+Three places state how many agent runs a dispatcher carries and how deep its
+queue goes: the runtime dataclass, the ``triggers.yml`` loader's fallback, and
+the build profile's ``dispatch:`` block. A hand-run dispatcher and a built one
+must start at the same posture, so all three read the constants here.
+
+This leaf imports nothing from ``osprey`` and nothing outside the standard
+library. That is what lets the CLI's profile schema — which the ``build``,
+``config`` and ``init`` commands import on every invocation — share the numbers
+without pulling ``osprey.dispatch`` and its HTTP worker client into the profile
+import graph.
+"""
+
+#: Agent runs the dispatcher will carry at once when nothing says otherwise.
+DEFAULT_MAX_CONCURRENT_RUNS: int = 2
+
+#: Events the dispatcher will hold waiting for a slot before it refuses more.
+DEFAULT_MAX_QUEUE_DEPTH: int = 50

--- a/src/osprey/interfaces/ariel/api/routes.py
+++ b/src/osprey/interfaces/ariel/api/routes.py
@@ -481,9 +481,8 @@ async def list_entries(
     end_date: datetime | None = None,
     author: str | None = None,
     source_system: str | None = None,
-    sort_order: str = "desc",
 ) -> EntriesListResponse:
-    """List entries with pagination and filtering."""
+    """List entries with pagination and filtering, newest first."""
     service = _require_service(request)
 
     try:

--- a/src/osprey/interfaces/ariel/static/js/api.js
+++ b/src/osprey/interfaces/ariel/static/js/api.js
@@ -170,7 +170,6 @@ export const entriesApi = {
       end_date: params.endDate,
       author: params.author,
       source_system: params.sourceSystem,
-      sort_order: params.sortOrder || 'desc',
     });
   },
 

--- a/src/osprey/mcp_server/ariel/tools/browse.py
+++ b/src/osprey/mcp_server/ariel/tools/browse.py
@@ -34,7 +34,8 @@ async def browse(
         page_size: Number of entries to return (default 20, max 100).
         start_date: Filter entries after this ISO-8601 date.
         end_date: Filter entries before this ISO-8601 date.
-        author: Filter by author name (case-insensitive partial match).
+        author: Filter by author name (exact match — use ``filter_options``
+            for the spelling).
         source_system: Filter by source system (exact match).
 
     Returns:
@@ -48,20 +49,24 @@ async def browse(
 
         parsed_start, parsed_end = parse_date_filters(start_date, end_date)
 
+        # Both filters go into the query rather than over its result: a
+        # post-filter can only narrow the page the query already returned, so a
+        # corpus larger than page_size loses the author's older entries and the
+        # count describes a different set from the entries beside it.
         entries = await service.repository.search_by_time_range(
             start=parsed_start,
             end=parsed_end,
             limit=page_size,
+            author=author,
+            source_system=source_system,
         )
 
-        # Repository doesn't support author/source_system filters, so filter in Python.
-        if author:
-            author_lower = author.lower()
-            entries = [e for e in entries if author_lower in e.get("author", "").lower()]
-        if source_system:
-            entries = [e for e in entries if e["source_system"] == source_system]
-
-        total_count = await service.repository.count_entries()
+        total_count = await service.repository.count_entries(
+            start=parsed_start,
+            end=parsed_end,
+            author=author,
+            source_system=source_system,
+        )
 
         # TypedDict entries -- use dict access, not attribute access
         entries_out = [serialize_entry(e, text_limit=300) for e in entries]

--- a/src/osprey/mcp_server/session.py
+++ b/src/osprey/mcp_server/session.py
@@ -2,16 +2,20 @@
 
 import logging
 
+from osprey.utils.identity import acting_identity
+
 logger = logging.getLogger("osprey.mcp_server.session")
 
 
 def gather_session_metadata(created_via: str) -> dict:
     """Collect session metadata for logbook entries.
 
-    Returns a dict with 8 fields, all with graceful ``None`` fallback:
-    ``session_id``, ``transcript_path``, ``session_start_time``,
-    ``git_branch``, ``git_commit_short``, ``operator``, ``model_name``,
-    ``created_via``.
+    Returns a dict with 8 fields: ``session_id``, ``transcript_path``,
+    ``session_start_time``, ``git_branch``, ``git_commit_short``,
+    ``operator``, ``model_name``, ``created_via``. All fall back gracefully to
+    ``None`` except ``operator``, which floors at
+    :data:`~osprey.utils.identity.UNKNOWN_IDENTITY` — an entry always names
+    somebody, even if only honestly.
 
     Args:
         created_via: Caller identifier (e.g. ``"ariel-mcp"``, ``"gallery-compose"``).
@@ -93,12 +97,10 @@ def gather_session_metadata(created_via: str) -> dict:
     meta["git_commit_short"] = git_commit_short
 
     # --- Operator ---
-    operator: str | None = None
-    try:
-        operator = os.environ.get("USER") or os.getlogin()
-    except Exception as exc:
-        logger.warning("Session metadata: operator lookup failed (non-fatal): %s", exc)
-    meta["operator"] = operator
+    # The same ladder the audit ledger climbs, so an entry and the records of
+    # the session that wrote it name the same person. Never raises, so there is
+    # nothing to guard.
+    meta["operator"] = acting_identity()
 
     # --- Model name ---
     model_name: str | None = None

--- a/tests/interfaces/ariel/test_routes.py
+++ b/tests/interfaces/ariel/test_routes.py
@@ -242,6 +242,19 @@ def test_list_entries_passes_pagination_and_filters(client, mock_ariel_service):
     assert ckwargs["source_system"] == "ALS"
 
 
+def test_list_entries_advertises_no_sort_order(client):
+    """Every parameter the endpoint declares reaches the query.
+
+    Ordering is newest-first and is not a parameter.
+    """
+    schema = client.get("/openapi.json").json()
+    names = {
+        param["name"] for param in schema["paths"]["/api/entries"]["get"].get("parameters", [])
+    }
+
+    assert "sort_order" not in names
+
+
 def test_get_entry_endpoint(client, mock_ariel_service):
     """Test get single entry endpoint."""
     # Mock entry

--- a/tests/mcp_server/ariel/test_browse.py
+++ b/tests/mcp_server/ariel/test_browse.py
@@ -80,29 +80,70 @@ async def test_browse_empty_db(tmp_path, monkeypatch):
 
 @pytest.mark.unit
 async def test_browse_author_filter(tmp_path, monkeypatch):
-    """Browse filters by author (post-filter)."""
+    """Browse hands the author filter to the repository, not to a post-filter.
+
+    A post-filter can only narrow the one page the query already returned, so
+    on a corpus larger than ``page_size`` it drops the author's older entries
+    entirely and reports a ``total_count`` for the whole table. Both filters go
+    into the query instead, and the count carries them too.
+    """
     _setup_registry(tmp_path, monkeypatch)
 
+    # The page the filtered query returns: every entry is already Alice's.
     entries = [
         make_mock_entry(entry_id="e1", author="Alice"),
-        make_mock_entry(entry_id="e2", author="Bob"),
-        make_mock_entry(entry_id="e3", author="Alice"),
+        make_mock_entry(entry_id="e2", author="Alice"),
     ]
 
     mock_service = AsyncMock()
     mock_service.repository.search_by_time_range.return_value = entries
-    mock_service.repository.count_entries.return_value = 3
+    # Alice's entries, not the 500 in the table.
+    mock_service.repository.count_entries.return_value = 2
 
     with patch(
         "osprey.mcp_server.ariel.server_context.ARIELContext.service",
         new=AsyncMock(return_value=mock_service),
     ):
         fn = _get_browse()
-        result = await fn(author="Alice")
+        result = await fn(page_size=2, author="Alice")
+
+    search_kwargs = mock_service.repository.search_by_time_range.call_args.kwargs
+    assert search_kwargs["author"] == "Alice"
+    assert search_kwargs["source_system"] is None
+    count_kwargs = mock_service.repository.count_entries.call_args.kwargs
+    assert count_kwargs["author"] == "Alice"
+    assert count_kwargs["source_system"] is None
 
     data = json.loads(result)
     assert data["returned"] == 2
+    assert data["total_count"] == 2
     assert all(e["author"] == "Alice" for e in data["entries"])
+
+
+@pytest.mark.unit
+async def test_browse_source_system_filter(tmp_path, monkeypatch):
+    """The source-system filter takes the same route as the author one."""
+    _setup_registry(tmp_path, monkeypatch)
+
+    mock_service = AsyncMock()
+    mock_service.repository.search_by_time_range.return_value = [
+        make_mock_entry(entry_id="e1", source_system="ARIEL Web")
+    ]
+    mock_service.repository.count_entries.return_value = 1
+
+    with patch(
+        "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        fn = _get_browse()
+        result = await fn(source_system="ARIEL Web")
+
+    assert (
+        mock_service.repository.search_by_time_range.call_args.kwargs["source_system"]
+        == "ARIEL Web"
+    )
+    assert mock_service.repository.count_entries.call_args.kwargs["source_system"] == "ARIEL Web"
+    assert json.loads(result)["total_count"] == 1
 
 
 @pytest.mark.unit

--- a/tests/mcp_server/test_session_metadata.py
+++ b/tests/mcp_server/test_session_metadata.py
@@ -167,12 +167,29 @@ class TestGatherSessionMetadata:
         # settings.json doesn't exist, so env var should be used
         assert result["model_name"] == "claude-haiku-4-5"
 
-    def test_operator_from_user_env(self, fake_project, monkeypatch):
-        """operator comes from USER env var."""
+    def test_operator_is_the_container_user(self, fake_project, monkeypatch):
+        """operator names the person the audit ledger names.
+
+        A per-user terminal container sets ``OSPREY_TERMINAL_USER`` and no
+        ``USER``, so a lookup that read the process account would file the
+        entry under a service account while the ledger named the operator.
+        """
         from osprey.mcp_server.session import gather_session_metadata
 
-        monkeypatch.setenv("USER", "test-operator")
+        monkeypatch.delenv("USER", raising=False)
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "alice")
 
         result = gather_session_metadata("test")
 
-        assert result["operator"] == "test-operator"
+        assert result["operator"] == "alice"
+
+    def test_operator_floors_at_unknown(self, fake_project, monkeypatch):
+        """An unresolvable identity is spelled, not left empty."""
+        from osprey.mcp_server import session
+        from osprey.utils.identity import UNKNOWN_IDENTITY
+
+        monkeypatch.setattr(session, "acting_identity", lambda: UNKNOWN_IDENTITY)
+
+        result = session.gather_session_metadata("test")
+
+        assert result["operator"] == UNKNOWN_IDENTITY

--- a/tests/test_dispatch_pool_defaults.py
+++ b/tests/test_dispatch_pool_defaults.py
@@ -1,0 +1,112 @@
+"""Unit tests for the dispatcher pool limits and the leaf that holds them.
+
+:mod:`osprey.dispatch_pool_defaults` is the one place the dispatcher's
+concurrency and queue-depth defaults are spelled. Three consumers read it — the
+runtime dataclass, the ``triggers.yml`` loader, and the CLI's build-profile
+schema — so the tests here pin the numbers and both structural properties that
+let those three share them:
+
+* The module is a stdlib-only leaf. The profile schema is imported by every
+  ``osprey build`` / ``osprey config`` / ``osprey init`` invocation, and the
+  numbers must reach it without dragging :mod:`osprey.dispatch` (and its HTTP
+  worker client) into the profile import graph.
+* :mod:`osprey.dispatch.trigger_config` re-exports them, so code reading the
+  defaults from the runtime package sees the same pair.
+
+Both are checked on a fresh interpreter, not on the already-populated
+``sys.modules`` of the test session.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from osprey.cli.build_profile_schema import DispatchConfig
+from osprey.dispatch_pool_defaults import DEFAULT_MAX_CONCURRENT_RUNS, DEFAULT_MAX_QUEUE_DEPTH
+
+_SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+
+def _fresh_import_modules(module: str, allowed: set[str]) -> list[str]:
+    """Return the non-stdlib ``osprey`` modules a fresh import of ``module`` adds.
+
+    Args:
+        module: Dotted name to import in a child interpreter.
+        allowed: Module names the import may add without being reported.
+
+    Returns:
+        The offending module names, sorted — empty when the import stays
+        inside ``allowed``.
+
+    Raises:
+        AssertionError: If the child interpreter fails to import the module.
+    """
+    code = (
+        "import json, sys;"
+        "before = set(sys.modules);"
+        f"import {module};"
+        f"allowed = {sorted(allowed)!r};"
+        "delta = set(sys.modules) - before - set(allowed);"
+        "print(json.dumps(sorted("
+        "m for m in delta if m.split('.')[0] not in sys.stdlib_module_names)))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ, PYTHONPATH=_SRC),
+        check=False,
+    )
+    assert result.returncode == 0, f"fresh import of {module} failed:\n{result.stderr}"
+    return json.loads(result.stdout)
+
+
+def test_defaults_are_the_documented_pair():
+    """The hand-run dispatcher starts at the posture the documentation describes."""
+    assert (DEFAULT_MAX_CONCURRENT_RUNS, DEFAULT_MAX_QUEUE_DEPTH) == (2, 50)
+
+
+def test_the_leaf_imports_nothing_from_osprey():
+    """Importing the defaults costs the package ``__init__`` and nothing more.
+
+    The parent package ``__init__`` runs for any submodule import and pulls in
+    ``osprey`` and ``osprey.version``; those two and the module itself are the
+    only ``osprey`` names the import may add.
+    """
+    offenders = _fresh_import_modules(
+        "osprey.dispatch_pool_defaults",
+        {"osprey", "osprey.version", "osprey.dispatch_pool_defaults"},
+    )
+    assert offenders == []
+
+
+def test_the_profile_schema_keeps_the_dispatch_package_out_of_its_import_graph():
+    """The CLI reads the numbers from the leaf, not through ``osprey.dispatch``.
+
+    Every ``build``, ``config`` and ``init`` invocation imports the schema,
+    while ``osprey.dispatch`` pulls in the HTTP worker client the CLI never
+    calls. The profile's own trigger check imports the package on demand, and
+    the pool defaults must not undo that.
+    """
+    fresh = _fresh_import_modules("osprey.cli.build_profile_schema", set())
+    assert not [name for name in fresh if name.split(".")[:2] == ["osprey", "dispatch"]]
+
+
+def test_trigger_config_re_exports_the_leaf_values():
+    """The runtime package's spelling of the defaults agrees with the leaf's."""
+    from osprey.dispatch import trigger_config
+
+    assert trigger_config.DEFAULT_MAX_CONCURRENT_RUNS == DEFAULT_MAX_CONCURRENT_RUNS
+    assert trigger_config.DEFAULT_MAX_QUEUE_DEPTH == DEFAULT_MAX_QUEUE_DEPTH
+
+
+def test_every_consumer_starts_at_the_leaf_values():
+    """Runtime dataclass and build-profile block agree by construction."""
+    from osprey.dispatch.trigger_config import DispatcherConfig
+
+    assert DispatcherConfig(dispatch_target="").max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS
+    assert DispatcherConfig(dispatch_target="").max_queue_depth == DEFAULT_MAX_QUEUE_DEPTH
+    assert DispatchConfig(triggers="x").max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS
+    assert DispatchConfig(triggers="x").max_queue_depth == DEFAULT_MAX_QUEUE_DEPTH

--- a/tests/unit/dispatch/test_trigger_config.py
+++ b/tests/unit/dispatch/test_trigger_config.py
@@ -5,6 +5,8 @@ import textwrap
 import pytest
 
 from osprey.dispatch.trigger_config import (
+    DEFAULT_MAX_CONCURRENT_RUNS,
+    DEFAULT_MAX_QUEUE_DEPTH,
     DispatcherConfig,
     TriggerConfig,
     load_triggers,
@@ -181,7 +183,7 @@ def test_on_error_defaults_to_drop_when_omitted(tmp_path):
 
 # ---------------------------------------------------------------------------
 # Test 6: `dispatcher` section parses max_concurrent_runs and max_queue_depth
-#          with defaults (5, 100)
+#          with the package defaults
 # ---------------------------------------------------------------------------
 
 
@@ -210,8 +212,8 @@ def test_dispatcher_config_defaults_when_omitted(tmp_path):
     path = write_yaml(tmp_path, yaml_content)
     dispatcher_cfg, _ = load_triggers(path)
 
-    assert dispatcher_cfg.max_concurrent_runs == 5
-    assert dispatcher_cfg.max_queue_depth == 100
+    assert dispatcher_cfg.max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS
+    assert dispatcher_cfg.max_queue_depth == DEFAULT_MAX_QUEUE_DEPTH
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Four hand-kept restatements of a fact another module already owns, each replaced by the one producer — and each changing what a running deployment does.

- `fix(session): resolve the logbook operator through acting_identity()`
- `fix(ariel): push browse's author/source_system filters into the repository query`
- `fix(ariel): drop the sort_order parameter nothing reads`
- `fix(dispatch): one definition of the dispatcher pool defaults`

## Why

Each commit removes a place where a second copy of a fact had already drifted from the first.

Session metadata resolved the logbook operator from the process account (`USER`, then `os.getlogin()`), while the audit ledger resolved it through `osprey.utils.identity.acting_identity()`. In a per-user terminal container the two disagree by construction: the container sets `OSPREY_TERMINAL_USER` and no `USER`, so every logbook entry was filed under a service account — or under no name at all — while the ledger named the person at the keyboard. Both now climb the same ladder, and the value floors at `unknown` rather than `None`, so an entry always names somebody.

ARIEL's `browse` tool applied its author and source-system filters in Python, over the page the query had already returned, because the repository was once assumed not to support them. It does: `search_by_time_range` and `count_entries` both take `author=` and `source_system=`, and the REST route has been passing them all along. On any logbook larger than one page the post-filter silently dropped matching entries and reported a `total_count` for the whole table. Both filters now go into the query, and the count carries them too. The docstring's "case-insensitive partial match" was describing the post-filter; the repository predicate is `author = %s`, so it now says exact match and points at `filter_options` for the spelling.

The entries API advertised a `sort_order` parameter that reached no query. A caller passing `asc` got the same newest-first page back with no way to tell. It is gone from the route and from the JS client, which were its only two references.

Finally, the dispatcher pool limits were stated three times — the `DispatcherConfig` dataclass, the `triggers.yml` loader's fallback, and the build profile's `dispatch:` block — and the first two had drifted to 5/100 against the documented and profile-shipped 2/50. `DEFAULT_MAX_CONCURRENT_RUNS` and `DEFAULT_MAX_QUEUE_DEPTH` now live in `osprey.dispatch_pool_defaults`, a stdlib-only leaf on the `osprey.bluesky_tool_names` pattern. `osprey.dispatch.trigger_config` re-exports them for the runtime, and the CLI's profile schema and loader import the leaf directly — so the numbers reach the build profile without pulling `osprey.dispatch` and its HTTP worker client into the import graph of every `build`, `config` and `init` invocation. A test pins both halves of that on a fresh interpreter. A built deployment is unaffected — the build writes both keys from the profile — so the only thing that moves is a hand-run dispatcher with the keys omitted, which drops from the laxer 5/100 to the documented 2/50.

A deployer can now trust that a logbook entry and the audit records of the session that wrote it name the same person, that a filtered browse returns the entries it claims to, and that a dispatcher started by hand carries the posture the documentation describes.

## Not in this PR

- **The HTTP-service axis** (`services.<name>.config.http`). Split out of this PR and landed alongside the other configuration keys, where the rest of the profile-key surface is being added.
- **Widening the browse author filter to a partial match.** The repository predicate is an exact match and the REST route has never offered anything else; making `browse` case-insensitive would put a second producer of match semantics in the tool layer. That is a product call, not a mechanical one.
- **Threading `sort_order` through instead of removing it.** If ordering is wanted later it enters `search_by_time_range` as a validated enum, never as an interpolated string.
- **Replacing the framework's `_HTTP_SERVICES` / `_SERVICE_SLOTS` tables with a per-template manifest.** The slot tables map onto `osprey.port_layout.LAYOUT`, which has no slot for a facility service.

