### PR TITLE
fix(deploy): refuse a blank OIDC scope entry and a missing panel selection

### DIFF
--- a/changelog.d/oidc-blank-scope.changed.md
+++ b/changelog.d/oidc-blank-scope.changed.md
@@ -1,0 +1,3 @@
+A `web_terminals` OIDC scope list carrying a blank entry is now refused, with
+the offending index named. The blank entry used to be dropped and the remaining
+scopes shipped as if they were what you had written.

--- a/changelog.d/panel-selection-guard.internal.md
+++ b/changelog.d/panel-selection-guard.internal.md
@@ -1,0 +1,3 @@
+The project-config template refuses a render context with no panel selection
+instead of defaulting it to an empty list. Every shipped build path sets the
+key, so no deployment changes.

--- a/src/osprey/deployment/web_terminals/lint.py
+++ b/src/osprey/deployment/web_terminals/lint.py
@@ -65,6 +65,7 @@ from osprey.deployment.web_terminals.render import (
     TLS_LISTEN_PORT,
     _auth_tls_context,
     _authorization_context,
+    _blank_scope_index,
     _configured_external_origin,
     _external_origin,
     _port_int,
@@ -3059,9 +3060,9 @@ def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> lis
       restores the default, so the sidecar would read a variable the operator
       never set.
     * **Scopes.** ``auth.oidc.scopes`` is a list of scope strings (or one
-      space-separated string). Any other shape renders no scopes line at all,
-      so the sidecar's default applies and the authored scopes are gone
-      without a trace.
+      space-separated string). Any other shape — including a list carrying an
+      entry that is blank — renders no scopes line at all, so the sidecar's
+      default applies and the authored scopes are gone without a trace.
     * **External origin.** The OIDC ``redirect_uri`` is built from the
       deployment's one external origin, which needs ``deploy.fqdn``. An IdP
       rejects a callback whose ``redirect_uri`` isn't character-for-character
@@ -3109,14 +3110,30 @@ def _check_auth_oidc(root: dict[str, Any], web_terminals: dict[str, Any]) -> lis
 
     # `scopes` is read the same way and fails the same way: render joins a list
     # of strings (or an already-joined string) into the env line and treats
-    # every other shape as unset, so a wrong-typed value renders nothing and
-    # the sidecar's own default applies — the authored scopes are gone with no
-    # trace. Only the SHAPE is checked here; the sidecar refuses a list without
-    # `openid` at startup, where it also knows what the IdP was asked for.
+    # every other shape — including a list with a blank entry — as unset, so an
+    # unusable value renders nothing and the sidecar's own default applies — the
+    # authored scopes are gone with no trace. A blank entry gets its own finding
+    # because the index is the whole repair, and reporting it as an unreadable
+    # list would name everything except the one entry to fix. Only the SHAPE is
+    # checked here; the sidecar refuses a list without `openid` at startup,
+    # where it also knows what the IdP was asked for.
     if "scopes" in oidc:
         scopes = oidc.get("scopes")
