### PR TITLE
fix(deploy): carry the provider's gateway endpoint into .env.users

### DIFF
--- a/changelog.d/web-tier-gateway-url.fixed.md
+++ b/changelog.d/web-tier-gateway-url.fixed.md
@@ -1,0 +1,4 @@
+Per-user web terminals no longer restart forever on a deployment whose provider
+fronts a gateway with no default endpoint. The variable naming that endpoint now
+crosses into `.env.users` with the provider's key, and a deploy whose env chain
+sets neither is refused by name instead of generating the file.

--- a/docs/source/how-to/llm-providers/configure-providers.rst
+++ b/docs/source/how-to/llm-providers/configure-providers.rst
@@ -120,6 +120,13 @@ agent run — stops with::
 A direct model call and ``osprey health`` report the same thing more briefly,
 as ``Base URL required for als-apg``.
 
+On a multi-user deployment the endpoint has to be in the repository's env chain
+rather than only in your shell. Each per-user terminal runs with ``.env.users``,
+a generated file the deploy copies the provider's key and endpoint into, and it
+is copied from what is on disk — never from the environment ``osprey up`` runs
+in. A chain that sets neither is refused before any container starts, naming the
+variable.
+
 .. note::
 
    A shell export reaches a **deployment** only once, when ``osprey init``

--- a/src/osprey/build/claude_code_resolver.py
+++ b/src/osprey/build/claude_code_resolver.py
@@ -95,6 +95,42 @@ CLAUDE_CODE_PROVIDERS: dict[str, dict] = {
 }
 
 
+class ProviderEndpointError(ValueError):
+    """A provider that fronts a gateway was given no endpoint to call.
+
+    Its own error type, not a bare ``ValueError``, because one caller has to
+    tell it apart: the web pre-flight skips the ordinary config faults its
+    provider read can raise (an unparseable file, an unknown provider name —
+    each already diagnosed elsewhere) and would otherwise swallow this one too,
+    leaving the operator with a silent launch and a server that exits during
+    startup. Subclasses ``ValueError`` so every caller that catches the broad
+    type keeps catching this.
+    """
+
+
+def provider_base_url_env(provider_name: str) -> str | None:
+    """Name of the env var a built-in provider reads its gateway endpoint from.
+
+    The endpoint counterpart of :func:`provider_auth_secret_env`, and the same
+    indirection: the table records WHERE a deployment keeps its gateway URL,
+    never the URL. ``None`` for a provider that declares no such variable, and
+    for one the built-in table has never heard of — a custom proxy's endpoint
+    is named by its own ``api.providers`` entry instead.
+    """
+    return (CLAUDE_CODE_PROVIDERS.get(provider_name) or {}).get("base_url_env_var")
+
+
+def provider_requires_base_url(provider_name: str) -> bool:
+    """Whether ``provider_name`` fronts a gateway that ships no default endpoint.
+
+    True means a launch that resolves no URL is refused
+    (:class:`ProviderEndpointError`) rather than falling back to a host, so
+    whatever names the endpoint has to be delivered to the process that calls
+    the gateway.
+    """
+    return bool((CLAUDE_CODE_PROVIDERS.get(provider_name) or {}).get("requires_base_url"))
+
+
 def provider_auth_secret_env(provider_name: str, api_providers: dict | None = None) -> str | None:
     """Name of the shell env var holding ``provider_name``'s auth secret.
 
@@ -875,7 +911,7 @@ class ClaudeCodeModelResolver:
             sources = f"api.providers.{provider_name}.base_url in config.yml"
             if env_var:
                 sources = f"{env_var}, or {sources}"
-            raise ValueError(
+            raise ProviderEndpointError(
                 f"Provider '{provider_name}' has no base_url. It fronts models "
                 f"through a gateway that has no default endpoint, so the URL has "
                 f"to be named: set {sources}."

--- a/src/osprey/cli/users_cmd.py
+++ b/src/osprey/cli/users_cmd.py
@@ -936,6 +936,7 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
             USERS_ENV_FILENAME,
             _build_env_production_subset,
             _claude_code_auth_secret_vars,
+            _provider_endpoint_vars,
             render_env_users,
         )
         from osprey.utils.config import load_project_config
@@ -995,6 +996,7 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
         required_vars, extra_vars, _keyless_vars = _claude_code_auth_secret_vars(
             deploy_config, project_root
         )
+        required_url_vars, extra_url_vars = _provider_endpoint_vars(deploy_config, project_root)
         missing = {var: origin for var, origin in required_vars.items() if var not in dotenv}
         if missing:
             # Warn rather than refuse: whether an absent auth secret is fatal is
@@ -1007,8 +1009,26 @@ def env_production(repo: Path | None, env_file: str | None, output: str | None) 
                 "authentication unless they authenticate another way.",
             )
 
+        missing_urls = {
+            var: origin for var, origin in required_url_vars.items() if var not in dotenv
+        }
+        if missing_urls:
+            # Its own line, because the failure is a different one: a provider
+            # that fronts a gateway with no default host resolves no endpoint at
+            # all, so the container exits during startup instead of serving a
+            # terminal that fails on its first prompt.
+            needs = "; ".join(f"{origin} needs {var}" for var, origin in missing_urls.items())
+            warn(
+                f"Rendering without gateway endpoint(s) absent from {source_desc}",
+                f"{needs}. Web terminals started with this file will exit at "
+                "startup unless the endpoint reaches them another way.",
+            )
+
         subset = _build_env_production_subset(
-            deploy_config, dotenv, {**required_vars, **extra_vars}
+            deploy_config,
+            dotenv,
+            {**required_vars, **extra_vars},
+            {**required_url_vars, **extra_url_vars},
         )
         # The deploy path's own renderer (readme header + quoted lines), so a
         # file rendered here and one `osprey up` generates are byte-identical.

--- a/src/osprey/cli/web_cmd.py
+++ b/src/osprey/cli/web_cmd.py
@@ -638,6 +638,11 @@ def _probe_auth_secret(build_dir: Path, repo_root: Path) -> tuple[list[str], lis
     the launch itself) to report — this probe just skips quietly rather than
     duplicating that diagnosis.
 
+    A provider that resolves no gateway endpoint
+    (:class:`~osprey.build.claude_code_resolver.ProviderEndpointError`) is the
+    other refusal this probe reports rather than skips, and it aborts: the
+    server's own startup resolves the same spec and exits on it.
+
     The one exception is
     :class:`~osprey.build.claude_code_telemetry.ObservabilityCredentialError`:
     nothing else in pre-flight resolves telemetry credentials, so a quiet skip
@@ -646,7 +651,7 @@ def _probe_auth_secret(build_dir: Path, repo_root: Path) -> tuple[list[str], lis
     going (telemetry credentials are orthogonal to whether the terminal can
     authenticate) while saying why the auth check never ran.
     """
