### PR TITLE
fix(interfaces): front-end hand tables read their server/registry authority or gain parity tests

### DIFF
--- a/changelog.d/approval-tools-panel.changed.md
+++ b/changelog.d/approval-tools-panel.changed.md
@@ -1,3 +1,0 @@
-The settings panel now offers a policy dropdown for every `approval.tools` key a
-deployment can set. Four of them — `entry_publish`, `add_panel_to_rail`,
-`remove_panel_from_rail` and `register_panel` — rendered as free-text boxes.

--- a/changelog.d/frontend-hand-tables.fixed.md
+++ b/changelog.d/frontend-hand-tables.fixed.md
@@ -1,0 +1,9 @@
+The panel rail now draws its own glyph for the Jupyter and System Health
+panels instead of the generic placeholder both fell back to. The lattice
+dashboard renders in the fleet typeface rather than its own. The settings
+drawer offers the policy dropdown for every `approval.tools.*` key a
+deployment states, not just six of them, and no longer shows a
+`screen_capture.enabled` toggle nothing reads. Health check labels keep their
+leading word unless it really is the row's category. The theme lab's exported
+proposal names the families that actually ship, states per-document what to do
+about `$extensions.inherits`, and includes the optional `family_label` field.

--- a/src/osprey/health/models.py
+++ b/src/osprey/health/models.py
@@ -35,7 +35,7 @@ class CheckResult:
     """Result of a single health check.
 
     Attributes:
-        name: Machine-readable identifier, e.g. ``"epics.beam_current"``.
+        name: Machine-readable identifier, e.g. ``"control_system.beam_current"``.
         category: Category the check belongs to, e.g. ``"file_system"``.
         status: Outcome of the check.
         message: Human-readable one-line summary.

--- a/src/osprey/interfaces/artifacts/static/js/timeseries.js
+++ b/src/osprey/interfaces/artifacts/static/js/timeseries.js
@@ -38,7 +38,12 @@
  * @module timeseries
  */
 
-import { chartTheme, chartRelayout, chartSeries } from "/design-system/js/theme-manager.js";
+import {
+  chartTheme,
+  chartRelayout,
+  chartSeries,
+  monoFontStack,
+} from "/design-system/js/theme-manager.js";
 import { escapeHtml } from "/design-system/js/dom.js";
 import { isoToDate } from "./types.js";
 
@@ -445,7 +450,9 @@ export async function renderTimeseriesChart(el, chartData) {
   const layout = {
     paper_bgcolor: t.paper_bgcolor,
     plot_bgcolor: t.plot_bgcolor,
-    font: { family: "'JetBrains Mono', monospace", size: 11, color: t.font.color },
+    // First render only: a live re-theme goes through chartRelayout(), which
+    // sets the family from the same token.
+    font: { family: monoFontStack(), size: 11, color: t.font.color },
     margin: { t: 30, r: 20, b: 50, l: 60 },
     hovermode: "x unified",
     // zerolinecolor too: chartRelayout() sets it on a live re-theme, so the

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/draft-client.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/draft-client.js
@@ -578,12 +578,13 @@ export function classifyQueueAddResponse(status, body) {
  * @property {string} detail  The operator-facing sentence, shown VERBATIM —
  *   it carries the flip command for a browse-only deployment.
  * @property {string|null} lane  Which plan lane answered, by its service key
- *   (`bluesky`, `bluesky_va`, `bluesky_live`). `null` when the health surface
- *   itself could not be read — no lane spoke, so naming one would be a guess.
- * @property {string|null} laneTarget  The control target that lane serves,
- *   `live` or `va`. A RENDER-TIME fact about the bridge, never the session's
- *   own target: it does not change when the session switches, so the panel
- *   must not present it as "what you are pointed at".
+ *   as `GET /lanes` reports it. `null` when the health surface itself could
+ *   not be read — no lane spoke, so naming one would be a guess.
+ * @property {string|null} laneTarget  The control target that lane serves —
+ *   the target the lane's config block declares (one of `CONTROL_TARGETS`).
+ *   A RENDER-TIME fact about the bridge, never the session's own target: it
+ *   does not change when the session switches, so the panel must not present
+ *   it as "what you are pointed at".
  */
 
 /**

--- a/src/osprey/interfaces/bluesky_web/panels/bluesky/results-view.js
+++ b/src/osprey/interfaces/bluesky_web/panels/bluesky/results-view.js
@@ -80,7 +80,6 @@ import { TERMINAL_RUN_STATUSES, describeProgress } from './queue-client.js';
 /** @typedef {{ok: true, data: Figure} | {ok: false, notFound: boolean, message: string}} FigureFetch */
 
 const POLL_INTERVAL_MS = 1000;
-const TERMINAL_STATUSES = ['completed', 'stopped', 'error'];
 
 /**
  * Badge tone for a run status. `pending`/`running` read as in-flight, a clean
@@ -144,7 +143,7 @@ export function formatCell(value) {
  * @returns {boolean}
  */
 export function shouldKeepPolling(status, partial) {
-  return partial || !TERMINAL_STATUSES.includes(status);
+  return partial || !TERMINAL_RUN_STATUSES.includes(status);
 }
 
 /**

--- a/src/osprey/interfaces/design_system/static/js/theme-lab.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-lab.js
@@ -16,7 +16,7 @@
  *      theme? (`slugifyThemeName`, `checkCollision`)
  *
  * DERIVATION RULES (read off the generated `static/css/tokens.css`, which is
- * the authority -- the default `osprey` family is the shape proposers riff on):
+ * the authority -- the default `main` family is the shape proposers riff on):
  *
  *   --color-accent             the chosen accent for that mode
  *   --color-accent-light       the mode's *emphasis* variant. "light" means
@@ -45,9 +45,10 @@
  *                              whichever of the scope's bg.primary /
  *                              text.primary / black / white has the highest
  *                              WCAG contrast against the chosen accent. Every
- *                              shipped theme hand-picks this value (only `dark`
- *                              happens to use its own bg.primary), so there is
- *                              no convention to mirror -- what the lab
+ *                              shipped theme hand-picks this value, and they do
+ *                              not agree -- some land on their own bg.primary,
+ *                              the rest on an ink from neither scope color --
+ *                              so there is no convention to mirror. What the lab
  *                              guarantees is that it clears the gate whenever
  *                              any candidate can, and that the value it scores
  *                              is the value it exports.
@@ -345,10 +346,9 @@ export function rgbaCss(rgb, alpha) {
  * Pure black and white, always available as `--color-on-accent` candidates.
  *
  * Nothing in the design system requires `accent.on` to be one of the scope's
- * own colors, and the shipped themes prove it: of the six, only `dark` uses
- * its own `bg.primary`. `light` and both `apex` themes reuse dark's near-black
- * ink, `high-contrast-dark` ships pure black and `high-contrast-light` pure
- * white -- none of which is that scope's own background or primary text.
+ * own colors, and the shipped themes prove it: some dark themes use their own
+ * `bg.primary`; the rest, and every light theme, reach for an ink that is
+ * neither their own background nor their primary text.
  * Offering only the two scope colors would make the lab reject accents that
  * ship fine: a mid grey reaches 4.22:1 against both of dark's primaries (a
  * FAIL) but 4.62:1 against black (a PASS).
@@ -714,11 +714,14 @@ function exportTokenTable(modeExport) {
  *   * `accent.base` / `accent.light` / `accent.on` are authored as *references*
  *     into `core.json`'s ramps (`{color.teal.300}`), not as literal hex, so a
  *     new accent needs ramp steps adding there first.
- *   * every shipped non-default family (`apex`, `high-contrast`) *inherits* the
- *     interface groups rather than authoring them, so the change set asks for
- *     `$extensions.inherits` entries -- and notes that
- *     `wt-accent-system-tint-04` therefore keeps the default value unless the
- *     author opts out of inheriting.
+ *   * an interface document either *inherits* the base groups for a family or
+ *     authors its own, and the five do not agree on which -- `retro` is
+ *     inherited everywhere it can be, `high-contrast` is authored in most of
+ *     them, and `web_terminal.json` has every family author its own. So the
+ *     change set asks the proposer to read each document's
+ *     `$extensions.inherits` rather than assume, and notes that
+ *     `wt-accent-system-tint-04` keeps the default value wherever the new ids
+ *     are inherited.
  *
  * @param {ExportInput} input
  * @returns {string} markdown.
@@ -804,25 +807,30 @@ export function buildExportMarkdown(input) {
   lines.push(
     `   \`$extensions\` to \`{"mode": "dark"|"light", "id": "${slug}-dark"|"${slug}-light",`
   );
-  lines.push(`   "label": "${label || slug}", "family": "${slug}"}\` (no \`"default": true\` —`);
-  lines.push('   that belongs to the shipped default theme).');
+  lines.push(
+    `   "label": "${label || slug}", "family": "${slug}", "family_label": "<label>"}\``
+  );
+  lines.push('   (no `"default": true` — that belongs to the shipped default theme).');
+  lines.push('   `family_label` is optional: set it when the family id does not title-case');
+  lines.push('   into the name the theme switcher should show, and drop it when it does.');
   lines.push('');
-  lines.push('3. **`tokens/interfaces/*.json`** — add the new ids to each');
-  lines.push('   `$extensions.inherits` map so the five interface documents');
-  lines.push('   (`ariel.json`, `artifacts.json`, `channel_finder.json`,');
-  lines.push('   `lattice_dashboard.json`, `web_terminal.json`) reuse the base groups:');
+  lines.push('3. **`tokens/interfaces/*.json`** — check `$extensions.inherits` in each of');
+  lines.push('   the five interface documents (`ariel.json`, `artifacts.json`,');
+  lines.push('   `channel_finder.json`, `lattice_dashboard.json`, `web_terminal.json`).');
+  lines.push('   Add the new ids wherever the same-mode base groups fit:');
   lines.push('');
   lines.push('   ```json');
   lines.push(`   "${slug}-dark": "dark",`);
   lines.push(`   "${slug}-light": "light"`);
   lines.push('   ```');
   lines.push('');
-  lines.push('   This is what `apex` already does in all five, and `high-contrast` in');
-  lines.push('   four of them (`ariel.json` authors its own high-contrast groups). Note the');
-  lines.push('   consequence: `wt-accent-system-tint-04` is authored in');
-  lines.push('   `web_terminal.json`, so inheriting keeps the default value rather than');
-  lines.push('   the accent-matched one below. Author a full `web_terminal.json` group');
-  lines.push('   for the new ids only if that tint must match the accent:');
+  lines.push('   The documents do not agree on this, so read each one: where a document');
+  lines.push('   authors its own groups for the other non-default families, author a group');
+  lines.push('   for the new ids too. Note the consequence of inheriting:');
+  lines.push('   `wt-accent-system-tint-04` is authored in `web_terminal.json`, so an');
+  lines.push('   inherited group keeps the default value rather than the accent-matched');
+  lines.push('   one below. Author a full `web_terminal.json` group for the new ids only');
+  lines.push('   if that tint must match the accent:');
   lines.push('');
   lines.push(`   - dark: \`${dark.derived['--wt-accent-system-tint-04']}\``);
   lines.push(`   - light: \`${light.derived['--wt-accent-system-tint-04']}\``);

--- a/src/osprey/interfaces/design_system/static/js/theme-manager.js
+++ b/src/osprey/interfaces/design_system/static/js/theme-manager.js
@@ -102,6 +102,10 @@ const SENTINEL_VAR = '--bg-primary';
 // empty slot could just as easily be a transient hidden-iframe read).
 const MAX_CHART_SERIES = 12;
 
+// Rendered when --font-mono reads empty: the family the token itself ships,
+// so an unresolved read is a fallback rather than the browser's default.
+const MONO_FALLBACK = "'JetBrains Mono', monospace";
+
 // tokens.js is plain (unchecked) generated JS: cast its exports to the
 // shapes documented above rather than relying on tsc's own inference of
 // the literal object it emits. This also means theme-manager.js type-checks
@@ -768,6 +772,20 @@ function _checkSentinel(styles) {
   return false;
 }
 
+/**
+ * The monospace stack the design system is serving, with the shipped default
+ * for a document whose tokens have not resolved (an unstyled test DOM, or a
+ * page served without tokens.css).
+ *
+ * @param {CSSStyleDeclaration} [styles] Computed style to read the token
+ *   from; the document element's own when omitted.
+ * @returns {string}
+ */
+export function monoFontStack(styles) {
+  const source = styles ?? getComputedStyle(document.documentElement);
+  return _readVar(source, '--font-mono') || MONO_FALLBACK;
+}
+
 /** xterm.js `theme` option, built from --ansi-* custom properties. */
 export function xtermPalette() {
   const styles = _computedStyles();
@@ -854,7 +872,7 @@ export function chartRelayout(gd) {
     // an author who leaves colors unset gets the same series colors the native
     // time-series viewer draws with, in all eight themes.
     colorway: chartSeries(),
-    'font.family': _readVar(styles, '--font-mono') || "'JetBrains Mono', monospace",
+    'font.family': monoFontStack(styles),
     'legend.bgcolor': paper,
     'legend.bordercolor': line,
   };

--- a/src/osprey/interfaces/design_system/tokens/core.json
+++ b/src/osprey/interfaces/design_system/tokens/core.json
@@ -184,7 +184,7 @@
     }
   },
   "font": {
-    "display": { "$value": "'Outfit', system-ui, sans-serif", "$type": "fontFamily", "$description": "Fleet-wide display/UI font; canon = web-terminal variables.css. ariel/lattice's '--font-sans: Inter' is retired fleet-wide (Task 3.5/3.6 rename usages to this token)." },
+    "display": { "$value": "'Outfit', system-ui, sans-serif", "$type": "fontFamily", "$description": "Fleet-wide display/UI font; canon = web-terminal variables.css. A local '--font-sans: Inter' is retired fleet-wide -- every surface reads this token." },
     "mono": { "$value": "'JetBrains Mono', monospace", "$type": "fontFamily", "$description": "Sole monospace stack fleet-wide per user decision. Canon = web-terminal variables.css. Retires artifacts' 'DM Mono' and the richer fallback chains ('Fira Code'/'SF Mono'/Consolas) used elsewhere — those interfaces just get JetBrains Mono now." }
   },
   "weight": {

--- a/src/osprey/interfaces/health/static/js/dashboard.js
+++ b/src/osprey/interfaces/health/static/js/dashboard.js
@@ -121,7 +121,7 @@ function buildCheckRow(ck) {
   const row = el("div", { class: "ck" });
   row.appendChild(el("span", { class: "led " + (LED_CLS[ck.status] || "led-sk") }));
   row.appendChild(
-    el("span", { class: "ck-nm" + (ck.status === "skip" ? " sk" : ""), text: fmtName(ck.name) }),
+    el("span", { class: "ck-nm" + (ck.status === "skip" ? " sk" : ""), text: fmtName(ck.name, ck.category) }),
   );
   if (ck.value) row.appendChild(el("span", { class: "ck-val", text: ck.value }));
 

--- a/src/osprey/interfaces/health/static/js/helpers.js
+++ b/src/osprey/interfaces/health/static/js/helpers.js
@@ -79,16 +79,22 @@ export function worst(results) {
 }
 
 /**
- * Humanize a check name for display: drop a leading `"<category>."` prefix (up
- * to the first dot) and title-case the remaining underscore/space separated
- * words. `"epics.beam_current"` → `"Beam Current"`.
+ * Humanize a check name for display: drop the row's OWN `"<category>."` prefix
+ * and title-case the remaining underscore/space separated words.
+ * `fmtName("control_system.beam_current", "control_system")` → `"Beam Current"`.
+ *
+ * A check name is free-form, so a dot in it is not a category marker by
+ * itself — only the category the row actually carries is stripped, or a name
+ * that merely spells a dot loses its leading word. Existing capitalisation
+ * survives: the regex only ever raises a lowercase letter.
  *
  * @param {string} name
+ * @param {string} [category]
  * @returns {string}
  */
-export function fmtName(name) {
-  const dot = name.indexOf(".");
-  const s = dot > -1 ? name.slice(dot + 1) : name;
+export function fmtName(name, category) {
+  const prefix = category ? `${category}.` : "";
+  const s = prefix && name.startsWith(prefix) ? name.slice(prefix.length) : name;
   return s.replace(/_/g, " ").replace(/\b[a-z]/g, (c) => c.toUpperCase());
 }
 

--- a/src/osprey/interfaces/health/static/js/helpers.test.mjs
+++ b/src/osprey/interfaces/health/static/js/helpers.test.mjs
@@ -107,19 +107,23 @@ describe('worst', () => {
 
 describe('fmtName', () => {
   test('strips the leading "<category>." prefix and title-cases the rest', () => {
-    expect(fmtName('epics.beam_current')).toBe('Beam Current');
+    expect(fmtName('control_system.beam_current', 'control_system')).toBe('Beam Current');
   });
 
   test('a name with no dot is title-cased as-is', () => {
-    expect(fmtName('disk_space')).toBe('Disk Space');
+    expect(fmtName('disk_space', 'file_system')).toBe('Disk Space');
   });
 
-  test('only the first dot delimits the prefix', () => {
-    expect(fmtName('a.b_c')).toBe('B C');
+  // A check name is free-form, so a dot in it means nothing on its own: only
+  // the row's OWN category is a prefix. Stripping to the first dot regardless
+  // is how a name that merely spells one loses its leading word.
+  test('the prefix is stripped only when it is the row category', () => {
+    expect(fmtName('a.b_c', 'a')).toBe('B C');
+    expect(fmtName('a.b_c', 'x')).toBe('A.B C');
   });
 
   test('a single word is capitalized', () => {
-    expect(fmtName('latency')).toBe('Latency');
+    expect(fmtName('latency', 'network')).toBe('Latency');
   });
 });
 

--- a/src/osprey/interfaces/lattice_dashboard/static/dashboard.css
+++ b/src/osprey/interfaces/lattice_dashboard/static/dashboard.css
@@ -15,7 +15,6 @@
 :root {
   --verify-accent: #a78bfa; /* hygiene-allow-color: no canonical equivalent; theme-invariant one-off */
   --baseline-accent: #06b6d4; /* hygiene-allow-color: no canonical equivalent; theme-invariant one-off */
-  --font-sans: 'Inter', -apple-system, sans-serif;
   --ld-radius-sm: 4px;
   --ld-radius-md: 6px;
 }
@@ -31,7 +30,7 @@ html, body {
   overflow: hidden;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-family: var(--font-sans);
+  font-family: var(--font-display);
   font-size: 13px;
   -webkit-font-smoothing: antialiased;
 }
@@ -921,7 +920,7 @@ body.drag-active .figure-plot {
 :root[data-ui-mode="simple"] .lattice-simple-status {
   display: inline-flex;
   align-items: center;
-  font-family: var(--font-sans);
+  font-family: var(--font-display);
   font-size: 12px;
   color: var(--text-secondary);
   white-space: nowrap;

--- a/src/osprey/interfaces/lattice_dashboard/static/js/render.js
+++ b/src/osprey/interfaces/lattice_dashboard/static/js/render.js
@@ -11,13 +11,12 @@
  * throughout — no innerHTML with interpolated data.
  */
 
-import { subscribe, chartTheme } from '/design-system/js/theme-manager.js';
+import { subscribe, chartTheme, monoFontStack } from '/design-system/js/theme-manager.js';
 
 // Theme-independent Plotly layout — colors come from chartTheme() at
 // render/re-theme time (see renderPlotly() and the theme subscription
 // below).
 const FIGURE_MARGIN = { l: 45, r: 15, t: 30, b: 35 };
-const FIGURE_FONT_FAMILY = 'JetBrains Mono, monospace';
 const FIGURE_FONT_SIZE = 10;
 
 const PLOTLY_CONFIG = {
@@ -167,7 +166,9 @@ export function renderPlotly(name, figData) {
     ...figData.layout,
     paper_bgcolor: themeLayout.paper_bgcolor,
     plot_bgcolor: themeLayout.plot_bgcolor,
-    font: { family: FIGURE_FONT_FAMILY, size: FIGURE_FONT_SIZE, color: themeLayout.font.color },
+    // Read per render so a re-theme that changes the stack takes effect on
+    // the next draw.
+    font: { family: monoFontStack(), size: FIGURE_FONT_SIZE, color: themeLayout.font.color },
     margin: FIGURE_MARGIN,
   };
   const defaultFontColor = themeLayout.font.color;

--- a/src/osprey/interfaces/web_terminal/routes/config.py
+++ b/src/osprey/interfaces/web_terminal/routes/config.py
@@ -62,10 +62,13 @@ _RENDER_READONLY_DETAIL = "derived artifacts re-render on container restart"
 
 # Config sections the Form view offers for editing. Deliberately narrower than
 # the file: infra/build sections (api, cli, deploy, modules, file_paths, ...)
-# are left to the Raw YAML view. Every name here must match a real top-level
-# key -- an entry that matches nothing renders nothing, silently, which is how
-# "python_execution" (the section is called "execution") kept the execution
-# settings out of the form.
+# are left to the Raw YAML view, which reaches everything -- so this stays an
+# ALLOWLIST rather than becoming a denylist that would offer every new block by
+# default. Every name here must match a real top-level key -- an entry that
+# matches nothing renders nothing, silently, which is how "python_execution"
+# (the section is called "execution") kept the execution settings out of the
+# form. `tests/interfaces/web_terminal/test_config_form_sections.py` holds each
+# name against the sections the shipped presets carry.
 _AGENT_CONFIG_SECTIONS = [
     "control_system",
     "archiver",
@@ -77,7 +80,6 @@ _AGENT_CONFIG_SECTIONS = [
     "facility_knowledge",
     "execution",
     "artifact_server",
-    "screen_capture",
     "hooks",
 ]
 

--- a/src/osprey/interfaces/web_terminal/static/css/terminal.css
+++ b/src/osprey/interfaces/web_terminal/static/css/terminal.css
@@ -1114,7 +1114,10 @@ html[data-ui-mode="simple"] .session-selector {
 }
 
 /* Glyph — mapped from the panel id via data-icon, with a generic fallback for
-   runtime/custom panels. */
+   runtime/custom panels. Every built-in panel id gets a rule of its own, so a
+   rail never shows two panels wearing the fallback; the id set is
+   `profiles.web_panels.BUILTIN_PANEL_LABELS` plus the session tile's rail id,
+   and `test_panel_rail_glyph_parity.py` holds the two together. */
 .panel-rail-icon {
   font-size: var(--text-xl);
   line-height: var(--leading-none);
@@ -1127,6 +1130,8 @@ html[data-ui-mode="simple"] .session-selector {
 .panel-rail-icon[data-icon="channel-finder"]::before { content: "\2315"; } /* ⌕ channels */
 .panel-rail-icon[data-icon="lattice"]::before { content: "\2b21"; }   /* ⬡ lattice */
 .panel-rail-icon[data-icon="okf"]::before { content: "\1f56e"; }      /* 🕮 knowledge */
+.panel-rail-icon[data-icon="jupyter"]::before { content: "\25a6"; }  /* ▦ notebook cells */
+.panel-rail-icon[data-icon="system-health"]::before { content: "\223f"; } /* ∿ health trace */
 
 .panel-rail-label {
   font-size: var(--text-xs);

--- a/src/osprey/interfaces/web_terminal/static/js/settings.js
+++ b/src/osprey/interfaces/web_terminal/static/js/settings.js
@@ -52,30 +52,34 @@ const SETTINGS_WARNING_KEY_BASE = 'osprey-settings-warning-ack';
 // another. Guards against a rapid second click spawning a second dialog.
 let warningGatePending = false;
 
-// Known enum values for select dropdowns. Every `approval.tools.<tool>` key a
-// deployment can set has a row here: the panel is the surface an operator
-// changes approval posture through, so a settable policy the drawer renders as
-// a free-text box is a policy they can only get wrong.
-// tests/profiles/test_approval_tools_parity.py holds this list to the same set
-// the presets ship and the config-key manifest documents.
-/** @type {string[]} */
+// The policy vocabulary a per-tool approval entry offers. The approval hook
+// resolves a policy for ANY tool it gates, by short name, so which tools a
+// deployment states here is the deployment's business — the drawer renders the
+// select for whatever keys the config carries and never decides the roster.
 const APPROVAL_POLICIES = ['always', 'selective', 'skip'];
 
+// Every leaf under this prefix is a per-tool approval policy.
+const APPROVAL_TOOL_PREFIX = 'approval.tools.';
+
+// Known enum values for select dropdowns, keyed by the full dotted path of a
+// LEAF field. Per-tool approval policies are not here: they are the prefix
+// rule above.
 /** @type {Record<string, string[]>} */
 const ENUM_FIELDS = {
   'claude_code.effort': ['low', 'medium', 'high', 'max'],
   'approval.default_policy': APPROVAL_POLICIES,
-  'approval.tools.channel_write': APPROVAL_POLICIES,
-  'approval.tools.channel_read': APPROVAL_POLICIES,
-  'approval.tools.archiver_read': APPROVAL_POLICIES,
-  'approval.tools.execute': APPROVAL_POLICIES,
-  'approval.tools.setup_patch': APPROVAL_POLICIES,
-  'approval.tools.entry_create': APPROVAL_POLICIES,
-  'approval.tools.entry_publish': APPROVAL_POLICIES,
-  'approval.tools.add_panel_to_rail': APPROVAL_POLICIES,
-  'approval.tools.remove_panel_from_rail': APPROVAL_POLICIES,
-  'approval.tools.register_panel': APPROVAL_POLICIES,
 };
+
+/**
+ * The option list a key renders as a select over, or null for a plain input.
+ *
+ * @param {string} fullKey
+ * @returns {string[]|null}
+ */
+function enumOptionsFor(fullKey) {
+  if (fullKey.startsWith(APPROVAL_TOOL_PREFIX)) return APPROVAL_POLICIES;
+  return ENUM_FIELDS[fullKey] ?? null;
+}
 
 // Fields that should render as toggles even when the current value is null or
 // absent. A field whose value is already a boolean gets a toggle regardless
@@ -85,7 +89,6 @@ const BOOLEAN_FIELDS = new Set([
   'control_system.writes_enabled',
   'ariel.enabled',
   'artifact_server.auto_launch',
-  'screen_capture.enabled',
 ]);
 
 /**
@@ -507,11 +510,12 @@ function renderFields(container, obj, prefix, depth = 0) {
  * @returns {HTMLElement}
  */
 function createInputForValue(fullKey, value) {
-  if (ENUM_FIELDS[fullKey]) {
+  const options = enumOptionsFor(fullKey);
+  if (options) {
     const select = document.createElement('select');
     select.className = 'settings-select';
     select.dataset.key = fullKey;
-    for (const opt of ENUM_FIELDS[fullKey]) {
+    for (const opt of options) {
       const option = document.createElement('option');
       option.value = opt;
       option.textContent = opt;

--- a/src/osprey/interfaces/web_terminal/static/js/terminal.js
+++ b/src/osprey/interfaces/web_terminal/static/js/terminal.js
@@ -7,7 +7,7 @@ import {
   showHandoffPending,
   showHandoffRefused,
 } from './terminal-handoff.js';
-import { subscribe, xtermPalette } from '/design-system/js/theme-manager.js';
+import { monoFontStack, subscribe, xtermPalette } from '/design-system/js/theme-manager.js';
 
 /** @type {any} */
 let term = null;
@@ -189,7 +189,9 @@ export function initTerminal(containerId) {
   term = new Terminal({
     scrollback: 10000,
     cursorBlink: true,
-    fontFamily: "'JetBrains Mono', monospace",
+    // xterm takes a family at construction and measures cell width from it,
+    // so the stack is read once here rather than re-read on a theme change.
+    fontFamily: monoFontStack(),
     fontSize: 14,
     lineHeight: 1.2,
     theme: xtermPalette(),

--- a/src/osprey/interfaces/web_terminal/static/js/tour.js
+++ b/src/osprey/interfaces/web_terminal/static/js/tour.js
@@ -56,12 +56,29 @@ const SETTLE_MS = 160;
 /* ---- Server-derived facts (applyTourConfig) ---- */
 
 /**
- * The one thing the tour reads off `GET /api/panels` for itself: when to
- * invite. Everything the cards SAY about this deployment belongs to
- * first-contact.js, which panel-manager.js hands the same payload.
- * @type {{policy: string}}
+ * What the tour reads off `GET /api/panels` for itself: when to invite, and
+ * the display labels the rail is actually wearing. Everything the cards SAY
+ * about this deployment belongs to first-contact.js, which panel-manager.js
+ * hands the same payload.
+ *
+ * `labels` covers the ENABLED built-in panels only, so every card that names
+ * one keeps a literal fallback for the deployment where that panel is off.
+ * @type {{policy: string, labels: Record<string, string>}}
  */
-let facts = { policy: 'never' };
+let facts = { policy: 'never', labels: {} };
+
+/**
+ * The label the rail is wearing for a built-in panel, or `fallback` when this
+ * deployment does not enable it (`/api/panels` reports labels for enabled
+ * panels only).
+ *
+ * @param {string} panelId
+ * @param {string} fallback
+ * @returns {string}
+ */
+function panelLabel(panelId, fallback) {
+  return facts.labels[panelId] ?? fallback;
+}
 
 /* ---- Storage ---- */
 
@@ -304,7 +321,7 @@ const STEPS = [
     title: 'Your workspace',
     body: () => [
       'Everything the agent produces — plots, data files, reports — lands in ',
-      strong('WORKSPACE'),
+      strong(panelLabel('artifacts', 'WORKSPACE')),
       ', ready to open or download.',
     ],
     foot: '＋ on the rail adds more panels.',
@@ -315,7 +332,7 @@ const STEPS = [
     extras: () => [document.querySelector('iframe[data-panel-id="okf"]')],
     title: 'Facility knowledge',
     body: () => [
-      strong('KNOWLEDGE'),
+      strong(panelLabel('okf', 'KNOWLEDGE')),
       ' holds this facility’s curated documentation, the same material the agent consults when you ask about the machine. Browse it directly here.',
     ],
   },
@@ -325,7 +342,7 @@ const STEPS = [
     extras: () => [document.querySelector('iframe[data-panel-id="ariel"]')],
     title: 'The logbook',
     body: () => [
-      strong('ARIEL'),
+      strong(panelLabel('ariel', 'ARIEL')),
       ' searches the electronic logbook. Ask the agent what happened on a shift, or search it yourself here.',
     ],
     foot: 'Tip: right-click any panel entry → “Open in a new window” for a standalone version.',
@@ -643,12 +660,16 @@ export function startTour() {
  * panel-manager calls whether or not this one returns early: what the cards
  * say must not depend on whether the tour is on offer.
  *
- * @param {{tour?: {policy?: unknown}} | null | undefined} panelsPayload
+ * @param {{tour?: {policy?: unknown}, labels?: Record<string, string>} | null | undefined} panelsPayload
  */
 export function applyTourConfig(panelsPayload) {
   const cfg = panelsPayload?.tour;
   if (!cfg) return;
-  facts = { policy: typeof cfg.policy === 'string' ? cfg.policy : 'never' };
+  const labels = panelsPayload?.labels;
+  facts = {
+    policy: typeof cfg.policy === 'string' ? cfg.policy : 'never',
+    labels: labels && typeof labels === 'object' ? labels : {},
+  };
 
   const invite =
     facts.policy === 'always' || (facts.policy === 'once' && !isDismissed());

--- a/tests/cli/test_bluesky_lane_config.py
+++ b/tests/cli/test_bluesky_lane_config.py
@@ -814,6 +814,17 @@ _LANE_REGISTRY_MODULE = "bluesky_bridge_connection.py"
 #: what keeps them in step. Excluded here rather than exempted quietly.
 _STANDALONE_TEMPLATES = "templates"
 
+#: The panel module that addresses lane 1. JavaScript cannot import the Python
+#: registry, so its copy of the key is pinned by test instead.
+_LANE_CLIENT_JS = (
+    Path(osprey.__file__).parent
+    / "interfaces"
+    / "bluesky_web"
+    / "panels"
+    / "bluesky"
+    / "lane-client.js"
+)
+
 
 def test_the_lane_service_keys_are_spelled_in_exactly_one_module() -> None:
     """No module but the registry writes a lane key as a string literal.
