### PR TITLE
fix(cli): refuse three preconditions where they are first known instead of failing later

### DIFF
--- a/changelog.d/audit-missing-provider.fixed.md
+++ b/changelog.d/audit-missing-provider.fixed.md
@@ -1,0 +1,3 @@
+`osprey audit` on a project whose `config.yml` names no provider now says so and
+names the fix, instead of exiting on a traceback from inside the reviewer's
+agent loop.

--- a/changelog.d/database-build-refusal.changed.md
+++ b/changelog.d/database-build-refusal.changed.md
@@ -1,0 +1,4 @@
+`osprey channel-finder build-database` now fails, naming the family, when a
+device family cannot be turned into a template. Such a family was previously
+degraded to plain rows and the run still reported success, so the database
+silently lost the family's device navigation.

--- a/changelog.d/ttl-level-grammar.fixed.md
+++ b/changelog.d/ttl-level-grammar.fixed.md
@@ -1,0 +1,3 @@
+`osprey knowledge build-ttl` now refuses a channel database written on another
+facility's level grammar by naming the grammar it reads, rather than failing
+with a message about the database's naming pattern.

--- a/src/osprey/cli/audit_cmd.py
+++ b/src/osprey/cli/audit_cmd.py
@@ -78,8 +78,19 @@ def _extract_json(text: str) -> str | None:
 def _reviewer_options(project_dir: Path, model: str, budget: float):
     """Build the reviewer's SDK options from the audited project's own provider.
 
-    Separate from :func:`_run_audit` so the wiring can be read — and pinned —
-    without opening an event loop.
+    The builder resolves that provider's endpoint, auth and model ids from the
+    project's ``config.yml``, and starts the translation proxy when the
+    provider needs one. Hand-building the options left the SDK to fall through
+    to ambient ``ANTHROPIC_*`` variables, so an audit of a gateway-fronted
+    deployment ran against whatever endpoint the operator's shell happened to
+    hold — or nothing at all.
+
+    ``setting_sources=[]`` is deliberate: the reviewer reads the target, it does
+    not run as it, so the audited project's own hooks and settings stay out of
+    the reviewing agent.
+
+    Raises:
+        RuntimeError: When the project names no resolvable provider.
     """
     from osprey.agent_runner.primitives import build_agent_options
 
@@ -96,30 +107,24 @@ def _reviewer_options(project_dir: Path, model: str, budget: float):
 
 async def _run_audit(
     prompt: str,
-    model: str,
-    cwd: Path,
-    budget: float,
+    options,
     verbose: bool,
 ) -> tuple[str, float | None, int | None]:
-    """Run the audit agent and collect its output.
+    """Run the audit agent with *options* and collect its output.
 
-    The reviewer runs on the audited deployment's own provider: the options come
-    from the shared builder, which resolves that provider's endpoint, auth and
-    model ids from the project's ``config.yml`` (and starts the translation
-    proxy when the provider needs one). Hand-building the options here left the
-    SDK to fall through to ambient ``ANTHROPIC_*`` variables, so an audit of a
-    gateway-fronted deployment ran against whatever endpoint the operator's
-    shell happened to hold — or nothing at all.
+    The options are built by the caller rather than here: building them is how
+    the audited deployment's provider is resolved, and a provider that cannot
+    be resolved is a refusal the command states in its own body, not an
+    exception raised inside an event loop.
 