-    from osprey.build.claude_code_resolver import load_provider_spec
+    from osprey.build.claude_code_resolver import ProviderEndpointError, load_provider_spec
     from osprey.build.claude_code_telemetry import ObservabilityCredentialError
 
     try:
@@ -669,6 +674,13 @@ def _probe_auth_secret(build_dir: Path, repo_root: Path) -> tuple[list[str], lis
             "deployment could not be resolved, so the provider was never read.\n"
             f"  {exc}"
         ]
+    except ProviderEndpointError as exc:
+        # Also ahead of the broad arm, and a FAILURE rather than a warning: the
+        # server resolves the same spec in its own startup and raises there too,
+        # so letting the launch through trades one named refusal for a process
+        # that exits seconds later with the reason buried in its log. Only
+        # names reach the message, never a value.
+        return [str(exc)], []
     except (OSError, ValueError):
         return [], []
     if spec is None or not spec.auth_secret_env:

--- a/src/osprey/deployment/web_terminals/env_production.py
+++ b/src/osprey/deployment/web_terminals/env_production.py
@@ -633,10 +633,128 @@ def _claude_code_auth_secret_vars(
     return required, extra, keyless
 
 
+def _provider_endpoint_var(cfg: dict, provider: str) -> tuple[str, bool] | None:
+    """``(var, required)`` for the endpoint one config's provider will call.
+
+    Two sources, in the order the launch paths read them. The config's own
+    ``api.providers.<provider>.base_url`` comes first when it holds an env
+    reference — the shipped catalog spells gateway endpoints that way
+    (``base_url: ${ALS_APG_BASE_URL}``), and a deployment that points the same
+    provider at a variable of its own is answered with that name rather than a
+    spelling this module decided. A config that names no reference falls back
+    to the variable the provider itself declares, which is the break-glass
+    redirect an already-built image can be repointed with.
+
+    ``required`` is the narrower question: whether the container resolves NO
+    endpoint without this variable. Only a provider that ships no default host
+    (:func:`~osprey.build.claude_code_resolver.provider_requires_base_url`) can
+    reach that state, and only when nothing else in the config answers for the
+    URL — a literal endpoint resolves on its own, and so does a reference
+    carrying its own ``:-default``.
+
+    :param cfg: One project's raw config — the deploy's, or a persona's.
+    :param provider: The provider name that config names.
+    :return: ``(var, required)``, or ``None`` when no variable names this
+        provider's endpoint at all.
+    """
+    from osprey.build.claude_code_resolver import (
+        provider_base_url_env,
+        provider_requires_base_url,
+    )
+
+    api_providers = (cfg.get("api") or {}).get("providers")
+    entry = api_providers.get(provider) if isinstance(api_providers, dict) else None
+    declared = entry.get("base_url") if isinstance(entry, dict) else None
+    needs_endpoint = provider_requires_base_url(provider)
+
+    reference = _env_reference(declared)
+    if reference is not None:
+        var, has_default = reference
+        return var, needs_endpoint and not has_default
+
+    var = provider_base_url_env(provider)
+    if not var:
+        return None
+    return var, needs_endpoint and not declared
+
+
+def _provider_endpoint_vars(
+    config: dict, project_root: Path
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Endpoint env-var names every provider in play reads its gateway URL from.
+
+    The endpoint half of :func:`_claude_code_auth_secret_vars`, over the same
+    set of configs and for the same reason: a per-user container sees only
+    ``.env.users``, so a gateway named by a variable nobody copied is no
+    gateway. A provider with no default host then resolves nothing, the
+    interface app raises during startup, and compose restarts it forever — a
+    terminal whose health never leaves ``starting`` and says nothing about why.
+
+    Returns two ``{var: origin}`` dicts, mirroring the auth-secret split:
+
+    - **required** — an agent provider that will resolve no endpoint without
+      the variable. Absent from the chain, the deploy is refused rather than
+      generated.
+    - **extra** — worth copying when present, never worth failing over: a
+      redirect variable for a provider that already has an endpoint, and every
+      ``llm.provider`` endpoint. The llm provider backs services inside the
+      container one call at a time rather than deciding whether the container
+      starts, which is the same reason ``llm.api_key_env_var`` is copied but
+      never required.
+
+    An endpoint is a URL, not a credential: it is copied so the terminals reach
+    the gateway the rest of the deployment reaches, and it grants nothing on
+    its own.
+    """
+    required: dict[str, str] = {}
+    extra: dict[str, str] = {}
+
+    def _record(cfg: dict, source: str, *, enforce: bool) -> None:
+        for field in ("claude_code", "llm"):
+            provider = (cfg.get(field) or {}).get("provider")
+            if not isinstance(provider, str) or not provider:
+                continue
+            resolved = _provider_endpoint_var(cfg, provider)
+            if resolved is None:
+                continue
+            var, needed = resolved
+            if var in required:
+                continue
+            origin = f"{field}.provider {provider!r} {source}"
+            if needed and enforce and field == "claude_code":
+                required[var] = origin
+                extra.pop(var, None)
+            else:
+                extra.setdefault(var, origin)
+
+    catalog = ((config.get("modules") or {}).get("web_terminals") or {}).get("personas")
+    catalog = catalog if isinstance(catalog, dict) else {}
+    referenced = _referenced_persona_names(config)
+
+    for persona_name, entry in _referenced_persona_entries(config):
+        config_yml = _persona_config_yml(project_root, entry)
+        if config_yml is None or not config_yml.is_file():
+            # Silent: _claude_code_auth_secret_vars warns about the same
+            # unreadable project already, and saying it twice per deploy would
+            # read as two separate problems.
+            continue
+        persona_config = _load_config_yml(config_yml)
+        if persona_config is None:
+            continue
+        _record(persona_config, f"(persona {persona_name!r})", enforce=True)
+
+    # Under a catalog the per-user containers run persona projects, so the
+    # deploy config's own provider answers for no container and its endpoint is
+    # copy-if-present — the same carve-out the auth secrets make.
+    _record(config, "(deploy config)", enforce=not (catalog and referenced))
+    return required, extra
+
+
 def _build_env_production_subset(
     config: dict,
     dotenv: dict[str, str],
     claude_code_secret_vars: dict[str, str] | None = None,
+    provider_endpoint_vars: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Build the module-conditional subset written into ``.env.users``.
 
@@ -657,6 +775,13 @@ def _build_env_production_subset(
       in by :func:`ensure_env_production`. Same chain-presence rule as
       every other entry; whether an *absent* var is an error is
       :func:`ensure_env_production`'s call, not this function's.
+    - ``provider_endpoint_vars`` — the gateway-endpoint vars resolved by
+      :func:`_provider_endpoint_vars` (the ``base_url`` reference, or the
+      provider's own redirect variable, for every ``claude_code.provider`` and
+      ``llm.provider`` in play). A URL rather than a credential, and here for
+      the same reason the secrets are: a provider that fronts a gateway with no
+      default host resolves no endpoint without it, so the interface app raises
+      during startup and the container restarts forever.
     - ``modules.olog.{username,password}_env_var`` — the electronic-logbook
       account, only if ``modules.olog.enabled``.
     - ``modules.wiki_search.token_env_var`` — the wiki credential, only if
@@ -781,6 +906,9 @@ def _build_env_production_subset(
     for var_name in claude_code_secret_vars or {}:
         _copy_named_env_var(var_name, dotenv, subset)
 
+    for var_name in provider_endpoint_vars or {}:
+        _copy_named_env_var(var_name, dotenv, subset)
+
     modules = config.get("modules") or {}
 
     olog = modules.get("olog") or {}
@@ -839,6 +967,8 @@ def users_env_generation_problem(config: dict, project_root: str | Path) -> str 
     :param project_root: Project root; ``.env.users`` and the env-chain files
         are resolved relative to it.
     :return: The refusal sentence, or ``None`` when generation would succeed.
+        It names the missing variables and what their absence costs — an
+        unauthenticated terminal, a provider with no endpoint, or both.
     """
     root = Path(project_root)
     users_env_path = root / USERS_ENV_FILENAME
@@ -857,6 +987,7 @@ def users_env_generation_problem(config: dict, project_root: str | Path) -> str 
 
     dotenv = merge_chain(root)
     required_cc_vars, _extra_cc_vars, _keyless_cc_vars = _claude_code_auth_secret_vars(config, root)
+    required_url_vars, _extra_url_vars = _provider_endpoint_vars(config, root)
     # Reported, never copied: these are variables a telemetry block depends on
     # that this file is not allowed to carry, so they join the gate below and
     # nothing else. Keeping them out of the {**required, **extra} pair handed to
@@ -868,11 +999,22 @@ def users_env_generation_problem(config: dict, project_root: str | Path) -> str 
     # sets is set.
     missing = {
         var: origin
-        for var, origin in {**telemetry_vars, **required_cc_vars}.items()
+        for var, origin in {**telemetry_vars, **required_cc_vars, **required_url_vars}.items()
         if var not in dotenv
     }
     if not missing:
         return None
+
+    # Named for what the absence actually costs, since the two halves fail
+    # differently: a secret is every terminal failing authentication on its
+    # first prompt, an endpoint is a container that exits during startup and
+    # restarts forever with its health stuck at "starting".
+    consequences = []
+    if any(var not in required_url_vars for var in missing):
+        consequences.append("unauthenticated")
+    if any(var in required_url_vars for var in missing):
+        consequences.append("without the gateway endpoint their provider has no default for")
+    consequence = " and ".join(consequences)
 
     needs = "; ".join(f"{origin} needs {var}" for var, origin in missing.items())
     # The chain on disk stays the only SOURCE (see ensure_env_production's
@@ -926,7 +1068,7 @@ def users_env_generation_problem(config: dict, project_root: str | Path) -> str 
         )
     return (
         f"Generating {users_env_path} from {sources_desc} would leave web "
-        f"terminals unauthenticated: {needs}, set in none of them. Add the "
+        f"terminals {consequence}: {needs}, set in none of them. Add the "
         f"missing variable(s) to {env_path}, or author .env.users "
         "yourself (an existing file is never regenerated) if this deploy "
         f"authenticates another way.{telemetry_note}{shell_hint}"
@@ -1068,7 +1210,13 @@ def users_env_drift(config: dict, project_root: str | Path) -> UsersEnvDrift | N
 
     dotenv = merge_chain(root)
     required_cc_vars, extra_cc_vars, _keyless_cc_vars = _claude_code_auth_secret_vars(config, root)
-    subset = _build_env_production_subset(config, dotenv, {**required_cc_vars, **extra_cc_vars})
+    required_url_vars, extra_url_vars = _provider_endpoint_vars(config, root)
+    subset = _build_env_production_subset(
+        config,
+        dotenv,
+        {**required_cc_vars, **extra_cc_vars},
+        {**required_url_vars, **extra_url_vars},
+    )
     rendered = render_env_users(subset)
     if text == rendered:
         return None
@@ -1174,7 +1322,10 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
       authenticate another way). A telemetry password reference that carries no
       default of its own (see :func:`_telemetry_credential_requirements`) joins
       the same gate: the variable it names is reported when the chain does not
-      set it, and is never written into the generated file either way.
+      set it, and is never written into the generated file either way. So does
+      the gateway endpoint of a provider that ships no default host (see
+      :func:`_provider_endpoint_vars`), whose absence is a container that exits
+      during startup rather than one that fails on its first prompt.
     - **Local mode, absent, the whole chain absent too**: raises, before any
       compose invocation — there is nothing to generate from and no file to
       fall back on.
@@ -1269,6 +1420,7 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
 
     dotenv = merge_chain(root)
     required_cc_vars, extra_cc_vars, _keyless_cc_vars = _claude_code_auth_secret_vars(config, root)
+    required_url_vars, extra_url_vars = _provider_endpoint_vars(config, root)
 
     # Unlike every optional module var above (silently skipped when absent —
     # see _copy_named_env_var), a missing claude_code auth secret means some
@@ -1282,7 +1434,12 @@ def ensure_env_production(config: dict, project_root: str | Path) -> Path:
     if problem is not None:
         raise RuntimeError(problem)
 
-    subset = _build_env_production_subset(config, dotenv, {**required_cc_vars, **extra_cc_vars})
+    subset = _build_env_production_subset(
+        config,
+        dotenv,
+        {**required_cc_vars, **extra_cc_vars},
+        {**required_url_vars, **extra_url_vars},
+    )
 
     # Every value above is a verbatim copy out of the operator's env chain (or,
     # for ARIEL_DSN, straight out of facility config), and this file is handed to

--- a/tests/cli/test_users_cmd.py
+++ b/tests/cli/test_users_cmd.py
@@ -60,6 +60,22 @@ RENDERED_CONFIG = textwrap.dedent(
     """
 )
 
+#: The same deployment run through a gateway provider that ships no default
+#: endpoint, so the URL is named by a variable rather than baked into the
+#: catalog entry.
+RENDERED_CONFIG_GATEWAY = RENDERED_CONFIG.replace(
+    "llm:\n  provider: cborg\n  api_key_env_var: CBORG_API_KEY\n",
+    "api:\n"
+    "  providers:\n"
+    "    als-apg:\n"
+    "      base_url: ${ALS_APG_BASE_URL}\n"
+    "llm:\n"
+    "  provider: als-apg\n"
+    "  api_key_env_var: ALS_APG_API_KEY\n"
+    "claude_code:\n"
+    "  provider: als-apg\n",
+)
+
 #: The same deployment after bob has been hand-edited off the roster — what
 #: ``prune`` sees when it goes looking for orphans.
 RENDERED_CONFIG_ALICE_ONLY = RENDERED_CONFIG.replace("      - name: bob\n        index: 1\n", "")
@@ -224,6 +240,23 @@ class TestEnvMintsTerminalSecrets:
         assert TERMINAL_SECRET_VAR_PREFIX not in result.stdout
         for value in read_env(repo_root).values():
             assert value not in result.stdout or value == "llm-secret"
+
+    def test_the_gateway_endpoint_reaches_the_rendered_file(
+        self, cli_runner, tmp_path, monkeypatch
+    ):
+        """This verb and `osprey up` render one subset, so the variable a
+        gateway provider reads its URL from crosses on this route too."""
+        root = _make_repo(tmp_path, RENDERED_CONFIG_GATEWAY)
+        monkeypatch.chdir(root)
+        (root / ENV_LOCAL_FILENAME).write_text(
+            "ALS_APG_API_KEY=llm-secret\nALS_APG_BASE_URL=https://gw.test/v1\n",
+            encoding="utf-8",
+        )
+
+        result = cli_runner.invoke(users, ["env"])
+
+        assert result.exit_code == 0
+        assert "ALS_APG_BASE_URL=https://gw.test/v1" in result.stdout
 
 
 class TestRemovePurgesTheDepartedSecret:

--- a/tests/cli/test_web_cmd.py
+++ b/tests/cli/test_web_cmd.py
@@ -1142,6 +1142,35 @@ class TestPreflightAuthSecret:
         assert "provider auth check skipped" not in result.stderr
         assert "nowhere" not in result.output
 
+    def test_missing_gateway_endpoint_is_reported_by_name(self, runner, monkeypatch, deployment):
+        """A provider with no endpoint is a server that exits during startup, so
+        pre-flight names the variable instead of launching into the crash."""
+        from osprey.build.claude_code_resolver import ProviderEndpointError
+
+        self._stub_launch(monkeypatch)
+        self._stub_clean_ports(monkeypatch)
+
+        def _raise(*_a, **_kw):
+            raise ProviderEndpointError(
+                "Provider 'als-apg' has no base_url. It fronts models through a "
+                "gateway that has no default endpoint, so the URL has to be "
+                "named: set ALS_APG_BASE_URL, or "
+                "api.providers.als-apg.base_url in config.yml."
+            )
+
+        monkeypatch.setattr("osprey.build.claude_code_resolver.load_provider_spec", _raise)
+        own_port = _free_port()
+
+        result = runner.invoke(
+            web,
+            ["--repo", str(deployment), "--port", str(own_port), "--shell", "true"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        assert "ALS_APG_BASE_URL" in result.output
+        assert "als-apg" in result.output
+
 
 class TestPreflightConfigValidity:
     """Probe 3: config.yml and .claude/settings.json must at least parse."""

--- a/tests/deployment/web_terminals/test_env_production.py
+++ b/tests/deployment/web_terminals/test_env_production.py
@@ -330,7 +330,11 @@ def test_env_production_copies_each_persona_projects_claude_code_secret(tmp_path
     ships, even when the deploy config's provider differs."""
     _write_dotenv(
         tmp_path / ".env",
-        {"ALS_APG_API_KEY": "persona-secret", "CBORG_API_KEY": "deploy-secret"},
+        {
+            "ALS_APG_API_KEY": "persona-secret",
+            "ALS_APG_BASE_URL": "https://gw.test/v1",
+            "CBORG_API_KEY": "deploy-secret",
+        },
     )
     config = _persona_config(tmp_path, {"operator": "als-apg"})
     config["claude_code"] = {"provider": "cborg"}
@@ -363,7 +367,10 @@ def test_env_production_deploy_configs_own_secret_not_required_under_catalog(tmp
     """With a persona catalog in play the per-user containers run persona
     projects, so the deploy config's own provider secret is copy-if-present
     but its absence must NOT fail the deploy."""
-    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "persona-secret"})
+    _write_dotenv(
+        tmp_path / ".env",
+        {"ALS_APG_API_KEY": "persona-secret", "ALS_APG_BASE_URL": "https://gw.test/v1"},
+    )
     config = _persona_config(tmp_path, {"operator": "als-apg"})
     config["claude_code"] = {"provider": "anthropic"}  # ANTHROPIC_API_KEY not in .env
 
@@ -452,7 +459,10 @@ def test_env_production_keyless_persona_provider_secret_not_required(tmp_path):
     """A persona project running a keyless provider must not block the deploy
     when the derived var is absent from the chain, while a co-deployed
     key-requiring persona's secret stays required."""
-    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "persona-secret"})
+    _write_dotenv(
+        tmp_path / ".env",
+        {"ALS_APG_API_KEY": "persona-secret", "ALS_APG_BASE_URL": "https://gw.test/v1"},
+    )
     config = _persona_config(tmp_path, {"operator": "als-apg", "local": "ollama"})
     # The keyless persona derives OLLAMA_API_KEY only when its own config
     # declares the provider under api.providers -- same rule as the resolver.
