### PR TITLE
test: grow the shipped-identity guard to the hosts and domain the sweep removed

### DIFF
--- a/changelog.d/example-identities.internal.md
+++ b/changelog.d/example-identities.internal.md
@@ -1,0 +1,3 @@
+Login and roster examples in the identity layer's docstrings and the multi-user
+how-to use placeholder domains and a placeholder facility. The upstream scout
+escalates to the project's issue tracker rather than a maintainer's mailbox.

--- a/docs/source/how-to/web-terminal/multi-user/index.rst
+++ b/docs/source/how-to/web-terminal/multi-user/index.rst
@@ -447,7 +447,7 @@ markdown file, listed in config:
        notices:
        - data/landing/working-safely.md
        - data/landing/local-procedures.md
-       footer: "ALS control room. Questions: ext. 5555."
+       footer: "Example Research Facility control room. Questions: ext. 5555."
 
 The file's first heading (``# Working safely with the agent``) becomes the
 section label, and everything after it becomes the panel. So adding a section

--- a/plugins/osprey/skills/install/SKILL.md
+++ b/plugins/osprey/skills/install/SKILL.md
@@ -76,7 +76,7 @@ Record candidates in `INTERVIEW.md` under `## Upstream candidates`, one entry ea
   status: open
 ```
 
-`status` may only be `open`, `scouting`, `filed <url>`, `emailed <date>`, `branch <name>`,
+`status` may only be `open`, `scouting`, `filed <url>`, `branch <name>`,
 `dropped`, `profile-local`, or `already-supported (<key>)` — and only the scout moves an
 entry beyond `open`/`dropped`.
 

--- a/plugins/osprey/skills/upstream-scout/SKILL.md
+++ b/plugins/osprey/skills/upstream-scout/SKILL.md
@@ -242,16 +242,19 @@ gh issue create -R als-apg/osprey --title "<title>" --label enhancement \
 ```
 
 On success set `status: filed <returned url>`; on failure show stderr and offer the
-email option.
+browser path below.
 
-### Email
+### Without `gh`
 
-Build a `mailto:` URL — recipient `thellert@lbl.gov`, subject
-`OSPREY upstream request — <title> (<facility>)`, body = the write-up as plain text,
-URL-encoded (space `%20`, newline `%0A`, `&` `%26`, `=` `%3D`, `#` `%23`). Open it
-with `open` (macOS) / `xdg-open` (Linux). If the URL exceeds ~2000 characters or no
-opener works (headless host), tell the user to send `upstream/<short-id>.md` to that
-address themselves. Then set `status: emailed <YYYY-MM-DD>`.
+The destination is the same tracker, reached in a browser: build
+`https://github.com/als-apg/osprey/issues/new` with `title` and `body` query
+parameters — the title as above, the body the write-up as plain text — URL-encoded
+(space `%20`, newline `%0A`, `&` `%26`, `=` `%3D`, `#` `%23`). Open it with `open`
+(macOS) / `xdg-open` (Linux). If the URL exceeds ~2000 characters or no opener works
+(headless host), give the user the bare
+`https://github.com/als-apg/osprey/issues/new` and tell them to paste
+`upstream/<short-id>.md` into it themselves. Set `status: filed <url>` once they have
+the issue URL; leave `status: open` if they do not file it now.
 
 ### Keep it local
 

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -3599,8 +3599,8 @@ def _check_duplicate_access_principals(
 
     * ``domain:`` under every claim, because the resolver ASCII-lower-cases the
       value and the login side folds the asserted domain the same way — so
-      ``domain:LBL.gov`` and ``domain:lbl.gov`` are one principal wherever they
-      are read, and the pair is invisible in the resolved set;
+      ``domain:EXAMPLE.org`` and ``domain:example.org`` are one principal
+      wherever they are read, and the pair is invisible in the resolved set;
     * ``user:`` byte-exact, and additionally without regard to case under an
       ``email`` claim — the fold
       :data:`~osprey.services.auth_sidecar.identity_headers.CASE_INSENSITIVE_CLAIMS`

--- a/src/osprey/registry/builtins.py
+++ b/src/osprey/registry/builtins.py
@@ -200,19 +200,19 @@ class FrameworkRegistryProvider(RegistryConfigProvider):
                     name="als_logbook",
                     module_path="osprey.services.ariel_search.ingestion.adapters.als",
                     class_name="ALSLogbookAdapter",
-                    description="ALS eLog adapter with JSONL streaming and HTTP API support",
+                    description="ALS eLog reference format: JSONL streaming and HTTP API support",
                 ),
                 ArielIngestionAdapterRegistration(
                     name="jlab_logbook",
                     module_path="osprey.services.ariel_search.ingestion.adapters.jlab",
                     class_name="JLabLogbookAdapter",
-                    description="Jefferson Lab logbook adapter",
+                    description="JLab logbook reference format",
                 ),
                 ArielIngestionAdapterRegistration(
                     name="ornl_logbook",
                     module_path="osprey.services.ariel_search.ingestion.adapters.ornl",
                     class_name="ORNLLogbookAdapter",
-                    description="Oak Ridge National Laboratory logbook adapter",
+                    description="ORNL logbook reference format",
                 ),
                 ArielIngestionAdapterRegistration(
                     name="generic_json",

--- a/src/osprey/services/auth_sidecar/app.py
+++ b/src/osprey/services/auth_sidecar/app.py
@@ -173,10 +173,10 @@ principal rather than a rule of its own.
 """
 
 ACCESS_USER_PREFIX = "user:"
-"""Prefix of a principal naming one asserted identity: ``user:carol@lbl.gov``."""
+"""Prefix of a principal naming one asserted identity: ``user:carol@example.org``."""
 
 ACCESS_DOMAIN_PREFIX = "domain:"
-"""Prefix of a principal naming an identity domain: ``domain:lbl.gov``."""
+"""Prefix of a principal naming an identity domain: ``domain:example.org``."""
 
 OWNER_ONLY: frozenset[str] = frozenset({ACCESS_SELF})
 """The resolved set of an unshared card, and the reading an absent variable gets."""

--- a/src/osprey/services/auth_sidecar/identity_headers.py
+++ b/src/osprey/services/auth_sidecar/identity_headers.py
@@ -216,12 +216,13 @@ def same_domain(identity: str, domain: str) -> bool:
     5321 leaves its interpretation to the destination host, so ``Alice`` and
     ``alice`` are the same person only if that host says so.
 
-    The match is exact, never by suffix. ``lbl.gov`` admits ``alice@lbl.gov``
-    and refuses ``alice@als.lbl.gov``: a rule that admitted subdomains would
-    hand every host under a domain the grant its operator wrote for one, and a
-    subdomain is often delegated to someone else entirely. A trailing dot is a
-    different string and so is a different domain here; the resolver refuses
-    it at author time, so it never reaches this comparator.
+    The match is exact, never by suffix. ``example.org`` admits
+    ``alice@example.org`` and refuses ``alice@sub.example.org``: a rule that
+    admitted subdomains would hand every host under a domain the grant its
+    operator wrote for one, and a subdomain is often delegated to someone else
+    entirely. A trailing dot is a different string and so is a different domain
+    here; the resolver refuses it at author time, so it never reaches this
+    comparator.
 
     Both sides are folded with :data:`_ASCII_LOWER` rather than
     ``str.lower()``, which is what keeps this comparator in step with the fold

--- a/tests/cli/test_provider_isolation.py
+++ b/tests/cli/test_provider_isolation.py
@@ -693,18 +693,18 @@ class TestSpendAttributionEnv:
         assert spec.gateway == "litellm"
 
     def test_inject_sets_identity_headers_for_gateway(self, monkeypatch):
-        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "alice")
         spec = ClaudeCodeModelResolver.resolve({"provider": "als-apg"}, _ALS_APG)
         environ = {"ALS_APG_API_KEY": "sk-secret"}
 
         inject_provider_env(environ, spec)
 
         assert environ["ANTHROPIC_CUSTOM_HEADERS"] == (
-            "x-litellm-end-user-id: thellert\nx-litellm-tags: osprey,surface:terminal"
+            "x-litellm-end-user-id: alice\nx-litellm-tags: osprey,surface:terminal"
         )
 
     def test_inject_keeps_operator_headers(self, monkeypatch):
-        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "alice")
         spec = ClaudeCodeModelResolver.resolve({"provider": "cborg"})
         environ = {
             "CBORG_API_KEY": "sk-secret",
@@ -715,10 +715,10 @@ class TestSpendAttributionEnv:
 
         lines = environ["ANTHROPIC_CUSTOM_HEADERS"].splitlines()
         assert lines[0] == "X-Corp-Trace: abc123"
-        assert "x-litellm-end-user-id: thellert" in lines
+        assert "x-litellm-end-user-id: alice" in lines
 
     def test_inject_leaves_direct_provider_alone(self, monkeypatch):
-        monkeypatch.setenv("OSPREY_TERMINAL_USER", "thellert")
+        monkeypatch.setenv("OSPREY_TERMINAL_USER", "alice")
         spec = ClaudeCodeModelResolver.resolve({"provider": "anthropic"})
         environ = {"ANTHROPIC_API_KEY": "secret-123"}
 

--- a/tests/cli/test_set_verb.py
+++ b/tests/cli/test_set_verb.py
@@ -242,7 +242,10 @@ def test_no_facility_gateway_addresses_are_shipped():
     """Core carries no table of named facilities' gateway hostnames."""
     import osprey.templates as templates_pkg
 
-    assert not (Path(templates_pkg.__file__).parent / "data").exists()
+    # A stale ``__pycache__`` from a checkout that still had the table leaves the
+    # directory behind with no source in it; the guard is about shipped source.
+    data_dir = Path(templates_pkg.__file__).parent / "data"
+    assert not data_dir.exists() or not any(data_dir.rglob("*.py")), sorted(data_dir.rglob("*.py"))
 
 
 def test_tier_is_a_settable_key(runner, lifecycle_repo):

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -48,7 +48,7 @@ _CLEAN_CONFIG = {
             "artifact_base_port": default_port("artifact", 0, base=_OVERRIDE_PORT_BASE),
             "ariel_base_port": default_port("ariel", 0, base=_OVERRIDE_PORT_BASE),
             "lattice_base_port": default_port("lattice", 0, base=_OVERRIDE_PORT_BASE),
-            "users": ["thellert", "gmartino"],
+            "users": ["alice", "bob"],
         },
     },
 }
