### PR TITLE
build(mypy): install the missing stub packages, stop following an installed package mypy cannot parse, and resolve siblings from source

### DIFF
--- a/changelog.d/mypy-stubs-and-resolution.internal.md
+++ b/changelog.d/mypy-stubs-and-resolution.internal.md
@@ -1,0 +1,5 @@
+The type check now runs over the source tree instead of stopping before it
+examines anything: the stub packages its imports need are declared, a
+dependency whose syntax the targeted Python cannot parse is no longer
+followed, and both the framework source and the connectors package resolve
+from source however the check is invoked.

--- a/docs/source/contributing/development-setup.rst
+++ b/docs/source/contributing/development-setup.rst
@@ -88,7 +88,12 @@ Linting and Formatting
    uv run ruff check --fix src/ tests/
 
    # Type checking
-   uv run mypy src/
+   uv run mypy
+
+The type check's targets are declared in ``pyproject.toml``: it covers the
+framework source and the connectors package together. A run that names a single
+file is for a quick look only — it resolves less than the full run and reports
+errors the full run does not.
 
 Testing
 ^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,6 +252,12 @@ dev = [
                        # CI unit lane both pass --timeout (see .github/workflows/ci.yml)
     "pytest-xdist",  # Parallel test lanes in CI (-n 4; unit lane --dist loadgroup, e2e lane --dist loadfile)
     "mypy",
+    # Stub distributions for the typeless third-party imports in src/. Without any
+    # one of them mypy stops with "errors prevented further checking" and examines
+    # no module at all.
+    "types-PyYAML",  # `yaml`
+    "types-Markdown",  # `markdown`
+    "types-aiofiles",  # `aiofiles`
     "pre-commit",
     # Pinned to the same minor the pre-commit hook uses. Ruff's formatter output
     # changes between minors, so an unpinned floor lets CI and the local hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -501,6 +501,14 @@ packages = ["src/osprey"]
 # Development tool configurations
 [tool.mypy]
 python_version = "3.11"
+# The source roots, searched in this order. `osprey_connectors` also sits in the
+# environment as an installed wheel; naming its source here is what makes a run
+# over a single file resolve the same packages a whole-tree run resolves, so both
+# report the same errors. `explicit_package_bases` is the half that makes the
+# roots count: it derives each module's name from them rather than from the
+# directory the file happens to live in.
+mypy_path = "src:packages/osprey-connectors/src"
+explicit_package_bases = true
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Gradual typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -547,6 +547,15 @@ module = [
 ]
 ignore_missing_imports = true
 
+# Sphinx is never imported by this tree; mypy reaches it by following bokeh's
+# own property module, and bokeh ships types, so `ignore_missing_imports` does
+# not apply. Sphinx's source uses syntax newer than the `python_version` above,
+# and parsing it raises a syntax error that aborts the entire run — skipping it
+# is what keeps the check able to report on this repository.
+[[tool.mypy.overrides]]
+module = ["sphinx.*"]
+follow_imports = "skip"
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -v --tb=short --strict-markers --color=yes"

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -5460,3 +5460,55 @@ def test_the_type_check_completes__mutation_weakens_the_override() -> None:
             override["ignore_missing_imports"] = True
     with pytest.raises(AssertionError, match="follow_imports"):
         test_the_type_check_completes_over_the_declared_targets(mutated)
+
+
+# ---------------------------------------------------------------------------
+# The type check resolves the same packages however it is invoked
+# ---------------------------------------------------------------------------
+#
+# `osprey_connectors` lives in this repository under `packages/`, but it also
+# sits in the environment as an installed wheel. Which of the two mypy resolves
+# decides whether values crossing that boundary carry their real types or
+# collapse to `Any` — and with `warn_return_any` on, the collapsed ones surface
+# as `no-any-return` at every return site that touches them. Declaring the
+# source roots is what makes a run naming a single file report the same thing a
+# whole-tree run reports.
+
+
+#: The roots `mypy_path` must carry, in the order it searches them: the
+#: framework source and the sibling package's source, not its installed wheel.
+MYPY_SOURCE_ROOTS = ("src", "packages/osprey-connectors/src")
+
+
+def test_the_type_check_declares_its_source_roots(pyproject: dict[str, Any]) -> None:
+    """`explicit_package_bases` is half the pair: without it mypy derives a
+    module's name from its own directory rather than from these roots, and the
+    roots buy nothing."""
+    mypy_config = pyproject["tool"]["mypy"]
+    assert mypy_config.get("explicit_package_bases") is True, (
+        "[tool.mypy] must set explicit_package_bases = true so module names are "
+        "derived from the declared roots"
+    )
+    declared = mypy_config.get("mypy_path", "").split(":")
+    for root in MYPY_SOURCE_ROOTS:
+        assert root in declared, (
+            f"mypy_path must name {root!r} — without it a run naming a single file "
+            "resolves less than a whole-tree run and reports errors it does not"
+        )
+
+
+def test_the_type_check_declares_its_source_roots__mutation_drops_the_bases() -> None:
+    mutated = _load_pyproject()
+    del mutated["tool"]["mypy"]["explicit_package_bases"]
+    with pytest.raises(AssertionError, match="explicit_package_bases"):
+        test_the_type_check_declares_its_source_roots(mutated)
+
+
+@pytest.mark.parametrize("root", MYPY_SOURCE_ROOTS)
+def test_the_type_check_declares_its_source_roots__mutation_drops_a_root(root: str) -> None:
+    mutated = _load_pyproject()
+    mutated["tool"]["mypy"]["mypy_path"] = ":".join(
+        entry for entry in MYPY_SOURCE_ROOTS if entry != root
+    )
+    with pytest.raises(AssertionError, match=re.escape(root)):
+        test_the_type_check_declares_its_source_roots(mutated)

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -48,6 +48,7 @@ from typing import Any
 import pytest
 import yaml
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 CI_YML = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
 
@@ -5346,3 +5347,60 @@ def test_gate_summary_tells_an_unlabeled_pr_what_did_not_run__mutation_drops_the
     step["run"] = step["run"].replace("--add-label full-ci", "")
     with pytest.raises(AssertionError):
         test_gate_summary_tells_an_unlabeled_pr_what_did_not_run(mutated)
+
+
+# ---------------------------------------------------------------------------
+# The type check can run at all: the stubs its imports need are declared
+# ---------------------------------------------------------------------------
+#
+# A "Library stubs not installed" error is fatal to the whole run, not local to
+# the file that raised it: mypy stops with "errors prevented further checking"
+# and examines no module. So an import in `src/` that ships no inline types
+# needs its stub distribution in the `dev` extra, or the type check reports
+# nothing about this repository whatever else is wrong with it.
+
+
+#: Stub distributions the `dev` extra carries, keyed by the import each one
+#: serves. `ignore_missing_imports` is deliberately not the answer here: it
+#: would silence the abort by making every value from these libraries `Any`,
+#: which is the opposite of checking the modules that import them.
+STUB_DISTRIBUTIONS = {
+    "types-PyYAML": "yaml",
+    "types-Markdown": "markdown",
+    "types-aiofiles": "aiofiles",
+}
+
+
+def _dev_extra(pyproject: dict[str, Any]) -> list[str]:
+    return pyproject["project"]["optional-dependencies"]["dev"]
+
+
+def _declared_names(deps: list[str]) -> set[str]:
+    return {canonicalize_name(Requirement(dep).name) for dep in deps}
+
+
+def test_the_type_check_declares_a_stub_for_every_stubless_import(
+    pyproject: dict[str, Any],
+) -> None:
+    """Every import named here appears in `src/` and ships no types of its own,
+    so each missing stub package costs the entire run, not one file."""
+    declared = _declared_names(_dev_extra(pyproject))
+    for distribution, module in STUB_DISTRIBUTIONS.items():
+        assert canonicalize_name(distribution) in declared, (
+            f"the `dev` extra must declare {distribution} — without it mypy aborts "
+            f"on every `import {module}` in src/ and checks nothing"
+        )
+
+
+@pytest.mark.parametrize("distribution", sorted(STUB_DISTRIBUTIONS))
+def test_the_type_check_declares_a_stub__mutation_drops_one(distribution: str) -> None:
+    """Dropping any one of the three must fail: one absent stub aborts the run
+    exactly as thoroughly as three do."""
+    mutated = _load_pyproject()
+    mutated["project"]["optional-dependencies"]["dev"] = [
+        dep
+        for dep in _dev_extra(mutated)
+        if canonicalize_name(Requirement(dep).name) != canonicalize_name(distribution)
+    ]
+    with pytest.raises(AssertionError, match=distribution):
+        test_the_type_check_declares_a_stub_for_every_stubless_import(mutated)

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -5404,3 +5404,59 @@ def test_the_type_check_declares_a_stub__mutation_drops_one(distribution: str) -
     ]
     with pytest.raises(AssertionError, match=distribution):
         test_the_type_check_declares_a_stub_for_every_stubless_import(mutated)