@@ -469,6 +479,198 @@ def test_env_production_keyless_persona_provider_secret_not_required(tmp_path):
 
     assert generated["ALS_APG_API_KEY"] == "persona-secret"
     assert "OLLAMA_API_KEY" not in generated
+
+
+# ---------------------------------------------------------------------------
+# Gateway endpoints -- the variable a provider with no default endpoint reads
+# its URL from. Same closed-allowlist rule as the auth secrets: a web container
+# sees only .env.users, so a provider whose endpoint is named by a variable
+# nobody copied resolves no URL and the container exits at startup.
+# ---------------------------------------------------------------------------
+
+
+def _gateway_persona_config(tmp_path, base_url="${ALS_APG_BASE_URL}"):
+    """A persona catalog whose single persona runs als-apg through a gateway.
+
+    The persona's rendered ``config.yml`` carries the provider catalog the real
+    render ships, so the endpoint reaches the resolver the same way it does in
+    a deployed container.
+    """
+    config = _persona_config(tmp_path, {"operator": "als-apg"})
+    (tmp_path / "operator-proj" / "config.yml").write_text(
+        "project_name: operator-proj\n"
+        "api:\n"
+        "  providers:\n"
+        "    als-apg:\n"
+        f"      base_url: {base_url}\n"
+        "claude_code:\n  provider: als-apg\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_env_production_copies_the_gateway_endpoint_its_provider_needs(tmp_path):
+    """als-apg fronts a gateway with no default host, so the container resolves
+    no endpoint at all unless the variable naming it crosses into .env.users."""
+    _write_dotenv(
+        tmp_path / ".env",
+        {"ALS_APG_API_KEY": "persona-secret", "ALS_APG_BASE_URL": "https://gw.test/v1"},
+    )
+    config = _gateway_persona_config(tmp_path)
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert generated["ALS_APG_BASE_URL"] == "https://gw.test/v1"
+
+
+def test_env_production_endpoint_variable_is_read_off_the_provider_catalog(tmp_path):
+    """The NAME comes from the config's own reference, never a fixed spelling:
+    a deployment that points the same provider at its own variable gets that
+    one copied."""
+    _write_dotenv(
+        tmp_path / ".env",
+        {
+            "ALS_APG_API_KEY": "persona-secret",
+            "SITE_GATEWAY_URL": "https://site.test/v1",
+            "ALS_APG_BASE_URL": "https://unused.test/v1",
+        },
+    )
+    config = _gateway_persona_config(tmp_path, base_url="${SITE_GATEWAY_URL}")
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert generated["SITE_GATEWAY_URL"] == "https://site.test/v1"
+
+
+def test_env_production_provider_with_its_own_endpoint_adds_nothing(tmp_path):
+    """A provider that ships a working host (cborg) needs no endpoint variable,
+    so the subset is exactly what it was before endpoints were copied at all."""
+    _write_dotenv(
+        tmp_path / ".env", {"CBORG_API_KEY": "deploy-secret", "CBORG_BASE_URL": "https://gw.test"}
+    )
+    config = {
+        "facility": {},
+        "claude_code": {"provider": "cborg"},
+        "modules": {"web_terminals": {"image_source": "local"}},
+    }
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert set(generated) == {"CBORG_API_KEY", "TZ"}
+
+
+def test_env_production_missing_gateway_endpoint_refuses_the_deploy(tmp_path):
+    """Absent from the whole chain, the endpoint is a container that exits at
+    startup and restarts forever -- refused here, naming the variable."""
+    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "persona-secret"})
+    config = _gateway_persona_config(tmp_path)
+
+    with pytest.raises(RuntimeError, match="ALS_APG_BASE_URL") as excinfo:
+        env_production.ensure_env_production(config, tmp_path)
+
+    assert "als-apg" in str(excinfo.value)
+    assert "operator" in str(excinfo.value)
+    assert not (tmp_path / ".env.users").exists()
+
+
+def test_env_production_a_literal_endpoint_asks_nothing_of_the_chain(tmp_path):
+    """A config that names the URL outright resolves it inside the container
+    with no variable at all, so nothing is required and nothing is copied."""
+    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "persona-secret"})
+    config = _gateway_persona_config(tmp_path, base_url="https://literal.test/v1")
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert "ALS_APG_BASE_URL" not in generated
+
+
+def test_env_production_a_defaulted_endpoint_reference_is_not_required(tmp_path):
+    """A reference carrying its own fallback resolves on its own, so its
+    absence from the chain is no refusal -- it is copied when set, as a
+    redirect."""
+    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "persona-secret"})
+    config = _gateway_persona_config(tmp_path, base_url="${ALS_APG_BASE_URL:-https://fb.test/v1}")
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert "ALS_APG_BASE_URL" not in generated
+
+
+def test_env_production_endpoint_of_the_deploys_own_provider_is_required(tmp_path):
+    """The zero-migration path: no persona catalog, so the web image runs the
+    deploy config itself and its provider's endpoint is the container's."""
+    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "cc-secret"})
+    config = {
+        "facility": {},
+        "api": {"providers": {"als-apg": {"base_url": "${ALS_APG_BASE_URL}"}}},
+        "claude_code": {"provider": "als-apg"},
+        "modules": {"web_terminals": {"image_source": "local"}},
+    }
+
+    with pytest.raises(RuntimeError, match="ALS_APG_BASE_URL"):
+        env_production.ensure_env_production(config, tmp_path)
+
+
+def test_env_production_copies_the_llm_providers_endpoint_without_requiring_it(tmp_path):
+    """The llm provider serves in-container services rather than deciding
+    whether the container starts, so its endpoint is copy-if-present -- the
+    same rule llm.api_key_env_var already follows."""
+    _write_dotenv(tmp_path / ".env", {"ALS_APG_API_KEY": "llm-secret"})
+    config = {
+        "facility": {},
+        "api": {"providers": {"als-apg": {"base_url": "${ALS_APG_BASE_URL}"}}},
+        "llm": {"provider": "als-apg", "api_key_env_var": "ALS_APG_API_KEY"},
+        "modules": {"web_terminals": {"image_source": "local"}},
+    }
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert "ALS_APG_BASE_URL" not in generated
+
+    _write_dotenv(
+        tmp_path / ".env",
+        {"ALS_APG_API_KEY": "llm-secret", "ALS_APG_BASE_URL": "https://gw.test/v1"},
+    )
+    (tmp_path / ".env.users").unlink()
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert generated["ALS_APG_BASE_URL"] == "https://gw.test/v1"
+
+
+def test_env_production_a_generated_file_without_the_endpoint_is_re_rendered(tmp_path):
+    """A file rendered before the endpoint crossed is OSPREY's own, so the next
+    deploy re-renders it in place rather than shipping terminals that cannot
+    reach their gateway."""
+    _write_dotenv(
+        tmp_path / ".env",
+        {"ALS_APG_API_KEY": "persona-secret", "ALS_APG_BASE_URL": "https://gw.test/v1"},
+    )
+    config = _gateway_persona_config(tmp_path)
+    stale = env_production.render_env_users(
+        {"ALS_APG_API_KEY": "persona-secret", "TZ": "UTC"},
+    )
+    (tmp_path / ".env.users").write_text(stale, encoding="utf-8")
+
+    generated = env_production.parse_dotenv_file(
+        env_production.ensure_env_production(config, tmp_path)
+    )
+
+    assert generated["ALS_APG_BASE_URL"] == "https://gw.test/v1"
 
 
 def test_env_production_stale_existing_file_without_credentials_warns(tmp_path, caplog):