@@ -84,7 +84,7 @@ def test_lint_duplicate_user_is_an_error() -> None:
     """Repeating a username breaks the one-service-per-user invariant."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["thellert", "thellert"]
+    config["modules"]["web_terminals"]["users"] = ["alice", "alice"]
 
     # Act
     findings = lint_web_terminals(config)
@@ -208,7 +208,7 @@ def test_lint_username_matching_a_service_name_is_not_an_error() -> None:
     """
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["nginx", "gmartino"]
+    config["modules"]["web_terminals"]["users"] = ["nginx", "bob"]
 
     # Act
     findings = lint_web_terminals(config)
@@ -225,7 +225,7 @@ def test_lint_username_matching_a_service_audit_identity_is_an_error(name: str) 
     same rejection at scaffold time, before a deploy is attempted."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [name, "gmartino"]
+    config["modules"]["web_terminals"]["users"] = [name, "bob"]
 
     # Act
     findings = lint_web_terminals(config)
@@ -287,8 +287,8 @@ def test_lint_roster_index_past_the_family_band_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": INDEX_MAX + 1},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": INDEX_MAX + 1},
     ]
 
     # Act
@@ -310,8 +310,8 @@ def test_lint_roster_filling_the_family_band_is_not_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": INDEX_MAX},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": INDEX_MAX},
     ]
 
     # Act
@@ -342,7 +342,7 @@ def test_lint_username_bad_charset_is_an_error() -> None:
     ``^[a-z0-9][a-z0-9_-]*$``."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["Bad_User", "gmartino"]
+    config["modules"]["web_terminals"]["users"] = ["Bad_User", "bob"]
 
     # Act
     findings = lint_web_terminals(config)
@@ -442,8 +442,8 @@ def test_lint_duplicate_explicit_index_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": 0},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": 0},
     ]
 
     # Act
@@ -459,8 +459,8 @@ def test_lint_distinct_explicit_indices_are_not_a_duplicate_index_error() -> Non
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": 1},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": 1},
     ]
 
     # Act