-        joined = _scope_list(scopes)
-        if joined is None:
+        blank_index = _blank_scope_index(scopes)
+        if blank_index is not None:
+            findings.append(
+                Finding(
+                    severity="error",
+                    code="web_terminals.auth_oidc_blank_scope",
+                    message=(
+                        f"modules.web_terminals.auth.oidc.scopes[{blank_index}] is blank "
+                        "where a scope was meant to go; render would emit no scopes line "
+                        "and the sidecar would fall back to its own default, silently "
+                        "dropping what was authored"
+                    ),
+                )
+            )
+        elif _scope_list(scopes) is None:
             findings.append(
                 Finding(
                     severity="error",

--- a/src/osprey/deployment/web_terminals/render.py
+++ b/src/osprey/deployment/web_terminals/render.py
@@ -2342,19 +2342,38 @@ def _non_empty_str(value: Any, default: str) -> str:
     return value if isinstance(value, str) and value.strip() else default
 
 
+def _blank_scope_index(value: Any) -> int | None:
+    """The index of the first ``auth.oidc.scopes`` entry that is blank.
+
+    A blank entry is an authoring slip with no legitimate reading, and it is
+    the one unusable shape a reader can point at precisely. Only a list or
+    tuple carries indices, so every other shape — a bare string included —
+    returns ``None`` and is left to :func:`_scope_list` to judge.
+    """
+    if not isinstance(value, list | tuple):
+        return None
+    for index, item in enumerate(value):
+        if isinstance(item, str) and not item.strip():
+            return index
+    return None
+
+
 def _scope_list(value: Any) -> str | None:
     """``auth.oidc.scopes`` read as the space-separated string OAuth spells.
 
     A list of strings is the authored shape; a bare string is accepted as
     already-joined scopes, because that is what an operator who has copied the
-    line out of their IdP's documentation will write. Anything else — and an
-    empty list — reads as unset, which renders no env line and leaves the
-    sidecar's own default in force.
+    line out of their IdP's documentation will write. Anything else — an empty
+    list, and a list with a blank entry — reads as unset, which renders no env
+    line and leaves the sidecar's own default in force.
     """
     if isinstance(value, str):
         return " ".join(value.split()) or None
     if isinstance(value, list | tuple) and all(isinstance(item, str) for item in value):
-        return " ".join(item.strip() for item in value if item.strip()) or None
+        stripped = [item.strip() for item in value]
+        if not stripped or any(not item for item in stripped):
+            return None
+        return " ".join(stripped)
     return None
 
 

--- a/src/osprey/templates/project/config.yml.j2
+++ b/src/osprey/templates/project/config.yml.j2
@@ -197,13 +197,16 @@ ariel:
       model:
         model_id: {{ default_model }}
 {%- endif %}
-{#- The registry, never a default: `builtin_panels` is set on every render
-    context the manager builds, so a render that reaches here without it is
-    a wiring fault. Defaulting to an empty list would swallow that and emit
+{#- The registry and the selection, never defaults: `builtin_panels` and
+    `selected_web_panels` are both set on every render context the manager
+    builds, so a render that reaches here without one is a wiring fault.
+    Defaulting either to an empty list would swallow that and emit
     `panels: {}` — every selected tab silently missing from the build. #}
 {%- set _builtin_panels = builtin_panels if builtin_panels is defined
     else fail("builtin_panels missing from render context") %}
-{%- set _enabled_builtin_panels = selected_web_panels | default([]) | select("in", _builtin_panels) | list %}
+{%- set _selected_web_panels = selected_web_panels if selected_web_panels is defined
+    else fail("selected_web_panels missing from render context") %}
+{%- set _enabled_builtin_panels = _selected_web_panels | select("in", _builtin_panels) | list %}
 {%- set _has_default_panel = default_panel is defined and default_panel %}
 {%- set _has_presets = panel_presets is defined and panel_presets %}
 {%- if _has_default_panel or _enabled_builtin_panels or _has_presets %}

--- a/tests/cli/test_config_records_environment.py
+++ b/tests/cli/test_config_records_environment.py
@@ -124,12 +124,14 @@ class TestTemplatesRenderTheDeclaration:
     #: The port table and panel registry the real render builds in
     #: TemplateManager._project_context. These tests reach the
     #: environment directly, so they carry them themselves. The template
-    #: refuses a render with no ``builtin_panels``, deliberately: it has no
-    #: other source for what a selected tab may name.
+    #: refuses a render with no ``builtin_panels`` or no ``selected_web_panels``,
+    #: deliberately: both are wiring the manager sets on every context, and an
+    #: empty selection is a profile that chose no builtin, not a missing input.
     PORTS = {
         "port_base": DEFAULT_PORT_BASE,
         "osprey_ports": layout_ports(DEFAULT_PORT_BASE),
         "builtin_panels": sorted(BUILTIN_PANELS),
+        "selected_web_panels": [],
     }
 
     @pytest.mark.parametrize("template_name", CONFIG_TEMPLATES)

--- a/tests/deployment/web_terminals/test_lint.py
+++ b/tests/deployment/web_terminals/test_lint.py
@@ -2625,6 +2625,7 @@ _AUTH_CODES = frozenset(
         "web_terminals.auth_oidc_missing_issuer",
         "web_terminals.auth_oidc_invalid_client_env",
         "web_terminals.auth_oidc_invalid_scopes",
+        "web_terminals.auth_oidc_blank_scope",
         "web_terminals.auth_oidc_unresolvable_origin",
         "web_terminals.auth_oidc_subject_unsafe",
         "web_terminals.auth_credential_collision",
@@ -3250,6 +3251,29 @@ def test_lint_auth_oidc_unreadable_scopes_are_an_error(scopes: object) -> None:
     errors = _errors(findings)
     assert any(f.code == "web_terminals.auth_oidc_invalid_scopes" for f in errors)
     assert any("auth.oidc.scopes" in f.message for f in errors)
+
+
+def test_lint_auth_oidc_blank_scope_entry_is_an_error() -> None:
+    """One slip, reported once, with the entry named.
+
+    A blank entry has no legitimate reading, so the finding points at the index
+    rather than restating the whole list as unreadable.
+    """
+    # Arrange
+    config = _auth_config(
+        {
+            "method": "oidc",
+            "oidc": {"issuer": "https://idp.example.org", "scopes": ["openid", "  "]},
+        }
+    )
+
+    # Act
+    findings = lint_web_terminals(config)
+
+    # Assert
+    errors = _auth_findings(_errors(findings))
+    assert [f.code for f in errors] == ["web_terminals.auth_oidc_blank_scope"]
+    assert "modules.web_terminals.auth.oidc.scopes[1]" in errors[0].message
 
 
 @pytest.mark.parametrize(

--- a/tests/deployment/web_terminals/test_render.py
+++ b/tests/deployment/web_terminals/test_render.py
@@ -3692,6 +3692,7 @@ def test_auth_context_reads_the_oidc_scopes_and_leaves_them_none_when_unusable()
         == "openid groups"
     )
     assert _auth_tls_context(_with({"scopes": []}))["auth_oidc_scopes"] is None
+    assert _auth_tls_context(_with({"scopes": ["openid", "  "]}))["auth_oidc_scopes"] is None
     assert _auth_tls_context(_with({"scopes": {"openid": True}}))["auth_oidc_scopes"] is None
     assert _auth_tls_context(_with({}))["auth_oidc_scopes"] is None
 

--- a/tests/templates/test_framework_config_template.py
+++ b/tests/templates/test_framework_config_template.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import pytest
 import yaml
+from jinja2 import TemplateRuntimeError
 
 from osprey.build.build_tiers import VALID_CHANNEL_FINDER_MODES
 from osprey.cli.build_cmd import _ariel_server_enabled
@@ -370,6 +371,29 @@ def test_web_renders_an_explicit_empty_panels_map_when_a_field_opens_it():
     """
     config = _config(panel_presets={"Empty": ["artifacts"]})
     assert config["web"]["panels"] == {}
+
+
+def test_a_render_without_the_panel_selection_refuses():
+    """The selection is wiring, not a profile field, so an absent one is a fault.
+
+    Defaulting it to `[]` would render `panels: {}` — a tab strip with every
+    selected tab silently missing — and nothing downstream could tell that
+    apart from a profile that selected no builtin.
+    """
+    context = {key: value for key, value in _MINIMAL_CTX.items() if key != "selected_web_panels"}
+    with pytest.raises(TemplateRuntimeError, match="selected_web_panels"):
+        TemplateManager().jinja_env.get_template(CONFIG_TEMPLATE).render(**context)
+
+
+def test_a_render_without_the_builtin_panel_registry_refuses():
+    """The registry the selection is filtered against is wiring too.
+
+    Without it every selected builtin filters away, so the same `panels: {}`
+    comes out — an absent registry is a wiring fault, not an empty one.
+    """
+    context = {key: value for key, value in _MINIMAL_CTX.items() if key != "builtin_panels"}
+    with pytest.raises(TemplateRuntimeError, match="builtin_panels"):
+        TemplateManager().jinja_env.get_template(CONFIG_TEMPLATE).render(**context)
 
 
 # ── The ARIEL gate ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Two render-context slips that used to be repaired silently on the way through a renderer now fail where they are authored.

- `fix(web-terminal): refuse an OIDC scope list carrying a blank entry`
- `fix(build): fail the project-config render when the panel selection is missing`

## Why

Both values were "almost right" inputs the renderer quietly fixed up, so the deployment came up carrying something nobody wrote and no downstream reader could report it. A blank entry in `auth.oidc.scopes` was dropped and the surviving scopes shipped as if the operator had authored exactly them; render now reads such a list as unset like every other unusable shape, and lint reports it with the offending index named, so one slip is reported once rather than as an unreadable list. A project-config render context arriving without `selected_web_panels` defaulted to `[]` and emitted `panels: {}` — every selected tab silently missing — which is indistinguishable from a profile that selected no builtin; the template now fails the render the way the neighbouring `builtin_panels` guard does. A deployer authoring a scope list gets the index to fix instead of a deployment that logs in with the wrong scopes, and anyone building a render context by hand gets a refusal instead of an empty panel block.

## Not in this PR

`default_panel` and `panel_presets` keep their `is defined` guards. `osprey build` injects each only when the profile sets it, so they are legitimately absent from a correct context and a `fail()` there would refuse every profile that states neither.