-    ``setting_sources=[]`` is deliberate: the reviewer reads the target, it does
-    not run as it, so the audited project's own hooks and settings stay out of
-    the reviewing agent.
+    Args:
+        prompt: The reviewer's prompt.
+        options: The SDK options from :func:`_reviewer_options`.
+        verbose: Whether to echo the reviewer's transcript as it arrives.
 
     Returns:
         Tuple of (collected_text, total_cost, num_turns).
     """
-    options = _reviewer_options(cwd, model, budget)
-
     collected_text: list[str] = []
     total_cost: float | None = None
     num_turns: int | None = None
@@ -356,10 +361,22 @@ def audit(
             file_listing = _list_files(audit_root)
             prompt = build_audit_prompt(target_type, target_dir, file_listing)
 
+            # Built here rather than inside the agent loop: the builder is what
+            # resolves the audited deployment's provider, and it is also what
+            # starts the translation proxy when that provider needs one, so a
+            # discard-the-result pre-check would leave a stray proxy behind.
+            try:
+                reviewer_options = _reviewer_options(audit_root, resolved_model, budget)
+            except RuntimeError as exc:
+                output.fail(
+                    "The reviewer has no provider to run on",
+                    str(exc),
+                    "set `provider:` in profile.yml and run `osprey build`",
+                )
+                raise SystemExit(1) from None
+
             # Run the agent
-            raw_text, cost, turns = asyncio.run(
-                _run_audit(prompt, resolved_model, audit_root, budget, verbose)
-            )
+            raw_text, cost, turns = asyncio.run(_run_audit(prompt, reviewer_options, verbose))
 
             # Parse the result
             json_str = _extract_json(raw_text)

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -737,6 +737,35 @@ def _resolve_channel_db(channel_db: Path | None) -> Path:
     return path
 
 
+def _check_level_grammar(raw: Mapping[str, Any], db_path: Path) -> None:
+    """Refuse a database whose levels are not the grammar this verb reads.
+
+    Runs on the raw document, before anything expands it. A database on
+    another machine's grammar carries that machine's naming pattern too, and
+    expansion fails on the pattern first — a sentence about a naming pattern,
+    for a file whose real problem is that it is not this verb's grammar at all.
+
+    Args:
+        raw: The parsed database payload.
+        db_path: Where it came from, for the error message.
+
+    Raises:
+        click.ClickException: When the file's levels are not the six-token
+            grammar this verb reads.
+    """
+    from osprey.services.facility_knowledge.ttl_generator.model import check_hierarchy_levels
+
+    hierarchy = raw.get("hierarchy")
+    levels = (hierarchy.get("levels") or []) if isinstance(hierarchy, Mapping) else []
+    try:
+        check_hierarchy_levels(levels)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise click.ClickException(
+            f"Cannot read the level grammar in {db_path}: {exc}\n"
+            f"build-ttl reads the six-token grammar: {_address_grammar().replace(':', ', ')}."
+        ) from exc
+
+
 def _load_channel_map(db_path: Path) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
     """Expand *db_path* into its flat address map, keeping the file's own blocks.
 