@@ -846,6 +857,22 @@ def test_the_lane_service_keys_are_spelled_in_exactly_one_module() -> None:
     assert offenders == [], (
         "Lane service keys belong to osprey.bluesky_bridge_connection. Import "
         "SECOND_LANE_KEYS or LANE_KEYS instead of respelling them:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_panel_addresses_lane_one_by_the_registry_key() -> None:
+    """The panel's own ``LANE_ONE`` is the registry's, spelled once.
+
+    JavaScript cannot import the Python registry, so this literal is the one
+    respelling the rule above cannot reach. It is load-bearing: every request
+    the panel addresses to lane 1 goes out bare, and a respelled key would
+    address a lane the sidecar does not serve.
+    """
+    source = _LANE_CLIENT_JS.read_text(encoding="utf-8")
+    assert f"export const LANE_ONE = '{LANE_ONE}';" in source, (
+        f"{_LANE_CLIENT_JS} must spell lane 1's service key as the registry "
+        f"does ({LANE_ONE!r}); found:\n"
+        + "\n".join(line for line in source.splitlines() if "LANE_ONE =" in line)
     )
 
 

--- a/tests/interfaces/design_system/js/theme-lab-math.test.mjs
+++ b/tests/interfaces/design_system/js/theme-lab-math.test.mjs
@@ -40,15 +40,23 @@ import {
   slugifyThemeName,
   checkCollision,
 } from '/design-system/js/theme-lab.js';
+import { THEMES, DEFAULTS, DEFAULT_FAMILY } from '/design-system/js/tokens.js';
 
-/** The osprey family's two scopes, verbatim from the generated tokens.css. */
+/** The main family's two scopes, verbatim from the generated tokens.css. */
 const DARK_SCOPE = { bgPrimary: '#0a0f1a', textPrimary: '#f1f5f9' };
 const LIGHT_SCOPE = { bgPrimary: '#f7f9fc', textPrimary: '#0c1322' };
 
-/** The shipped registry, as the DOM layer will pass it in from tokens.js. */
+/**
+ * The shipped registry, built from the generated `tokens.js` exactly as the DOM
+ * layer builds it before calling `checkCollision`. Derived rather than copied:
+ * a hand-listed snapshot goes stale the moment a family is added, and then the
+ * collision tests below pin a registry that is not the one that ships.
+ */
 const MANIFEST = {
-  ids: ['apex-dark', 'apex-light', 'dark', 'high-contrast-dark', 'high-contrast-light', 'light'],
-  families: ['osprey', 'apex', 'high-contrast'],
+  ids: THEMES.map((theme) => theme.id),
+  families: [
+    ...new Set([DEFAULT_FAMILY, ...Object.keys(DEFAULTS), ...THEMES.map((t) => t.family)]),
+  ],
 };
 
 /**
@@ -428,6 +436,17 @@ describe('slugifyThemeName', () => {
 });
 
 describe('checkCollision', () => {
+  test('the fixture registry really carries the ids and families these tests name', () => {
+    // The cases below pick their slugs out of the shipped registry; this keeps
+    // them honest if a theme is renamed or retired out from under them.
+    expect(MANIFEST.ids).toContain('dark');
+    expect(MANIFEST.ids).toEqual(expect.arrayContaining(['retro-dark', 'retro-light']));
+    expect(MANIFEST.families).toContain('high-contrast');
+    expect(MANIFEST.families).toContain(DEFAULT_FAMILY);
+    expect(MANIFEST.ids).not.toContain('midnight-teal');
+    expect(MANIFEST.families).not.toContain('midnight-teal');
+  });
+
   test('accepts a clean name', () => {
     expect(checkCollision('midnight-teal', MANIFEST)).toEqual({ collides: false, reason: null });
   });
@@ -449,9 +468,9 @@ describe('checkCollision', () => {
     // if `<slug>-dark`/`<slug>-light` already exist even when the slug itself
     // is free. Uses a manifest with the family list deliberately empty so the
     // derived-id rule is what does the rejecting.
-    const result = checkCollision('apex', { ids: MANIFEST.ids, families: [] });
+    const result = checkCollision('retro', { ids: MANIFEST.ids, families: [] });
     expect(result.collides).toBe(true);
-    expect(result.reason).toContain('apex-dark');
+    expect(result.reason).toContain('retro-dark');
   });
 
   test('rejects the empty slug', () => {

--- a/tests/interfaces/design_system/test_hygiene.py
+++ b/tests/interfaces/design_system/test_hygiene.py
@@ -851,3 +851,93 @@ def test_ariel_scale_layer_stays_retired() -> None:
         "--radius-*/--space-*/--z-*/--duration-*)); --ariel-score-* is the only "
         "sanctioned --ariel- name:\n" + "\n".join(offenders)
     )
