### PR TITLE
fix(models): derive the endpoint refusal, the base-URL fallback and the keyless placeholder from what a provider declares

### DIFF
--- a/changelog.d/namer-provider-list.internal.md
+++ b/changelog.d/namer-provider-list.internal.md
@@ -1,0 +1,3 @@
+The channel-name generator's "no provider configured" refusal lists the
+providers the registry actually carries instead of a hand-written roster of six
+names.

--- a/changelog.d/provider-declared-defaults.changed.md
+++ b/changelog.d/provider-declared-defaults.changed.md
@@ -1,0 +1,5 @@
+An adapter's declared default endpoint and its keyless posture now follow from
+what the provider itself declares, instead of each adapter opting in by hand. A
+provider added to a deployment cannot carry a default endpoint that is silently
+ignored, and a provider that declares it needs no API key sends the placeholder
+the endpoint expects without its adapter having to repeat it.

--- a/changelog.d/provider-endpoint-refusal.fixed.md
+++ b/changelog.d/provider-endpoint-refusal.fixed.md
@@ -1,0 +1,7 @@
+A provider that needs an endpoint and has no source for one now says so,
+whichever way it is called. Previously only calls that went through OSPREY's
+completion entry point were refused; a direct call to the provider adapter ran
+on with no endpoint and failed inside the model client with an unrelated
+authentication error. Affects `als-apg`, `amsc-i2` and `cborg`, whose endpoint
+comes from `api.providers.<name>.base_url` or the provider's environment
+variable.

--- a/src/osprey/models/providers/argo.py
+++ b/src/osprey/models/providers/argo.py
@@ -151,9 +151,6 @@ class ArgoProviderAdapter(BaseProvider):
     # through litellm), so a deployment with a baked-in URL can be pointed at a
     # different gateway at runtime.
     base_url_env_var = "ARGO_BASE_URL"