@@ -475,7 +475,7 @@ def test_lint_missing_index_on_object_form_user_is_an_error() -> None:
     """An object-form entry with no `index` key at all is invalid."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert"}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -489,7 +489,7 @@ def test_lint_non_integer_index_is_an_error() -> None:
     """A string index (e.g. from a hand-edited YAML) is not a valid port offset."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": "0"}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": "0"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -503,7 +503,7 @@ def test_lint_boolean_index_is_an_error() -> None:
     """`bool` is an `int` subclass in Python, but `index: true`/`false` is invalid."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": True}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": True}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -517,7 +517,7 @@ def test_lint_negative_index_is_an_error() -> None:
     """A negative index can't resolve to a real port offset."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": -1}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": -1}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -532,8 +532,8 @@ def test_lint_valid_object_form_users_report_no_index_errors() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": 1},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": 1},
     ]
 
     # Act
@@ -551,7 +551,7 @@ def test_lint_non_string_display_name_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "display_name": ["not", "a", "string"]}
+        {"name": "alice", "index": 0, "display_name": ["not", "a", "string"]}
     ]
 
     # Act
@@ -567,8 +567,8 @@ def test_lint_string_display_name_reports_no_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "display_name": "Operations"},
-        {"name": "gmartino", "index": 1},  # no display_name at all is equally fine
+        {"name": "alice", "index": 0, "display_name": "Operations"},
+        {"name": "bob", "index": 1},  # no display_name at all is equally fine
     ]
 
     # Act
@@ -591,7 +591,7 @@ def test_lint_has_no_rule_about_the_retired_login_key(method: str) -> None:
     # Arrange
     config = _auth_config({"method": method, "allow_insecure_http": True}, tls=False, fqdn=None)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "login": True},
+        {"name": "alice", "index": 0, "login": True},
         {"name": "ariel", "index": 1, "login": False},
         {"name": "kiosk", "index": 2, "login": "false"},
     ]
@@ -610,9 +610,7 @@ def test_lint_non_literal_user_access_is_an_error() -> None:
     — so the typo is an ERROR rather than a silent narrowing."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "maybe"}
-    ]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": "maybe"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -626,9 +624,7 @@ def test_lint_wrong_case_user_access_is_an_error() -> None:
     so lint must call the spelling out."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "ANY"}
-    ]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": "ANY"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -642,7 +638,7 @@ def test_lint_boolean_user_access_is_an_error() -> None:
     a principal list, and deploys as `own` — an ERROR, not a widened entry."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "access": True}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": True}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -656,7 +652,7 @@ def test_lint_user_access_skips_non_dict_entries() -> None:
     key — the check skips them without crashing and reports nothing."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["thellert", 42]
+    config["modules"]["web_terminals"]["users"] = ["alice", 42]
 
     # Act
     findings = lint_web_terminals(config)
@@ -674,9 +670,7 @@ def test_lint_access_any_without_sidecar_is_silent() -> None:
     entry, exactly where `oidc_subject` already sits silently."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "any"}
-    ]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": "any"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -690,9 +684,7 @@ def test_lint_access_any_under_auth_none_is_silent() -> None:
     tunnel-only posture is the usual passive base an `sso` variant arms."""
     # Arrange
     config = _auth_config({"method": "none"}, tls=False, fqdn=None)
-    config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "any"}
-    ]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": "any"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -712,7 +704,7 @@ def test_lint_access_any_beside_the_retired_login_key_is_not_inert() -> None:
     web_terminals = config["modules"]["web_terminals"]
     web_terminals["auth"] = {"method": "password", "allow_insecure_http": True}
     web_terminals["users"] = [
-        {"name": "thellert", "index": 0, "access": "any", "login": False},
+        {"name": "alice", "index": 0, "access": "any", "login": False},
     ]
 
     # Act
@@ -729,7 +721,7 @@ def test_lint_access_any_under_walled_auth_reports_nothing() -> None:
     config = copy.deepcopy(_CLEAN_CONFIG)
     web_terminals = config["modules"]["web_terminals"]
     web_terminals["auth"] = {"method": "password", "allow_insecure_http": True}
-    web_terminals["users"] = [{"name": "thellert", "index": 0, "access": "any"}]
+    web_terminals["users"] = [{"name": "alice", "index": 0, "access": "any"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -744,9 +736,7 @@ def test_lint_explicit_access_own_reports_nothing() -> None:
     the normalizer drops it."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "own"}
-    ]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": "own"}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -779,9 +769,7 @@ def test_lint_well_formed_access_principal_lists_report_nothing(access: list[str
     sugar for — lint accepts every member kind the resolver does."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": access}
-    ]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": access}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -795,7 +783,7 @@ def test_lint_null_user_access_is_silent() -> None:
     out: the resolver reads it as the entry's own login, so lint stays silent."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "access": None}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": None}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -809,7 +797,7 @@ def test_lint_empty_access_list_is_an_error() -> None:
     so it is refused with the entry named."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "access": []}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "access": []}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -817,7 +805,7 @@ def test_lint_empty_access_list_is_an_error() -> None:
     # Assert
     offenders = [f for f in _errors(findings) if f.code == "web_terminals.invalid_user_access"]
     assert len(offenders) == 1
-    assert "'thellert'" in offenders[0].message
+    assert "'alice'" in offenders[0].message
     assert "empty access list" in offenders[0].message
 
 
@@ -827,7 +815,7 @@ def test_lint_unknown_access_prefix_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["team:controls"]}
+        {"name": "alice", "index": 0, "access": ["team:controls"]}
     ]
 
     # Act
@@ -846,7 +834,7 @@ def test_lint_non_string_access_member_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["self", 42]}
+        {"name": "alice", "index": 0, "access": ["self", 42]}
     ]
 
     # Act
@@ -855,7 +843,7 @@ def test_lint_non_string_access_member_is_an_error() -> None:
     # Assert
     offenders = [f for f in _errors(findings) if f.code == "web_terminals.invalid_user_access"]
     assert len(offenders) == 1
-    assert "'thellert'" in offenders[0].message
+    assert "'alice'" in offenders[0].message
     assert "not a string" in offenders[0].message
 
 
@@ -866,7 +854,7 @@ def test_lint_group_access_member_says_not_supported_yet() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["group:operators"]}
+        {"name": "alice", "index": 0, "access": ["group:operators"]}
     ]
 
     # Act
@@ -886,7 +874,7 @@ def test_lint_bare_access_word_outside_the_vocabulary_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["everyone"]}
+        {"name": "alice", "index": 0, "access": ["everyone"]}
     ]
 
     # Act
@@ -906,7 +894,7 @@ def test_lint_user_access_member_with_whitespace_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["user:alice smith@lbl.gov"]}
+        {"name": "alice", "index": 0, "access": ["user:alice smith@lbl.gov"]}
     ]
 
     # Act
@@ -926,7 +914,7 @@ def test_lint_domain_access_member_holding_an_address_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["domain:alice@lbl.gov"]}
+        {"name": "alice", "index": 0, "access": ["domain:alice@lbl.gov"]}
     ]
 
     # Act
@@ -948,7 +936,7 @@ def test_lint_access_member_carrying_a_dollar_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["user:$ALICE@lbl.gov"]}
+        {"name": "alice", "index": 0, "access": ["user:$ALICE@lbl.gov"]}
     ]
 
     # Act
@@ -967,7 +955,7 @@ def test_lint_malformed_access_reports_one_finding_per_entry() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": ["group:operators"]},
+        {"name": "alice", "index": 0, "access": ["group:operators"]},
         {"name": "ariel", "index": 1, "access": "maybe"},
         {"name": "control", "index": 2, "access": ["domain:lbl.gov"]},
     ]
@@ -978,7 +966,7 @@ def test_lint_malformed_access_reports_one_finding_per_entry() -> None:
     # Assert
     offenders = [f for f in _errors(findings) if f.code == "web_terminals.invalid_user_access"]
     assert len(offenders) == 2
-    assert any("'thellert'" in f.message for f in offenders)
+    assert any("'alice'" in f.message for f in offenders)
     assert any("'ariel'" in f.message for f in offenders)
 
 
@@ -988,7 +976,7 @@ def test_lint_non_string_user_theme_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "theme": {"family": "desy"}}
+        {"name": "alice", "index": 0, "theme": {"family": "desy"}}
     ]
 
     # Act
@@ -1004,8 +992,8 @@ def test_lint_string_user_theme_reports_no_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "theme": "desy"},
-        {"name": "gmartino", "index": 1, "theme": "desy-light"},
+        {"name": "alice", "index": 0, "theme": "desy"},
+        {"name": "bob", "index": 1, "theme": "desy-light"},
         {"name": "aallezy", "index": 2},  # no theme at all is equally fine
     ]
 
@@ -1027,7 +1015,7 @@ def test_lint_does_not_validate_the_theme_name_itself() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "theme": "no-such-theme"}
+        {"name": "alice", "index": 0, "theme": "no-such-theme"}
     ]
 
     # Act
@@ -1042,7 +1030,7 @@ def test_lint_non_string_user_tour_reports_error() -> None:
     renderer would drop it silently otherwise."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0, "tour": False}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0, "tour": False}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1058,8 +1046,8 @@ def test_lint_does_not_validate_the_tour_word_itself() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "tour": "always"},
-        {"name": "gmartino", "index": 1, "tour": "sometimes"},  # unknown word, still a string
+        {"name": "alice", "index": 0, "tour": "always"},
+        {"name": "bob", "index": 1, "tour": "sometimes"},  # unknown word, still a string
         {"name": "aallezy", "index": 2},  # no tour at all is equally fine
     ]
 
@@ -1074,7 +1062,7 @@ def test_lint_bare_multi_user_list_warns_about_port_drift_risk() -> None:
     """A legacy bare list with >1 user risks positional port drift on decommission."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["thellert", "gmartino"]