+
+
+# ---------------------------------------------------------------------------
+# The type check completes: it does not follow an installed package the
+# configured Python cannot parse
+# ---------------------------------------------------------------------------
+#
+# A syntax error raised while mypy parses a followed dependency is fatal to the
+# whole run, the same way a missing stub is. Nothing in this tree imports
+# sphinx; mypy reaches it through bokeh's own property module, bokeh ships
+# types, so `ignore_missing_imports` never applies. Sphinx's source uses syntax
+# newer than the `python_version` this project targets, and that floor is the
+# point of the check — so the package mypy cannot parse is the thing that gives,
+# not the version it is parsed against.
+
+
+def _mypy_overrides(pyproject: dict[str, Any]) -> list[dict[str, Any]]:
+    return pyproject["tool"]["mypy"]["overrides"]
+
+
+def test_the_type_check_completes_over_the_declared_targets(
+    pyproject: dict[str, Any],
+) -> None:
+    """Pinned so the block cannot be dropped as mysterious: without it the run
+    ends in "errors prevented further checking" and no module is examined."""
+    skipped = [
+        override for override in _mypy_overrides(pyproject) if "sphinx.*" in override["module"]
+    ]
+    assert skipped, "[tool.mypy] must carry an override for `sphinx.*`"
+    for override in skipped:
+        assert override.get("follow_imports") == "skip", (
+            'the `sphinx.*` override must set follow_imports = "skip" — '
+            "ignore_missing_imports does not apply to a package that ships types"
+        )
+
+
+def test_the_type_check_completes__mutation_drops_the_override() -> None:
+    mutated = _load_pyproject()
+    mutated["tool"]["mypy"]["overrides"] = [
+        override for override in _mypy_overrides(mutated) if "sphinx.*" not in override["module"]
+    ]
+    with pytest.raises(AssertionError, match="sphinx"):
+        test_the_type_check_completes_over_the_declared_targets(mutated)
+
+
+def test_the_type_check_completes__mutation_weakens_the_override() -> None:
+    """Swapping the skip for `ignore_missing_imports` must fail: bokeh's
+    dependency ships types, so the import is never missing and the run still
+    follows it into syntax it cannot parse."""
+    mutated = _load_pyproject()
+    for override in _mypy_overrides(mutated):
+        if "sphinx.*" in override["module"]:
+            del override["follow_imports"]
+            override["ignore_missing_imports"] = True
+    with pytest.raises(AssertionError, match="follow_imports"):
+        test_the_type_check_completes_over_the_declared_targets(mutated)