+
+
+# --- Check (f): no literal font stack outside the font sources --------------------
+
+#: Same shape as the color and scale markers, with its own name so a font
+#: exception cannot be mistaken for either: a line carrying it is never counted,
+#: and the ``-start``/``-end`` pair brackets a span (both boundary lines exempt).
+_ALLOW_FONT_LINE_MARKER = "hygiene-allow-font"
+_ALLOW_FONT_BLOCK_START_MARKER = "hygiene-allow-font-start"
+_ALLOW_FONT_BLOCK_END_MARKER = "hygiene-allow-font-end"
+
+#: The two files that legitimately SPELL a typeface: the ``@font-face`` source
+#: (which must name the family it is declaring) and the generated token sheet
+#: (which is where ``--font-display``/``--font-mono`` come from).
+_FONT_SOURCE_FILES = frozenset(
+    {
+        _INTERFACES_ROOT / "shared_fonts" / "fonts.css",
+        _TOKENS_CSS,
+    }
+)
+
+#: A ``font-family:`` declaration, or a custom property whose name says it holds
+#: a font stack. Both state a typeface, and a local ``--font-sans: 'Inter'`` is
+#: how one interface ended up rendering a face the token file calls retired.
+_FONT_DECLARATION_RE = re.compile(r"(font-family|--[\w-]*font[\w-]*)\s*:\s*([^;{}]+)")
+
+#: What makes a value a LITERAL stack rather than a pass-through: a quoted
+#: family name, or one of the generic/system keywords a stack ends with. A bare
+#: ``inherit``/``initial``/``unset`` names no typeface and is untouched.
+_LITERAL_FAMILY_RE = re.compile(
+    r"[\'\"]|\b(?:system-ui|ui-sans-serif|ui-monospace|ui-serif|sans-serif|serif|"
+    r"monospace|cursive|fantasy|-apple-system|BlinkMacSystemFont)\b"
+)
+
+
+def _literal_font_stacks(text: str) -> list[str]:
+    """Every non-allowlisted literal font stack in one stylesheet's text."""
+    hits: list[str] = []
+    in_allowed_block = False
+    for line in text.splitlines():
+        if _ALLOW_FONT_BLOCK_START_MARKER in line:
+            in_allowed_block = True
+            continue
+        if _ALLOW_FONT_BLOCK_END_MARKER in line:
+            in_allowed_block = False
+            continue
+        if in_allowed_block or _ALLOW_FONT_LINE_MARKER in line:
+            continue
+        for prop, raw_value in _FONT_DECLARATION_RE.findall(line):
+            value = re.sub(r"var\([^()]*\)", "", raw_value).strip()
+            if _LITERAL_FAMILY_RE.search(value):
+                hits.append(f"{prop}: {raw_value.strip()}")
+    return hits
+
+
+def test_literal_font_stack_scanner() -> None:
+    assert _literal_font_stacks("a { font-family: var(--font-mono); }") == []
+    assert _literal_font_stacks("a { font-family: inherit; }") == []
+    assert _literal_font_stacks("a { font-family: 'Inter', sans-serif; }") == [
+        "font-family: 'Inter', sans-serif"
+    ]
+    assert _literal_font_stacks(":root { --font-sans: 'Inter', -apple-system; }") == [
+        "--font-sans: 'Inter', -apple-system"
+    ]
+    assert _literal_font_stacks(":root { --font-d: var(--font-display); }") == []
+    assert _literal_font_stacks("a { font-family: monospace; /* hygiene-allow-font: x */ }") == []
+
+
+def test_no_literal_font_stacks_outside_the_font_sources() -> None:
+    """A typeface is named in two files; everywhere else reads the token.
+
+    The drift this forbids has a visible cost: a local ``--font-sans: 'Inter'``
+    renders a face the token file itself calls retired, in one surface out of
+    the fleet, and no test or reviewer sees it — the page looks fine, just not
+    like the rest of OSPREY. CSS only: the JS entry points that hand a font to
+    a canvas renderer read the token with a literal fallback, which this rule
+    would flag as a literal without being able to tell it apart from a
+    hardcoded one.
+    """
+    offenders: list[str] = []
+    for path in _in_scope_files():
+        if path.suffix != ".css" or path in _FONT_SOURCE_FILES:
+            continue
+        for hit in _literal_font_stacks(path.read_text(encoding="utf-8")):
+            offenders.append(f"{_relpath(path)}: {hit}")
+    assert not offenders, (
+        "Literal font stack(s) outside shared_fonts/fonts.css and the generated "
+        "tokens.css — use var(--font-display)/var(--font-mono), or mark a "
+        "deliberate exception with `/* hygiene-allow-font: <reason> */`:\n" + "\n".join(offenders)
+    )

