### PR TITLE
feat(ariel): run the agent's SQL tool under a read-only database role

### DIFF
--- a/changelog.d/sql-readonly-role.security.md
+++ b/changelog.d/sql-readonly-role.security.md
@@ -1,0 +1,9 @@
+The agent's SQL tool now queries the logbook through a SELECT-only Postgres
+role (``<username>_ro``) rather than the role ingestion writes with, so a
+statement naming a server-side function such as ``pg_read_file()`` is refused
+by the database itself. The role is created when the ARIEL database volume is
+first initialized, and ``osprey up`` mints its password as
+``ARIEL_DB_READONLY_PASSWORD``. A database created before this release has no
+such role and keeps working on the previous connection — the agent logs one
+warning at start-up, and "Read-only role for the SQL tool" in the standalone
+deployment how-to has a one-shot command for adopting it.

--- a/docs/source/how-to/ariel/standalone-deployment.rst
+++ b/docs/source/how-to/ariel/standalone-deployment.rst
@@ -211,3 +211,44 @@ The render lands in the repository's ``build/`` directory, which is kept out of
 git. The profile is your facility's source of truth — commit it. ``build/`` is a
 regenerable artifact. See :doc:`../build-profiles` for the full schema and the
 preset → profile → build model.
+
+Read-only role for the SQL tool
+===============================
+
+The agent can run raw SQL against the logbook database. That query path
+connects as its own Postgres role — ``<username>_ro``, derived from
+``services.postgresql.username`` — which can log in, read the tables in the
+``public`` schema, and do nothing else. It is not the role ingestion writes
+with, and it is not a superuser, so a query naming a server-side function such
+as ``pg_read_file()`` is refused by Postgres rather than by a pattern match over
+the query text.
+
+The role is created by an init script the Postgres entrypoint runs **once,
+while it initializes a fresh data volume**, the same window
+``POSTGRES_PASSWORD`` is read in. Its password is ``ARIEL_DB_READONLY_PASSWORD``
+in the deployment's ``.env``, minted by ``osprey up`` beside
+``ARIEL_DB_PASSWORD``. A new deployment gets all of this with no action from
+you.
+
+Tables created later are covered: the script grants ``SELECT`` on the schema's
+tables and sets default privileges for the owner, so the ``enhanced_entries``
+table the migrations create and the per-model ``text_embeddings_*`` tables an
+enhancement module adds are readable without a second grant.
+
+Adopting the role on an existing database
+-----------------------------------------
+
+A data volume created before the role existed never runs the init script, so it
+has no ``<username>_ro``. Nothing breaks: the agent notices at start-up, logs
+one warning, and runs the SQL tool on the ingestion connection as it did
+before. To adopt the role without recreating the volume, run the same script by
+hand once:
+
+.. code-block:: bash
+
+   docker exec -e ARIEL_DB_READONLY_PASSWORD="$(grep '^ARIEL_DB_READONLY_PASSWORD=' .env | cut -d= -f2-)" \
+       <project>-ariel-postgres bash /docker-entrypoint-initdb.d/10-readonly-role.sh
+
+Restart the agent afterwards so it picks up the role, and the warning stops.
+The script is idempotent — running it again is how you roll the role's password
+after changing it in ``.env``.

--- a/docs/source/how-to/deploy-project/env-chain.rst
+++ b/docs/source/how-to/deploy-project/env-chain.rst
@@ -171,6 +171,14 @@ are.
    the minted password, remove the ``ariel_postgres_data`` volume and redeploy
    (this deletes the stored logbook data — re-ingest afterwards).
 
+   ``ARIEL_DB_READONLY_PASSWORD`` is minted beside it and has the same
+   fresh-volume caveat: it is the login secret of the SELECT-only role the
+   agent's SQL tool queries through, created by an init script the same
+   volume initialization runs. A volume that predates the role simply does not
+   have it, and the agent says so once at start-up rather than failing. See
+   :doc:`../ariel/standalone-deployment` for adopting the role on an existing
+   database.
+
 Egress through a site proxy
 ---------------------------
 

--- a/src/osprey/cli/templates/scaffolding.py
+++ b/src/osprey/cli/templates/scaffolding.py
@@ -182,6 +182,9 @@ _SERVICE_TOKEN_VAR_NOTES: dict[str, str] = {
     "OSPREY_TERMINAL_SECRET": "the operator login secret for the bluesky-web panel's web gate",
     "ZO_ROOT_USER_PASSWORD": "OpenObserve root/ingest credential",
     "ARIEL_DB_PASSWORD": "ARIEL Postgres password (also fills the agent's derived DSN)",
+    "ARIEL_DB_READONLY_PASSWORD": (
+        "password of the SELECT-only Postgres role the agent's SQL tool queries through"
+    ),
     "MONGO_ROOT_PASSWORD": "archiver store root password (the seeder, recorder and agent all authenticate with it)",
     "GRAPHDB_PASSWORD": "graph store password (the seeder, health check and deploy staging all authenticate with it)",
 }

--- a/src/osprey/deployment/container_lifecycle.py
+++ b/src/osprey/deployment/container_lifecycle.py
@@ -199,7 +199,11 @@ _SERVICE_TOKEN_VARS: dict[str, tuple[str, ...]] = {
     # can learn — the mint here is what makes the deployed panel reachable.
     "bluesky_web": ("OSPREY_TERMINAL_SECRET",),
     "openobserve": ("ZO_ROOT_USER_PASSWORD",),
-    "postgresql": ("ARIEL_DB_PASSWORD",),
+    # Two identities on one store: the owner ingestion writes with, and the
+    # SELECT-only role the agent's raw-SQL path connects as. Both are read by
+    # Postgres only while it initializes a fresh volume, and both fill the
+    # password slot of a DSN the agent derives.
+    "postgresql": ("ARIEL_DB_PASSWORD", "ARIEL_DB_READONLY_PASSWORD"),
     "mongodb": ("MONGO_ROOT_PASSWORD",),
     "graphdb": ("GRAPHDB_PASSWORD",),
 }
@@ -314,6 +318,18 @@ class VolumeInitializedStore(NamedTuple):
       ``--reuse-stores`` would then "restore" ``neo4j/<password>`` into
       ``GRAPHDB_PASSWORD``, re-composing to ``neo4j/neo4j/<password>`` and
       locking the operator out of a store that was working.
+
+    And one field that is policy rather than a name:
+
+    * ``blocking`` — whether a stale value of this credential is a reason to
+      refuse the deploy. True for a store's root credential, where a mismatch
+      means the store will not authenticate at all. False for a credential the
+      deployment is *designed* to do without: the store starts, the feature the
+      credential unlocks falls back to the behavior it had before the credential
+      existed, and the fallback says so. Refusing there would turn a documented
+      degradation into a stop whose only remedy is discarding the volume — so a
+      non-blocking credential is adopted when its store's volume is adopted, and
+      is silent otherwise.
     """
 
     service: str
@@ -321,6 +337,7 @@ class VolumeInitializedStore(NamedTuple):
     container: str
     cred_env: str
     cred_prefix: str = ""
+    blocking: bool = True
 
 
 #: Minted vars a service reads ONLY when it initializes a fresh data volume.
@@ -347,6 +364,27 @@ _VOLUME_INITIALIZED_VARS: dict[str, VolumeInitializedStore] = {
         volume="ariel_postgres_data",
         container="-ariel-postgres",
         cred_env="POSTGRES_PASSWORD",
+    ),
+    # The second identity the SAME volume is initialized with: the init script
+    # that creates the SELECT-only role runs only while the entrypoint is
+    # building a fresh data directory, so a re-minted secret beside a surviving
+    # volume is stale for exactly the reason the owner password above is.
+    #
+    # NOT blocking, and this is the entry the field exists for. A volume older
+    # than the role has no `_ro` login to mismatch: the agent's SQL tool runs on
+    # the ingestion connection it always ran on, and says so once at start-up,
+    # pointing at the how-to section that adopts the role by hand. Refusing
+    # would stop every deployment that predates the role on its next start and
+    # offer it nothing but discarding the logbook. Listed all the same, so that `--reuse-stores` restores this
+    # credential along with the owner password whenever it adopts the volume —
+    # adopting one and re-minting the other is how the role quietly stops being
+    # reachable on a stack that has it.
+    "ARIEL_DB_READONLY_PASSWORD": VolumeInitializedStore(
+        service="postgresql",
+        volume="ariel_postgres_data",
+        container="-ariel-postgres",
+        cred_env="ARIEL_DB_READONLY_PASSWORD",
+        blocking=False,
     ),
     "MONGO_ROOT_PASSWORD": VolumeInitializedStore(
         service="mongodb",
@@ -1187,15 +1225,19 @@ def _preflight_stale_store_volumes(
     probe = RuntimeProbe(get_runtime_command(config)[0], run=subprocess.run)
 
     stale, originals = _stale_store_volumes(probe, project, minted, services, env_path)
-    if not stale:
+    # Only a blocking credential can produce a refusal or make one unavoidable.
+    # A non-blocking one rides along with its store's adoption and is otherwise
+    # not the operator's problem — see VolumeInitializedStore.blocking.
+    blocking = [(var, store) for var, store in stale if store.blocking]
+    if not blocking:
         return
 
-    if reuse_stores and all(originals.values()):
+    if reuse_stores and all(originals[var] is not None for var, _ in blocking):
         _adopt_original_credentials(env_path, stale, originals)
         return
 
     raise RuntimeError(
-        _stale_store_report(project, env_path, stale, originals, reuse_stores=reuse_stores)
+        _stale_store_report(project, env_path, blocking, originals, reuse_stores=reuse_stores)
     )
 
 
@@ -1222,7 +1264,12 @@ def _adopt_original_credentials(
     absent: dict[str, str] = {}
     for var, _store in stale:
         original = originals[var]
-        if original is None:  # unreachable via the caller's `all(...)` guard
+        if original is None:
+            # Only a non-blocking credential reaches here unreadable: the
+            # caller refuses rather than adopt when a blocking one is gone.
+            # Leave the fresh mint standing — the feature it unlocks falls
+            # back and says so, which is what it does on a volume that
+            # never had the credential at all.
             continue
         if var in on_disk:
             text = re.sub(
@@ -1242,7 +1289,12 @@ def _adopt_original_credentials(
         )
 
     written = parse_dotenv_file(env_path)
-    missed = [var for var, _ in stale if written.get(var) != originals[var]]
+    # A credential the container no longer carries was skipped above rather than
+    # restored, and only a non-blocking one reaches here in that state — the
+    # caller refuses outright when a blocking credential is unrecoverable.
+    missed = [
+        var for var, _ in stale if originals[var] is not None and written.get(var) != originals[var]
+    ]
     if missed:
         raise RuntimeError(
             f"Could not restore {', '.join(sorted(missed))} in {env_path.resolve()}. "

--- a/src/osprey/deployment/reach.py
+++ b/src/osprey/deployment/reach.py
@@ -880,7 +880,14 @@ REACH_CONTRACTS: dict[str, ReachContract] = {
             ProjectedKey("services.postgresql.username", gate=_ariel_on),
             ProjectedKey("services.postgresql.database_name", gate=_ariel_on),
         ),
-        credentials=(CredentialGrant("ARIEL_DB_PASSWORD", config_needs_ariel_password),),
+        credentials=(
+            CredentialGrant("ARIEL_DB_PASSWORD", config_needs_ariel_password),
+            # The SELECT-only role the agent's raw-SQL path connects as. Same
+            # entitlement as the owner password: a container that derives an
+            # ARIEL DSN derives both rungs of it, and without this one the SQL
+            # tool falls back to the ingestion connection with a warning.
+            CredentialGrant("ARIEL_DB_READONLY_PASSWORD", config_needs_ariel_password),
+        ),
         names_external=_ariel_database_named,
         note="resolve_ariel_dsn derives the DSN from the block on loopback",
     ),

--- a/src/osprey/deployment/service_tokens.py
+++ b/src/osprey/deployment/service_tokens.py
@@ -142,6 +142,11 @@ _VAR_GENERATORS: dict[str, Callable[[], str]] = {
     # alphanumeric by construction and matches the Tiled recipe: same 256
     # bits of entropy, zero escaping concerns in .env, YAML, or the URI.
     "ARIEL_DB_PASSWORD": lambda: secrets.token_hex(32),
+    # The login secret of the SELECT-only role the agent's raw-SQL path
+    # connects as. Same rationale as ARIEL_DB_PASSWORD one line up, and it has
+    # to be: the readonly rung of the derived DSN substitutes it into the same
+    # password slot of the same URI.
+    "ARIEL_DB_READONLY_PASSWORD": lambda: secrets.token_hex(32),
     # The archiver Mongo root password follows the ARIEL_DB_PASSWORD rationale.
     # The connector passes it to ``MongoClient`` as a keyword argument, where
     # escaping would not matter — but it is not the only consumer: the recorder
@@ -323,6 +328,8 @@ _VAR_VALIDATORS: dict[str, Callable[[str], bool]] = {
     # silently reshape the DSN (see _validate_ariel_dsn) — reject it at the
     # deploy boundary instead.
     "ARIEL_DB_PASSWORD": _validate_uri_safe_password,
+    # Same slot in the same derived DSN, one rung along.
+    "ARIEL_DB_READONLY_PASSWORD": _validate_uri_safe_password,
     # Same character rule, different consumer: the archiver Mongo password is
     # read by the recorder, the seeder, and the agent's connector, at least one
     # of which may assemble a mongodb:// URI around it.
@@ -352,6 +359,11 @@ _VAR_VALIDATOR_DESCRIPTIONS: dict[str, str] = {
     "ARIEL_DB_PASSWORD": (
         "must be non-empty with no whitespace and no URI-reserved character "
         "(@ : / ? #) — the value is substituted into the ariel DSN's password slot"
+    ),
+    "ARIEL_DB_READONLY_PASSWORD": (
+        "must be non-empty with no whitespace and no URI-reserved character "
+        "(@ : / ? #) — the value is substituted into the password slot of the "
+        "ariel DSN the read-only SQL role connects with"
     ),
     "MONGO_ROOT_PASSWORD": (
         "must be non-empty with no whitespace and no URI-reserved character "

--- a/src/osprey/mcp_server/ariel/server_context.py
+++ b/src/osprey/mcp_server/ariel/server_context.py
@@ -209,9 +209,18 @@ class ARIELContext:
         return self._service
 
     async def shutdown(self) -> None:
-        """Close the service's DB pool. Called on server shutdown."""
+        """Close the service's DB pools. Called on server shutdown.
+
+        Both of them: the service is built here directly rather than through
+        its async context manager, so the teardown the manager would have run
+        is this method's to run instead. The read-only pool opens at start-up
+        with a live connection of its own, so skipping it leaves the store
+        holding an idle session the process will never use again.
+        """
         if self._service is not None:
             try:
+                if self._service.readonly_pool is not None:
+                    await self._service.readonly_pool.close()
                 await self._service.pool.close()
             except Exception:
                 logger.debug("Error closing ARIEL pool (ignored)", exc_info=True)

--- a/src/osprey/mcp_server/ariel/tools/sql_query.py
+++ b/src/osprey/mcp_server/ariel/tools/sql_query.py
@@ -70,8 +70,15 @@ async def sql_query(
         registry = get_ariel_context()
         service = await registry.service()
 
+        # The SELECT-only role, where the deployment has one. `BEGIN READ ONLY`
+        # and the statement allowlist still apply underneath; what the role adds
+        # is the half neither can cover, since a transaction mode does not stop
+        # a server-side read and no pattern over query text enumerates every
+        # dangerous function. The fallback is a store whose data volume predates
+        # the role — the service logs one warning at start-up when it takes it.
         # execute_sql_query re-validates internally
-        rows = await execute_sql_query(service.pool, sql, max_rows=max_rows)
+        pool = service.readonly_pool or service.pool
+        rows = await execute_sql_query(pool, sql, max_rows=max_rows)
 
         # Egress: rows that select an entry_id column gain a canonical entry_url
         # (config-driven). Rows without entry_id (aggregates, projections) and

--- a/src/osprey/services/ariel_search/capability.py
+++ b/src/osprey/services/ariel_search/capability.py
@@ -71,11 +71,15 @@ def reset_ariel_service() -> None:
 async def close_ariel_service() -> None:
     """Close and reset the service singleton.
 
-    Properly closes the service's connection pool before resetting.
+    Properly closes both of the service's connection pools before resetting:
+    the singleton is created outside its async context manager, so nothing else
+    will close the SELECT-only pool the agent's raw-SQL path queries through.
     Use this in tests to avoid connection leaks.
     """
     global _ariel_service_instance
     if _ariel_service_instance is not None:
+        if _ariel_service_instance.readonly_pool is not None:
+            await _ariel_service_instance.readonly_pool.close()
         await _ariel_service_instance.pool.close()
     _ariel_service_instance = None
 

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -177,6 +177,38 @@ def _ariel_config(config_dict: dict) -> ARIELConfig:
     return ARIELConfig.from_dict(config_dict, _postgresql_services(), base=_port_base())
 
 
+def _require_ingestion_block(config_dict: dict) -> None:
+    """Refuse a logbook-reading command whose config declares no ingestion.
+
+    ``ariel watch`` and ``ariel sync`` both read a logbook, so an ``ariel``
+    section with no ``ingestion`` block at all has not configured the thing they
+    do. Left to the parser, that shape produces a message about the block's
+    ``adapter`` field -- naming a key inside a block the operator never wrote,
+    which reads as a typo in something they have rather than as something
+    missing. Checked here, before the parse, so the refusal names the block.
+
+    A block that IS present keeps the parser's message: ``adapter`` really is
+    the missing answer then.
+
+    Args:
+        config_dict: The raw ``ariel`` section, after any CLI override that
+            mints the block has been applied.
+
+    Raises:
+        ConfigurationError: If the section carries no ``ingestion`` block.
+    """
+    if config_dict.get("ingestion"):
+        return
+
+    from osprey.services.ariel_search.exceptions import ConfigurationError
+
+    raise ConfigurationError(
+        "ariel.ingestion is not configured: `ariel watch` and `ariel sync` read "
+        "a logbook, so name the adapter and source_url under ariel.ingestion",
+        config_key="ingestion",
+    )
+
+
 def check_vocabulary(
     config_dict: dict,
     path: str | None = None,
@@ -437,6 +469,7 @@ async def run_sync(
     from osprey.services.ariel_search.database.migrations import run_migrations
     from osprey.services.ariel_search.ingestion.scheduler import IngestionScheduler
 
+    _require_ingestion_block(config_dict)
     config = _ariel_config(config_dict)
 
     # Step 1: Migrate
@@ -653,6 +686,7 @@ async def run_watch(
         if require_initial_ingest is not None:
             ingestion.setdefault("watch", {})["require_initial_ingest"] = require_initial_ingest
 
+    _require_ingestion_block(config_dict)
     config = _ariel_config(config_dict)
 
     if not config.ingestion or not config.ingestion.source_url:

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -10,7 +10,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from osprey.port_layout import default_port
 from osprey.utils.config_paths import resolve_config_relative_path
@@ -37,6 +37,20 @@ _DEFAULT_DB_NAME = "ariel"
 #: uses, so the agent stays launchable before the first `osprey up`
 #: mints a real password into the project ``.env``.
 _DEFAULT_DB_PASSWORD = "ariel"
+
+#: Appended to the Postgres username to name the SELECT-only role the store's
+#: init script creates. Derived rather than configured: the owner is declared
+#: once, under ``services.postgresql.username``, and a second key naming the
+#: read-only role would be a copy of that fact with nothing keeping the two in
+#: step. The init template derives the same name from the same key.
+_READONLY_ROLE_SUFFIX = "_ro"
+
+#: Where the read-only role's password is read from, and the value that stands
+#: in before a deploy mints one -- mirroring ``ARIEL_DB_PASSWORD`` and the
+#: ``${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}`` fallback the compose service and
+#: the init script both carry.
+_DB_READONLY_PASSWORD_ENV_VAR = "ARIEL_DB_READONLY_PASSWORD"
+_DEFAULT_DB_READONLY_PASSWORD = _DEFAULT_DB_PASSWORD + _READONLY_ROLE_SUFFIX
 
 #: Store-address overrides for the *derived* DSN. A process inside the compose
 #: network reaches Postgres by its service name on the in-network port, not by
@@ -67,6 +81,7 @@ def resolve_ariel_dsn(
     env: Mapping[str, str] | None = None,
     *,
     base: int | None = None,
+    role: Literal["ingest", "readonly"] = "ingest",
 ) -> str:
     """Resolve the effective ARIEL database DSN.
 
@@ -94,6 +109,16 @@ def resolve_ariel_dsn(
     run at all, so redirecting it would point the agent at a different store
     than the project asked for.
 
+    ``role`` selects WHICH identity on that store the DSN authenticates as, and
+    only changes the derived third rung. ``"readonly"`` names
+    ``<username>_ro``, the SELECT-only role the store's init script creates,
+    with its password read from ``ARIEL_DB_READONLY_PASSWORD``. The first two
+    rungs are returned verbatim for either role: a DSN the project wrote down
+    names one endpoint and one identity on a database osprey did not
+    provision, and inventing a second login for it would fabricate a role that
+    may not exist. :class:`DatabaseConfig` reads that equality as "this
+    deployment has no separate read-only identity".
+
     Args:
         ariel_section: The ``ariel`` section from config.yml.
         services: The ``services.postgresql`` mapping from config.yml, or None
@@ -107,6 +132,9 @@ def resolve_ariel_dsn(
             ``.env`` instead: run from another directory, the ambient value
             belongs to some other deployment, and using it would either fail
             confusingly or reach a database this call was never pointed at.
+        role: Which identity on the derived store to authenticate as --
+            ``"ingest"``, the owner the container is initialized with, or
+            ``"readonly"``, the SELECT-only role beside it.
         base: The port base this deployment resolved, from
             :func:`osprey.port_layout.resolve_port_base`. Only consulted when
             ``services`` sets no ``port_host``, in which case the derived DSN
@@ -138,7 +166,11 @@ def resolve_ariel_dsn(
     postgresql = services or {}
     username = postgresql.get("username", _DEFAULT_DB_USERNAME)
     database_name = postgresql.get("database_name", _DEFAULT_DB_NAME)
-    password = source.get("ARIEL_DB_PASSWORD", _DEFAULT_DB_PASSWORD)
+    if role == "readonly":
+        username = f"{username}{_READONLY_ROLE_SUFFIX}"
+        password = source.get(_DB_READONLY_PASSWORD_ENV_VAR, _DEFAULT_DB_READONLY_PASSWORD)
+    else:
+        password = source.get("ARIEL_DB_PASSWORD", _DEFAULT_DB_PASSWORD)
 
     host = _env_override(source, _DB_HOST_ENV_VAR) or _DEFAULT_DB_HOST
 
@@ -456,9 +488,14 @@ class DatabaseConfig:
 
     Attributes:
         uri: PostgreSQL connection URI (e.g., "postgresql://localhost:5432/ariel")
+        readonly_uri: The same store reached as its SELECT-only role, for the
+            agent's raw-SQL path. ``None`` when this deployment has no separate
+            read-only identity -- an explicit ``uri`` names a database osprey
+            did not provision and therefore created no second role on.
     """
 
     uri: str
+    readonly_uri: str | None = None
 
     @classmethod
     def from_dict(
@@ -470,6 +507,13 @@ class DatabaseConfig:
     ) -> "DatabaseConfig":
         """Create DatabaseConfig from the ``ariel.database`` mapping.
 
+        Both identities come from the same resolver and the same inputs, so the
+        read-only DSN cannot drift from the one ingestion uses. They come back
+        equal exactly when an explicit ``uri`` (or the legacy alias) short-
+        circuits the derivation, which is the case where there is no second
+        role to reach -- recorded as ``None`` rather than as a duplicate DSN
+        that would silently connect the SQL tool as the owner.
+
         Args:
             data: The ``ariel.database`` mapping from config.yml.
             services: The ``services.postgresql`` mapping, used to derive the
@@ -478,7 +522,9 @@ class DatabaseConfig:
                 :func:`resolve_ariel_dsn` so a derived DSN dials this
                 deployment's ``postgres`` slot rather than the default base's.
         """
-        return cls(uri=resolve_ariel_dsn({"database": data}, services, base=base))
+        uri = resolve_ariel_dsn({"database": data}, services, base=base)
+        readonly_uri = resolve_ariel_dsn({"database": data}, services, base=base, role="readonly")
+        return cls(uri=uri, readonly_uri=None if readonly_uri == uri else readonly_uri)
 
 
 @dataclass

--- a/src/osprey/services/ariel_search/database/connection.py
+++ b/src/osprey/services/ariel_search/database/connection.py
@@ -11,11 +11,22 @@ if TYPE_CHECKING:
     from osprey.services.ariel_search.config import DatabaseConfig
 
 
-async def create_connection_pool(config: "DatabaseConfig") -> "AsyncConnectionPool":
+async def create_connection_pool(
+    config: "DatabaseConfig",
+    *,
+    uri: str | None = None,
+    max_size: int = 10,
+) -> "AsyncConnectionPool":
     """Create async connection pool for ARIEL repository.
 
     Args:
         config: Database configuration with connection URI
+        uri: Connect with this DSN instead of ``config.uri``. The one caller
+            that passes it is the read-only pool the agent's raw-SQL path uses,
+            which reaches the SAME store as a different role, so everything
+            else about the pool is unchanged.
+        max_size: Upper bound on pooled connections. The default sizes the
+            ingestion and search pool; a pool serving one tool wants far fewer.
 
     Returns:
         Configured AsyncConnectionPool ready for use
@@ -32,9 +43,9 @@ async def create_connection_pool(config: "DatabaseConfig") -> "AsyncConnectionPo
         ) from e
 
     pool = AsyncConnectionPool(
-        conninfo=config.uri,
+        conninfo=uri if uri is not None else config.uri,
         min_size=1,
-        max_size=10,
+        max_size=max_size,
         kwargs={"autocommit": True},
         open=False,  # Don't open immediately
         reconnect_timeout=0,  # Don't retry on failure

--- a/src/osprey/services/ariel_search/service.py
+++ b/src/osprey/services/ariel_search/service.py
@@ -116,6 +116,7 @@ class ARIELSearchService:
         config: ARIELConfig,
         pool: AsyncConnectionPool,
         repository: ARIELRepository,
+        readonly_pool: AsyncConnectionPool | None = None,
     ) -> None:
         """Initialize the service.
 
@@ -123,9 +124,14 @@ class ARIELSearchService:
             config: ARIEL configuration
             pool: Database connection pool
             repository: Database repository
+            readonly_pool: The same store reached as its SELECT-only role, for
+                the agent's raw-SQL path. ``None`` where this deployment has no
+                such role -- an explicit DSN, or a data volume older than the
+                role -- and the raw-SQL path then shares ``pool``.
         """
         self.config = config
         self.pool = pool
+        self.readonly_pool = readonly_pool
         self.repository = repository
         self._embedder: BaseEmbeddingProvider | None = None
         self._validated_search_model = False
@@ -854,6 +860,8 @@ class ARIELSearchService:
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Exit async context and cleanup."""
+        if self.readonly_pool is not None:
+            await self.readonly_pool.close()
         await self.pool.close()
 
 
@@ -879,12 +887,47 @@ async def create_ariel_service(
 
     pool = await create_connection_pool(config.database)
     repository = ARIELRepository(pool, config)
+    readonly_pool = await _open_readonly_pool(config)
 
     return ARIELSearchService(
         config=config,
         pool=pool,
         repository=repository,
+        readonly_pool=readonly_pool,
     )
+
+
+async def _open_readonly_pool(config: ARIELConfig) -> AsyncConnectionPool | None:
+    """Open the SELECT-only pool the agent's raw-SQL path queries through.
+
+    Small: it serves one tool, not the search and ingestion traffic the
+    ingestion pool carries.
+
+    Returns ``None`` -- with one warning, at start-up rather than per query --
+    when the deployment has no read-only identity to open. Two shapes reach
+    that: a project pointing at a database osprey did not provision (no
+    ``readonly_uri``), and a data volume initialized before the role existed,
+    where the DSN resolves but the login is refused. Neither is a reason to
+    refuse to start, because the tool already ran on the ingestion connection
+    before the role existed; falling back leaves it exactly there, and says so.
+    """
+    from osprey.services.ariel_search.database.connection import create_connection_pool
+
+    readonly_uri = config.database.readonly_uri
+    if readonly_uri is None:
+        reason = "no read-only role is configured for this database"
+    else:
+        try:
+            return await create_connection_pool(config.database, uri=readonly_uri, max_size=3)
+        except Exception as exc:  # noqa: BLE001 -- any failure to open falls back
+            reason = f"{type(exc).__name__}: {exc}"
+
+    logger.warning(
+        "SQL tool is running on the ingestion role: %s. See the how-to "
+        "'Standalone Deployment', section 'Read-only role for the SQL tool'.",
+        reason,
+    )
+    return None
 
 
 __all__ = [

--- a/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
+++ b/src/osprey/templates/modules/web_terminals/docker-compose.web.yml.j2
@@ -1163,6 +1163,16 @@ services:
          the host — an empty value would NOT, since `resolve_ariel_dsn` falls
          back only on an unset variable, never on an empty one. #}
       - ARIEL_DB_PASSWORD=${ARIEL_DB_PASSWORD:-ariel}
+      {#- The same password one rung along: the login secret of the SELECT-only
+         role the agent's raw-SQL tool connects as, which `resolve_ariel_dsn`
+         substitutes into the readonly DSN exactly as the line above is
+         substituted into the ingestion one. Without it the tool opens no
+         read-only pool and queries through the ingestion connection instead,
+         which is a superuser on a deployment that minted nothing.
+
+         Same gate, same per-user placement and the same `:-` mirror of the
+         postgresql service template's own default, for the reasons above. #}
+      - ARIEL_DB_READONLY_PASSWORD=${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}
 {%- endif %}
 {%- if svc.wants_launch_token %}
       {#- The Bluesky queue's launch token, for a persona entitled to arm a queue

--- a/src/osprey/templates/services/postgresql/10-readonly-role.sh.j2
+++ b/src/osprey/templates/services/postgresql/10-readonly-role.sh.j2
@@ -1,0 +1,66 @@
+{#- Rendered beside this service's docker-compose.yml — the build renders any
+    .j2 sitting next to a service's compose template with the same context —
+    and mounted read-only into /docker-entrypoint-initdb.d/, where the official
+    Postgres entrypoint runs it ONCE while initializing a FRESH data volume, as
+    the superuser the image is creating. That is the same window
+    POSTGRES_PASSWORD is read in: a volume that already exists never runs this
+    file, which is why the standalone-deployment how-to carries a one-shot
+    command for an existing stack.
+
+    A .sh rather than a .sql because the role's password comes from the
+    environment: the entrypoint feeds a .sql straight to psql, which does not
+    expand ${VAR}, while a .sh runs under the entrypoint's shell first and
+    hands the value to psql as a -v variable. -#}
+{%- set pg_user = services.postgresql.username | default('ariel') -%}
+{%- set pg_db = services.postgresql.database_name | default('ariel') -%}
+#!/usr/bin/env bash
+# The agent's raw-SQL tool connects as this role rather than as the owner the
+# image creates, which is a superuser. `BEGIN READ ONLY` stops writes but not
+# server-side reads (pg_read_file) or any other superuser-only function, and no
+# allowlist over SQL text can enumerate them all, so the privileges the
+# connection has at all are the line that holds. SELECT on this schema's tables
+# is the entire grant.
+#
+# Everything below runs in a SUBSHELL so `set` cannot escape this file. A file
+# under /docker-entrypoint-initdb.d/ is EXECUTED when it carries an executable
+# bit and SOURCED otherwise, and a bind mount preserves the mode of a file the
+# build wrote without one — so the sourced path is the one taken here, and
+# options set at the top level would stay set in the entrypoint's own shell for
+# the rest of initialization. `-u` in particular is not an option the entrypoint
+# runs under, and turning it on underneath it would abort the init on the first
+# unset variable the entrypoint reads. The entrypoint's own `-e` still carries
+# a non-zero exit from this subshell.
+(
+  set -euo pipefail
+  psql -v ON_ERROR_STOP=1 \
+       --username "$POSTGRES_USER" \
+       --dbname "$POSTGRES_DB" \
+       --no-password \
+       -v owner="{{ pg_user }}" \
+       -v ro_role="{{ pg_user }}_ro" \
+       -v ro_password="${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}" \
+       -v db_name="{{ pg_db }}" <<'EOSQL'
+-- Every statement below is idempotent, so the one-shot command an existing
+-- volume is migrated with can be run against a database that already has the
+-- role — and re-run after the password in .env changes.
+SELECT format('CREATE ROLE %I LOGIN', :'ro_role')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'ro_role')
+\gexec
+
+ALTER ROLE :"ro_role"
+  WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT PASSWORD :'ro_password';
+
+GRANT CONNECT ON DATABASE :"db_name" TO :"ro_role";
+GRANT USAGE ON SCHEMA public TO :"ro_role";
+
+-- enhanced_entries and the per-model text_embeddings_* tables are created
+-- later, by the migrations and by whichever enhancement modules are enabled.
+-- ON ALL TABLES covers whatever already exists (the migration path); ALTER
+-- DEFAULT PRIVILEGES covers everything the owner creates afterwards (the
+-- fresh-volume path this file normally runs on), so a table added later is
+-- readable without anyone remembering a second grant.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO :"ro_role";
+ALTER DEFAULT PRIVILEGES FOR ROLE :"owner" IN SCHEMA public
+  GRANT SELECT ON TABLES TO :"ro_role";
+EOSQL
+)

--- a/src/osprey/templates/services/postgresql/docker-compose.yml.j2
+++ b/src/osprey/templates/services/postgresql/docker-compose.yml.j2
@@ -64,10 +64,28 @@ services:
       # initializing a FRESH data volume; a pre-existing volume keeps its
       # original password until recreated.
       POSTGRES_PASSWORD: ${ARIEL_DB_PASSWORD:-ariel}
+      # The login secret for the SELECT-only role the initdb script below
+      # creates — the identity the agent's raw-SQL tool connects as, so a
+      # dangerous function it names is refused by the server instead of by a
+      # pattern match over the query text. Minted beside ARIEL_DB_PASSWORD by
+      # `osprey up` and read by the same derived-DSN path, one rung along. It is
+      # passed into the container rather than substituted into the mounted
+      # script because the script is rendered at build time and the secret lives
+      # in the project .env. Same fresh-volume caveat as POSTGRES_PASSWORD.
+      ARIEL_DB_READONLY_PASSWORD: ${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}
       TZ: {{ system.timezone }}
 {{- hostenv.passthrough(services.postgresql) }}
     volumes:
       - ariel_postgres_data:/var/lib/postgresql/data
+      # INITDB-ONLY: the entrypoint runs everything under this directory once,
+      # while it initializes a fresh data volume, and never looks at it again.
+      # So the read-only role arrives with a new store and a store that predates
+      # it keeps the role it has — the agent then falls back to the ingestion
+      # identity with one warning rather than failing to start. Adopting the
+      # role on an existing volume is the one-shot command in the
+      # "Read-only role for the SQL tool" section of the standalone-deployment
+      # how-to, which runs this same file by hand.
+      - ./build/services/postgresql/10-readonly-role.sh:/docker-entrypoint-initdb.d/10-readonly-role.sh:ro
     networks:
       # The container_name above is now per-project, but the ARIEL DSN
       # (`postgresql://ariel:ariel@ariel-postgres:5432/ariel`) hosts the stable

--- a/tests/deployment/test_bluesky_token_mint.py
+++ b/tests/deployment/test_bluesky_token_mint.py
@@ -286,13 +286,15 @@ def test_var_generators_registry_is_pinned():
     """Pin the blast radius: only vars with a downstream alphabet/policy
     constraint override the default token recipe (Tiled's alphanumeric
     --api-key, OpenObserve's four-class root password, the URI-safe alphabet
-    the ARIEL Postgres and archiver Mongo passwords share, and the graph
-    store's password, which adds a no-``/`` rule because Neo4j receives it as
-    the password half of the composite ``NEO4J_AUTH``)."""
+    the ARIEL Postgres passwords -- both roles on that store -- and the
+    archiver Mongo password share, and the graph store's password, which adds a
+    no-``/`` rule because Neo4j receives it as the password half of the
+    composite ``NEO4J_AUTH``)."""
     assert set(container_lifecycle._VAR_GENERATORS) == {
         "BLUESKY_TILED_API_KEY",
         "ZO_ROOT_USER_PASSWORD",
         "ARIEL_DB_PASSWORD",
+        "ARIEL_DB_READONLY_PASSWORD",
         "MONGO_ROOT_PASSWORD",
         "GRAPHDB_PASSWORD",
     }
@@ -525,6 +527,7 @@ def test_validator_registry_keyset_is_pinned():
         "ARIEL_DSN",
         "ZO_ROOT_USER_PASSWORD",
         "ARIEL_DB_PASSWORD",
+        "ARIEL_DB_READONLY_PASSWORD",
         "MONGO_ROOT_PASSWORD",
         "GRAPHDB_PASSWORD",
     }

--- a/tests/deployment/test_postgres_password_mint.py
+++ b/tests/deployment/test_postgres_password_mint.py
@@ -49,6 +49,7 @@ def captured_argv(monkeypatch, tmp_path):
 @pytest.fixture
 def _clean_token_env(monkeypatch):
     monkeypatch.delenv("ARIEL_DB_PASSWORD", raising=False)
+    monkeypatch.delenv("ARIEL_DB_READONLY_PASSWORD", raising=False)
     monkeypatch.delenv("ARIEL_DSN", raising=False)
 
 
@@ -145,4 +146,37 @@ def test_operator_password_with_reserved_char_is_rejected(
     silently reshape the ariel DSN — refuse at the deploy boundary instead."""
     (tmp_path / ".env").write_text("ARIEL_DB_PASSWORD=p@ssword\n", encoding="utf-8")
     with pytest.raises(RuntimeError, match="ARIEL_DB_PASSWORD"):
+        container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)
+
+
+def test_postgresql_deploy_mints_the_readonly_password_too(
+    captured_argv, _clean_token_env, tmp_path
+):
+    """The SELECT-only role's login secret is minted beside the owner's.
+
+    Both are Postgres identities the same fresh volume is initialized with, so
+    a deploy that mints one and not the other leaves the read-only role on a
+    publicly-known default.
+    """
+    container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True, dev_mode=False)
+
+    env = _parse_env(tmp_path)
+    assert env.get("ARIEL_DB_READONLY_PASSWORD")
+    assert len(env["ARIEL_DB_READONLY_PASSWORD"]) == 64
+    assert env["ARIEL_DB_READONLY_PASSWORD"] != env["ARIEL_DB_PASSWORD"]
+
+
+def test_readonly_password_generator_is_uri_safe_every_time():
+    """It lands unescaped in the readonly DSN's password slot."""
+    for _ in range(50):
+        value = _generate_token("ARIEL_DB_READONLY_PASSWORD")
+        assert value.isalnum()
+        assert _validate_var("ARIEL_DB_READONLY_PASSWORD", value)
+
+
+def test_operator_readonly_password_with_reserved_char_is_rejected(
+    captured_argv, _clean_token_env, tmp_path
+):
+    (tmp_path / ".env").write_text("ARIEL_DB_READONLY_PASSWORD=p@ssword\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="ARIEL_DB_READONLY_PASSWORD"):
         container_lifecycle.deploy_up(str(tmp_path / "config.yml"), detached=True)

--- a/tests/deployment/test_postgres_readonly_role_render.py
+++ b/tests/deployment/test_postgres_readonly_role_render.py
@@ -1,0 +1,180 @@
+"""The postgresql service ships a SELECT-only role for the agent's SQL tool.
+
+The raw-SQL tool is auto-allowed and, until this role existed, ran on the same
+connection ingestion writes with — the superuser the official image creates.
+``BEGIN READ ONLY`` stops writes but not ``pg_read_file`` or any other
+superuser-only function, and an allowlist over query text can never enumerate
+them, so the privileges the connection holds are the line that has to hold.
+
+The role is created by an init script the entrypoint runs while it initializes
+a fresh data volume, mounted from the service's build context. These tests
+render the packaged templates the way ``osprey up`` does and pin the two halves
+that have to agree: the mount and the password passthrough in the compose
+document, and what the script actually grants.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from importlib import resources
+
+import pytest
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+from osprey.port_layout import DEFAULT_PORT_BASE, layout_ports
+
+COMPOSE_TEMPLATE = "services/postgresql/docker-compose.yml.j2"
+INITDB_TEMPLATE = "services/postgresql/10-readonly-role.sh.j2"
+
+#: Where the entrypoint looks for the script, and the build path the compose
+#: document binds into it.
+INITDB_TARGET = "/docker-entrypoint-initdb.d/10-readonly-role.sh"
+INITDB_SOURCE = "./build/services/postgresql/10-readonly-role.sh"
+
+
+def _env() -> Environment:
+    templates_root = resources.files("osprey").joinpath("templates")
+    return Environment(loader=FileSystemLoader(str(templates_root)), autoescape=False)
+
+
+def _context(**postgresql_block: object) -> dict:
+    return {
+        "services": {"postgresql": postgresql_block},
+        "deployment": {},
+        "system": {"timezone": "UTC"},
+        "osprey_labels": {
+            "project_name": "probe-test",
+            "repo_id": "0123456789ab",
+            "project_root": "/r/probe-test",
+        },
+        "osprey_ports": layout_ports(DEFAULT_PORT_BASE),
+    }
+
+
+def _render_compose(**postgresql_block: object) -> dict:
+    rendered = _env().get_template(COMPOSE_TEMPLATE).render(**_context(**postgresql_block))
+    return yaml.safe_load(rendered)
+
+
+def _render_initdb(**postgresql_block: object) -> str:
+    """The init script as the build renders it beside the compose document."""
+    return _env().get_template(INITDB_TEMPLATE).render(**_context(**postgresql_block))
+
+
+def test_compose_mounts_the_init_script_the_entrypoint_runs():
+    """The rendered script is bound read-only where initdb looks for it."""
+    volumes = _render_compose()["services"]["postgresql"]["volumes"]
+    assert f"{INITDB_SOURCE}:{INITDB_TARGET}:ro" in volumes
+
+
+def test_compose_passes_the_readonly_password_into_the_container():
+    """The script reads the secret from the environment, so it has to arrive."""
+    environment = _render_compose()["services"]["postgresql"]["environment"]
+    assert environment["ARIEL_DB_READONLY_PASSWORD"] == "${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}"
+
+
+def test_default_render_names_the_ariel_ro_role():
+    script = _render_initdb()
+    assert 'ro_role="ariel_ro"' in script
+    assert 'owner="ariel"' in script
+
+
+@pytest.mark.parametrize("username", ["logbook", "erf_ariel"])
+def test_role_name_is_derived_from_a_custom_username(username: str):
+    """A facility that renames the Postgres user gets a matching ``_ro`` role.
+
+    The suffix is derived from ``services.postgresql.username``, the one place
+    the owner is declared, so nothing has to be renamed in a second file.
+    """
+    script = _render_initdb(username=username, database_name=f"{username}_db")
+    assert f'ro_role="{username}_ro"' in script
+    assert f'owner="{username}"' in script
+    assert f'db_name="{username}_db"' in script
+
+
+def test_script_reads_the_password_from_the_environment():
+    """Rendered at build time, so the secret cannot be baked in: the script
+    reads it from the variable the compose service passes through, with the
+    same fallback the compose document carries."""
+    script = _render_initdb()
+    assert "${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}" in script
+
+
+def test_role_is_created_without_any_superuser_privilege():
+    script = _render_initdb()
+    assert "NOSUPERUSER" in script
+    assert "NOCREATEDB" in script
+    assert "NOCREATEROLE" in script
+    assert "NOINHERIT" in script
+
+
+def test_the_only_grant_is_select():
+    """Read the logbook, nothing else — including tables created later.
+
+    ``ON ALL TABLES`` covers what exists when the script runs and ``ALTER
+    DEFAULT PRIVILEGES`` covers what the owner creates afterwards, which is how
+    a ``text_embeddings_*`` table an enhancement module adds becomes readable
+    without a second grant.
+    """
+    script = _render_initdb()
+    assert "GRANT SELECT ON ALL TABLES IN SCHEMA public" in script
+    assert "ALTER DEFAULT PRIVILEGES FOR ROLE" in script
+    assert "GRANT SELECT ON TABLES" in script
+
+    granted = [line for line in script.splitlines() if line.strip().startswith("GRANT ")]
+    for line in granted:
+        assert "SELECT" in line or "CONNECT" in line or "USAGE" in line, line
+    assert not any(
+        word in script for word in ("GRANT INSERT", "GRANT UPDATE", "GRANT DELETE", "GRANT ALL")
+    )
+
+
+# ---------------------------------------------------------------------------
+# The init script is SOURCED, not executed
+#
+# The official entrypoint executes a file under /docker-entrypoint-initdb.d/
+# only when it carries an executable bit, and sources it otherwise. The build
+# writes the rendered script without one and the bind mount is read-only, so
+# the sourced path is the one that runs — which makes every `set` in the file
+# a change to the entrypoint's own shell unless it is scoped.
+# ---------------------------------------------------------------------------
+
+
+def _write_script(tmp_path, **postgresql_block: object):
+    script = tmp_path / "10-readonly-role.sh"
+    script.write_text(_render_initdb(**postgresql_block), encoding="utf-8")
+    return script
+
+
+def test_the_rendered_script_is_valid_shell(tmp_path):
+    script = _write_script(tmp_path)
+    assert subprocess.run(["bash", "-n", str(script)]).returncode == 0
+
+
+def test_sourcing_it_leaves_the_callers_shell_options_alone(tmp_path):
+    """`set -u` under an entrypoint that does not run with it would abort the
+    initialization on the first unset variable the entrypoint reads next."""
+    script = _write_script(tmp_path)
+    # The entrypoint's own options, and a psql that succeeds without a server.
+    (tmp_path / "psql").write_text("#!/usr/bin/env bash\ncat >/dev/null\n", encoding="utf-8")
+    (tmp_path / "psql").chmod(0o755)
+
+    probe = subprocess.run(
+        ["bash", "-c", f'set -Eeo pipefail; . "{script}"; echo "OPTIONS:$-"'],
+        env={
+            "PATH": f"{tmp_path}:/usr/bin:/bin",
+            "POSTGRES_USER": "ariel",
+            "POSTGRES_DB": "ariel",
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert probe.returncode == 0, probe.stderr
+    (options,) = [
+        line.removeprefix("OPTIONS:")
+        for line in probe.stdout.splitlines()
+        if line.startswith("OPTIONS:")
+    ]
+    assert "u" not in options

--- a/tests/deployment/test_stale_store_volume_preflight.py
+++ b/tests/deployment/test_stale_store_volume_preflight.py
@@ -1,10 +1,10 @@
 """A freshly minted store credential must never meet a volume that predates it.
 
-The three stores in ``_VOLUME_INITIALIZED_VARS`` read their root credential
-only while initializing an empty data volume. Mint a new value beside a volume
-that already exists and the store keeps the password it was born with: the
-stack starts, the deploy waits, and the store refuses the credential the
-``.env`` now claims.
+The stores in ``_VOLUME_INITIALIZED_VARS`` read their credentials only while
+initializing an empty data volume. Mint a new value beside a volume that
+already exists and the store keeps the password it was born with: the stack
+starts, the deploy waits, and the store refuses the credential the ``.env`` now
+claims.
 
 ``osprey up`` used to only *guess* at this — it warned "if this deployment's
 volume already exists" at the mint and started the stack anyway. Two things
@@ -357,3 +357,137 @@ def test_the_volume_probe_is_label_filtered_to_this_project(deploy, tmp_path):
 
     (volume_ls,) = [c for c in fake.calls if c[1:3] == ["volume", "ls"]]
     assert f"label=com.docker.compose.project={PROJECT}" in volume_ls
+
+
+class TestBothPostgresIdentities:
+    """One volume, two credentials — and only one of them may stop a deploy.
+
+    ``ariel_postgres_data`` is initialized with the owner password *and* with
+    the SELECT-only role the init script creates. They fail differently, and
+    the registry has to say so:
+
+    * a stale owner password means the store will not authenticate at all —
+      the refusal this module is about;
+    * a stale read-only password means the role is unreachable and the agent's
+      SQL tool runs on the ingestion connection it ran on before the role
+      existed, saying so once at start-up. That is the designed fallback, and
+      it is what every deployment older than the role is in. Refusing there
+      would stop those deployments on their next start and offer them nothing
+      but discarding the logbook.
+
+    So the read-only password is registered non-blocking: never a refusal of
+    its own, and adopted whenever ``--reuse-stores`` adopts the volume it
+    belongs to — which is the case that would otherwise take the role away from
+    a stack that has one.
+    """
+
+    @pytest.fixture
+    def deploy_postgres(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        for var in ("ARIEL_DB_PASSWORD", "ARIEL_DB_READONLY_PASSWORD"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(
+            container_lifecycle,
+            "prepare_compose_files",
+            lambda *a, **k: (
+                {"deployed_services": ["postgresql"], "project_name": PROJECT},
+                ["docker-compose.yml"],
+            ),
+        )
+        monkeypatch.setattr(
+            container_lifecycle, "verify_runtime_is_running", lambda config: (True, "")
+        )
+        monkeypatch.setattr(
+            container_lifecycle, "get_runtime_command", lambda config: ["docker", "compose"]
+        )
+
+        def _run(fake: FakeRuntime):
+            monkeypatch.setattr(container_lifecycle.subprocess, "run", fake)
+            return lambda **kw: container_lifecycle.deploy_up(
+                str(tmp_path / "config.yml"), detached=True, **kw
+            )
+
+        return _run
+
+    def test_the_readonly_password_is_registered_non_blocking(self):
+        store = container_lifecycle._VOLUME_INITIALIZED_VARS["ARIEL_DB_READONLY_PASSWORD"]
+        assert store.service == "postgresql"
+        assert store.volume == "ariel_postgres_data"
+        # The container spells it the same way the .env does, so nothing is
+        # stripped on the way back out.
+        assert store.cred_env == "ARIEL_DB_READONLY_PASSWORD"
+        assert store.cred_prefix == ""
+        assert store.blocking is False
+        # Every other store's credential is the one its login depends on.
+        assert container_lifecycle._VOLUME_INITIALIZED_VARS["ARIEL_DB_PASSWORD"].blocking is True
+
+    def test_an_upgrade_onto_a_volume_older_than_the_role_still_deploys(
+        self, deploy_postgres, tmp_path
+    ):
+        """The shape every existing deployment is in on its first start after
+        the role ships: the owner password is already in ``.env``, the read-only
+        one is minted for the first time, and the volume predates both the role
+        and the secret. Refusing here would be a fail-closed flip on a stack
+        that works."""
+        (tmp_path / ".env").write_text("ARIEL_DB_PASSWORD=preexistingvalue\n", encoding="utf-8")
+        up = deploy_postgres(FakeRuntime(volumes=[f"{PROJECT}_ariel_postgres_data"]))
+
+        up()
+
+        env = _env(tmp_path)
+        assert env["ARIEL_DB_PASSWORD"] == "preexistingvalue"
+        assert len(env["ARIEL_DB_READONLY_PASSWORD"]) == 64
+
+    def test_a_stale_owner_password_still_refuses(self, deploy_postgres, tmp_path):
+        """The blocking half is unchanged by the non-blocking one beside it."""
+        up = deploy_postgres(FakeRuntime(volumes=[f"{PROJECT}_ariel_postgres_data"]))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            up()
+
+        message = str(excinfo.value)
+        assert "1 store(s)" in message
+        assert f"{PROJECT}_ariel_postgres_data" in message
+
+    def test_reuse_stores_harvests_both_from_the_container(self, deploy_postgres, tmp_path):
+        """Adopting the owner password and re-minting the read-only one would
+        take the role away from a stack that has it."""
+        up = deploy_postgres(
+            FakeRuntime(
+                volumes=[f"{PROJECT}_ariel_postgres_data"],
+                container_env={
+                    f"{PROJECT}-ariel-postgres": {
+                        "POSTGRES_PASSWORD": "theowner",
+                        "ARIEL_DB_READONLY_PASSWORD": "thereadonly",
+                    }
+                },
+            )
+        )
+
+        up(reuse_stores=True)
+
+        env = _env(tmp_path)
+        assert env["ARIEL_DB_PASSWORD"] == "theowner"
+        assert env["ARIEL_DB_READONLY_PASSWORD"] == "thereadonly"
+
+    def test_reuse_stores_adopts_the_owner_from_a_container_predating_the_role(
+        self, deploy_postgres, tmp_path
+    ):
+        """A container older than the role carries no read-only password, and
+        that must not make the volume unadoptable: the owner password is what
+        reopens it, and the role is adopted separately by the documented
+        one-shot command."""
+        up = deploy_postgres(
+            FakeRuntime(
+                volumes=[f"{PROJECT}_ariel_postgres_data"],
+                container_env={f"{PROJECT}-ariel-postgres": {"POSTGRES_PASSWORD": "theowner"}},
+            )
+        )
+
+        up(reuse_stores=True)
+
+        env = _env(tmp_path)
+        assert env["ARIEL_DB_PASSWORD"] == "theowner"
+        # Nothing to restore it from, so the fresh mint stands and the agent
+        # falls back with its start-up warning.
+        assert len(env["ARIEL_DB_READONLY_PASSWORD"]) == 64

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -4252,6 +4252,7 @@ def test_render_without_dispatcher_personas_emits_no_token_line() -> None:
 # ---------------------------------------------------------------------------
 
 _ARIEL_PASSWORD_LINE = "ARIEL_DB_PASSWORD=${ARIEL_DB_PASSWORD:-ariel}"
+_ARIEL_READONLY_PASSWORD_LINE = "ARIEL_DB_READONLY_PASSWORD=${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}"
 
 
 def test_ariel_persona_gets_the_database_password() -> None:
@@ -4281,6 +4282,26 @@ def test_persona_without_ariel_gets_no_database_password() -> None:
     # Assert
     bob_env = compose["services"]["web-bob"]["environment"]
     assert not any("ARIEL_DB_PASSWORD" in line for line in bob_env)
+
+
+def test_ariel_persona_gets_the_readonly_role_password() -> None:
+    """The SQL tool's own identity travels with the ingestion one.
+
+    Both rungs of the derived DSN are read by the same process; a container
+    handed only the owner password opens no read-only pool and queries the
+    logbook through the ingestion connection instead.
+    """
+    # Act
+    compose = yaml.safe_load(
+        render_web_terminals(_events_persona_config(), ariel_personas={"readwrite"})[
+            "docker-compose.web.yml"
+        ]
+    )
+
+    # Assert
+    assert _ARIEL_READONLY_PASSWORD_LINE in compose["services"]["web-alice"]["environment"]
+    bob_env = compose["services"]["web-bob"]["environment"]
+    assert not any("ARIEL_DB_READONLY_PASSWORD" in line for line in bob_env)
 
 
 def test_render_without_ariel_personas_emits_no_password_line() -> None:

--- a/tests/e2e/test_ariel_search.py
+++ b/tests/e2e/test_ariel_search.py
@@ -807,3 +807,157 @@ async def test_vocabulary_mcp_server_refuses_to_start_without_vocabulary_file(
     finally:
         reset_ariel_context()
         reset_config_cache()
+
+
+# =============================================================================
+# The read-only role, against a live server
+#
+# `BEGIN READ ONLY` and the query allowlist are the first line and they hold on
+# their own — the allowlist would refuse `pg_read_file()` before it reached the
+# server, because the query reads no allowlisted table. What it cannot do is
+# prove anything about the privileges the connection HOLDS, and an allowlist
+# over SQL text can never enumerate every function worth refusing. So these
+# tests skip the tool and talk to the server directly, as the role: the point is
+# what the server says no to when nothing upstream said no first.
+# =============================================================================
+
+READONLY_TEMPLATE = "services/postgresql/10-readonly-role.sh.j2"
+READONLY_SECRET = "role-probe-secret"
+
+
+def _render_readonly_script(username: str, database: str) -> str:
+    from importlib import resources
+
+    from jinja2 import Environment, FileSystemLoader
+
+    from osprey.port_layout import DEFAULT_PORT_BASE, layout_ports
+
+    templates_root = resources.files("osprey").joinpath("templates")
+    env = Environment(loader=FileSystemLoader(str(templates_root)), autoescape=False)
+    return env.get_template(READONLY_TEMPLATE).render(
+        services={"postgresql": {"username": username, "database_name": database}},
+        deployment={},
+        system={"timezone": "UTC"},
+        osprey_labels={"project_name": "e2e", "repo_id": "0123456789ab", "project_root": "/r/e2e"},
+        osprey_ports=layout_ports(DEFAULT_PORT_BASE),
+    )
+
+
+@pytest.fixture
+def readonly_role(e2e_database_url: str, tmp_path):
+    """Adopt the role on the live database the way an existing stack does.
+
+    Exactly the documented migration: run the init script the fresh-volume path
+    would have run, as the owner, against a database that already has tables.
+    Yields the DSN of the role it created.
+    """
+    import shutil
+    import subprocess
+    from urllib.parse import urlsplit
+
+    if shutil.which("psql") is None:
+        pytest.skip("psql is required to run the init script the entrypoint runs")
+
+    parts = urlsplit(e2e_database_url)
+    owner, database = parts.username or "ariel", parts.path.lstrip("/")
+    script = tmp_path / "10-readonly-role.sh"
+    script.write_text(_render_readonly_script(owner, database), encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        env={
+            **os.environ,
+            "PGHOST": parts.hostname or "localhost",
+            "PGPORT": str(parts.port or 5432),
+            "PGPASSWORD": parts.password or "",
+            "POSTGRES_USER": owner,
+            "POSTGRES_DB": database,
+            "ARIEL_DB_READONLY_PASSWORD": READONLY_SECRET,
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    yield e2e_database_url.replace(
+        f"{owner}:{parts.password}@", f"{owner}_ro:{READONLY_SECRET}@", 1
+    )
+
+
+@pytest.fixture
+def owner_tables(e2e_database_url: str, readonly_role: str):
+    """One table created before the script ran and one created after it.
+
+    The second is the case the ``ALTER DEFAULT PRIVILEGES`` clause exists for:
+    a ``text_embeddings_*`` table an enhancement module adds later has to be
+    readable without anyone remembering a second grant.
+    """
+    import psycopg
+
+    before, after = "ro_probe_before", "ro_probe_after"
+    with psycopg.connect(e2e_database_url, autocommit=True) as conn:
+        conn.execute(f"DROP TABLE IF EXISTS {before}")
+        conn.execute(f"CREATE TABLE {before} (id int)")
+    yield_error = None
+    try:
+        yield before, after
+    except Exception as exc:  # pragma: no cover - re-raised below
+        yield_error = exc
+    finally:
+        with psycopg.connect(e2e_database_url, autocommit=True) as conn:
+            conn.execute(f"DROP TABLE IF EXISTS {before}")
+            conn.execute(f"DROP TABLE IF EXISTS {after}")
+    if yield_error is not None:  # pragma: no cover
+        raise yield_error
+
+
+@pytest.mark.e2e_services
+async def test_the_readonly_role_selects_and_is_refused_everything_else(
+    e2e_database_url: str, readonly_role: str, owner_tables
+):
+    """SELECT on the owner's tables, and nothing else — including a table the
+    owner creates after the role exists, and a server-side file read."""
+    import psycopg
+
+    from osprey.services.ariel_search.config import DatabaseConfig
+    from osprey.services.ariel_search.database import create_connection_pool
+
+    before, after = owner_tables
+    with psycopg.connect(e2e_database_url, autocommit=True) as conn:
+        conn.execute(f"CREATE TABLE {after} (id int)")
+
+    pool = await create_connection_pool(DatabaseConfig(uri=readonly_role), max_size=3)
+    try:
+        async with pool.connection() as conn:
+            assert (await (await conn.execute(f"SELECT count(*) FROM {before}")).fetchone()) == (0,)
+            assert (await (await conn.execute(f"SELECT count(*) FROM {after}")).fetchone()) == (0,)
+
+            # No read-only transaction around either of these: the refusal has
+            # to come from the privileges the role holds, not from the
+            # transaction mode the tool opens on top of them.
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute(f"INSERT INTO {before} VALUES (1)")
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                await conn.execute("SELECT pg_read_file('/etc/hostname')")
+    finally:
+        await pool.close()
+
+
+@pytest.mark.e2e_services
+async def test_the_readonly_role_holds_no_superuser_attribute(
+    e2e_database_url: str, readonly_role: str
+):
+    """The attributes the script asks for are the ones the server recorded."""
+    from urllib.parse import urlsplit
+
+    import psycopg
+
+    role = urlsplit(readonly_role).username
+    with psycopg.connect(e2e_database_url, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT rolsuper, rolcreatedb, rolcreaterole, rolinherit, rolcanlogin "
+            "FROM pg_roles WHERE rolname = %s",
+            (role,),
+        ).fetchone()
+
+    assert row == (False, False, False, False, True)

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -2119,6 +2119,7 @@ OSPREY_AUTH_PW_CAROL=carol
 # OSPREY_TERMINAL_SECRET=  # bluesky_web — the operator login secret for the bluesky-web panel's web gate
 # ZO_ROOT_USER_PASSWORD=  # openobserve — OpenObserve root/ingest credential
 # ARIEL_DB_PASSWORD=  # postgresql — ARIEL Postgres password (also fills the agent's derived DSN)
+# ARIEL_DB_READONLY_PASSWORD=  # postgresql — password of the SELECT-only Postgres role the agent's SQL tool queries through
 # MONGO_ROOT_PASSWORD=  # mongodb — archiver store root password (the seeder, recorder and agent all authenticate with it)
 # GRAPHDB_PASSWORD=  # graphdb — graph store password (the seeder, health check and deploy staging all authenticate with it)
 """

--- a/tests/mcp_server/ariel/test_sql_query.py
+++ b/tests/mcp_server/ariel/test_sql_query.py
@@ -232,3 +232,61 @@ async def test_sql_query_service_error(tmp_path, monkeypatch):
 
     data = _exc_ctx["envelope"]
     assert "Connection refused" in data["error_message"]
+
+
+@pytest.mark.unit
+async def test_sql_query_uses_the_readonly_pool(tmp_path, monkeypatch):
+    """The tool queries through the SELECT-only role where the deployment has
+    one, so a dangerous function is refused by Postgres rather than by a
+    pattern match over the query text."""
+    _setup_registry(tmp_path, monkeypatch)
+
+    mock_service = AsyncMock()
+    mock_service.pool = AsyncMock()
+    mock_service.readonly_pool = AsyncMock()
+
+    mock_sql = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+            new=AsyncMock(return_value=mock_service),
+        ),
+        patch(
+            "osprey.mcp_server.ariel.tools.sql_query.execute_sql_query",
+            new=mock_sql,
+        ),
+    ):
+        fn = _get_sql_query()
+        await fn(sql="SELECT entry_id FROM enhanced_entries")
+
+    assert mock_sql.call_args.args[0] is mock_service.readonly_pool
+
+
+@pytest.mark.unit
+async def test_sql_query_falls_back_to_the_ingestion_pool(tmp_path, monkeypatch):
+    """A store whose data volume predates the role has no read-only pool. The
+    tool keeps working on the connection it always used; the service logs the
+    one warning about it at start-up rather than here, per query."""
+    _setup_registry(tmp_path, monkeypatch)
+
+    mock_service = AsyncMock()
+    mock_service.pool = AsyncMock()
+    mock_service.readonly_pool = None
+
+    mock_sql = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "osprey.mcp_server.ariel.server_context.ARIELContext.service",
+            new=AsyncMock(return_value=mock_service),
+        ),
+        patch(
+            "osprey.mcp_server.ariel.tools.sql_query.execute_sql_query",
+            new=mock_sql,
+        ),
+    ):
+        fn = _get_sql_query()
+        await fn(sql="SELECT entry_id FROM enhanced_entries")
+
+    assert mock_sql.call_args.args[0] is mock_service.pool

--- a/tests/services/ariel_search/_cli_ops_doubles.py
+++ b/tests/services/ariel_search/_cli_ops_doubles.py
@@ -180,7 +180,7 @@ def _patch_pool(monkeypatch: pytest.MonkeyPatch, pool: Any) -> list[Any]:
 
     seen: list[Any] = []
 
-    async def _fake_create_pool(db_config):
+    async def _fake_create_pool(db_config, **kwargs):
         seen.append(db_config)
         return pool
 

--- a/tests/services/ariel_search/test_cli_operations.py
+++ b/tests/services/ariel_search/test_cli_operations.py
@@ -669,14 +669,35 @@ class TestRunReembedDryRun:
 
 
 class TestRunWatch:
-    async def test_missing_source_raises_valueerror(self, monkeypatch):
-        # No source arg and no ingestion.source_url in config -> rejected before
-        # any service is created.
+    async def test_missing_ingestion_block_names_the_block(self, monkeypatch):
+        """A config with no ``ingestion`` at all has not configured what watch
+        does, so the refusal names the block rather than a field inside one the
+        operator never wrote. Rejected before any service is created."""
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
         _patch_service_raises(monkeypatch, AssertionError("service should not be created"))
 
-        with pytest.raises(ValueError, match="No ingestion source configured"):
+        with pytest.raises(ConfigurationError, match="ariel.ingestion is not configured") as exc:
             await ops.run_watch(
                 dict(_DB),
+                source=None,
+                adapter=None,
+                once=True,
+                interval=None,
+                dry_run=False,
+            )
+
+        assert exc.value.config_key == "ingestion"
+
+    async def test_a_configured_block_without_a_source_still_names_the_source(self, monkeypatch):
+        """The block is there and names its adapter; what is missing is where to
+        read from, and that is what the message says."""
+        _patch_service_raises(monkeypatch, AssertionError("service should not be created"))
+
+        config_dict = {**_DB, "ingestion": {"adapter": "generic_json"}}
+        with pytest.raises(ValueError, match="No ingestion source configured"):
+            await ops.run_watch(
+                config_dict,
                 source=None,
                 adapter=None,
                 once=True,

--- a/tests/services/ariel_search/test_cli_operations_pipeline.py
+++ b/tests/services/ariel_search/test_cli_operations_pipeline.py
@@ -242,7 +242,12 @@ class TestRunSync:
     async def test_missing_ingestion_block_is_refused(
         self, monkeypatch, mock_repository, fake_pool
     ):
-        """A sync with nothing to ingest from is refused, naming the missing key."""
+        """A sync with nothing to ingest from is refused, naming the missing block.
+
+        Not ``ingestion.adapter``: the block is absent entirely, and a message
+        about a field inside it reads as a typo in something the operator has
+        rather than as something they never wrote.
+        """
         from osprey.services.ariel_search.exceptions import ConfigurationError
 
         _patch_pool(monkeypatch, fake_pool)
@@ -253,11 +258,27 @@ class TestRunSync:
 
         config_dict = dict(_DB)
 
-        with pytest.raises(ConfigurationError, match="ariel.ingestion.adapter is required"):
+        with pytest.raises(ConfigurationError, match="ariel.ingestion is not configured") as exc:
             await ops.run_sync(config_dict)
 
+        assert exc.value.config_key == "ingestion"
         # The synthesized block never leaks back to the caller.
         assert "ingestion" not in config_dict
+
+    async def test_a_block_without_an_adapter_keeps_the_adapter_message(
+        self, monkeypatch, mock_repository, fake_pool
+    ):
+        """The block is declared, so what is missing really is the adapter."""
+        from osprey.services.ariel_search.exceptions import ConfigurationError
+
+        _patch_pool(monkeypatch, fake_pool)
+        _patch_migrations(monkeypatch, applied=[])
+        _patch_scheduler(monkeypatch, _poll_result(added=0))
+        _patch_service(monkeypatch, _StubService(mock_repository))
+        _patch_enhancers(monkeypatch, [])
+
+        with pytest.raises(ConfigurationError, match="ariel.ingestion.adapter is required"):
+            await ops.run_sync({**_DB, "ingestion": {"source_url": _SOURCE}})
 
     async def test_up_to_date_and_incremental_poll_report_no_initial_ingest(
         self, monkeypatch, mock_repository, fake_pool

--- a/tests/services/ariel_search/test_dsn_derivation.py
+++ b/tests/services/ariel_search/test_dsn_derivation.py
@@ -30,7 +30,7 @@ from osprey.port_layout import (
     default_port,
     resolve_port_base,
 )
-from osprey.services.ariel_search.config import ARIELConfig, resolve_ariel_dsn
+from osprey.services.ariel_search.config import ARIELConfig, DatabaseConfig, resolve_ariel_dsn
 
 DSN_LOGGER = "osprey.services.ariel_search.config"
 
@@ -66,7 +66,12 @@ def no_ambient_store_address(monkeypatch):
     environment, so a shell that happens to export one of them would otherwise
     move an assertion in this file.
     """
-    for name in ("ARIEL_DB_PASSWORD", "ARIEL_DATABASE_HOST", "ARIEL_DATABASE_PORT"):
+    for name in (
+        "ARIEL_DB_PASSWORD",
+        "ARIEL_DB_READONLY_PASSWORD",
+        "ARIEL_DATABASE_HOST",
+        "ARIEL_DATABASE_PORT",
+    ):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -490,3 +495,101 @@ def test_deriving_the_dsn_stays_silent(caplog, rearmed_connection_string_warning
 
     noisy = [r for r in caplog.records if r.levelno >= logging.WARNING]
     assert not noisy, "deriving the DSN emitted: " + "; ".join(r.getMessage() for r in noisy)
+
+
+# ---------------------------------------------------------------------------
+# The readonly rung
+#
+# The agent's raw-SQL path connects as a SELECT-only role rather than as the
+# owner ingestion writes with. Both DSNs come out of the same resolver and the
+# same declared facts, so the read-only identity cannot drift from the store it
+# is supposed to reach.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_readonly_role_is_the_username_with_the_ro_suffix(monkeypatch) -> None:
+    """The role name is derived from the one place the owner is declared."""
+    monkeypatch.setenv("ARIEL_DB_READONLY_PASSWORD", "ro-from-dotenv")
+
+    uri = resolve_ariel_dsn(
+        {}, {"username": "logbook", "database_name": "olog", "port_host": 6543}, role="readonly"
+    )
+
+    assert uri == "postgresql://logbook_ro:ro-from-dotenv@localhost:6543/olog"
+
+
+@pytest.mark.unit
+def test_readonly_password_falls_back_to_the_shipped_default(monkeypatch) -> None:
+    """Mirrors ``${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}`` in the compose
+    service and the init script, so the agent stays launchable before a deploy
+    mints a real secret."""
+    monkeypatch.delenv("ARIEL_DB_READONLY_PASSWORD", raising=False)
+
+    assert resolve_ariel_dsn({}, None, role="readonly") == (
+        f"postgresql://ariel_ro:ariel_ro@localhost:{default_port('postgres')}/ariel"
+    )
+
+
+@pytest.mark.unit
+def test_the_two_roles_differ_only_in_identity(monkeypatch) -> None:
+    """Same host, same port, same database — a different login."""
+    monkeypatch.setenv("ARIEL_DB_PASSWORD", "owner-secret")
+    monkeypatch.setenv("ARIEL_DB_READONLY_PASSWORD", "ro-secret")
+
+    services = {"username": "ariel", "database_name": "ariel", "port_host": 5432}
+
+    assert resolve_ariel_dsn({}, services) == "postgresql://ariel:owner-secret@localhost:5432/ariel"
+    assert (
+        resolve_ariel_dsn({}, services, role="readonly")
+        == "postgresql://ariel_ro:ro-secret@localhost:5432/ariel"
+    )
+
+
+@pytest.mark.unit
+def test_store_address_overrides_apply_to_the_readonly_rung_too(monkeypatch) -> None:
+    """A process inside the compose network reaches the same Postgres by
+    service name with either identity."""
+    monkeypatch.setenv("ARIEL_DATABASE_HOST", "ariel-postgres")
+    monkeypatch.setenv("ARIEL_DATABASE_PORT", "5432")
+    monkeypatch.setenv("ARIEL_DB_READONLY_PASSWORD", "ro-secret")
+
+    assert resolve_ariel_dsn({}, None, role="readonly") == (
+        "postgresql://ariel_ro:ro-secret@ariel-postgres:5432/ariel"
+    )
+
+
+@pytest.mark.unit
+def test_an_explicit_uri_is_returned_verbatim_for_either_role() -> None:
+    """A DSN the project wrote down names one identity on a database osprey did
+    not provision — there is no ``_ro`` role there to invent."""
+    explicit = "postgresql://someone:else@logbook-db.example.org:5432/ariel"
+
+    assert resolve_ariel_dsn({"database": {"uri": explicit}}, None) == explicit
+    assert resolve_ariel_dsn({"database": {"uri": explicit}}, None, role="readonly") == explicit
+
+
+@pytest.mark.unit
+def test_database_config_carries_both_identities(monkeypatch) -> None:
+    """``from_dict`` fills the read-only DSN on the same path that fills the
+    ingestion one, so a project cannot end up with one and not the other."""
+    monkeypatch.setenv("ARIEL_DB_PASSWORD", "owner-secret")
+    monkeypatch.setenv("ARIEL_DB_READONLY_PASSWORD", "ro-secret")
+
+    config = DatabaseConfig.from_dict({}, {"username": "ariel", "port_host": 5432})
+
+    assert config.uri == "postgresql://ariel:owner-secret@localhost:5432/ariel"
+    assert config.readonly_uri == "postgresql://ariel_ro:ro-secret@localhost:5432/ariel"
+
+
+@pytest.mark.unit
+def test_an_explicit_uri_leaves_no_readonly_identity() -> None:
+    """Recorded as absent rather than as a duplicate of the ingestion DSN: a
+    copy would silently connect the SQL tool as whatever the explicit URI names.
+    """
+    explicit = "postgresql://someone:else@logbook-db.example.org:5432/ariel"
+
+    config = DatabaseConfig.from_dict({"uri": explicit}, None)
+
+    assert config.uri == explicit
+    assert config.readonly_uri is None

--- a/tests/services/ariel_search/test_readonly_pool.py
+++ b/tests/services/ariel_search/test_readonly_pool.py
@@ -1,0 +1,251 @@
+"""The service opens a second, SELECT-only pool for the agent's raw-SQL path.
+
+``sql_query`` is auto-allowed and, before the read-only role existed, ran on the
+pool ingestion writes with — a superuser on every stack that deployed the
+bundled Postgres. ``BEGIN READ ONLY`` and the statement allowlist stay, but
+neither covers a server-side read such as ``pg_read_file()``; the privileges the
+connection holds do.
+
+The fallback is the part that has to keep working: a data volume older than the
+role has no ``_ro`` login, and a project pointing at a database osprey did not
+provision has no read-only identity at all. Both keep the tool on the ingestion
+pool — where it already was — and say so once, at start-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from osprey.services.ariel_search.config import ARIELConfig
+
+ARIEL_LOGGER = "ariel"
+
+
+def _config(**database: Any) -> ARIELConfig:
+    """An ARIEL config whose database block is whatever the test needs."""
+    return ARIELConfig.from_dict(
+        {"database": database, "ingestion": {"adapter": "generic_json"}},
+        {"username": "ariel", "database_name": "ariel", "port_host": 5432},
+    )
+
+
+@pytest.fixture
+def pool_factory(monkeypatch):
+    """Record every ``create_connection_pool`` call and hand back a stand-in.
+
+    Returns the list of ``(uri, max_size)`` pairs the service asked for, in
+    order, so a test can say which DSNs were dialed without a database.
+    """
+    calls: list[tuple[str, int]] = []
+
+    async def _fake_create_pool(config, *, uri=None, max_size=10):
+        calls.append((uri if uri is not None else config.uri, max_size))
+        return object()
+
+    import osprey.services.ariel_search.database.connection as conn_mod
+
+    monkeypatch.setattr(conn_mod, "create_connection_pool", _fake_create_pool)
+    monkeypatch.setattr(
+        "osprey.services.ariel_search.database.repository.ARIELRepository",
+        lambda pool, config: object(),
+    )
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def pinned_passwords(monkeypatch):
+    """Neither password may come from the developer's own shell."""
+    monkeypatch.setenv("ARIEL_DB_PASSWORD", "owner-secret")
+    monkeypatch.setenv("ARIEL_DB_READONLY_PASSWORD", "ro-secret")
+    for name in ("ARIEL_DATABASE_HOST", "ARIEL_DATABASE_PORT"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_derived_dsn_opens_both_pools(pool_factory):
+    """Two logins on one store, and the read-only one is the smaller pool: it
+    serves a single tool, not the search and ingestion traffic."""
+    from osprey.services.ariel_search.service import create_ariel_service
+
+    service = await create_ariel_service(_config())
+
+    assert pool_factory == [
+        ("postgresql://ariel:owner-secret@localhost:5432/ariel", 10),
+        ("postgresql://ariel_ro:ro-secret@localhost:5432/ariel", 3),
+    ]
+    assert service.readonly_pool is not None
+    assert service.readonly_pool is not service.pool
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_an_explicit_dsn_leaves_one_pool_and_one_warning(pool_factory, caplog):
+    """A database osprey did not provision has no ``_ro`` role to open."""
+    from osprey.services.ariel_search.service import create_ariel_service
+
+    explicit = "postgresql://someone:else@logbook-db.example.org:5432/ariel"
+    with caplog.at_level(logging.WARNING, logger=ARIEL_LOGGER):
+        service = await create_ariel_service(_config(uri=explicit))
+
+    assert pool_factory == [(explicit, 10)]
+    assert service.readonly_pool is None
+    assert "SQL tool is running on the ingestion role" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_refused_readonly_login_falls_back_and_says_so(monkeypatch, caplog):
+    """The shape an existing data volume has: the DSN resolves, the login does
+    not exist. The tool already ran on the ingestion connection before the role
+    existed, so this is a warning rather than a refusal to start.
+    """
+    calls: list[str] = []
+
+    async def _fake_create_pool(config, *, uri=None, max_size=10):
+        dialed = uri if uri is not None else config.uri
+        calls.append(dialed)
+        if uri is not None:
+            raise OSError('password authentication failed for user "ariel_ro"')
+        return object()
+
+    import osprey.services.ariel_search.database.connection as conn_mod
+
+    monkeypatch.setattr(conn_mod, "create_connection_pool", _fake_create_pool)
+    monkeypatch.setattr(
+        "osprey.services.ariel_search.database.repository.ARIELRepository",
+        lambda pool, config: object(),
+    )
+
+    from osprey.services.ariel_search.service import create_ariel_service
+
+    with caplog.at_level(logging.WARNING, logger=ARIEL_LOGGER):
+        service = await create_ariel_service(_config())
+
+    assert len(calls) == 2
+    assert service.readonly_pool is None
+    assert "SQL tool is running on the ingestion role" in caplog.text
+    assert "ariel_ro" in caplog.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_readonly_pool_is_closed_with_the_service(pool_factory):
+    """Both pools are the service's to close; leaking the smaller one would
+    hold idle connections on a store the process is done with."""
+
+    class _Pool:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    ingest, readonly = _Pool(), _Pool()
+
+    from osprey.services.ariel_search.service import ARIELSearchService
+
+    service = ARIELSearchService(
+        config=_config(),
+        pool=ingest,  # type: ignore[arg-type]
+        repository=object(),  # type: ignore[arg-type]
+        readonly_pool=readonly,  # type: ignore[arg-type]
+    )
+    async with service:
+        pass
+
+    assert ingest.closed
+    assert readonly.closed
+
+
+# ---------------------------------------------------------------------------
+# The two consumers that close the service by hand
+#
+# `async with service` closes both pools, but neither long-lived consumer uses
+# it: the MCP server builds the service directly so it can outlive one request,
+# and the capability path caches a module singleton. Whatever the context
+# manager would have done is theirs to do instead.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPool:
+    """Stands in for an ``AsyncConnectionPool`` that only has to be closed."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _service_with_two_pools() -> tuple[Any, _RecordingPool, _RecordingPool]:
+    from osprey.services.ariel_search.service import ARIELSearchService
+
+    ingest, readonly = _RecordingPool(), _RecordingPool()
+    service = ARIELSearchService(
+        config=_config(),
+        pool=ingest,  # type: ignore[arg-type]
+        repository=object(),  # type: ignore[arg-type]
+        readonly_pool=readonly,  # type: ignore[arg-type]
+    )
+    return service, ingest, readonly
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_the_mcp_context_shutdown_closes_both_pools():
+    """The server that hosts ``sql_query`` is the readonly pool's one consumer."""
+    from osprey.mcp_server.ariel.server_context import ARIELContext
+
+    service, ingest, readonly = _service_with_two_pools()
+    context = ARIELContext.__new__(ARIELContext)
+    context._service = service
+
+    await context.shutdown()
+
+    assert ingest.closed
+    assert readonly.closed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_closing_the_capability_singleton_closes_both_pools(monkeypatch):
+    """Same hand-rolled teardown, one module along."""
+    from osprey.services.ariel_search import capability
+
+    service, ingest, readonly = _service_with_two_pools()
+    monkeypatch.setattr(capability, "_ariel_service_instance", service)
+
+    await capability.close_ariel_service()
+
+    assert ingest.closed
+    assert readonly.closed
+    assert capability._ariel_service_instance is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a_single_pool_service_still_closes_cleanly(monkeypatch):
+    """A stack on the fallback has no readonly pool; neither teardown may trip."""
+    from osprey.mcp_server.ariel.server_context import ARIELContext
+    from osprey.services.ariel_search import capability
+    from osprey.services.ariel_search.service import ARIELSearchService
+
+    for close in ("context", "singleton"):
+        pool = _RecordingPool()
+        service = ARIELSearchService(
+            config=_config(),
+            pool=pool,  # type: ignore[arg-type]
+            repository=object(),  # type: ignore[arg-type]
+        )
+        if close == "context":
+            context = ARIELContext.__new__(ARIELContext)
+            context._service = service
+            await context.shutdown()
+        else:
+            monkeypatch.setattr(capability, "_ariel_service_instance", service)
+            await capability.close_ariel_service()
+        assert pool.closed

--- a/tests/templates/render_defaults/postgresql.yml
+++ b/tests/templates/render_defaults/postgresql.yml
@@ -58,9 +58,27 @@ services:
       # initializing a FRESH data volume; a pre-existing volume keeps its
       # original password until recreated.
       POSTGRES_PASSWORD: ${ARIEL_DB_PASSWORD:-ariel}
+      # The login secret for the SELECT-only role the initdb script below
+      # creates — the identity the agent's raw-SQL tool connects as, so a
+      # dangerous function it names is refused by the server instead of by a
+      # pattern match over the query text. Minted beside ARIEL_DB_PASSWORD by
+      # `osprey up` and read by the same derived-DSN path, one rung along. It is
+      # passed into the container rather than substituted into the mounted
+      # script because the script is rendered at build time and the secret lives
+      # in the project .env. Same fresh-volume caveat as POSTGRES_PASSWORD.
+      ARIEL_DB_READONLY_PASSWORD: ${ARIEL_DB_READONLY_PASSWORD:-ariel_ro}
       TZ: UTC
     volumes:
       - ariel_postgres_data:/var/lib/postgresql/data
+      # INITDB-ONLY: the entrypoint runs everything under this directory once,
+      # while it initializes a fresh data volume, and never looks at it again.
+      # So the read-only role arrives with a new store and a store that predates
+      # it keeps the role it has — the agent then falls back to the ingestion
+      # identity with one warning rather than failing to start. Adopting the
+      # role on an existing volume is the one-shot command in the
+      # "Read-only role for the SQL tool" section of the standalone-deployment
+      # how-to, which runs this same file by hand.
+      - ./build/services/postgresql/10-readonly-role.sh:/docker-entrypoint-initdb.d/10-readonly-role.sh:ro
     networks:
       # The container_name above is now per-project, but the ARIEL DSN
       # (`postgresql://ariel:ariel@ariel-postgres:5432/ariel`) hosts the stable


### PR DESCRIPTION
The agent's raw-SQL tool connects to the logbook as a SELECT-only Postgres role instead of the role ingestion writes with, and `ariel watch`/`ariel sync` refuse a config with no ingestion block by naming the block.

Commits:

- `feat(postgresql): create a read-only role on a fresh volume`
- `feat(deploy): mint ARIEL_DB_READONLY_PASSWORD beside ARIEL_DB_PASSWORD`
- `feat(ariel): the DSN resolver knows a readonly rung`
- `feat(ariel): the SQL tool queries through its own read-only pool`
- `fix(ariel): watch and sync name the missing ingestion block, not the adapter`

## Why

`sql_query` is auto-allowed and ran on the same pool ingestion writes with, whose DSN carries the `POSTGRES_USER` the official image creates as a superuser. `BEGIN READ ONLY` blocks writes but not server-side reads such as `pg_read_file()`, and the regex allowlist over query text can never enumerate every dangerous function — so the only line that holds is what privileges the connection has at all.

The store now creates a `<username>_ro` role while Postgres initializes a fresh data volume: LOGIN, NOSUPERUSER, and `SELECT` on the `public` schema plus default privileges for the owner, so the `enhanced_entries` table the migrations create and the `text_embeddings_*` tables an enhancement module adds later are readable with no second grant. `osprey up` mints its password as `ARIEL_DB_READONLY_PASSWORD` and it reaches persona containers through the same grant and passthrough the owner password uses. `resolve_ariel_dsn` gains a `role`, `DatabaseConfig` a `readonly_uri`, and the service a small second pool the SQL tool queries through.

A deployer whose stack predates this keeps working: a data volume with no `_ro` role, and a project naming a database OSPREY did not provision, both fall back to the ingestion pool with one warning at start-up. The standalone-deployment how-to has a one-shot command for adopting the role on an existing database without recreating the volume. The `_ro` name is derived from `services.postgresql.username`, so a facility that renamed its Postgres user gets a matching role with nothing to rename in a second file.

The last commit is unrelated to the role: a config with no `ingestion:` block at all reached a refusal naming `ariel.ingestion.adapter` — a key inside a block the operator never wrote, which reads as a typo in something they have. Both entry points now check for the block before the parse. A block that is present keeps today's adapter message.

## Not in this PR

- No runtime provisioning of the role, and no AST validator over SQL text: the init-script role was the ruled option, and the other two were rejected.
- No fail-closed flip. The tool already ran on the ingestion connection, so a store without the role keeps working rather than losing the tool.
- No new config key. The role name and its password variable are derived from `services.postgresql.username`, which already declares the owner.

## Notes for review

Two places outside the spec's file list had to move for the credential to reach its consumer, both mirroring what `ARIEL_DB_PASSWORD` already does: the `postgresql` entry in `_SERVICE_TOKEN_VARS` (nothing is minted without it), and the reach grant plus the per-user web-terminal passthrough (without those the deployed agent never sees the secret and every stack would fall back with a warning). The init template is `10-readonly-role.sh.j2` beside the compose template rather than under an `initdb/` subdirectory: the build renders only the `.j2` files sitting directly beside a service's compose file, and a `.sh` is used because the entrypoint feeds a `.sql` straight to psql, which does not expand `${VAR}`.