+    config["modules"]["web_terminals"]["users"] = ["alice", "bob"]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1088,7 +1076,7 @@ def test_lint_bare_single_user_list_does_not_warn_about_port_drift_risk() -> Non
     """A single-user bare list has no positional drift risk to warn about."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["thellert"]
+    config["modules"]["web_terminals"]["users"] = ["alice"]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1103,8 +1091,8 @@ def test_lint_explicit_index_roster_does_not_warn_about_port_drift_risk() -> Non
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": 1},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": 1},
     ]
 
     # Act
@@ -1120,7 +1108,7 @@ def test_lint_mixed_roster_does_not_crash_and_does_not_warn_about_port_drift_ris
     is exempt from the bare-list drift warning (it isn't a pure legacy list)."""
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
-    config["modules"]["web_terminals"]["users"] = ["thellert", {"name": "gmartino", "index": 1}]
+    config["modules"]["web_terminals"]["users"] = ["alice", {"name": "bob", "index": 1}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1150,8 +1138,8 @@ def test_lint_object_form_valid_name_reports_no_charset_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": 1},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": 1},
     ]
 
     # Act
@@ -1168,8 +1156,8 @@ def test_lint_object_form_duplicate_name_is_still_a_duplicate_user_error() -> No
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "thellert", "index": 1},
+        {"name": "alice", "index": 0},
+        {"name": "alice", "index": 1},
     ]
 
     # Act
@@ -1195,8 +1183,8 @@ def test_lint_clean_persona_catalog_reports_no_error_findings() -> None:
     }
     config["modules"]["web_terminals"]["default_persona"] = "assistant"
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0},
-        {"name": "gmartino", "index": 1, "persona": "analysis"},
+        {"name": "alice", "index": 0},
+        {"name": "bob", "index": 1, "persona": "analysis"},
     ]
 
     # Act
@@ -1213,7 +1201,7 @@ def test_lint_unknown_explicit_persona_reference_is_an_error() -> None:
     config["modules"]["web_terminals"]["personas"] = {"assistant": {"project": "als-assistant"}}
     config["modules"]["web_terminals"]["default_persona"] = "assistant"
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "persona": "ghost"}
+        {"name": "alice", "index": 0, "persona": "ghost"}
     ]
 
     # Act
@@ -1223,7 +1211,7 @@ def test_lint_unknown_explicit_persona_reference_is_an_error() -> None:
     errors = _errors(findings)
     unknown_ref = [f for f in errors if f.code == "web_terminals.unknown_persona_reference"]
     assert unknown_ref
-    assert any("thellert" in f.message and "ghost" in f.message for f in unknown_ref)
+    assert any("alice" in f.message and "ghost" in f.message for f in unknown_ref)
 
 
 def test_lint_unknown_inherited_default_persona_reference_is_an_error() -> None:
@@ -1233,7 +1221,7 @@ def test_lint_unknown_inherited_default_persona_reference_is_an_error() -> None:
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"assistant": {"project": "als-assistant"}}
     config["modules"]["web_terminals"]["default_persona"] = "ghost"
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1249,7 +1237,7 @@ def test_lint_default_persona_not_in_catalog_is_an_error() -> None:
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"assistant": {"project": "als-assistant"}}
     config["modules"]["web_terminals"]["default_persona"] = "ghost"
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1268,7 +1256,7 @@ def test_lint_default_persona_in_catalog_reports_no_error() -> None:
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"assistant": {"project": "als-assistant"}}
     config["modules"]["web_terminals"]["default_persona"] = "assistant"
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1284,7 +1272,7 @@ def test_lint_persona_catalog_bad_charset_is_an_error() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"Bad Persona": {"project": "als-x"}}
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1300,7 +1288,7 @@ def test_lint_persona_charset_rejects_a_trailing_newline() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"ops\n": {"project": "als-x"}}
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1319,7 +1307,7 @@ def test_lint_persona_named_after_a_service_is_not_an_error() -> None:
     config["modules"]["web_terminals"]["personas"] = {"nginx": {"project": "als-x"}}
     config["modules"]["web_terminals"]["default_persona"] = "nginx"
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "persona": "nginx"}
+        {"name": "alice", "index": 0, "persona": "nginx"}
     ]
 
     # Act
@@ -1338,7 +1326,7 @@ def test_lint_persona_seed_base_non_bool_is_an_error() -> None:
     config["modules"]["web_terminals"]["personas"] = {
         "standalone": {"project": "als-x", "seed_base": "false"}
     }
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1356,7 +1344,7 @@ def test_lint_persona_seed_base_bool_is_accepted() -> None:
         "keep": {"project": "als-keep", "seed_base": True},
         "drop": {"project": "als-drop", "seed_base": False},
     }
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1370,7 +1358,7 @@ def test_lint_persona_seed_base_absent_is_accepted() -> None:
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["personas"] = {"plain": {"project": "als-x"}}
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
 
     # Act
     findings = lint_web_terminals(config)
@@ -1414,7 +1402,7 @@ def _persona_config(**overrides: object) -> dict:
         "assistant": {"project": "als-assistant"},
     }
     config["modules"]["web_terminals"]["default_persona"] = "assistant"
-    config["modules"]["web_terminals"]["users"] = [{"name": "thellert", "index": 0}]
+    config["modules"]["web_terminals"]["users"] = [{"name": "alice", "index": 0}]
     config["modules"]["web_terminals"].update(web_terminals_overrides)
     if registry_overrides is not None:
         config["registry"] = registry_overrides
@@ -2182,8 +2170,8 @@ def test_lint_registry_mode_non_default_persona_without_build_profile_is_an_erro
                 "analysis": {"project": "als-analysis"},
             },
             "users": [
-                {"name": "thellert", "index": 0},
-                {"name": "gmartino", "index": 1, "persona": "analysis"},
+                {"name": "alice", "index": 0},
+                {"name": "bob", "index": 1, "persona": "analysis"},
             ],
         },
         registry={"url": "registry.example.org:5050"},
@@ -2226,8 +2214,8 @@ def test_lint_registry_mode_non_default_persona_with_build_profile_reports_no_er
                 },
             },
             "users": [
-                {"name": "thellert", "index": 0},
-                {"name": "gmartino", "index": 1, "persona": "analysis"},
+                {"name": "alice", "index": 0},
+                {"name": "bob", "index": 1, "persona": "analysis"},
             ],
         },
         registry={"url": "registry.example.org:5050"},
@@ -3338,8 +3326,8 @@ def test_lint_auth_oidc_subject_with_dollar_is_an_error() -> None:
         {"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}},
     )
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "oidc_subject": "user$123@example.org"},
-        {"name": "gmartino", "oidc_subject": "gmartino@example.org"},
+        {"name": "alice", "oidc_subject": "user$123@example.org"},
+        {"name": "bob", "oidc_subject": "bob@example.org"},
     ]
 
     # Act
@@ -3349,8 +3337,8 @@ def test_lint_auth_oidc_subject_with_dollar_is_an_error() -> None:
     errors = _errors(findings)
     offenders = [f for f in errors if f.code == "web_terminals.auth_oidc_subject_unsafe"]
     assert len(offenders) == 1
-    assert "'thellert'" in offenders[0].message
-    assert "gmartino" not in offenders[0].message
+    assert "'alice'" in offenders[0].message
+    assert "bob" not in offenders[0].message
 
 
 def test_lint_auth_oidc_clean_subjects_report_no_subject_finding() -> None:
@@ -3360,8 +3348,8 @@ def test_lint_auth_oidc_clean_subjects_report_no_subject_finding() -> None:
         {"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}},
     )
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "oidc_subject": "8f14e45f-ceea-4a5c-9c76-01dd8f7f56a2"},
-        {"name": "gmartino", "oidc_subject": "gmartino@example.org"},
+        {"name": "alice", "oidc_subject": "8f14e45f-ceea-4a5c-9c76-01dd8f7f56a2"},
+        {"name": "bob", "oidc_subject": "bob@example.org"},
     ]
 
     # Act
@@ -3378,7 +3366,7 @@ def test_lint_auth_oidc_subject_check_is_mode_gated() -> None:
     # Arrange
     config = _auth_config({"method": "password"})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "oidc_subject": "user$123@example.org"},
+        {"name": "alice", "oidc_subject": "user$123@example.org"},
     ]
 
     # Act
@@ -3469,8 +3457,8 @@ def test_lint_duplicate_subject_with_a_shared_card_is_an_error() -> None:
     # Arrange
     config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
-        {"name": "thellert-admin", "index": 1, "oidc_subject": " thorsten@example.org "},
+        {"name": "alice", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice-admin", "index": 1, "oidc_subject": " thorsten@example.org "},
         {"name": "control", "index": 2, "access": "any"},
     ]
 
@@ -3482,8 +3470,8 @@ def test_lint_duplicate_subject_with_a_shared_card_is_an_error() -> None:
         f for f in _errors(findings) if f.code == "web_terminals.shared_card_duplicate_subject"
     ]
     assert len(offenders) == 1
-    assert "thellert" in offenders[0].message
-    assert "thellert-admin" in offenders[0].message
+    assert "alice" in offenders[0].message
+    assert "alice-admin" in offenders[0].message
     assert "control" not in offenders[0].message
     assert "ambiguous_identity" in offenders[0].message
     assert "one of them only" in offenders[0].message