--- a/tests/interfaces/design_system/test_theme_lab_export_refs.py
+++ b/tests/interfaces/design_system/test_theme_lab_export_refs.py
@@ -1,0 +1,124 @@
+"""Theme-lab prose names themes, families and token documents that exist.
+
+The export is written to be read on its own — a proposer implements a theme from
+it without opening the lab — so a family or document it names has to be real.
+Nothing checks that by running the lab: the markdown is a string, every name in
+it is prose, and a family that was renamed or never shipped reads exactly like
+one that did. This scans the source for the names it hands out and holds each
+against the token tree.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import osprey.interfaces.design_system as design_system_pkg
+
+_DESIGN_SYSTEM = Path(design_system_pkg.__file__).parent
+_THEME_LAB_JS = _DESIGN_SYSTEM / "static" / "js" / "theme-lab.js"
+_TOKENS = _DESIGN_SYSTEM / "tokens"
+_TOKENS_CSS = _DESIGN_SYSTEM / "static" / "css" / "tokens.css"
+
+#: A backticked span with no whitespace — the shape a name is written in.
+_BACKTICKED_RE = re.compile(r"`([^`\s]+)`")
+
+#: A bare lowercase identifier: no dot, so `accent.base` and `tokens.css` are
+#: not candidates, and no slash.
+_BARE_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+
+#: Backticked bare words in theme-lab.js that name neither a theme nor a family:
+#: JS globals, CSS function names, and the vocabulary the prose uses for its own
+#: concepts. Checked in BOTH directions — a word that becomes a family name has
+#: to leave this set, and a word that leaves the file has to leave it too — so
+#: the set cannot quietly grow into a blanket exemption.
+_NON_THEME_WORDS = frozenset(
+    {
+        "document",
+        "hover",
+        "hsl",
+        "lightness",
+        "null",
+        "on",
+        "reason",
+        "rgba",
+        "value",
+        "window",
+    }
+)
+
+
+def _shipped() -> tuple[set[str], set[str]]:
+    """``(theme ids, family ids)`` as ``tokens/themes/*.json`` declares them."""
+    ids: set[str] = set()
+    families: set[str] = set()
+    for path in sorted((_TOKENS / "themes").glob("*.json")):
+        extensions = json.loads(path.read_text(encoding="utf-8"))["$extensions"]
+        ids.add(extensions["id"])
+        families.add(extensions["family"])
+    return ids, families
+
+
+def _emitted_property_names() -> set[str]:
+    """Custom-property names the generator writes, without the ``--`` prefix.
+
+    The prose quotes a few of these (``wt-accent-system-tint-04``), and they are
+    hyphenated bare words like a family id is.
+    """
+    return set(re.findall(r"--([\w-]+)\s*:", _TOKENS_CSS.read_text(encoding="utf-8")))
+
+
+def _backticked() -> list[str]:
+    return _BACKTICKED_RE.findall(_THEME_LAB_JS.read_text(encoding="utf-8"))
+
+
+def _resolves_under_tokens(token: str) -> bool:
+    """Whether a backticked `*.json` reference names something in ``tokens/``.
+
+    Three spellings all appear in the prose and all have to work: a bare file
+    name (``core.json``), a path with or without the ``tokens/`` prefix
+    (``themes/dark.json``), and a glob (``tokens/interfaces/*.json``).
+    """
+    relative = token[len("tokens/") :] if token.startswith("tokens/") else token
+    if "*" in relative:
+        return any(_TOKENS.glob(relative))
+    if "/" in relative:
+        return (_TOKENS / relative).is_file()
+    return any(candidate.name == relative for candidate in _TOKENS.rglob("*.json"))
+
+
+def test_every_token_document_named_exists() -> None:
+    """A `*.json` the export tells a proposer to edit is a real file."""
+    documents = {token for token in _backticked() if token.endswith(".json")}
+    assert documents, "theme-lab.js names no token document at all"
+    missing = sorted(token for token in documents if not _resolves_under_tokens(token))
+    assert not missing, f"theme-lab.js names token documents that do not exist: {missing}"
+
+
+def test_every_theme_or_family_named_is_shipped() -> None:
+    """No prose names a theme family the token tree does not have.
+
+    The failure this catches is silent and durable: a renamed or never-shipped
+    family reads as authoritative in an exported proposal, and the proposer
+    follows it into a change set that cannot land.
+    """
+    ids, families = _shipped()
+    exempt = _NON_THEME_WORDS | _emitted_property_names()
+
+    unknown = sorted(
+        {
+            token
+            for token in _backticked()
+            if _BARE_NAME_RE.match(token) and token not in exempt and token not in ids | families
+        }
+    )
+    assert not unknown, (
+        "theme-lab.js names themes/families that are not in tokens/themes/: "
+        f"{unknown} — shipped ids {sorted(ids)}, families {sorted(families)}"
+    )
+
+
+def test_the_non_theme_word_list_has_no_stale_entries() -> None:
+    """Every exemption still earns its place in the file."""
+    present = set(_backticked())
+    stale = sorted(_NON_THEME_WORDS - present)
+    assert not stale, f"words exempted but no longer backticked in theme-lab.js: {stale}"

--- a/tests/interfaces/lattice_dashboard/render.test.mjs
+++ b/tests/interfaces/lattice_dashboard/render.test.mjs
@@ -156,8 +156,10 @@ describe('renderPlotly', () => {
     // mapping, but element-identical for figures with no themed markers).
     expect(traces).toEqual(figData.data);
 
-    // Theme-independent shape: fixed font family/size, fixed margin, autosize on.
-    expect(layout.font.family).toBe('JetBrains Mono, monospace');
+    // Theme-independent shape: fixed font size, fixed margin, autosize on. The
+    // family comes from --font-mono; this unstyled DOM has no tokens.css, so
+    // the shipped fallback is what renders (see the token case below).
+    expect(layout.font.family).toBe("'JetBrains Mono', monospace");
     expect(layout.font.size).toBe(10);
     expect(layout.margin).toEqual({ l: 45, r: 15, t: 30, b: 35 });
     expect(layout.autosize).toBe(true);
@@ -177,6 +179,17 @@ describe('renderPlotly', () => {
       modeBarButtonsToRemove: ['select2d', 'lasso2d', 'autoScale2d'],
       displaylogo: false,
     });
+  });
+
+  test('the figure font follows the design-system --font-mono token', () => {
+    document.documentElement.style.setProperty('--font-mono', "'Iosevka', monospace");
+    try {
+      renderPlotly('optics', { data: [], layout: {} });
+      const [, , layout] = Plotly.react.mock.calls[0];
+      expect(layout.font.family).toBe("'Iosevka', monospace");
+    } finally {
+      document.documentElement.style.removeProperty('--font-mono');
+    }
   });
 
   test("a trace tagged meta='themed-fg-marker' gets its marker color set from the theme", () => {

--- a/tests/interfaces/lattice_dashboard/test_settings_schema_parity.py
+++ b/tests/interfaces/lattice_dashboard/test_settings_schema_parity.py
@@ -1,0 +1,95 @@
+"""The dashboard's JS settings schema and figure catalog track their Python owner.
+
+Two tables the browser holds restate facts the server owns:
+
+* ``settings.js``'s ``SETTINGS_FIELDS`` carries a min/max per field, which is
+  what the number inputs are bounded by. The server clamps independently
+  (``state._VALIDATION_RANGES``), so a widened browser bound does not break —
+  it silently clamps, and the operator sees a value they did not ask for come
+  back. A narrowed one simply makes a legal value unreachable.
+* the figure catalog is written four times over — ``state.ALL_FIGURES``,
+  ``app.FIGURE_BUILDERS``, ``app.js``, and the ``data-figure`` cells of
+  ``index.html``. A figure in three of the four renders an empty cell, a dead
+  slot, or nothing at all, with no error anywhere.
+
+Both are read out of the JS/HTML source, so this fails the moment one side
+moves alone.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from osprey.interfaces.lattice_dashboard.app import FIGURE_BUILDERS
+from osprey.interfaces.lattice_dashboard.state import (
+    _VALIDATION_RANGES,
+    ALL_FIGURES,
+    DEFAULT_SETTINGS,
+)
+
+_STATIC = (
+    Path(__file__).parents[3] / "src" / "osprey" / "interfaces" / "lattice_dashboard" / "static"
+)
+_SETTINGS_JS = _STATIC / "js" / "settings.js"
+_APP_JS = _STATIC / "js" / "app.js"
+_INDEX_HTML = _STATIC / "index.html"
+
+_FIELD_RE = re.compile(
+    r"\{\s*key:\s*'(?P<key>\w+)'.*?min:\s*(?P<min>-?[\d.]+),\s*max:\s*(?P<max>-?[\d.]+)"
+)
+
+
+def _js_settings_fields() -> dict[str, dict[str, tuple[float, float]]]:
+    """``{group: {key: (min, max)}}`` as ``SETTINGS_FIELDS`` declares it."""
+    source = _SETTINGS_JS.read_text(encoding="utf-8")
+    body = re.search(r"export const SETTINGS_FIELDS = \{(.*?)\n\};", source, re.DOTALL)
+    assert body, f"SETTINGS_FIELDS object literal not found in {_SETTINGS_JS}"
+
+    groups: dict[str, dict[str, tuple[float, float]]] = {}
+    current: str | None = None
+    for line in body.group(1).splitlines():
+        group_start = re.match(r"\s{2}(\w+): \{", line)
+        if group_start:
+            current = group_start.group(1)
+            groups[current] = {}
+            continue
+        field = _FIELD_RE.search(line)
+        if field and current is not None:
+            groups[current][field.group("key")] = (
+                float(field.group("min")),
+                float(field.group("max")),
+            )
+    return groups
+
+
+def _js_all_figures() -> list[str]:
+    source = _APP_JS.read_text(encoding="utf-8")
+    names: list[str] = []
+    for const in ("FAST_FIGURES", "VERIFICATION_FIGURES"):
+        match = re.search(rf"const {const} = (\[[^\]]*\]);", source)
+        assert match, f"{const} not found in {_APP_JS}"
+        names.extend(json.loads(match.group(1).replace("'", '"')))
+    return names
+
+
+def test_the_js_schema_declares_the_server_validation_ranges() -> None:
+    js = _js_settings_fields()
+    assert {group: dict(fields) for group, fields in js.items()} == {
+        group: {key: (float(lo), float(hi)) for key, (lo, hi) in fields.items()}
+        for group, fields in _VALIDATION_RANGES.items()
+    }
+
+
+def test_the_js_schema_covers_exactly_the_settings_the_server_defaults() -> None:
+    js = _js_settings_fields()
+    assert js.keys() == DEFAULT_SETTINGS.keys()
+    for group, defaults in DEFAULT_SETTINGS.items():
+        assert js[group].keys() == defaults.keys(), group
+
+
+def test_every_holder_of_the_figure_catalog_agrees() -> None:
+    html_figures = re.findall(r'data-figure="([\w-]+)"', _INDEX_HTML.read_text(encoding="utf-8"))
+    assert set(ALL_FIGURES) == set(FIGURE_BUILDERS)
+    assert set(ALL_FIGURES) == set(_js_all_figures())
+    assert set(ALL_FIGURES) == set(html_figures)
+    assert len(html_figures) == len(set(html_figures)), "a figure has two cells"

--- a/tests/interfaces/test_vendor.py
+++ b/tests/interfaces/test_vendor.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import ssl
 import urllib.error
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import osprey.interfaces.vendor as vendor_mod
-from osprey.interfaces.vendor import _fetch_one, asset_cdn_url, is_offline, vendor_url
+from osprey.interfaces.vendor import (
+    MANIFEST_PATH,
+    _fetch_one,
+    _load_manifest,
+    asset_cdn_url,
+    is_offline,
+    vendor_url,
+)
 
 
 @contextmanager
@@ -232,3 +241,60 @@ class TestWebTerminalRendering:
         body = resp.text
         assert "/static/vendor/xterm.min.js" in body
         assert "cdn.jsdelivr.net" not in body
+
+
+# --- vendored filename drift ------------------------------------------------
+
+#: Sources that can name a vendored bundle. The vendored payloads themselves are
+#: excluded: a minified bundle is one enormous line in which a filename-shaped
+#: token is coincidence, and none of it is ours to reword.
+_INTERFACES_ROOT = Path(vendor_mod.__file__).parent
+_SCAN_SUFFIXES = (".py", ".js", ".html")
+
+#: A bundle filename as it appears in source — basename only, no directory part.
+_BUNDLE_TOKEN_RE = re.compile(r"[\w.@-]+\.(?:min\.)?(?:js|css)\b")
+
+#: The version segment of a vendored filename: ``plotly-3.3.1.min.js`` and
+#: ``plotly-4.0.0.min.js`` are the same asset at two versions.
+_VERSION_SEGMENT_RE = re.compile(r"-\d+(?:\.\d+)*(?=\.)")
+
+
+def _asset_family(filename: str) -> str:
+    """The version-free identity of a vendored filename."""
+    return _VERSION_SEGMENT_RE.sub("", filename)
+
+
+def _scanned_sources() -> list[Path]:
+    return [
+        path
+        for path in sorted(_INTERFACES_ROOT.rglob("*"))
+        if path.suffix in _SCAN_SUFFIXES and "vendor" not in path.parts and ".min." not in path.name
+    ]
+
+
+def test_every_vendored_filename_literal_matches_the_manifest() -> None:
+    """A filename carrying a version is a copy of the manifest, and copies rot.
+
+    ``vendor_url()`` takes the local path from its caller and the panel JS has
+    no manifest access at all, so these literals cannot be re-plumbed away. What
+    they can have is a lint: bump an asset in ``vendor_manifest.json`` and every
+    literal still naming the old file is named here rather than 404-ing in the
+    one deployment that serves vendored assets (offline builds).
+    """
+    by_family = {_asset_family(a["filename"]): a["filename"] for a in _load_manifest()["assets"]}
+    assert len(by_family) == len(_load_manifest()["assets"]), (
+        f"two assets in {MANIFEST_PATH.name} share a version-free filename"
+    )
+
+    stale: list[str] = []
+    for path in _scanned_sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for token in _BUNDLE_TOKEN_RE.findall(line):
+                expected = by_family.get(_asset_family(token))
+                if expected is not None and token != expected:
+                    rel = path.relative_to(_INTERFACES_ROOT)
+                    stale.append(f"{rel}:{lineno} names {token}, manifest has {expected}")
+
+    assert not stale, (
+        "vendored filename literals out of step with vendor_manifest.json:\n  " + "\n  ".join(stale)
+    )

--- a/tests/interfaces/web_terminal/settings.test.mjs
+++ b/tests/interfaces/web_terminal/settings.test.mjs
@@ -276,4 +276,33 @@ describe('form mode: enum fields', () => {
       document.querySelector('[data-key="claude_code.default_model"]')?.tagName,
     ).toBe('INPUT');
   });
+
+  // Per-tool approval policies are a PREFIX rule, not a hand-list: the approval
+  // hook resolves a policy for any tool it gates, so a deployment that states a
+  // tool the drawer was never told about still gets the policy select rather
+  // than a free-text box that can spell a policy the hook does not know.
+  test('any approval.tools.* leaf renders as a policy select', async () => {
+    stubConfig({
+      approval: {
+        default_policy: 'always',
+        tools: { channel_write: 'always', queue_start: 'selective' },
+      },
+    });
+
+    /** @type {HTMLElement} */ (
+      document.getElementById('tab-config')
+    ).dispatchEvent(new Event('drawer:tab-activate'));
+
+    const selector = 'select[data-key="approval.tools.queue_start"]';
+    await vi.waitFor(() => expect(document.querySelector(selector)).not.toBeNull());
+    const select = /** @type {HTMLSelectElement} */ (document.querySelector(selector));
+
+    expect([...select.options].map((o) => o.value)).toEqual(['always', 'selective', 'skip']);
+    expect(select.value).toBe('selective');
+    expect(
+      /** @type {HTMLSelectElement} */ (
+        document.querySelector('select[data-key="approval.tools.channel_write"]')
+      ).value,
+    ).toBe('always');
+  });
 });