@@ -754,21 +783,33 @@ def _load_channel_map(db_path: Path) -> tuple[Mapping[str, Any], Mapping[str, An
         database payload — its ``tree`` and ``hierarchy`` blocks).
 
     Raises:
-        click.ClickException: When the file cannot be read or expanded.
+        click.ClickException: When the file cannot be read or expanded, or when
+            its levels are not the grammar this verb reads.
     """
     from osprey.services.channel_finder.databases.hierarchical import HierarchicalChannelDatabase
+
+    def unreadable(exc: Exception) -> click.ClickException:
+        return click.ClickException(
+            f"Cannot read the channel database at {db_path}: {exc}\n"
+            "build-ttl expects a hierarchical database: a 'hierarchy' block naming the "
+            "levels, and a 'tree' block holding them."
+        )
 
     try:
         raw = json.loads(db_path.read_text(encoding="utf-8"))
         if not isinstance(raw, Mapping):
             raise ValueError("the file is not a JSON object")
+    except (OSError, ValueError, TypeError) as exc:
+        raise unreadable(exc) from exc
+
+    # Between reading and expanding: the level list is on the raw document, and
+    # a foreign grammar's naming pattern is what expansion would fail on first.
+    _check_level_grammar(raw, db_path)
+
+    try:
         return HierarchicalChannelDatabase(str(db_path)).channel_map, raw
     except (OSError, ValueError, KeyError, TypeError) as exc:
-        raise click.ClickException(
-            f"Cannot read the channel database at {db_path}: {exc}\n"
-            "build-ttl expects a hierarchical database: a 'hierarchy' block naming the "
-            "levels, and a 'tree' block holding them."
-        ) from exc
+        raise unreadable(exc) from exc
 
 
 def _resolve_descriptions(descriptions: Path | None, db_path: Path) -> Path:

--- a/src/osprey/services/channel_finder/core/exceptions.py
+++ b/src/osprey/services/channel_finder/core/exceptions.py
@@ -57,3 +57,14 @@ class AddressPatternError(ChannelFinderError):
     otherwise reach the database as channels whose address is the literal
     pattern text.  It is a defect in the input, not a family to skip.
     """
+
+
+class TemplateBuildError(ChannelFinderError):
+    """Raised when a device family cannot be turned into a template.
+
+    The rows of one family describe one template; a cell the builder cannot
+    read leaves it with no template to write.  Dropping the family to plain
+    rows instead would answer navigation queries about it with nothing while
+    the build still reported success, so the input is named and the build
+    stops.
+    """

--- a/src/osprey/services/channel_finder/tools/build_database.py
+++ b/src/osprey/services/channel_finder/tools/build_database.py
@@ -23,7 +23,10 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
-from osprey.services.channel_finder.core.exceptions import AddressPatternError
+from osprey.services.channel_finder.core.exceptions import (
+    AddressPatternError,
+    TemplateBuildError,
+)
 
 
 def load_csv(csv_path: Path, delimiter: str = ",") -> list[dict]:
@@ -289,9 +292,10 @@ def build_database(
 
     Raises:
         AddressPatternError: When a family's address pattern cannot be
-            expanded. Every other per-family failure demotes that family to
-            standalone rows; this one would write addresses that are the
-            literal pattern, so the build stops instead.
+            expanded.
+        TemplateBuildError: When a family cannot be turned into a template for
+            any other reason. Either way the build stops with the family named
+            rather than writing a database that is missing it.
     """
     print("=" * 80)
     print("Channel Database Builder")
@@ -314,13 +318,18 @@ def build_database(
         try:
             template = create_template(family_name, family_channels)
         except AddressPatternError:
-            # Not a family to skip: every address it would contribute is the
-            # literal pattern text, so degrading it to standalone rows writes a
-            # database nothing can resolve. The input is wrong; say so and stop.
+            # Already names the family, and says which pattern it could not
+            # fill in; re-wrapping would only bury that.
             raise
-        except Exception as e:
-            print(f"  \u2717 {family_name}: ERROR - {e}")
-            standalone.extend(family_channels)
+        except Exception as exc:
+            # Not a family to skip: a family that reaches the database as plain
+            # rows, or not at all, answers navigation queries about it with
+            # nothing while the run still reports success. The input is wrong;
+            # say which family and stop.
+            raise TemplateBuildError(
+                f"family {family_name!r} cannot be built into a template ({exc}); "
+                "fix the family's rows in the input"
+            ) from exc
         else:
             templates.append(template)
             print(f"  \u2713 {family_name}: {len(family_channels)} channels \u2192 template")

--- a/src/osprey/services/facility_knowledge/ttl_generator/model.py
+++ b/src/osprey/services/facility_knowledge/ttl_generator/model.py
@@ -235,7 +235,7 @@ def resolve_hierarchy_descriptions(
             (RING, SYSTEM, FAMILY, DEVICE, FIELD, SUBFIELD, with DEVICE the one
             generated level).
     """
-    _check_levels(levels)
+    check_hierarchy_levels(levels)
     collected: dict[str, dict[tuple[str, ...], str]] = {
         name: {} for name, kind in _EXPECTED_LEVELS if kind == TREE_LEVEL
     }
@@ -249,8 +249,21 @@ def resolve_hierarchy_descriptions(
     )
 
 
-def _check_levels(levels: Sequence[Mapping[str, object]]) -> None:
-    """Refuse a level list that is not the grammar the five maps are named for."""
+def check_hierarchy_levels(levels: Sequence[Mapping[str, object]]) -> None:
+    """Refuse a level list that is not the grammar the five maps are named for.
+
+    Public because the check is worth running on a raw database before anything
+    expands it: a document on another machine's grammar carries another
+    machine's naming pattern too, and that fails first with a sentence about
+    the pattern rather than about the grammar.
+
+    Args:
+        levels: A database's ``hierarchy.levels`` list, each entry a mapping
+            with a ``name`` and a ``type``.
+
+    Raises:
+        ValueError: If *levels* is not the six-token grammar this module reads.
+    """
     given = tuple((str(level.get("name", "")), str(level.get("type", ""))) for level in levels)
     if given != _EXPECTED_LEVELS:
         expected = ", ".join(f"{name} ({kind})" for name, kind in _EXPECTED_LEVELS)

--- a/tests/cli/test_audit_cmd.py
+++ b/tests/cli/test_audit_cmd.py
@@ -59,6 +59,22 @@ def tmp_project(tmp_path):
 
 
 @pytest.fixture
+def stub_reviewer_options(monkeypatch):
+    """Stand in for the reviewer's options builder.
+
+    The command builds them in its own body, so a test that drives it with a
+    faked agent loop reaches the real builder — which refuses these fixture
+    projects, none of which names a provider. What the options are does not
+    matter to those tests: the loop they run is a stub.
+    """
+    monkeypatch.setattr(
+        "osprey.cli.audit_cmd._reviewer_options",
+        lambda project_dir, model, budget: object(),
+        raising=True,
+    )
+
+
+@pytest.fixture
 def tmp_profile(tmp_path):
     """Create a minimal profile YAML."""
     profile = tmp_path / "test-profile.yml"
@@ -202,7 +218,9 @@ class TestAuditCLI:
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
-    def test_audit_project_success(self, mock_asyncio, runner, tmp_project, sample_report):
+    def test_audit_project_success(
+        self, mock_asyncio, runner, tmp_project, sample_report, stub_reviewer_options
+    ):
         report_json = sample_report.model_dump_json()
         mock_asyncio.run.return_value = (report_json, 0.01, 5)
 
@@ -211,7 +229,9 @@ class TestAuditCLI:
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
-    def test_audit_json_output(self, mock_asyncio, runner, tmp_project, sample_report):
+    def test_audit_json_output(
+        self, mock_asyncio, runner, tmp_project, sample_report, stub_reviewer_options
+    ):
         report_json = sample_report.model_dump_json()
         mock_asyncio.run.return_value = (report_json, 0.01, 5)
 
@@ -222,7 +242,9 @@ class TestAuditCLI:
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
-    def test_audit_verbose(self, mock_asyncio, runner, tmp_project, sample_report):
+    def test_audit_verbose(
+        self, mock_asyncio, runner, tmp_project, sample_report, stub_reviewer_options
+    ):
         report_json = sample_report.model_dump_json()
         mock_asyncio.run.return_value = (report_json, 0.05, 10)
 
@@ -241,7 +263,9 @@ class TestAuditCLI:
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
-    def test_audit_invalid_json_output(self, mock_asyncio, runner, tmp_project):
+    def test_audit_invalid_json_output(
+        self, mock_asyncio, runner, tmp_project, stub_reviewer_options
+    ):
         mock_asyncio.run.return_value = ("Not valid JSON at all", None, None)
 
         result = runner.invoke(self._get_audit_cmd(), [str(tmp_project)])
@@ -249,7 +273,9 @@ class TestAuditCLI:
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
-    def test_audit_markdown_fenced_json(self, mock_asyncio, runner, tmp_project, sample_report):
+    def test_audit_markdown_fenced_json(
+        self, mock_asyncio, runner, tmp_project, sample_report, stub_reviewer_options
+    ):
         report_json = sample_report.model_dump_json()
         fenced = f"```json\n{report_json}\n```"
         mock_asyncio.run.return_value = (fenced, 0.01, 5)
@@ -280,7 +306,7 @@ class TestBuildFlag:
     @patch("osprey.cli.audit_cmd.asyncio")
     @patch("osprey.cli.audit_cmd.click.get_current_context")
     def test_build_flag_invokes_build_cmd(
-        self, mock_ctx, mock_asyncio, runner, tmp_profile, sample_report
+        self, mock_ctx, mock_asyncio, runner, tmp_profile, sample_report, stub_reviewer_options
     ):
         report_json = sample_report.model_dump_json()
         mock_asyncio.run.return_value = (report_json, 0.01, 5)
@@ -333,9 +359,24 @@ class TestReviewerProvider:
         assert captured["setting_sources"] == []
 
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
+    def test_a_project_that_names_no_provider_is_refused(self, runner, tmp_project):
+        """A project whose config.yml sets no provider has nothing to run on.
+
+        The builder already says so, but it was called from inside the event
+        loop, so the sentence reached the operator as a traceback.
+        """
+        result = runner.invoke(self._get_audit_cmd(), [str(tmp_project)])
+
+        flat = " ".join(result.output.split())
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "The reviewer has no provider to run on" in flat
+        assert "set `provider:` in profile.yml and run `osprey build`" in flat
+
+    @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
     def test_default_model_is_the_projects_sonnet_tier(
-        self, mock_asyncio, runner, tmp_project, sample_report, monkeypatch
+        self, mock_asyncio, runner, tmp_project, sample_report, monkeypatch, stub_reviewer_options
     ):
         mock_asyncio.run.return_value = (sample_report.model_dump_json(), 0.01, 5)
         seen: dict = {}
@@ -359,7 +400,7 @@ class TestReviewerProvider:
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
     def test_an_explicit_model_still_wins(
-        self, mock_asyncio, runner, tmp_project, sample_report, monkeypatch
+        self, mock_asyncio, runner, tmp_project, sample_report, monkeypatch, stub_reviewer_options
     ):
         mock_asyncio.run.return_value = (sample_report.model_dump_json(), 0.01, 5)
         monkeypatch.setattr(
@@ -385,7 +426,7 @@ class TestReviewerProvider:
     @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
     @patch("osprey.cli.audit_cmd.asyncio")
     def test_a_bare_profile_in_a_repo_runs_from_the_repos_build(
-        self, mock_asyncio, runner, tmp_path, sample_report, monkeypatch
+        self, mock_asyncio, runner, tmp_path, sample_report, monkeypatch, stub_reviewer_options
     ):
         """The render under ``build/`` holds ``config.yml``; the repo root does
         not, so resolving from the root is a FileNotFoundError on any real repo."""

--- a/tests/cli/test_json_contracts.py
+++ b/tests/cli/test_json_contracts.py
@@ -175,6 +175,12 @@ def _invoke_audit(
     with (
         patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True),
         patch("osprey.cli.audit_cmd.asyncio") as mock_asyncio,
+        # The fixture project names no provider, so the real builder refuses it;
+        # these contracts pin the streams, not the reviewer's wiring.
+        patch(
+            "osprey.cli.audit_cmd._reviewer_options",
+            new=lambda project_dir, model, budget: object(),
+        ),
     ):
         mock_asyncio.run.side_effect = _run
         return runner.invoke(audit, [str(project), "--json"])

--- a/tests/cli/test_json_keyset_capture.py
+++ b/tests/cli/test_json_keyset_capture.py
@@ -163,6 +163,12 @@ def audit_project(tmp_path: Path) -> Path:
 
 @patch("osprey.cli.audit_cmd._SDK_AVAILABLE", True)
 @patch("osprey.cli.audit_cmd.asyncio")
+# The fixture project names no provider, so the real options builder refuses it;
+# this test pins the document's key set, not the reviewer's wiring.
+@patch(
+    "osprey.cli.audit_cmd._reviewer_options",
+    new=lambda project_dir, model, budget: object(),
+)
 def test_audit_json_keyset(mock_asyncio: MagicMock, runner: CliRunner, audit_project: Path) -> None:
     """``audit --json`` emits the recorded ``AuditReport`` key set."""
     report = AuditReport(

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -946,9 +946,9 @@ def test_build_ttl_refuses_a_foreign_level_list_before_it_parses_addresses(
 ) -> None:
     """A machine on another level grammar gets one refusal, not one per address.
 
-    The level list is read while the prose is resolved, which happens before
-    any address is parsed; that order is what turns a whole foreign database
-    into a single line naming the grammar this verb reads.
+    The level list is read when the file is, before anything is expanded; that
+    order is what turns a whole foreign database into a single line naming the
+    grammar this verb reads.
     """
     payload = _hierarchical_payload()
     # A machine whose top level is a section rather than a ring, and whose last
@@ -980,6 +980,52 @@ def test_build_ttl_refuses_a_foreign_level_list_before_it_parses_addresses(
     assert "six-token grammar: RING, SYSTEM, FAMILY, DEVICE, FIELD, SUBFIELD" in flat
     # Not the per-address refusal: nothing was parsed before the list was checked.
     assert "holds an address build-ttl cannot read" not in flat
+    assert not output.exists()
+
+
+def test_build_ttl_refuses_a_foreign_level_list_before_it_expands(
+    descriptions_db: Path, tmp_path: Path
+) -> None:
+    """A database the expander cannot even open still gets the grammar sentence.
+
+    A foreign machine's level list comes with a foreign naming pattern, and a
+    pattern naming a level that list does not carry fails in expansion -- which
+    is a sentence about the naming pattern, not about the grammar this verb
+    reads. The level list is on the raw document, so nothing has to expand for
+    the check that names the grammar to run.
+    """
+    payload = _hierarchical_payload()
+    # Another machine's levels: five of them, none of them a ring, and a
+    # pattern that names one the list does not carry.
+    payload["hierarchy"]["levels"] = [
+        {"name": "system", "type": "tree"},
+        {"name": "family", "type": "tree"},
+        {"name": "sector", "type": "tree"},
+        {"name": "device", "type": "tree"},
+        {"name": "pv", "type": "tree"},
+    ]
+    payload["hierarchy"]["naming_pattern"] = "{ring}:{pv}"
+    db_path = tmp_path / "foreign_grammar.json"
+    db_path.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "out.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(db_path),
+            "--descriptions",
+            str(descriptions_db),
+        ],
+    )
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "Traceback" not in result.output
+    assert "six-token grammar: RING, SYSTEM, FAMILY, DEVICE, FIELD, SUBFIELD" in flat
+    assert "Cannot read the channel database" not in flat
     assert not output.exists()
 
 

--- a/tests/cli/test_subcommand_verbose_flags.py
+++ b/tests/cli/test_subcommand_verbose_flags.py
@@ -97,6 +97,12 @@ def run_audit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         return document, 0.01, 2
 
     monkeypatch.setattr("osprey.cli.audit_cmd._run_audit", _fake_run_audit)
+    # The options are built in the command body now, and this target names no
+    # provider; the flag under test is the gate, not the reviewer's wiring.
+    monkeypatch.setattr(
+        "osprey.cli.audit_cmd._reviewer_options",
+        lambda project_dir, model, budget: object(),
+    )
 
     target = tmp_path / "audited-project"
     target.mkdir()

--- a/tests/services/channel_finder/tools/test_build_database_helpers.py
+++ b/tests/services/channel_finder/tools/test_build_database_helpers.py
@@ -12,7 +12,10 @@ from pathlib import Path
 
 import pytest
 
-from osprey.services.channel_finder.core.exceptions import AddressPatternError
+from osprey.services.channel_finder.core.exceptions import (
+    AddressPatternError,
+    TemplateBuildError,
+)
 from osprey.services.channel_finder.tools.build_database import (
     build_database,
     create_template,
@@ -356,10 +359,10 @@ def test_parse_instance_range_refuses_a_backwards_range() -> None:
 def test_build_database_stops_on_an_unfillable_address_pattern(tmp_path: Path) -> None:
     """The build fails rather than writing addresses that are the pattern text.
 
-    Every other per-family failure demotes the family to standalone rows, which
-    is why this one has to be a distinct exception: a family whose pattern
-    cannot be expanded would otherwise land in the database verbatim, braces
-    and all, and the run would still report success.
+    A family whose pattern cannot be expanded would otherwise land in the
+    database verbatim, braces and all. It keeps its own exception because the
+    pattern is the fact worth naming; every other way a family fails to
+    template is a :class:`TemplateBuildError`.
     """
     csv_path = _write_csv(
         tmp_path,
@@ -369,6 +372,36 @@ def test_build_database_stops_on_an_unfillable_address_pattern(tmp_path: Path) -
     output = tmp_path / "database.json"
 
     with pytest.raises(AddressPatternError, match="cannot be filled in"):
+        build_database(csv_path=csv_path, output_path=output)
+
+    assert not output.exists()
+
+
+def test_build_database_stops_on_a_non_numeric_instance_count(tmp_path: Path) -> None:
+    """A family the builder cannot template fails the build, naming the family."""
+    csv_path = _write_csv(
+        tmp_path,
+        "address,description,family_name,instances,sub_channel\n"
+        "SR:BPM:{instance:02d}:{sub_channel},X position,BPM,many,XPOS\n",
+    )
+    output = tmp_path / "database.json"
+
+    with pytest.raises(TemplateBuildError, match="family 'BPM' cannot be built"):
+        build_database(csv_path=csv_path, output_path=output)
+
+    assert not output.exists()
+
+
+def test_build_database_stops_on_a_backwards_instance_range(tmp_path: Path) -> None:
+    """A range that ends before it starts expands to nothing, so nothing is written."""
+    csv_path = _write_csv(
+        tmp_path,
+        "address,description,family_name,instances,sub_channel\n"
+        "SR:BPM:{instance:02d}:{sub_channel},X position,BPM,11-4,XPOS\n",
+    )
+    output = tmp_path / "database.json"
+
+    with pytest.raises(TemplateBuildError, match="family 'BPM' cannot be built"):
         build_database(csv_path=csv_path, output_path=output)
 
     assert not output.exists()

--- a/tests/services/channel_finder/tools/test_build_database_llm.py
+++ b/tests/services/channel_finder/tools/test_build_database_llm.py
@@ -1,9 +1,9 @@
 """Tests for the LLM-naming and error-recovery branches of ``build_database``.
 
-Covers the three arms that the plain (no-LLM) path never reaches: successful
-LLM naming, degradation to addresses when the namer cannot be constructed, and
-the per-family fallthrough that turns a template-creation failure into
-standalone entries instead of aborting the whole build.
+Covers the arms that the plain (no-LLM) path never reaches: successful LLM
+naming, and degradation to addresses when the namer cannot be constructed. A
+family whose template cannot be built is not one of them -- that stops the
+build, so nothing downstream of it runs.
 
 ``build_database`` imports ``create_namer_from_config`` *inside* the function
 body, so the name is never bound on ``build_database``'s module globals.
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from osprey.services.channel_finder.core.exceptions import TemplateBuildError
 from osprey.services.channel_finder.tools.build_database import build_database
 
 NAMER_FACTORY = "osprey.services.channel_finder.tools.llm_channel_namer.create_namer_from_config"
@@ -149,15 +150,20 @@ def test_llm_naming_failure_degrades_to_addresses(tmp_path, monkeypatch):
     assert on_disk == db
 
 
-def test_template_failure_falls_through_to_standalone(tmp_path):
-    """A family whose template cannot be built becomes standalone entries."""
+def test_template_failure_stops_the_build(tmp_path):
+    """A family whose template cannot be built fails the build, naming it.
+
+    Degrading it to standalone rows wrote a database that was missing the
+    family's device navigation while the run still reported success, so the
+    file the well-formed families would have gone into is not written either.
+    """
     csv_path = _write_csv(
         tmp_path,
         [
             # instances="abc" makes create_template's int() raise ValueError.
             "BPM01:X,BPM horizontal position,BPM,abc,:X",
             "BPM01:Y,BPM vertical position,BPM,abc,:Y",
-            # A well-formed family must still make it into the database.
+            # A well-formed family is no reason to write half a database.
             "COR01:SP,Corrector setpoint,COR,4,:SP",
             "COR01:RB,Corrector readback,COR,4,:RB",
             "SR:TEMP,Ring temperature,,,",
@@ -165,31 +171,10 @@ def test_template_failure_falls_through_to_standalone(tmp_path):
     )
     output_path = tmp_path / "db.json"
 
-    db = build_database(csv_path, output_path)
+    with pytest.raises(TemplateBuildError, match="family 'BPM' cannot be built"):
+        build_database(csv_path, output_path)
 
-    templates = _templates(db)
-    assert [t["base_name"] for t in templates] == ["COR"]
-
-    # The two BPM rows fell through to standalone, appended after the genuine
-    # standalone row, and are named by address.
-    entries = _standalone(db)
-    assert [e["address"] for e in entries] == ["SR:TEMP", "BPM01:X", "BPM01:Y"]
-    assert [e["channel"] for e in entries] == ["SR:TEMP", "BPM01:X", "BPM01:Y"]
-    assert [e["description"] for e in entries] == [
-        "Ring temperature",
-        "BPM horizontal position",
-        "BPM vertical position",
-    ]
-
-    stats = db["_metadata"]["stats"]
-    assert stats == {
-        "template_entries": 1,
-        "standalone_entries": 3,
-        "total_entries": 4,
-    }
-
-    on_disk = json.loads(output_path.read_text(encoding="utf-8"))
-    assert on_disk == db
+    assert not output_path.exists()
 
 
 def test_patch_target_is_the_owning_module():


### PR DESCRIPTION
Three command-line paths reached a precondition they already knew how to state
too late, or not at all. Each check moves to where the fact is first known, and
says it in the shape the surrounding command already uses.

- `fix(cli): refuse an audit of a project that names no provider`
- `fix(channel-finder): fail a database build on any family it cannot template`
- `fix(cli): refuse a foreign level grammar before the database is expanded`

## Why

`osprey audit` built the reviewer's SDK options inside the agent loop, so a
project whose `config.yml` names no provider learned about it from an uncaught
`RuntimeError` — a traceback where the verb has a refusal shape of its own. The
options are now built in the command body, once, and the refusal names the
remedy. Building them there is also what resolves the deployment's provider, so
the check and the work are the same call rather than a pre-check that would
leave the translation proxy it starts behind.

`build-database` printed an error for a family it could not turn into a
template, dropped that family to plain rows, and reported success. The written
database looked complete while it had silently lost that family's device
navigation. Any such failure now raises `TemplateBuildError` naming the family,
beside the address-pattern refusal that already stopped the build, and no file
is written. Deployers reading their own CSV get told which family to fix
instead of discovering the gap from a query that returns nothing.

`build-ttl` read the hierarchy level list while it resolved the per-level
prose — after expansion. A database on another facility's grammar carries that
facility's naming pattern too, so it died in the expander first and the message
was about a naming pattern, for a file whose real problem is that it is not
this verb's grammar at all. The level list is on the raw document, so the check
now runs as soon as the file is parsed. `check_hierarchy_levels` is public for
its second caller; the grammar sentence still has a single producer.

## Not in this PR

No docs change: none of the three messages is quoted under `docs/`.
`parse_instance_range` keeps raising a plain `ValueError` — it validates one
cell, and its caller is what turns that into a build refusal. No lenient flag
for the database build, and no way to restore the old demotion behind one.