@@ -3499,8 +3487,8 @@ def test_lint_duplicate_email_subjects_differing_only_in_case_are_an_error() -> 
         {"method": "oidc", "oidc": {"issuer": "https://idp.example.org", "claim": "email"}}
     )
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "THellert@lbl.gov"},
-        {"name": "thellert-admin", "index": 1, "oidc_subject": "thellert@lbl.gov"},
+        {"name": "alice", "index": 0, "oidc_subject": "Alice@lbl.gov"},
+        {"name": "alice-admin", "index": 1, "oidc_subject": "alice@lbl.gov"},
         {"name": "control", "index": 2, "access": "any"},
     ]
 
@@ -3512,8 +3500,8 @@ def test_lint_duplicate_email_subjects_differing_only_in_case_are_an_error() -> 
         f for f in _errors(findings) if f.code == "web_terminals.shared_card_duplicate_subject"
     ]
     assert len(offenders) == 1
-    assert "thellert" in offenders[0].message
-    assert "thellert-admin" in offenders[0].message
+    assert "alice" in offenders[0].message
+    assert "alice-admin" in offenders[0].message
 
 
 def test_lint_sub_subjects_differing_only_in_case_are_distinct() -> None:
@@ -3522,8 +3510,8 @@ def test_lint_sub_subjects_differing_only_in_case_are_distinct() -> None:
     # Arrange
     config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "IDP|Thorsten"},
-        {"name": "thellert-admin", "index": 1, "oidc_subject": "idp|thorsten"},
+        {"name": "alice", "index": 0, "oidc_subject": "IDP|Thorsten"},
+        {"name": "alice-admin", "index": 1, "oidc_subject": "idp|thorsten"},
         {"name": "control", "index": 2, "access": "any"},
     ]
 
@@ -3541,8 +3529,8 @@ def test_lint_duplicate_subject_without_a_shared_card_reports_nothing() -> None:
     # Arrange
     config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
-        {"name": "thellert-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
     ]
 
     # Act
@@ -3558,8 +3546,8 @@ def test_lint_distinct_subjects_with_a_shared_card_report_nothing() -> None:
     # Arrange
     config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
-        {"name": "gmartino", "index": 1, "oidc_subject": "gmartino@example.org"},
+        {"name": "alice", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "bob", "index": 1, "oidc_subject": "bob@example.org"},
         {"name": "control", "index": 2, "access": "any"},
     ]
 
@@ -3580,8 +3568,8 @@ def test_lint_shared_card_with_a_subject_is_a_warning() -> None:
     # Arrange
     config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "any", "oidc_subject": "thorsten@example.org"},
-        {"name": "gmartino", "index": 1, "oidc_subject": "gmartino@example.org"},
+        {"name": "alice", "index": 0, "access": "any", "oidc_subject": "thorsten@example.org"},
+        {"name": "bob", "index": 1, "oidc_subject": "bob@example.org"},
     ]
 
     # Act
@@ -3590,8 +3578,8 @@ def test_lint_shared_card_with_a_subject_is_a_warning() -> None:
     # Assert
     offenders = [f for f in _warnings(findings) if f.code == "web_terminals.shared_card_subject"]
     assert len(offenders) == 1
-    assert "'thellert'" in offenders[0].message
-    assert "'gmartino'" not in offenders[0].message
+    assert "'alice'" in offenders[0].message
+    assert "'bob'" not in offenders[0].message
     assert "thorsten@example.org" not in offenders[0].message
     # The authored value, quoted as written — the sugar form reaches this rule
     # through the same predicate every list-valued card does.
@@ -3607,7 +3595,7 @@ def test_lint_shared_card_with_a_blank_subject_reports_nothing() -> None:
     config = _auth_config({"method": "oidc", "oidc": {"issuer": "https://idp.example.org"}})
     config["modules"]["web_terminals"]["users"] = [
         {"name": "control", "index": 0, "access": "any", "oidc_subject": "  "},
-        {"name": "gmartino", "index": 1, "oidc_subject": "gmartino@example.org"},
+        {"name": "bob", "index": 1, "oidc_subject": "bob@example.org"},
     ]
 
     # Act
@@ -3625,7 +3613,7 @@ def test_lint_shared_card_subject_check_is_mode_gated() -> None:
     # Arrange
     config = _auth_config({"method": "none"}, tls=False, fqdn=None)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "access": "any", "oidc_subject": "thorsten@example.org"},
+        {"name": "alice", "index": 0, "access": "any", "oidc_subject": "thorsten@example.org"},
     ]
 
     # Act
@@ -3641,8 +3629,8 @@ def test_lint_duplicate_subject_check_is_mode_gated() -> None:
     # Arrange
     config = _auth_config({"method": "password"})
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
-        {"name": "thellert-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
         {"name": "control", "index": 2, "access": "any"},
     ]
 
@@ -4057,8 +4045,8 @@ def test_lint_duplicate_subject_gate_sees_a_list_valued_shared_card() -> None:
     # Arrange
     config = _auth_config(_oidc(claim="email"))
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "oidc_subject": "thorsten@example.org"},
-        {"name": "thellert-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice", "index": 0, "oidc_subject": "thorsten@example.org"},
+        {"name": "alice-admin", "index": 1, "oidc_subject": "thorsten@example.org"},
         {"name": "logbook", "index": 2, "access": ["domain:lbl.gov"]},
     ]
 
@@ -4068,7 +4056,7 @@ def test_lint_duplicate_subject_gate_sees_a_list_valued_shared_card() -> None:
     # Assert
     offenders = _coded(_errors(findings), "shared_card_duplicate_subject")
     assert len(offenders) == 1
-    assert "'thellert'" in offenders[0].message
+    assert "'alice'" in offenders[0].message
 
 
 # --- profile altitude: the same engine over a build profile's `config:` block -
@@ -4584,7 +4572,7 @@ def _role_config(role_persona: str, *, catalog: dict | None = None) -> dict:
     """A clean config whose sole roster entry reaches its persona through a role."""
     config = copy.deepcopy(_CLEAN_CONFIG)
     web = config["modules"]["web_terminals"]
-    web["users"] = [{"name": "thellert", "index": 0, "role": "operator"}]
+    web["users"] = [{"name": "alice", "index": 0, "role": "operator"}]
     web["authorization"] = {"roles": {"operator": {"persona": role_persona}}}
     if catalog is not None:
         web["personas"] = catalog