--- a/tests/interfaces/web_terminal/test_config_form_sections.py
+++ b/tests/interfaces/web_terminal/test_config_form_sections.py
@@ -1,0 +1,46 @@
+"""The Config panel's Form view offers only sections a config file really has.
+
+``_AGENT_CONFIG_SECTIONS`` is an allowlist, and an entry that matches no
+top-level key renders nothing — silently. That is how ``python_execution`` (the
+section is called ``execution``) kept the execution settings out of the form
+until someone noticed by eye. The shipped presets carry the whole configuration
+a build renders, so they are what an entry is checked against.
+
+The list stays an ALLOWLIST. Inverting it to a denylist would make every new
+config block editable in the Form view by default, and the Raw YAML view
+already reaches everything.
+"""
+
+from typing import Any
+
+import yaml
+
+from osprey.cli.build_profile_presets import _presets_dir, list_presets
+from osprey.interfaces.web_terminal.routes.config import _AGENT_CONFIG_SECTIONS
+
+
+def _shipped_top_level_keys() -> set[str]:
+    """Every top-level config section the presets OSPREY ships can render."""
+    keys: set[str] = set()
+    for name in list_presets():
+        document: dict[str, Any] = (
+            yaml.safe_load((_presets_dir() / f"{name}.yml").read_text(encoding="utf-8")) or {}
+        )
+        for dotted in document.get("config") or {}:
+            keys.add(str(dotted).split(".", 1)[0])
+    return keys
+
+
+def test_every_form_section_is_a_real_config_section() -> None:
+    shipped = _shipped_top_level_keys()
+    assert shipped, "no preset carried a config block — the authority moved"
+    phantom = [name for name in _AGENT_CONFIG_SECTIONS if name not in shipped]
+    assert not phantom, (
+        f"Form view sections matching no shipped config key: {phantom} — such an "
+        "entry renders nothing at all, with no error"
+    )
+
+
+def test_the_form_view_stays_an_allowlist() -> None:
+    """Narrower than the file on purpose: infra/build blocks stay in Raw YAML."""
+    assert set(_AGENT_CONFIG_SECTIONS) < _shipped_top_level_keys()

