### PR TITLE
perf(dispatch): resolve the package's exports on first use

### DIFF
--- a/changelog.d/dispatch-lazy-exports.internal.md
+++ b/changelog.d/dispatch-lazy-exports.internal.md
@@ -1,0 +1,3 @@
+The `osprey.dispatch` package resolves its public names on first attribute
+access, so importing one leaf of it — the trigger-configuration reader, say —
+no longer pulls the HTTP worker client in behind it.

--- a/src/osprey/dispatch/__init__.py
+++ b/src/osprey/dispatch/__init__.py
@@ -1,34 +1,50 @@
-"""OSPREY event dispatch package — pool, registry, trigger configuration, and worker client."""
+"""OSPREY event dispatch package — pool, registry, trigger configuration, and worker client.
 
-from osprey.dispatch.pool import DispatchPool, QueueFullError
-from osprey.dispatch.registry import TriggerRegistry
-from osprey.dispatch.trigger_config import DispatcherConfig, TriggerConfig, load_triggers
-from osprey.dispatch.worker_client import (
-    WorkerAuthRejectedError,
-    WorkerRejectedRequestError,
-    WorkerRequestError,
-    WorkerUnavailableError,
-    WorkerUnreachableError,
-    cancel_worker_run,
-    dispatch_to_worker,
-    fetch_worker_runs,
-    proxy_worker_stream,
-)
+Importing this package, or any one leaf of it, costs only that leaf. The four
+pieces gathered here have unrelated dependencies: the trigger-configuration
+reader needs a YAML parser, while the worker client speaks HTTP. Re-exporting
+them eagerly would make reading ``triggers.yml`` pull the HTTP worker client in
+behind it, so every public name is resolved on first attribute access instead.
+"""
 