@@ -4658,7 +4646,7 @@ def test_lint_conflicting_persona_and_role_survives_an_undeclared_role() -> None
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "persona": "cli", "role": "nope"}
+        {"name": "alice", "index": 0, "persona": "cli", "role": "nope"}
     ]
 
     # Act
@@ -4723,7 +4711,7 @@ def test_lint_a_roster_role_under_oidc_is_not_reported_as_inert() -> None:
     # Arrange
     config = _auth_config({"method": "oidc"})
     web = config["modules"]["web_terminals"]
-    web["users"] = [{"name": "thellert", "index": 0, "role": "operator"}]
+    web["users"] = [{"name": "alice", "index": 0, "role": "operator"}]
     web["authorization"] = {"roles": {"operator": {"persona": "cli"}}}
 
     # Act
@@ -4740,7 +4728,7 @@ def test_lint_does_not_raise_on_an_incoherent_authorization_stanza_with_roles() 
     # Arrange
     config = copy.deepcopy(_CLEAN_CONFIG)
     config["modules"]["web_terminals"]["users"] = [
-        {"name": "thellert", "index": 0, "role": "operator"}
+        {"name": "alice", "index": 0, "role": "operator"}
     ]
     config["modules"]["web_terminals"]["authorization"] = {"roles": {"operator": {}}}
 