--- a/tests/interfaces/web_terminal/test_effort_level.py
+++ b/tests/interfaces/web_terminal/test_effort_level.py
@@ -1,9 +1,24 @@
 """Tests for effort level reading from config."""
 
+import re
+from pathlib import Path
+
 import pytest
 import yaml
 
+from osprey.cli.chat_cmd import chat as chat_command
 from osprey.interfaces.web_terminal.routes.websocket import _read_effort_level
+
+_SETTINGS_JS = (
+    Path(__file__).parents[3]
+    / "src"
+    / "osprey"
+    / "interfaces"
+    / "web_terminal"
+    / "static"
+    / "js"
+    / "settings.js"
+)
 
 
 class TestReadEffortLevel:
@@ -45,3 +60,27 @@ class TestReadEffortLevel:
         config = tmp_path / "config.yml"
         config.write_text(yaml.dump({"claude_code": {"effort": effort}}))
         assert _read_effort_level(config) == effort
+
+
+def _cli_effort_choices() -> list[str]:
+    """The effort vocabulary ``osprey chat --effort`` accepts."""
+    for param in chat_command.params:
+        if param.name == "effort":
+            return list(param.type.choices)
+    raise AssertionError("osprey chat has no --effort option")
+
+
+def test_the_settings_drawer_offers_the_cli_effort_vocabulary() -> None:
+    """The drawer's effort select and the CLI flag speak one vocabulary.
+
+    The drawer writes ``claude_code.effort`` straight into the deployment's
+    config; a value the CLI would reject is a setting that looks applied and
+    then falls back at the next launch, with nothing said. JavaScript cannot
+    import the click option, so the list is pinned here instead.
+    """
+    match = re.search(
+        r"'claude_code\.effort':\s*\[([^\]]*)\]", _SETTINGS_JS.read_text(encoding="utf-8")
+    )
+    assert match, f"no claude_code.effort entry in {_SETTINGS_JS}"
+    rendered = re.findall(r"'([^']+)'", match.group(1))
+    assert rendered == _cli_effort_choices()