-__all__ = [
-    "DispatchPool",
-    "DispatcherConfig",
-    "QueueFullError",
-    "TriggerConfig",
-    "TriggerRegistry",
-    "WorkerAuthRejectedError",
-    "WorkerRejectedRequestError",
-    "WorkerRequestError",
-    "WorkerUnavailableError",
-    "WorkerUnreachableError",
-    "cancel_worker_run",
-    "dispatch_to_worker",
-    "fetch_worker_runs",
-    "load_triggers",
-    "proxy_worker_stream",
-]
+from __future__ import annotations
+
+from typing import Any
+
+#: Public name -> the submodule of this package that defines it. Entries are
+#: resolved on first attribute access, never at import.
+_LAZY_EXPORTS: dict[str, str] = {
+    "DispatchPool": ".pool",
+    "QueueFullError": ".pool",
+    "TriggerRegistry": ".registry",
+    "DispatcherConfig": ".trigger_config",
+    "TriggerConfig": ".trigger_config",
+    "load_triggers": ".trigger_config",
+    "WorkerAuthRejectedError": ".worker_client",
+    "WorkerRejectedRequestError": ".worker_client",
+    "WorkerRequestError": ".worker_client",
+    "WorkerUnavailableError": ".worker_client",
+    "WorkerUnreachableError": ".worker_client",
+    "cancel_worker_run": ".worker_client",
+    "dispatch_to_worker": ".worker_client",
+    "fetch_worker_runs": ".worker_client",
+    "proxy_worker_stream": ".worker_client",
+}
+
+__all__ = sorted(_LAZY_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a public name from its defining module on first access."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY_EXPORTS})

--- a/tests/dispatch/test_package_lazy_exports.py
+++ b/tests/dispatch/test_package_lazy_exports.py
@@ -1,0 +1,92 @@
+"""Unit tests for the import cost of the :mod:`osprey.dispatch` package.
+
+The package gathers four unrelated pieces of the dispatcher — the pool, the
+trigger registry, the trigger-configuration reader and the HTTP worker client.
+Only the last of those needs an HTTP stack, so re-exporting the four eagerly
+would make the cheapest leaf the most expensive import in the tree: reading
+``triggers.yml`` would pull ``httpx`` in behind it.
+
+The tests here hold the invariant that importing the package, or any one leaf
+of it, costs only that leaf, and that the lazy map behind the public names
+cannot drift from the modules that define them.
+
+The import checks run in a fresh interpreter, not on the already-populated
+``sys.modules`` of the test session.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import osprey.dispatch
+
+_SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+
+def _modules_added_by_import(module: str) -> set[str]:
+    """Return the module names a fresh import of ``module`` adds to ``sys.modules``.
+
+    Args:
+        module: Dotted name to import in a child interpreter.
+
+    Returns:
+        Every module name the import added, stdlib included.
+
+    Raises:
+        AssertionError: If the child interpreter fails to import the module.
+    """
+    code = (
+        "import json, sys;"
+        "before = set(sys.modules);"
+        f"import {module};"
+        "print(json.dumps(sorted(set(sys.modules) - before)))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ, PYTHONPATH=_SRC),
+        check=False,
+    )
+    assert result.returncode == 0, f"fresh import of {module} failed:\n{result.stderr}"
+    return set(json.loads(result.stdout))
+
+
+def test_reading_trigger_configuration_costs_no_http_stack():
+    """``trigger_config`` needs a YAML parser; it must not drag ``httpx`` in.
+
+    The assertion names ``httpx`` rather than demanding that nothing new
+    appears at all: the reader legitimately imports ``yaml``.
+    """
+    added = _modules_added_by_import("osprey.dispatch.trigger_config")
+
+    assert not [name for name in added if name.split(".")[0] == "httpx"]
+
+
+def test_importing_the_package_pulls_in_neither_the_client_nor_the_pool():
+    """The package root resolves its exports on access, so it imports no leaf."""
+    added = _modules_added_by_import("osprey.dispatch")
+
+    assert not [name for name in added if name.split(".")[0] == "httpx"]
+    assert "osprey.dispatch.pool" not in added
+
+
+@pytest.mark.parametrize("name", sorted(osprey.dispatch.__all__))
+def test_every_public_name_resolves_to_its_defining_module(name):
+    """Attribute access yields the object the submodule exports, not a stale copy."""
+    from importlib import import_module
+
+    value = getattr(osprey.dispatch, name)
+    module = import_module(osprey.dispatch._LAZY_EXPORTS[name], osprey.dispatch.__name__)
+
+    assert value is getattr(module, name)
+
+
+def test_an_unknown_name_raises_attribute_error():
+    """The lazy lookup refuses names the package does not export."""
+    with pytest.raises(AttributeError):
+        osprey.dispatch.no_such_export

--- a/tests/test_dispatch_pool_defaults.py
+++ b/tests/test_dispatch_pool_defaults.py
@@ -8,8 +8,8 @@ let those three share them:
 
 * The module is a stdlib-only leaf. The profile schema is imported by every
   ``osprey build`` / ``osprey config`` / ``osprey init`` invocation, and the
-  numbers must reach it without dragging :mod:`osprey.dispatch` (and its HTTP
-  worker client) into the profile import graph.
+  numbers must reach it without dragging :mod:`osprey.dispatch` into the
+  profile import graph at all.
 * :mod:`osprey.dispatch.trigger_config` re-exports them, so code reading the
   defaults from the runtime package sees the same pair.
 
@@ -85,10 +85,12 @@ def test_the_leaf_imports_nothing_from_osprey():
 def test_the_profile_schema_keeps_the_dispatch_package_out_of_its_import_graph():
     """The CLI reads the numbers from the leaf, not through ``osprey.dispatch``.
 
-    Every ``build``, ``config`` and ``init`` invocation imports the schema,
-    while ``osprey.dispatch`` pulls in the HTTP worker client the CLI never
-    calls. The profile's own trigger check imports the package on demand, and
-    the pool defaults must not undo that.
+    Every ``build``, ``config`` and ``init`` invocation imports the schema, and
+    the dispatcher package has no place in that import graph at all: the
+    profile's own trigger check imports it on demand, and the pool defaults
+    must not undo that. This is a stronger guarantee than the package's own
+    lazy exports, which say only that importing the package is cheap, and it
+    must not be relaxed into it.
     """
     fresh = _fresh_import_modules("osprey.cli.build_profile_schema", set())
     assert not [name for name in fresh if name.split(".")[:2] == ["osprey", "dispatch"]]


### PR DESCRIPTION
The `osprey.dispatch` package resolves its fifteen public names on first attribute access instead of importing all four submodules at package import.

Commits:
- `perf(dispatch): resolve the package's exports on first use`

## Why

The package re-exported the pool, the trigger registry, the trigger-configuration reader and the HTTP worker client eagerly, so importing any one leaf cost all four: `import osprey.dispatch.trigger_config` — configuration reading that needs nothing but a YAML parser — loaded `httpx` and `idna` and the pool behind it. The package now carries a `_LAZY_EXPORTS` map from each public name to its defining submodule, with a PEP 562 `__getattr__` that imports the submodule on first access and caches the value, the same pattern eight other packages in this tree already use. Importing a leaf now costs only that leaf, so code that reads `triggers.yml` no longer drags an HTTP stack in with it, and a new test module pins all three properties: no `httpx` behind `trigger_config`, no leaf behind the package root, and every name in `__all__` resolving to the same object its defining module exports.

No public name moves and no behavior changes; every existing caller already imports its submodule directly.

## Not in this PR

No docs change — the import cost is not user-visible behavior, so the fragment is `internal`. The profile-schema import guard in `tests/test_dispatch_pool_defaults.py` keeps its own, stronger contract (the dispatcher package stays out of the CLI's import graph entirely) rather than being relaxed into the package-level one; only its docstring is updated.