--- a/uv.lock
+++ b/uv.lock
@@ -4960,6 +4960,9 @@ all = [
     { name = "sphinx-reredirects" },
     { name = "sphinxcontrib-jsmath" },
     { name = "testcontainers", extra = ["mongodb"] },
+    { name = "types-aiofiles" },
+    { name = "types-markdown" },
+    { name = "types-pyyaml" },
 ]
 ariel = [
     { name = "psycopg", extra = ["pool"] },
@@ -4986,6 +4989,9 @@ dev = [
     { name = "ruff" },
     { name = "setuptools-scm" },
     { name = "testcontainers", extra = ["mongodb"] },
+    { name = "types-aiofiles" },
+    { name = "types-markdown" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "graphviz" },
@@ -5166,6 +5172,12 @@ requires-dist = [
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'all'", specifier = ">=4.15.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.15.0" },
     { name = "tiled", extras = ["client"], specifier = ">=0.2.14" },
+    { name = "types-aiofiles", marker = "extra == 'all'" },
+    { name = "types-aiofiles", marker = "extra == 'dev'" },
+    { name = "types-markdown", marker = "extra == 'all'" },
+    { name = "types-markdown", marker = "extra == 'dev'" },
+    { name = "types-pyyaml", marker = "extra == 'all'" },
+    { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
     { name = "unique-namer", specifier = ">=1.6.2" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -7976,6 +7988,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/22/b9c47b8655937b6877d40791b937931702ba9c5f9d28753199266aa96f50/typer_slim-0.23.1.tar.gz", hash = "sha256:dfe92a6317030ee2380f65bf92e540d7c77fefcc689e10d585b4925b45b5e06a", size = 4762, upload-time = "2026-02-13T10:04:26.416Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/8a/5764b851659345f34787f1b6eb30b9d308bbd6c294825cbe38b6b869c97a/typer_slim-0.23.1-py3-none-any.whl", hash = "sha256:8146d5df1eb89f628191c4c604c8464fa841885d0733c58e6e700ff0228adac5", size = 3397, upload-time = "2026-02-13T10:04:27.132Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/42/f5b9b90162d2196f016b87228d6bf43f2c2c0c6501bfd5415001b3eb68bb/types_aiofiles-25.1.0.20260518.tar.gz", hash = "sha256:c0c95eb78755d4fa7b397d4f0332c632714dd7cd0d17f49b96e31d4d7a8d8c76", size = 14891, upload-time = "2026-05-18T06:05:27.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/3d/7a9ed9faafeae3aa3b5bc22fa5b979ff9cf3c83ecbe919b58eae07795b8c/types_aiofiles-25.1.0.20260518-py3-none-any.whl", hash = "sha256:f776bdfb4bec17f743d9ef042e61edf03bdcc7821fc08556fba9b63d873fdea9", size = 14377, upload-time = "2026-05-18T06:05:26.871Z" },
+]
+
+[[package]]
+name = "types-markdown"
+version = "3.10.2.20260712"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/eb/9520ed01687401b47265594955c0a9202a4f547795176de61bff77c8dfda/types_markdown-3.10.2.20260712.tar.gz", hash = "sha256:25aea17282490f35ab6b17a87771abd2f479185aaff8e8f4a0035043f02f2c52", size = 20185, upload-time = "2026-07-12T05:13:53.537Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/ea/a8dc2c8977870d27b8b44c4ba2952d765f9d39626e42d0083c871c1c1ebf/types_markdown-3.10.2.20260712-py3-none-any.whl", hash = "sha256:a551ddedde46e0eaca7059aa3d0e42db71afe2b53d8b58f72f2de63f3284f625", size = 25842, upload-time = "2026-07-12T05:13:52.702Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260906"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/6e/abec85b9013db5b934b0280a6dd104904d84f7bcbaab2e2f3def87ac7463/types_pyyaml-6.0.12.20260906.tar.gz", hash = "sha256:f59c1cc05010b833d2d72287bbaa72610106b28d42d89a907313117faba85212", size = 18649, upload-time = "2026-09-06T06:35:35.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/c0/fc0644b7ddcfb969e95845837143cb5173ddd6e06ee4ba5fc493cd9329b7/types_pyyaml-6.0.12.20260906-py3-none-any.whl", hash = "sha256:bca893ff0d51df5c9053137d5d0e6ccd36e939a196356f1d5c16372422f5137b", size = 21282, upload-time = "2026-09-06T06:35:34.372Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`uv run mypy` stops before it examines a single module; these four commits make it run over the tree, and make a single-file run resolve the same packages the tree-wide run does.

- `build(deps): declare the type stubs the source tree's imports need`
- `build(mypy): stop following an installed package the configured Python cannot parse`
- `build(mypy): resolve the sibling package from source, not from the installed wheel`
- `docs(contributing): say what the type check covers and how to run it`

## Why

The type check aborted on two unrelated fatal conditions. Missing stub distributions for `yaml`, `markdown` and `aiofiles` produced 46 "Library stubs not installed" errors, and following `bokeh.core.property._sphinx` into sphinx's own source raised a syntax error under the configured `python_version = "3.11"` — either one ends the run with `errors prevented further checking` and zero modules checked. With the stubs declared and `sphinx.*` set to `follow_imports = "skip"`, the same command now checks 939 source files and reports real findings. Separately, `osprey_connectors` resolved to its installed wheel rather than to `packages/osprey-connectors/src`, so every value crossing that boundary became `Any` and `warn_return_any` fired at each return site: `mypy` on one file reported errors the whole-tree run did not. `mypy_path` plus `explicit_package_bases` make both invocations resolve the same packages — verified on `src/osprey/mcp_server/control_system/target_state.py`, whose two spurious `no-any-return` errors are gone, with the tree-wide totals unchanged before and after (1044 errors in 315 files).

`mypy` remains non-blocking on both paths, so no gate changes colour; the step's log grows, which is the visible outcome of a check that now checks something. Three tests in `tests/deployment/test_ci_workflow_wiring.py` pin each setting so none can be dropped as mysterious, each paired with a mutation that reintroduces the abort.

## Not in this PR

- The five typing defects the checker now surfaces, and the `files` key that lets `uv run mypy` be typed without targets — those belong to the sibling change that rebases onto this one.
- The ~1044 findings themselves. Turning the check on is the change; fixing what it reports is not.
- `scripts/ci_check.sh` and `.github/workflows/ci.yml` are untouched: both already invoke the check, and both already treat it as non-blocking.