-    # Argo routes openai-compatible; without a base_url litellm would fall
-    # through to api.openai.com, so a missing base_url resolves to the default.
-    apply_default_base_url_fallback = True
     default_model_id = "claudesonnet45"  # Claude 4.5 Sonnet via ARGO for general use
     health_check_model_id = "gpt5mini"  # Fast and cost-effective for health checks
     available_models = [

--- a/src/osprey/models/providers/base.py
+++ b/src/osprey/models/providers/base.py
@@ -6,6 +6,11 @@ from typing import Any
 
 from osprey_connectors.config import is_unresolved_placeholder
 
+# A keyless endpoint (an on-prem vLLM, a local Ollama) still needs a non-empty
+# key on the wire: the OpenAI-compatible clients underneath refuse to send
+# without one.
+KEYLESS_API_KEY_PLACEHOLDER = "EMPTY"
+
 
 class BaseProvider(ABC):
     """Abstract base class for AI model providers.
@@ -190,6 +195,27 @@ class BaseProvider(ABC):
         if cls.requires_base_url:
             return cls.require_effective_base_url(base_url)
         return cls.effective_base_url(base_url)
+
+    @classmethod
+    def effective_api_key(cls, api_key: str | None) -> str | None:
+        """The key to send: the placeholder when this provider declares none is needed.
+
+        An absent key is passed through untouched for a provider that requires
+        one — refusing it is the requirement gate's job, and substituting here
+        would turn "no key configured" into an authentication failure from the
+        vendor, reported nowhere near its cause.
+
+        Args:
+            api_key: The caller's value, usually from deployment config. May be
+                ``None``.
+
+        Returns:
+            The key to put on the wire, or ``None`` when there is none and this
+            provider requires one.
+        """
+        if api_key:
+            return api_key
+        return None if cls.requires_api_key else KEYLESS_API_KEY_PLACEHOLDER
 
     @abstractmethod
     def execute_completion(

--- a/src/osprey/models/providers/base.py
+++ b/src/osprey/models/providers/base.py
@@ -163,6 +163,31 @@ class BaseProvider(ABC):
             raise ValueError(f"Base URL required for {cls.name}")
         return resolved
 
+    @classmethod
+    def resolve_base_url(cls, base_url: str | None) -> str | None:
+        """The endpoint to call, refusing ``None`` when this provider needs one.
+
+        Composes the two resolvers above by the provider's own
+        :attr:`requires_base_url` declaration, so a caller that just wants "the
+        endpoint, resolved correctly for whichever provider this is" does not
+        have to branch on that attribute itself.
+
+        Args:
+            base_url: The caller's value, usually from deployment config. May be
+                ``None``.
+
+        Returns:
+            The URL this provider will use, or ``None`` for a provider that
+            needs none.
+
+        Raises:
+            ValueError: When this provider requires an endpoint and no source
+                supplies one.
+        """
+        if cls.requires_base_url:
+            return cls.require_effective_base_url(base_url)
+        return cls.effective_base_url(base_url)
+
     @abstractmethod
     def execute_completion(
         self,

--- a/src/osprey/models/providers/base.py
+++ b/src/osprey/models/providers/base.py
@@ -64,15 +64,6 @@ class BaseProvider(ABC):
     supports_proxy: bool = NotImplemented
     default_base_url: str | None = None
     base_url_env_var: str | None = None  # Env var overriding all base_url sources (opt-in)
-    # Whether a missing base_url resolves to default_base_url. Opt-in: for most
-    # providers litellm derives the endpoint from the model prefix, and forcing a
-    # default would redirect them. A provider turns this on when a config that
-    # omits base_url means "the default I declare" — openai-compatible routes
-    # (which would otherwise fall through to api.openai.com) and local servers on
-    # a well-known port. Declaring a default_base_url without this flag makes that
-    # default unreachable through get_chat_completion, which rejects the call for a
-    # missing base_url before any adapter body runs.
-    apply_default_base_url_fallback: bool = False
     default_model_id: str | None = None  # Default model for templates/general use
     health_check_model_id: str | None = None  # Cheapest model for health checks
     available_models: list[str] = []  # List of available models for this provider
@@ -115,6 +106,18 @@ class BaseProvider(ABC):
         otherwise hand the literal string to the HTTP client and fail somewhere
         far from the cause.
 
+        **When a missing value falls back to** :attr:`default_base_url`: when
+        this provider also requires one. Requiring an endpoint is what makes a
+        config that omits ``base_url`` mean "the default I declare" — an
+        openai-compatible route that would otherwise fall through to
+        api.openai.com, or a local server on a well-known port — and it is what
+        would otherwise make the declared default unreachable, since
+        :mod:`osprey.models.completion` rejects the call for a missing base_url
+        before any adapter body runs. A provider that requires no endpoint keeps
+        resolving to ``None`` even with a default declared: litellm derives the
+        endpoint from the model prefix there, and forwarding a default would pin
+        a route the client is meant to choose.
+
         Args:
             base_url: The caller's value, usually from deployment config. May be
                 ``None``.
@@ -130,7 +133,7 @@ class BaseProvider(ABC):
                 return override
         if is_unresolved_placeholder(base_url):
             base_url = None
-        if cls.apply_default_base_url_fallback:
+        if cls.requires_base_url and cls.default_base_url:
             return base_url or cls.default_base_url
         return base_url
 

--- a/src/osprey/models/providers/ds4.py
+++ b/src/osprey/models/providers/ds4.py
@@ -68,12 +68,11 @@ class DS4ProviderAdapter(BaseProvider):
         **kwargs,
     ) -> str | Any:
         """Execute a ds4 chat completion via LiteLLM's OpenAI-compatible path."""
-        effective_api_key = api_key if api_key else "EMPTY"
         return execute_litellm_completion(
             provider=self.name,
             message=message,
             model_id=model_id,
-            api_key=effective_api_key,
+            api_key=self.effective_api_key(api_key),
             base_url=self.require_effective_base_url(base_url),
             max_tokens=max_tokens,
             temperature=temperature,
@@ -90,7 +89,7 @@ class DS4ProviderAdapter(BaseProvider):
     ) -> tuple[bool, str]:
         """Check ds4 server health, discovering a model if none is given."""
         effective_base_url = self.require_effective_base_url(base_url)
-        effective_api_key = api_key if api_key else "EMPTY"
+        effective_api_key = self.effective_api_key(api_key)
 
         if not model_id:
             try:

--- a/src/osprey/models/providers/ds4.py
+++ b/src/osprey/models/providers/ds4.py
@@ -32,11 +32,6 @@ class DS4ProviderAdapter(BaseProvider):
     requires_model_id = True
     supports_proxy = True
     default_base_url = "http://127.0.0.1:8000/v1"
-    # ds4 routes openai-compatible, so without a base_url litellm would fall
-    # through to api.openai.com. The fallback also makes the local default above
-    # reachable through get_chat_completion, whose requires_base_url check would
-    # otherwise reject a config that deliberately relies on it.
-    apply_default_base_url_fallback = True
     default_model_id = "deepseek-v4-flash"
     health_check_model_id = None  # query the server for available models
 

--- a/src/osprey/models/providers/litellm_adapter.py
+++ b/src/osprey/models/providers/litellm_adapter.py
@@ -47,6 +47,8 @@ from osprey.models.spend_attribution import (  # noqa: E402
 from osprey.utils.identity import acting_identity  # noqa: E402
 from osprey.utils.logger import get_logger  # noqa: E402
 
+from .base import KEYLESS_API_KEY_PLACEHOLDER  # noqa: E402
+
 if TYPE_CHECKING:
     from .base import BaseProvider
 
@@ -622,12 +624,9 @@ def check_litellm_health(
     if not api_key:
         if _requires_api_key(provider):
             return False, "API key not set"
-        # A keyless endpoint (an on-prem vLLM, a local Ollama) still needs a
-        # non-empty key on the wire: litellm's OpenAI client refuses to send
-        # without one. "EMPTY" is the placeholder the shipped keyless adapters
-        # already substitute by hand on the completion path; this is its one
-        # home on the health path.
-        api_key = "EMPTY"
+        # The provider declares no key is needed, but the endpoint still has to
+        # be given a non-empty one — see KEYLESS_API_KEY_PLACEHOLDER.
+        api_key = KEYLESS_API_KEY_PLACEHOLDER
 
     # Check for placeholder values
     if api_key and (api_key.startswith("${") or "YOUR_API_KEY" in api_key.upper()):

--- a/src/osprey/models/providers/litellm_delegating.py
+++ b/src/osprey/models/providers/litellm_delegating.py
@@ -30,9 +30,8 @@ from .litellm_adapter import check_litellm_health, execute_litellm_completion
 class LiteLLMDelegatingProvider(BaseProvider):
     """Data-driven base for providers that only delegate to ``litellm_adapter``.
 
-    Subclasses override the :class:`BaseProvider` metadata attributes and,
-    optionally, :attr:`apply_default_base_url_fallback`. They inherit the
-    ``execute_completion`` / ``check_health`` bodies unchanged.
+    Subclasses override the :class:`BaseProvider` metadata attributes and
+    inherit the ``execute_completion`` / ``check_health`` bodies unchanged.
     """
 
     # The endpoint is resolved through BaseProvider.resolve_base_url, which

--- a/src/osprey/models/providers/litellm_delegating.py
+++ b/src/osprey/models/providers/litellm_delegating.py
@@ -35,11 +35,12 @@ class LiteLLMDelegatingProvider(BaseProvider):
     ``execute_completion`` / ``check_health`` bodies unchanged.
     """
 
-    # Resolution (env override > caller value > default fallback) is
-    # BaseProvider.effective_base_url, so the requirement check in
-    # osprey.models.completion resolves exactly what this class will delegate.
-    # A second copy here would drift, and the drift is silent: it only shows up
-    # when a provider carrying a default is asked to run with none supplied.
+    # The endpoint is resolved through BaseProvider.resolve_base_url, which
+    # refuses a provider that requires one and has no source for it. The refusal
+    # belongs here because a direct adapter call never passes through
+    # osprey.models.completion: without it such a call reached litellm with no
+    # api_base, and a gateway-fronted provider then failed with an
+    # authentication error against a host nobody configured.
 
     def execute_completion(
         self,
@@ -65,7 +66,7 @@ class LiteLLMDelegatingProvider(BaseProvider):
             message=message,
             model_id=model_id,
             api_key=api_key,
-            base_url=self.effective_base_url(base_url),
+            base_url=self.resolve_base_url(base_url),
             max_tokens=max_tokens,
             temperature=temperature,
             output_format=output_format,
@@ -88,7 +89,7 @@ class LiteLLMDelegatingProvider(BaseProvider):
         result: tuple[bool, str] = check(
             provider=self.name,
             api_key=api_key,
-            base_url=self.effective_base_url(base_url),
+            base_url=self.resolve_base_url(base_url),
             timeout=timeout,
             model_id=model_id or self.health_check_model_id,
         )

--- a/src/osprey/models/providers/ollama.py
+++ b/src/osprey/models/providers/ollama.py
@@ -25,11 +25,6 @@ class OllamaProviderAdapter(BaseProvider):
     requires_model_id = True
     supports_proxy = False
     default_base_url = "http://localhost:11434"
-    # A local Ollama on the default port is the normal case, so a config that
-    # omits base_url means "the default" rather than "unconfigured". Without the
-    # fallback the requires_base_url check in get_chat_completion rejects such a
-    # config, and this adapter's own URL probing is handed None.
-    apply_default_base_url_fallback = True
     default_model_id = "mistral:7b"  # Mistral 7B as recommended default
     health_check_model_id = "mistral:7b"  # Same for health check (local, no cost)
     available_models = ["mistral:7b", "gpt-oss:20b", "gpt-oss:120b"]

--- a/src/osprey/models/providers/stanford.py
+++ b/src/osprey/models/providers/stanford.py
@@ -52,9 +52,3 @@ class StanfordProviderAdapter(LiteLLMDelegatingProvider):
     # LiteLLM integration - Stanford is an OpenAI-compatible proxy
     is_openai_compatible = True
     supports_native_structured_output = True  # proxies to models with native json_schema support
-
-    # Stanford routes openai-compatible, so a missing base_url must resolve to its
-    # own default rather than falling through to api.openai.com;
-    # execute_completion / check_health are inherited from
-    # LiteLLMDelegatingProvider, which applies the fallback when this flag is set.
-    apply_default_base_url_fallback = True

--- a/src/osprey/models/providers/vllm.py
+++ b/src/osprey/models/providers/vllm.py
@@ -37,11 +37,6 @@ class VLLMProviderAdapter(BaseProvider):
     requires_model_id = True
     supports_proxy = True
     default_base_url = "http://localhost:8000/v1"
-    # vLLM routes openai-compatible, so without a base_url litellm would fall
-    # through to api.openai.com. The fallback also makes the local default above
-    # reachable through get_chat_completion, whose requires_base_url check would
-    # otherwise reject a config that deliberately relies on it.
-    apply_default_base_url_fallback = True
     default_model_id = None  # Model depends on what's served
     health_check_model_id = None  # Will query the server for available models
 

--- a/src/osprey/models/providers/vllm.py
+++ b/src/osprey/models/providers/vllm.py
@@ -97,14 +97,11 @@ class VLLMProviderAdapter(BaseProvider):
         :param kwargs: Additional arguments
         :return: Response text or structured output
         """
-        # Use placeholder API key if none provided
-        effective_api_key = api_key if api_key else "EMPTY"
-
         return execute_litellm_completion(
             provider=self.name,
             message=message,
             model_id=model_id,
-            api_key=effective_api_key,
+            api_key=self.effective_api_key(api_key),
             base_url=self.require_effective_base_url(base_url),
             max_tokens=max_tokens,
             temperature=temperature,
@@ -131,7 +128,7 @@ class VLLMProviderAdapter(BaseProvider):
         :return: (success, message) tuple
         """
         effective_base_url = self.require_effective_base_url(base_url)
-        effective_api_key = api_key if api_key else "EMPTY"
+        effective_api_key = self.effective_api_key(api_key)
 
         # First, try to get the list of models from the server
         if not model_id:

--- a/src/osprey/services/channel_finder/tools/llm_channel_namer.py
+++ b/src/osprey/services/channel_finder/tools/llm_channel_namer.py
@@ -39,8 +39,8 @@ class LLMChannelNamer:
         """Initialize the LLM channel namer.
 
         Args:
-            provider: LLM provider (keyword-only, required — one of
-                'als-apg', 'cborg', 'amsc-i2', 'anthropic', 'argo', 'openai')
+            provider: LLM provider (keyword-only, required — any name the
+                provider registry carries, configured under ``api.providers``)
             model_id: Model identifier
             max_tokens: Maximum tokens per request
             batch_size: Number of channels to process per batch
@@ -345,10 +345,16 @@ def create_namer_from_config(config_path: str | None = None) -> LLMChannelNamer:
     llm_config = name_gen_config.get("llm_model", {})
     provider = llm_config.get("provider")
     if not provider:
+        # The registry is what a provider name may be: naming one it does not
+        # carry reaches no adapter at all. Listing it here keeps the refusal in
+        # step with a deployment that excluded a provider or added its own.
+        from osprey.models.provider_registry import get_provider_registry
+
+        known = ", ".join(sorted(get_provider_registry().list_providers()))
         raise ValueError(
             "channel_finder.channel_name_generation.llm_model.provider is "
-            "required in config.yml (must be one of "
-            "als-apg|cborg|amsc-i2|anthropic|argo|openai)."
+            f"required in config.yml. Name one of {known}, and configure it "
+            "under api.providers so its endpoint and key are resolvable."
         )
 
     api_config = config.get("api", {}).get("providers", {}).get(provider, {})

--- a/tests/models/test_providers_als_apg.py
+++ b/tests/models/test_providers_als_apg.py
@@ -156,18 +156,19 @@ class TestALSAPGExecuteCompletion:
         assert kwargs["enable_thinking"] is True
         assert kwargs["budget_tokens"] == 256
 
-    def test_missing_base_url_resolves_to_nothing(self):
-        """No endpoint is invented; the requirement gate refuses the call instead.
+    def test_missing_base_url_is_refused(self):
+        """A provider that requires an endpoint and has no source for one refuses.
 
-        ``osprey.models.completion`` rejects a ``requires_base_url`` provider
-        that resolves to None, which is what makes "you have to name your
-        gateway" the error a deployer sees.
+        No endpoint is invented: the gateway is a site's own host. The refusal
+        is raised here rather than left to the model client, so a direct adapter
+        call -- which never passes the requirement gate in
+        ``osprey.models.completion`` -- still tells a deployer to name their
+        gateway instead of failing as an authentication error somewhere else.
         """
-        with patch(COMPLETION, return_value="ok") as mock_exec:
+        with pytest.raises(ValueError, match="Base URL required for als-apg"):
             ALSAPGProviderAdapter().execute_completion(
                 message="hi", model_id="m", api_key="key", base_url=None
             )
-        assert mock_exec.call_args.kwargs["base_url"] is None
 
 
 class TestALSAPGBaseURLEnvOverride:
@@ -211,14 +212,13 @@ class TestALSAPGBaseURLEnvOverride:
 
         The config resolver keeps a reference verbatim when the variable is
         unset, so without this the literal string would be handed to litellm as
-        a hostname.
+        a hostname. Resolving to nothing is the refusal, not a pass-through.
         """
         monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
-        with patch(COMPLETION, return_value="ok") as mock_exec:
+        with pytest.raises(ValueError, match="Base URL required for als-apg"):
             ALSAPGProviderAdapter().execute_completion(
                 message="hi", model_id="m", api_key="key", base_url="${ALS_APG_BASE_URL}"
             )
-        assert mock_exec.call_args.kwargs["base_url"] is None
 
     def test_env_var_redirects_check_health_too(self, monkeypatch):
         """osprey health must probe the endpoint completions actually use."""
@@ -273,10 +273,10 @@ class TestALSAPGCheckHealth:
             )
         assert mock_health.call_args.kwargs["timeout"] == 12.0
 
-    def test_missing_base_url_resolves_to_nothing(self):
-        with patch(HEALTH, return_value=(True, "ok")) as mock_health:
+    def test_missing_base_url_is_refused(self):
+        """The health probe refuses the same missing endpoint completions do."""
+        with pytest.raises(ValueError, match="Base URL required for als-apg"):
             ALSAPGProviderAdapter().check_health(api_key="key", base_url=None)
-        assert mock_health.call_args.kwargs["base_url"] is None
 
     def test_propagates_failure(self):
         with patch(HEALTH, return_value=(False, "down")):

--- a/tests/models/test_providers_als_apg.py
+++ b/tests/models/test_providers_als_apg.py
@@ -69,7 +69,7 @@ class TestALSAPGMetadata:
         instead of asking for the deployment's own.
         """
         assert ALSAPGProviderAdapter.default_base_url is None
-        assert ALSAPGProviderAdapter.apply_default_base_url_fallback is False
+        assert ALSAPGProviderAdapter.effective_base_url(None) is None
 
     def test_default_and_health_models(self):
         assert ALSAPGProviderAdapter.default_model_id == "claude-haiku-4-5-20251001"

--- a/tests/models/test_providers_amsc_i2.py
+++ b/tests/models/test_providers_amsc_i2.py
@@ -10,6 +10,7 @@ near-identical LiteLLM adapters into one data-driven class.
 
 from unittest.mock import patch
 
+import pytest
 from pydantic import BaseModel
 
 from osprey.models.providers.amsc_i2 import AMSCI2ProviderAdapter
@@ -122,15 +123,18 @@ class TestAMSCI2ExecuteCompletion:
         assert kwargs["enable_thinking"] is True
         assert kwargs["budget_tokens"] == 256
 
-    def test_missing_base_url_is_forwarded_as_none(self):
-        """AMSC i2 does NOT substitute a default base_url; None passes through
-        (unlike stanford). A dedup applying ``base_url or default`` to every
-        adapter would regress this."""
-        with patch(COMPLETION, return_value="ok") as mock_exec:
+    def test_missing_base_url_is_refused(self):
+        """A provider that requires an endpoint and has no source for one refuses.
+
+        No default is invented -- amsc-i2 fronts a gateway that is a site's own
+        host -- and the refusal is raised here rather than left to the model
+        client, so a direct adapter call fails for the reason a deployer can act
+        on instead of as an authentication error against someone else's API.
+        """
+        with pytest.raises(ValueError, match="Base URL required for amsc-i2"):
             AMSCI2ProviderAdapter().execute_completion(
                 message="hi", model_id="m", api_key="key", base_url=None
             )
-        assert mock_exec.call_args.kwargs["base_url"] is None
 
 
 class TestAMSCI2CheckHealth:
@@ -170,10 +174,10 @@ class TestAMSCI2CheckHealth:
             )
         assert mock_health.call_args.kwargs["timeout"] == 12.0
 
-    def test_missing_base_url_is_forwarded_as_none(self):
-        with patch(HEALTH, return_value=(True, "ok")) as mock_health:
+    def test_missing_base_url_is_refused(self):
+        """The health probe refuses the same missing endpoint completions do."""
+        with pytest.raises(ValueError, match="Base URL required for amsc-i2"):
             AMSCI2ProviderAdapter().check_health(api_key="key", base_url=None)
-        assert mock_health.call_args.kwargs["base_url"] is None
 
     def test_propagates_failure(self):
         with patch(HEALTH, return_value=(False, "down")):

--- a/tests/models/test_providers_base.py
+++ b/tests/models/test_providers_base.py
@@ -1,0 +1,78 @@
+"""Tests for the resolution rules :class:`BaseProvider` holds for every adapter.
+
+The rule here used to be a per-adapter opt-in: a flag each provider set to turn
+the default-endpoint fallback on. It is now derived from what a provider already
+declares, so this test sweeps the whole registry rather than naming adapters — a
+provider added later inherits the rule instead of having to remember it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osprey.models.provider_registry import get_provider_registry
+from osprey.models.providers.base import BaseProvider
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_base_url_override(monkeypatch):
+    """Drop every provider's base_url env override.
+
+    An export supplies an endpoint and beats every other source, which would
+    hide exactly the fallback these tests check.
+    """
+    registry = get_provider_registry()
+    for name in registry.list_providers():
+        provider_class = registry.get_provider(name)
+        if provider_class is not None and provider_class.base_url_env_var:
+            monkeypatch.delenv(provider_class.base_url_env_var, raising=False)
+
+
+def _registered_providers() -> list[tuple[str, type[BaseProvider]]]:
+    registry = get_provider_registry()
+    loaded = []
+    for name in registry.list_providers():
+        provider_class = registry.get_provider(name)
+        if provider_class is not None:
+            loaded.append((name, provider_class))
+    return loaded
+
+
+class TestDefaultBaseURLFallback:
+    """A declared default is used exactly when the provider requires an endpoint."""
+
+    def test_a_required_endpoint_falls_back_to_the_declared_default(self):
+        checked = []
+        for name, provider_class in _registered_providers():
+            if not (provider_class.requires_base_url and provider_class.default_base_url):
+                continue
+            checked.append(name)
+            assert provider_class.effective_base_url(None) == provider_class.default_base_url, (
+                f"{name} requires a base_url and declares a default the resolver never returns"
+            )
+        assert checked, "no registered provider both requires a base_url and declares a default"
+
+    def test_an_unrequired_endpoint_keeps_resolving_to_nothing(self):
+        """A default on a provider that needs no endpoint stays documentation.
+
+        ``openai`` declares ``https://api.openai.com/v1`` and requires no
+        base_url: litellm derives the endpoint from the model prefix, so
+        forwarding the default would pin a route the client is meant to choose.
+        """
+        checked = []
+        for name, provider_class in _registered_providers():
+            if provider_class.requires_base_url or not provider_class.default_base_url:
+                continue
+            checked.append(name)
+            assert provider_class.effective_base_url(None) is None, (
+                f"{name} declares a default it does not require; it must not be forwarded"
+            )
+        assert checked, "no registered provider declares a default without requiring one"
+
+    def test_a_configured_value_still_beats_the_default(self):
+        for name, provider_class in _registered_providers():
+            if not provider_class.default_base_url:
+                continue
+            assert provider_class.effective_base_url("https://configured.example") == (
+                "https://configured.example"
+            ), f"{name} overrode a configured base_url with its default"

--- a/tests/models/test_providers_base.py
+++ b/tests/models/test_providers_base.py
@@ -1,9 +1,11 @@
 """Tests for the resolution rules :class:`BaseProvider` holds for every adapter.
 
-The rule here used to be a per-adapter opt-in: a flag each provider set to turn
-the default-endpoint fallback on. It is now derived from what a provider already
-declares, so this test sweeps the whole registry rather than naming adapters — a
-provider added later inherits the rule instead of having to remember it.
+Each rule here used to be a per-adapter opt-in or a hand-copied literal: a flag
+each provider set to turn the default-endpoint fallback on, and an ``"EMPTY"``
+string substituted in four adapter bodies. Both are now derived from what a
+provider already declares, so these tests sweep the whole registry rather than
+naming adapters — a provider added later inherits the rules instead of having to
+remember them.
 """
 
 from __future__ import annotations
@@ -11,7 +13,7 @@ from __future__ import annotations
 import pytest
 
 from osprey.models.provider_registry import get_provider_registry
-from osprey.models.providers.base import BaseProvider
+from osprey.models.providers.base import KEYLESS_API_KEY_PLACEHOLDER, BaseProvider
 
 
 @pytest.fixture(autouse=True)
@@ -76,3 +78,38 @@ class TestDefaultBaseURLFallback:
             assert provider_class.effective_base_url("https://configured.example") == (
                 "https://configured.example"
             ), f"{name} overrode a configured base_url with its default"
+
+
+class TestKeylessAPIKeyPlaceholder:
+    """An absent key is substituted exactly for providers that declare none is needed."""
+
+    def test_a_keyless_provider_substitutes_the_placeholder(self):
+        checked = []
+        for name, provider_class in _registered_providers():
+            if provider_class.requires_api_key:
+                continue
+            checked.append(name)
+            assert provider_class.effective_api_key(None) == KEYLESS_API_KEY_PLACEHOLDER, (
+                f"{name} declares no API key is needed but sends nothing on the wire"
+            )
+        assert checked, "no registered provider declares itself keyless"
+
+    def test_a_key_requiring_provider_passes_an_absent_key_through(self):
+        """The requirement gate refuses a missing key, not the adapter.
+
+        Substituting here would turn "you forgot the key" into an
+        authentication failure from the vendor.
+        """
+        checked = []
+        for name, provider_class in _registered_providers():
+            if not provider_class.requires_api_key:
+                continue
+            checked.append(name)
+            assert provider_class.effective_api_key(None) is None, (
+                f"{name} requires an API key but invented one for an absent value"
+            )
+        assert checked, "no registered provider requires an API key"
+
+    def test_a_supplied_key_is_never_replaced(self):
+        for _name, provider_class in _registered_providers():
+            assert provider_class.effective_api_key("real-key") == "real-key"

--- a/tests/models/test_providers_cborg.py
+++ b/tests/models/test_providers_cborg.py
@@ -10,6 +10,7 @@ near-identical LiteLLM adapters into one data-driven class.
 
 from unittest.mock import patch
 
+import pytest
 from pydantic import BaseModel
 
 from osprey.models.providers.cborg import CBorgProviderAdapter
@@ -122,15 +123,18 @@ class TestCBorgExecuteCompletion:
         assert kwargs["enable_thinking"] is True
         assert kwargs["budget_tokens"] == 256
 
-    def test_missing_base_url_is_forwarded_as_none(self):
-        """CBORG does NOT substitute a default base_url; None passes through
-        (unlike stanford). A dedup applying ``base_url or default`` to every
-        adapter would regress this."""
-        with patch(COMPLETION, return_value="ok") as mock_exec:
+    def test_missing_base_url_is_refused(self):
+        """A provider that requires an endpoint and has no source for one refuses.
+
+        No default is invented -- cborg fronts a gateway that is a site's own
+        host -- and the refusal is raised here rather than left to the model
+        client, so a direct adapter call fails for the reason a deployer can act
+        on instead of as an authentication error against someone else's API.
+        """
+        with pytest.raises(ValueError, match="Base URL required for cborg"):
             CBorgProviderAdapter().execute_completion(
                 message="hi", model_id="m", api_key="key", base_url=None
             )
-        assert mock_exec.call_args.kwargs["base_url"] is None
 
 
 class TestCBorgCheckHealth:
@@ -170,10 +174,10 @@ class TestCBorgCheckHealth:
             )
         assert mock_health.call_args.kwargs["timeout"] == 12.0
 
-    def test_missing_base_url_is_forwarded_as_none(self):
-        with patch(HEALTH, return_value=(True, "ok")) as mock_health:
+    def test_missing_base_url_is_refused(self):
+        """The health probe refuses the same missing endpoint completions do."""
+        with pytest.raises(ValueError, match="Base URL required for cborg"):
             CBorgProviderAdapter().check_health(api_key="key", base_url=None)
-        assert mock_health.call_args.kwargs["base_url"] is None
 
     def test_propagates_failure(self):
         with patch(HEALTH, return_value=(False, "down")):

--- a/tests/services/channel_finder/tools/test_llm_channel_namer.py
+++ b/tests/services/channel_finder/tools/test_llm_channel_namer.py
@@ -264,6 +264,34 @@ class TestCreateNamerFromConfig:
         with pytest.raises(ValueError, match="provider is"):
             create_namer_from_config()
 
+    def test_missing_provider_names_the_registry(self, monkeypatch):
+        """The refusal lists providers that exist here, not a frozen roster.
+
+        A hand-written list goes stale in both directions: it keeps offering a
+        provider a deployment has excluded, and it hides one the deployment
+        added.
+        """
+        import osprey.utils.config as config_mod
+        from osprey.models.provider_registry import get_provider_registry
+
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda *a, **k: {"channel_finder": {"channel_name_generation": {"llm_model": {}}}},
+        )
+        registered = get_provider_registry().list_providers()
+        assert registered, "the provider registry is empty; the rest of this test is vacuous"
+
+        with pytest.raises(ValueError) as excinfo:
+            create_namer_from_config()
+        message = str(excinfo.value)
+
+        for name in registered:
+            assert name in message, f"{name} is registered but the refusal does not offer it"
+        assert "api.providers" in message
+        for absent in ("sonnet-gateway", "not-a-provider"):
+            assert absent not in message
+
     def test_builds_namer_from_config_values(self, monkeypatch):
         import osprey.models.tiers as tiers_mod
         import osprey.utils.config as config_mod


### PR DESCRIPTION
Four facts a provider class already declares — `requires_base_url`,
`default_base_url`, `requires_api_key`, and its registry entry — are now read
from the declaration instead of re-derived by hand downstream.

- `fix(models): refuse a missing endpoint in the delegating provider base`
- `refactor(models): derive the base-URL fallback from what the provider declares`
- `refactor(models): one producer for the keyless API-key placeholder`
- `refactor(channel-finder): name the provider registry instead of a fixed provider list`

## Why

Each hand copy could disagree with the declaration it copied, and the
disagreement was silent until a deployment ran the path nobody tests. A
delegating provider that requires an endpoint and has no source for one now
refuses the call itself, with the same wording the completion entry point
already produces, instead of reaching the model client with no `api_base` and
failing as an authentication error against a host nobody configured — so a
direct adapter call fails for the reason a deployer can act on. The
default-endpoint fallback is derived as `requires_base_url and
default_base_url` rather than set by five per-adapter opt-in flags, so a
provider added to a deployment cannot carry a default the requirement gate
silently rejects; `openai` declares a default it does not require and still
resolves to nothing, which the registry-wide test pins. The keyless API-key
placeholder has one home on the base class instead of four inline copies plus
the adapter's own, so a keyless provider — an on-prem vLLM, a local Ollama, or a
facility's own — gets the substitution from declaring `requires_api_key =
False`. And the channel-name generator's refusal lists the providers the
registry carries, so a deployment that excluded a provider or added its own sees
its real choices.

No new configuration key: every fix reads a class attribute that already exists
and already has exactly one producer.

## Not in this PR

No docs change — none of the four facts is documented as an adapter-authoring
step. No new exception class: `require_effective_base_url` already raises the
`ValueError` whose wording the completion path produces, and one shared wording
is the point.

## Risk

The first commit is the only behavior flip: `cborg`, `amsc-i2` and `als-apg` now
raise on a direct adapter call that previously forwarded `None` and failed
deeper. Every caller through the completion entry point already got this
refusal, so the flip is reachable only from direct adapter use. The other three
commits are behavior-preserving by construction and pinned as such.