@@ -616,6 +818,7 @@ def test_env_production_never_carries_the_dispatcher_token(tmp_path):
         tmp_path / ".env",
         {
             "ALS_APG_API_KEY": "cc-secret",
+            "ALS_APG_BASE_URL": "https://gw.test/v1",
             "EVENT_DISPATCHER_TOKEN": "fire-any-trigger",
             "DISPATCH_WORKER_TOKEN": "worker",
             "BLUESKY_LAUNCH_TOKEN": "arm-the-queue",
@@ -710,7 +913,10 @@ def test_env_production_required_auth_secret_in_shared_half_does_not_raise(tmp_p
     """The refusal asks whether the MERGED chain sets the var, so a provider
     secret kept in the shared defaults produces authenticated terminals rather
     than a refused deploy."""
-    _write_dotenv(tmp_path / ".env.shared", {"ALS_APG_API_KEY": "shared-secret"})
+    _write_dotenv(
+        tmp_path / ".env.shared",
+        {"ALS_APG_API_KEY": "shared-secret", "ALS_APG_BASE_URL": "https://gw.test/v1"},
+    )
     _write_dotenv(tmp_path / ".env", {"SOMETHING_ELSE": "x"})
     config = _persona_config(tmp_path, {"operator": "als-apg"})
 

--- a/tests/deployment/web_terminals/test_env_production.py
+++ b/tests/deployment/web_terminals/test_env_production.py
@@ -796,7 +796,11 @@ def test_env_production_missing_secret_hint_names_only_the_repo_env(tmp_path, mo
 
 
 def test_env_production_missing_secret_absent_everywhere_has_no_shell_hint(tmp_path, monkeypatch):
+    """Every variable the persona needs is cleared from the ambient shell, the
+    gateway endpoint included: an ambient export of any of them earns the
+    shell hint, which is exactly what this asserts against."""
     monkeypatch.delenv("ALS_APG_API_KEY", raising=False)
+    monkeypatch.delenv("ALS_APG_BASE_URL", raising=False)
     _write_dotenv(tmp_path / ".env", {"SOMETHING_ELSE": "x"})
     config = _persona_config(tmp_path, {"operator": "als-apg"})
 

--- a/tests/deployment/web_terminals/test_role_roster_regressions.py
+++ b/tests/deployment/web_terminals/test_role_roster_regressions.py
@@ -503,6 +503,7 @@ def _env_project_root(tmp_path: Path) -> Path:
         )
     (root / ".env").write_text(
         "ALS_APG_API_KEY=readonly-secret\n"
+        "ALS_APG_BASE_URL=https://gw.test/v1\n"
         "ANTHROPIC_API_KEY=admin-secret\n"
         "CBORG_API_KEY=deploy-secret\n",
         encoding="utf-8",


### PR DESCRIPTION
Per-user web terminals run with the `.env.users` allowlist, which copied the LLM provider key but never the variable naming the provider's gateway. Since the ALS-APG provider ships no default endpoint, the interface app inside each per-user container resolved no URL, raised at startup, and was restarted by compose indefinitely with a health status stuck at `starting`. On the Dispatch Deploy E2E lane this surfaces as `dde-web-alice did not reach 'healthy' within 180s`, and the crash-looping containers starve the dispatch worker's MCP startup on the same runner.

This change:
- derives the endpoint variable name from the config's own `api.providers.<name>.base_url` reference, falling back to the provider's declared redirect variable, and writes it into `.env.users` beside the key on both producers of the file (`ensure_env_production`, `osprey users env`);
- refuses the deploy by name when a provider that requires an endpoint has none in the env chain, and makes the web pre-flight report that refusal instead of returning nothing;
- introduces `ProviderEndpointError` for that refusal so callers can tell it from other `ValueError`s.

Tests: 11 new (env subset required/optional/negative cases, `users env` rendering and warning, pre-flight finding); six existing als-apg fixtures now set the endpoint in their env chain.

## Not in this PR
- The `.env.users` drift check still tracks provider secrets only; an operator-authored file pinning a stale endpoint is not yet flagged.