--- a/tests/interfaces/web_terminal/test_handoff_phase_b.py
+++ b/tests/interfaces/web_terminal/test_handoff_phase_b.py
@@ -575,23 +575,30 @@ async def test_hookless_pty_held_key_is_refused_without_an_interrupt():
 
 
 async def test_hookless_pty_with_interrupt_is_escaped_and_ends_on_the_marker(tmp_path):
+    # The marker lands on a named look for the reason spelt out on the
+    # store-edge test below: a wait whose sleeps are free takes an unbounded
+    # number of looks while the test body waits in real time.
     app = make_pty_app(hook=False)
     pty = pool_pty(app)
     transcript = write_transcript(tmp_path / f"{KEY}.jsonl", [user_entry("do it")], time.time())
+    looks_before_marker = 4
+
+    def marker_on_the_fourth_look(count: int) -> None:
+        assert pty.writes == [ESC], "Escape is written on the first look, before any sleep"
+        if count == looks_before_marker:
+            write_transcript(transcript, [user_entry("do it"), INTERRUPT_ENTRY], time.time())
+
+    app.clock.on_sleep.append(marker_on_the_fourth_look)
     recorder = Recorder()
     with (
         patch.object(session_handoff, "_transcript_path", lambda _app, _tid: transcript),
         patch.object(session_handoff, "_phase_c", recorder),
     ):
-        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object(), interrupt=True))
-        await until(lambda: pty.writes == [ESC])
-        await ticks(app, 3)
-        assert not task.done()
-        write_transcript(transcript, [user_entry("do it"), INTERRUPT_ENTRY], time.time())
-        await task
+        await acquire_surface(app, KEY, "simple", object(), interrupt=True)
     assert recorder.calls[-1][1] == WaitOutcome(REASON_INTERRUPTED)
     assert pty.writes == [ESC]
     assert pty.terminates == 0
+    assert len(app.clock.sleeps) == looks_before_marker
     assert sum(app.clock.sleeps) < INTERRUPT_GRACE_S
 
 
@@ -614,20 +621,32 @@ async def test_hookless_pty_without_a_transcript_is_not_assumed_idle():
 
 
 async def test_interrupt_writes_escape_then_proceeds_on_the_store_idle_edge():
+    # The flip to idle is driven from the fake clock rather than from the test
+    # body, because the wait's sleeps cost no real time: every real-time poll
+    # the body makes lets the wait take tens of further looks, and past the
+    # fiftieth the grace has expired and the outcome is `forced`. Flipping on a
+    # named look keeps "several looks pass while the store says busy" exact.
     app = make_pty_app()
     pty = pool_pty(app)
     set_store(app, "busy", time.time())
+    looks_before_idle = 4
+
+    def idle_on_the_fourth_look(count: int) -> None:
+        assert pty.writes == [ESC], "Escape is written on the first look, before any sleep"
+        if count >= looks_before_idle:
+            set_store(app, "idle", time.time())
+
+    app.clock.on_sleep.append(idle_on_the_fourth_look)
     recorder = Recorder()
     with patch.object(session_handoff, "_phase_c", recorder):
-        task = asyncio.create_task(acquire_surface(app, KEY, "simple", object(), interrupt=True))
-        await until(lambda: pty.writes == [ESC])
-        await ticks(app, 3)
-        assert not task.done()
-        set_store(app, "idle", time.time())
-        plan = await task
+        plan = await acquire_surface(app, KEY, "simple", object(), interrupt=True)
+    assert pty.writes == [ESC]
     assert plan.interrupt is True
     assert recorder.calls[-1][1] == WaitOutcome(REASON_INTERRUPTED)
     assert pty.terminates == 0
+    # The wait held for every look the store said busy, and ended well inside
+    # the grace rather than by running it out.
+    assert len(app.clock.sleeps) == looks_before_idle
     assert sum(app.clock.sleeps) < INTERRUPT_GRACE_S
 
 

--- a/tests/interfaces/web_terminal/test_panel_rail_glyph_parity.py
+++ b/tests/interfaces/web_terminal/test_panel_rail_glyph_parity.py
@@ -1,0 +1,49 @@
+"""Registry ↔ stylesheet parity: every built-in panel has a rail glyph.
+
+``panel-rail.js`` sets ``data-icon`` to the panel's own id for every entry it
+renders, and ``terminal.css`` maps that id to a glyph. A built-in panel with no
+rule falls to the generic ``◈``, so the rail shows two or three panels wearing
+the same placeholder — a silent regression, since nothing errors and the label
+still reads. This reads the CSS source so it fails the moment a panel joins the
+registry without a glyph, and the moment a rule outlives its panel.
+"""
+
+import re
+from pathlib import Path
+
+from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
+
+_CSS = (
+    Path(__file__).parents[3]
+    / "src"
+    / "osprey"
+    / "interfaces"
+    / "web_terminal"
+    / "static"
+    / "css"
+    / "terminal.css"
+)
+
+#: The session tile's rail entry. It wears a ``data-icon`` like a panel but is
+#: dock-layout state rather than a service panel, so it is not in the panel
+#: registry and its rule is not stale (``panel-catalog.TERMINAL_RAIL_ID``).
+_TERMINAL_RAIL_ID = "terminal"
+
+
+def _glyph_ids() -> set[str]:
+    """Every id ``terminal.css`` writes a ``.panel-rail-icon`` rule for."""
+    return set(re.findall(r'\.panel-rail-icon\[data-icon="([\w-]+)"\]', _CSS.read_text()))
+
+
+def test_every_builtin_panel_has_a_rail_glyph() -> None:
+    missing = set(BUILTIN_PANEL_LABELS) - _glyph_ids()
+    assert not missing, (
+        "built-in panels falling back to the generic rail glyph: "
+        f"{sorted(missing)} — add a .panel-rail-icon[data-icon=...] rule"
+    )
+
+
+def test_no_stale_rail_glyph_rules() -> None:
+    """A rule naming no built-in panel is dead weight — the rename trap."""
+    stale = _glyph_ids() - set(BUILTIN_PANEL_LABELS) - {_TERMINAL_RAIL_ID}
+    assert not stale, f"rail glyph rules naming no built-in panel: {sorted(stale)}"

--- a/tests/interfaces/web_terminal/tour.test.mjs
+++ b/tests/interfaces/web_terminal/tour.test.mjs
@@ -248,6 +248,41 @@ describe('steps', () => {
     expect(document.querySelector('.tour-card')).toBe(null);
   });
 