@@ -4781,7 +4769,7 @@ def _open_mode_config(tmp_path, *, method: str = "none", deny: list[str] | None 
         web_terminals={
             "image_source": "local",
             "auth": {"method": method},
-            "users": [{"name": "thellert", "index": 0, "persona": "assistant"}],
+            "users": [{"name": "alice", "index": 0, "persona": "assistant"}],
             "personas": {
                 "assistant": {"project": "als-assistant", "project_path": str(project_dir)}
             },

--- a/tests/docs/test_shipped_identity_literals.py
+++ b/tests/docs/test_shipped_identity_literals.py
@@ -13,8 +13,8 @@ institution or site. Magnitudes stay — "~135,000 documents", "~41 minutes" —
 because they are facts about the software's behaviour rather than about whose
 machine produced them. Examples use the placeholder cast the roster
 documentation already uses: ``alice`` and ``carol`` at ``example.org``, a
-facility called *Example Research Facility*, a ``simulation`` gateway, a
-project at ``~/my-assistant``.
+facility called *Example Research Facility*, a gateway written as its own
+dotted keys (``gw.example.org``), a project at ``~/my-assistant``.
 
 Removing a literal is a one-line edit; keeping it removed is what needs a
 guard, because every new pull request is an opportunity to add one back and
@@ -23,15 +23,18 @@ nothing else would notice.
 **The list grows.** It starts at what has actually been swept out of the tree,
 because a pattern that fires on the current tree is not a guard, it is a
 failing test. As each remaining literal is removed, its pattern joins
-:data:`DENIED` in the same change that removes it: ``lbl.gov``,
-``\\bALS\\b`` and ``ALS-U`` outside the simulation and virtual-accelerator
-packages, ``BELLA``, ``GEECS``.
+:data:`DENIED` in the same change that removes it. ``lbl.gov``, ``ALS-U``,
+``BELLA`` and ``GEECS`` are in the table now. One name is still to come: the
+word-boundary facility abbreviation ``\\bALS\\b``, which still reads across
+dozens of files the wording sweep has not reached, and which cannot join until
+it does — an entry that exempted them all would be a list of files this guard
+does not cover rather than a guard.
 
-Three kinds of surface legitimately name an institution and will need an
-``allow`` entry rather than an edit when their patterns land: the shipped
-provider adapters for named LLM gateways, the named ingestion adapter, and the
-packaging and escalation metadata that has to spell the upstream project's own
-``owner/repo``.
+Three kinds of surface legitimately name an institution and carry an ``allow``
+entry rather than an edit: the shipped provider adapters for named LLM
+gateways, the named ingestion adapter, and the packaging and escalation
+metadata that has to spell the upstream project's own ``owner/repo`` — the
+last of these has no pattern yet.
 """
 
 from __future__ import annotations
@@ -112,6 +115,92 @@ DENIED: tuple[Denied, ...] = (
         pattern=re.compile(r"gianluca[-.]?martino", re.IGNORECASE),
         why="a maintainer's own gateway endpoint is not one another deployment can call",
         sample="  base_url: https://llm.gianluca-martino.com/v1",
+    ),
+    Denied(
+        name="institutional domain",
+        pattern=re.compile(r"lbl\.gov", re.IGNORECASE),
+        why="an institution's own domain is not an example anyone else can copy",
+        sample='"""Prefix of a principal naming an identity domain: ``domain:lbl.gov``."""',
+        # Each exemption names the gateway provider OSPREY ships an adapter
+        # for, or the reference ingestion adapter — surfaces where the
+        # institution is the subject rather than the example.
+        allow=frozenset(
+            {
+                "docs/source/getting-started/installation.rst",
+                "docs/source/how-to/llm-providers/configure-providers.rst",
+                "docs/source/how-to/llm-providers/run-open-models.rst",
+                "src/osprey/build/claude_code_resolver.py",
+                "src/osprey/models/providers/cborg.py",
+                "src/osprey/profiles/providers.yml",
+                "src/osprey/services/ariel_search/ingestion/adapters/als.py",
+                "src/osprey/services/channel_finder/benchmarks/evaluation.py",
+            }
+        ),
+    ),
+    Denied(
+        name="ring name",
+        pattern=re.compile(r"ALS-U", re.IGNORECASE),
+        why=(
+            "one laboratory's ring is the bundled demo lattice, not a machine "
+            "another deployment's prose should describe as its own"
+        ),
+        sample="# \u2500\u2500 The ALS-U Accumulator Ring instance \u2500\u2500",
+        # The demo ring ships as the simulation and virtual-accelerator
+        # packages' own subject, plus the two manifests and the preset data
+        # file that name the lattice those packages load.
+        allow=frozenset(
+            {
+                "src/osprey/profiles/config_key_manifest.yml",
+                "src/osprey/services/channel_finder/naming.py",
+                "src/osprey/services/virtual_accelerator/lattice/__init__.py",
+                "src/osprey/services/virtual_accelerator/lattice/calibration.py",
+                "src/osprey/services/virtual_accelerator/lattice/response.py",
+                "src/osprey/services/virtual_accelerator/lattice/ring.py",
+                "src/osprey/services/virtual_accelerator/lattice/strengths.py",
+                "src/osprey/services/virtual_accelerator/model/__init__.py",
+                "src/osprey/services/virtual_accelerator/model/bindings.py",
+                "src/osprey/services/virtual_accelerator/model/pyat.py",
+                "src/osprey/services/virtual_accelerator/model/variables.py",
+                "src/osprey/simulation/channel_schema.py",
+                "src/osprey/simulation/facility_spec.py",
+                "src/osprey/simulation/lattice/__init__.py",
+                "src/osprey/simulation/lattice/artifact.py",
+                "src/osprey/simulation/lattice/build.py",
+                "src/osprey/simulation/lattice/ring.py",
+                "src/osprey/templates/apps/control_assistant/data/channel_limits.json",
+            }
+        ),
+    ),
+    Denied(
+        # Case-sensitive on purpose: the acronym is always written in capitals,
+        # and a case-insensitive read matches a word inside the vendored
+        # plotly bundles, which would tie an exemption to a pinned version.
+        name="named external installation",
+        pattern=re.compile(r"BELLA"),
+        why="another site's installation is that site's own facility, not a shipped example",
+        sample="sends. Mirrors BELLA's ``runs.require_armed`` / ``launch_intent``",
+        # Both name the upstream contract these modules were generalized from.
+        allow=frozenset(
+            {
+                "src/osprey/services/bluesky_bridge/live_rows.py",
+                "src/osprey/services/bluesky_bridge/security.py",
+            }
+        ),
+    ),
+    Denied(
+        name="named external control system",
+        pattern=re.compile(r"GEECS", re.IGNORECASE),
+        why="another site's control system is that site's own stack, not a shipped example",
+        sample="parameter, so a document-shaped parameter (a GEECS ``ScanRequest``, say)",
+        # Each names the document-shaped scan parameter this code accepts, by
+        # the upstream system the shape comes from.
+        allow=frozenset(
+            {
+                "src/osprey/cli/build_profile_schema.py",
+                "src/osprey/services/bluesky_bridge/live_rows.py",
+                "src/osprey/services/bluesky_bridge/queue_backend.py",
+            }
+        ),
     ),
 )
 
@@ -202,7 +291,7 @@ def test_the_placeholder_cast_is_not_swept() -> None:
         "carol@example.org",
         "Example Research Facility",
         "~/my-assistant",
-        "epics_gateway=simulation",
+        "config.control_system.connector.epics.gateways.read_only.address=gw.example.org",
     )
     for denied in DENIED:
         for placeholder in placeholders:

--- a/tests/simulation/matlab_reference.py
+++ b/tests/simulation/matlab_reference.py
@@ -8,8 +8,8 @@ ring-vs-spec consistency test is circular (same author/source), this is not
 
 Provenance
 ----------
-* Source:  ``/Users/thellert/LBL/matlab/sc/applications/ALSU_AR_work/lattices/ALS_U_AR_v6.m``
-* Toolbox: MATLAB AT (``atmat`` at ``/Users/thellert/LBL/matlab/at``), MATLAB R2023b
+* Source:  ``ALS_U_AR_v6.m``
+* Toolbox: MATLAB AT (``atmat``), MATLAB R2023b
 * Date:    2026-07-15
 * Recipe (4D — radiation OFF and cavity OFF, apples-to-apples with pyAT
   ``ring.disable_6d()``)::


### PR DESCRIPTION
Closes the two gaps the first mechanical batch left: four example lines still spelled a real institutional mail domain, and the guard that is supposed to keep swept identities out had one row while four more literals were already gone or already exemptible.

- `chore: use placeholder identities in the remaining login and roster examples`
- `test: grow the shipped-identity guard to the hosts and domain the sweep removed`
- `test(cli): let the gateway-table guard ignore a stale bytecode cache`

## Why

The identity layer's own docstrings are the examples an operator copies when writing an access rule, and they spelled one institution's mail domain — so `domain:` and `user:` rules read as if that institution were the deployment's own. They now use `example.org`, matching the placeholder cast the roster documentation already uses, and the multi-user how-to's footer names a placeholder facility instead of a real control room. The upstream scout's fallback escalation went to a maintainer's personal mailbox; it now goes to the project's issue tracker, the same destination the feedback panel already uses, so there is one shipped place for a deployment to send an upstream request.

The guard is the part that keeps this from regressing. It carried one pattern and a promise that each remaining identity would join the table as it was swept. Four join it here: the institutional domain, the ring name, and the two named external installations. Each carries an allow list of the surfaces that legitimately name it — the provider adapter for a named LLM gateway, the reference ingestion adapter, the bundled demo lattice, and the upstream contracts the Bluesky bridge was generalized from — so the guard covers the whole shipped tree rather than stopping at the first exemption. The sibling staleness test means an exemption whose file stops carrying the literal has to be deleted, which keeps the allow lists from drifting into a list of files nobody checks.

The sibling guard in the `set` verb's tests asserted the retired gateway table's package directory was gone outright, which a stale `__pycache__` left behind by an older checkout can contradict without any source returning. It now asserts no source module lives there, and reports the offending paths when one does.

A deployer can now copy any login or roster example out of the docstrings and the how-to without editing an institution's name out of it first, and a new pull request that reintroduces one of the seven identities in the table fails in CI instead of shipping.

## Not in this PR

- A row for the upstream project's `owner/repo`. It is deliberately the feedback tracker default and appears in packaging, install and contributing pages; whether it gets a row with an allow list is a separate decision.
- The word-boundary facility abbreviation. It still reads across roughly 49 files under `src/osprey` and `docs/source` — the CLI, the OKF panel, a provider adapter, shipped templates and eight docs pages. A row for it today would need an allow list naming nearly every one of them, which is a snapshot of the unswept tree rather than a guard, so it waits for the prose sweep that removes them. The module docstring records it as the one name still to come.
- `web.docs_url` in the three presets, which renders the upstream documentation URL live.
- The refusal wording on the completion path, which does not name the gateway variable the resolver's refusal names.
- The fallbacks under `.github/workflows/`, `scripts/benchmark/` and `tests/e2e/`; the guard scans `src/osprey` and `docs/source` only, by design.
- The maintainer username in test fixtures outside the two roster test modules swept here (config fixtures, spend-attribution and ARIEL interface tests). Those are not shipped surfaces and no guard pattern reaches them.