+  test('panel cards wear the labels the server serves, not a private copy', () => {
+    mountFullShell();
+    applyTourConfig({
+      tour: { policy: 'never' },
+      labels: { artifacts: 'FILES', okf: 'DOCS', ariel: 'LOGBOOK' },
+    });
+    startTour();
+
+    const bodies = [];
+    for (let i = 0; i < 8; i++) {
+      bodies.push(cardBody());
+      click(nextBtn());
+      vi.advanceTimersByTime(200);
+    }
+    expect(bodies[5]).toContain('FILES');
+    expect(bodies[6]).toContain('DOCS');
+    expect(bodies[7]).toContain('LOGBOOK');
+  });
+
+  test('a payload with no labels leaves the shipped names on the cards', () => {
+    mountFullShell();
+    applyTourConfig({ tour: { policy: 'never' } });
+    startTour();
+
+    const bodies = [];
+    for (let i = 0; i < 8; i++) {
+      bodies.push(cardBody());
+      click(nextBtn());
+      vi.advanceTimersByTime(200);
+    }
+    expect(bodies[5]).toContain('WORKSPACE');
+    expect(bodies[6]).toContain('KNOWLEDGE');
+    expect(bodies[7]).toContain('ARIEL');
+  });
+
   test('steps with absent anchors drop out and the count adjusts', () => {
     document.body.innerHTML = '<div class="terminal-card"></div>';
     startTour();

--- a/tests/profiles/test_approval_tools_parity.py
+++ b/tests/profiles/test_approval_tools_parity.py
@@ -11,11 +11,8 @@ newly gated tool appears.
 What is NOT protected by any of that is the other direction: a row naming a tool
 the preset's resolved servers do not gate. Such a row governs nothing, reads as
 posture the deployment does not have, and nothing errors. That is what these
-tests pin, plus the two other surfaces the same set has to appear on: the
-manifest documents every shipped row, and the settings panel's ``ENUM_FIELDS``
-offers each one as a policy dropdown. A key the panel does not know renders as a
-free-text box, which is an approval policy an operator can only get wrong, so
-the panel is held to the whole set rather than to a subset of it.
+tests pin, along with the one other surface the same set has to appear on: the
+manifest documents every shipped row, and documents no row that is unshipped.
 """
 
 from __future__ import annotations
@@ -32,9 +29,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PRESET_DIR = REPO_ROOT / "src" / "osprey" / "profiles" / "presets"
 MANIFEST_PATH = REPO_ROOT / "src" / "osprey" / "profiles" / "config_key_manifest.yml"
 GUARD_PATH = REPO_ROOT / "scripts" / "check_config_keys.py"
-SETTINGS_JS = (
-    REPO_ROOT / "src" / "osprey" / "interfaces" / "web_terminal" / "static" / "js" / "settings.js"
-)
 
 #: The four documents an operator starts from. Persona presets extend
 #: control-assistant and carry deltas, not blocks of their own.
@@ -54,10 +48,6 @@ _INERT_ROWS = {("hello-world", "entry_create"), ("hello-world", "entry_publish")
 _INERT_NOTE_RE = re.compile(r"inert in hello[-_]world", re.IGNORECASE)
 
 _ROW_RE = re.compile(r"^\s*approval\.tools\.([a-z_]+):", re.MULTILINE)
-
-#: The same key in the settings panel's `ENUM_FIELDS` map, where it is a
-#: quoted JS string rather than a YAML key.
-_ENUM_FIELD_RE = re.compile(r"""['"]approval\.tools\.([a-z_]+)['"]\s*:""")
 
 pytestmark = pytest.mark.unit
 
@@ -122,43 +112,3 @@ def test_the_manifest_rows_are_the_union_of_what_the_presets_ship(manifest) -> N
         shipped |= _preset_rows(preset)
 
     assert documented == shipped
-
-
-def _settings_panel_rows() -> set[str]:
-    """The tool short names the settings panel offers a policy dropdown for."""
-    return set(_ENUM_FIELD_RE.findall(SETTINGS_JS.read_text()))
-
-
-def test_the_settings_panel_offers_every_shipped_row() -> None:
-    """A settable approval policy the panel does not know is a free-text box.
-
-    The drawer is where an operator changes posture at runtime, and
-    ``ENUM_FIELDS`` decides which keys it renders as a dropdown over the three
-    policies. A key missing from it is offered as prose the operator has to
-    spell correctly, for a value the hook reads fail-closed.
-    """
-    shipped: set[str] = set()
-    for preset in ROOT_PRESETS:
-        shipped |= _preset_rows(preset)
-
-    offered = _settings_panel_rows()
-
-    assert offered == shipped, (
-        "the settings panel and the shipped presets name different approval.tools "
-        f"keys: panel-only {sorted(offered - shipped)}, preset-only "
-        f"{sorted(shipped - offered)}. Every settable policy gets a dropdown."
-    )
-
-
-def test_the_panel_offers_no_policy_the_servers_do_not_gate(guard) -> None:
-    """The panel's own rows, read against the registry rather than via a preset."""
-    governed: set[str] = set()
-    for preset in ROOT_PRESETS:
-        governed |= guard.governed_tools(preset)
-
-    ungated = {tool for tool in _settings_panel_rows() if tool not in governed}
-
-    assert not ungated, (
-        f"the settings panel offers approval policies for {sorted(ungated)}, which "
-        f"no root preset's resolved servers attach the approval hook to"
-    )

--- a/tests/unit/dispatch/test_server_routes.py
+++ b/tests/unit/dispatch/test_server_routes.py
@@ -20,6 +20,8 @@ from an earlier ``create_server()`` would shadow the live one and 503).
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from starlette.testclient import TestClient
 
@@ -544,10 +546,18 @@ async def test_dispatch_with_policy_retries_with_backoff_on_dispatch_error(monke
     async def fake_sleep(seconds):
         slept.append(seconds)
 
-    # ``server`` calls ``await asyncio.sleep(...)`` against its module-level
-    # ``asyncio`` import; patch that so the backoff is asserted without delay.
+    # ``server`` awaits ``asyncio.sleep(...)`` through its module-level ``asyncio``
+    # name. Patch THAT name, never ``asyncio.sleep`` itself: the function is shared
+    # with every other event loop alive in the process, and a daemon thread left
+    # by an earlier test in the same worker would tick through the fake.
+    class _AsyncioForServer:
+        sleep = staticmethod(fake_sleep)
+
+        def __getattr__(self, name):
+            return getattr(asyncio, name)
+
     monkeypatch.setattr(server, "dispatch_to_worker", always_fails)
-    monkeypatch.setattr(server.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(server, "asyncio", _AsyncioForServer())
 
     reg = TriggerRegistry()
     trig = TriggerConfig(


### PR DESCRIPTION
Eleven front-end tables that restated a fact the server, a registry or the token tree already owns now read that authority, or gain a parity test that fails when the two drift.

- `fix(bluesky-web): drop the private terminal-status copy in results-view`
- `docs(bluesky-web): stop enumerating lane keys and targets in the panel typedefs`
- `fix(web-terminal): tour reads built-in panel labels from /api/panels`
- `fix(web-terminal): rail glyphs for jupyter and system-health, pinned to BUILTIN_PANEL_LABELS`
- `fix(web-terminal): settings drawer renders any approval.tools.* key as a policy select; drop the phantom screen_capture.enabled toggle`
- `fix(web-terminal): Config form allowlist drops the dead screen_capture entry and is pinned to the shipped template`
- `fix(health): check-name humaniser strips only the row's own category prefix`
- `test(interfaces): pin every vendored-Plotly filename literal to vendor_manifest.json`
- `test(lattice-dashboard): pin the JS settings schema and figure catalog to the Python authority`
- `fix(interfaces): font stacks read the design-system tokens; lattice dashboard drops its private --font-sans`
- `fix(design-system): theme-lab export names real families, the true inherits rule, and the family_label field`
- `test(web-terminal): land the interrupt's idle edge on a named look, not on real time`
- `test(dispatch): patch the server's asyncio name, not the process-global sleep`

## Why

Each of these is a browser-side copy of a list the backend already decides: the panel labels, the panel ids, the approval-policy vocabulary, the config sections that exist, the check categories, the vendored bundle filenames, the lattice validation ranges and figure catalog, the font stacks, the shipped theme families. Six had already drifted; the rest were one edit from drifting with nothing to catch it. A deployment that adds a panel, a tool, a figure, a theme family or a config section now gets the right rendering without an edit in the browser layer — and where the copy genuinely cannot be removed (JS with no access to a Python manifest), a test fails the moment the two disagree instead of a deployment 404-ing or a control silently rendering as free text.

Concretely, a deployer can now: enable the Jupyter or System Health panel and get a distinct rail glyph rather than the shared `◈` fallback; state any `approval.tools.<tool>` key and get the policy dropdown for it; rename a panel and have the onboarding tour say the new name; run the lattice dashboard in the fleet typeface; and read a health row's label without its leading word being eaten when the name happens to contain a dot.

Two unrelated deflakes ride along. The two interrupt waits in the web-terminal handoff tests flipped their idle witness from the test body after a real-time poll, while the wait itself spends only fake time. A single millisecond of real waiting buys the wait tens of further looks, and past the fiftieth the interrupt grace has expired and the outcome is `forced` rather than `interrupted` — a load-dependent failure. Both flips now land on a named look, driven from the fake clock. And the dispatch backoff test replaced `asyncio.sleep` process-wide to assert the retry delays without waiting: that function is shared with every other event loop alive in the worker, so a daemon thread left running by an earlier test ticked through the fake and its sleeps landed in the assertion. The patch now goes on the `server` module's own `asyncio` name, leaving the global untouched.

## Not in this PR

- An `icon` field on `web.panels.<id>` so a facility panel can register its own glyph (the documented `◈` fallback stands).
- The lattice server's silent range clamp at `state.py` — still clamps rather than reporting.
- Which additional sections the Config panel's Form view should offer; it stays an allowlist, deliberately not inverted to a denylist.
- A server-served field schema on `GET /api/config`.
- Re-plumbing `vendor_url()` so the local path comes from the manifest rather than the caller.
- `panel-catalog.js`'s own label table, which is module state read before `/api/panels` resolves.


