### PR TITLE
fix(typing): decode watcher event paths, read the knowledge CLI's configuration from the defining module, and check the connectors package locally

### DIFF
--- a/changelog.d/mypy-declared-targets.internal.md
+++ b/changelog.d/mypy-declared-targets.internal.md
@@ -1,0 +1,2 @@
+Declare the type-check targets in `[tool.mypy]` so a bare local `mypy` run
+covers the same trees CI does, and pin the two against drift.

--- a/changelog.d/typing-watchers-knowledge-connectors.internal.md
+++ b/changelog.d/typing-watchers-knowledge-connectors.internal.md
@@ -1,0 +1,2 @@
+Clear the remaining type errors in the workspace and artifact-store watchers,
+the knowledge CLI and the connectors limits validator.

--- a/changelog.d/watcher-event-path-decode.fixed.md
+++ b/changelog.d/watcher-event-path-decode.fixed.md
@@ -1,0 +1,3 @@
+A workspace or artifact-store change whose path the operating system reports as
+bytes no longer stops the watcher with a `TypeError`. The file panel and the
+artifact gallery keep updating for the rest of the session.

--- a/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
+++ b/packages/osprey-connectors/src/osprey_connectors/control_system/limits_validator.py
@@ -480,15 +480,17 @@ class LimitsValidator:
             if posture.enabled is not True:
                 return None
 
-            loaded, reason = cls.load_configured_database()
+            loaded, load_reason = cls.load_configured_database()
             if loaded is None:
                 # Same failsafe as the incomplete-block case above: a missing
                 # or unparseable database must never crash the connector (a
                 # read-only deployment needs no limits) nor silently disable
                 # checking (returning None would leave writes unchecked) -- an
                 # empty DB blocks every write with a clear refusal instead.
-                logger.warning(f"Limits checking enabled but {reason} - blocking all writes")
-                return cls({}, {}, {}, failsafe_reason=f"limits checking is enabled but {reason}")
+                logger.warning(f"Limits checking enabled but {load_reason} - blocking all writes")
+                return cls(
+                    {}, {}, {}, failsafe_reason=f"limits checking is enabled but {load_reason}"
+                )
             limits_db, raw_db = loaded
 
             # Both entries are JSON-serialisable: the python executor embeds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -509,6 +509,7 @@ python_version = "3.11"
 # directory the file happens to live in.
 mypy_path = "src:packages/osprey-connectors/src"
 explicit_package_bases = true
+files = ["src", "packages/osprey-connectors/src"]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false  # Gradual typing

--- a/scripts/ci_check.sh
+++ b/scripts/ci_check.sh
@@ -40,7 +40,7 @@ fi
 echo ""
 
 echo "→ Running mypy (type checking)..."
-if ! uv run mypy src/ --no-error-summary; then
+if ! uv run mypy --no-error-summary; then
     echo "⚠️  Mypy found type issues (not blocking)"
 else
     echo "✅ Mypy passed"

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -32,6 +32,9 @@ from typing import Any
 
 import click
 
+from osprey_connectors.config import get_config_value
+from osprey_connectors.workspace import resolve_config_path
+
 from .output import fail, note, report, warn
 
 #: Default token for ``build-ttl --facility``.  Spelled out rather than imported
@@ -89,7 +92,6 @@ def _resolve_bundle(bundle: Path | None) -> Path:
         return bundle
 
     from osprey.services.facility_knowledge.bundle_path import resolve_bundle_path
-    from osprey.utils.config import get_config_value
 
     raw = get_config_value("facility_knowledge.bundle_path", None)
     if raw is None:
@@ -318,7 +320,6 @@ def _resolve_ttl(ttl: Path | None) -> Path:
     if ttl is not None:
         return ttl
 
-    from osprey.utils.config import get_config_value
     from osprey.utils.config_paths import resolve_render_relative_path
 
     raw = get_config_value("services.graphdb.ttl_path", None)
@@ -347,8 +348,6 @@ def _graphdb_block() -> Mapping[str, Any] | None:
     on the default port has a working command, and a store that is not there
     fails later with the address it tried.
     """
-    from osprey.utils.config import get_config_value
-
     block = get_config_value("services.graphdb", None)
     return block if isinstance(block, Mapping) else None
 
@@ -367,7 +366,6 @@ def _graphdb_port_base() -> int:
         none.
     """
     from osprey.port_layout import resolve_port_base
-    from osprey.utils.config import get_config_value
 
     return resolve_port_base({"deployment": get_config_value("deployment", {})})
 
@@ -479,7 +477,6 @@ def _bake_prompt_snapshot(session: Any) -> None:
         session: The verb's open driver session.
     """
     from osprey.services.facility_knowledge.seeder import prompt_snapshot
-    from osprey.utils.workspace import resolve_config_path
 
     config_file = Path(resolve_config_path())
     if not config_file.is_file():
@@ -702,7 +699,6 @@ def _resolve_channel_db(channel_db: Path | None) -> Path:
         return channel_db
 
     from osprey.services.facility_knowledge.bundle_path import resolve_bundle_path
-    from osprey.utils.config import get_config_value
 
     if get_config_value(PIPELINE_MODE_CONFIG_KEY, None) == "graph":
         # A graph project has no hierarchical database path configured at all,
@@ -977,7 +973,6 @@ def _resolve_facility(explicit: str | None) -> tuple[str, str]:
         click.ClickException: When the token cannot be part of an identifier.
     """
     from osprey.services.facility_knowledge.ttl_generator.model import PN_LOCAL
-    from osprey.utils.config import get_config_value
 
     if explicit is not None:
         token, source = explicit, "--facility"

--- a/src/osprey/cli/knowledge_cmd.py
+++ b/src/osprey/cli/knowledge_cmd.py
@@ -901,9 +901,11 @@ def _resolve_hierarchy_descriptions(raw: Mapping[str, Any], db_path: Path) -> An
         resolve_hierarchy_descriptions,
     )
 
-    hierarchy = raw.get("hierarchy") if isinstance(raw.get("hierarchy"), Mapping) else {}
+    raw_hierarchy = raw.get("hierarchy")
+    hierarchy: Mapping[str, Any] = raw_hierarchy if isinstance(raw_hierarchy, Mapping) else {}
     levels = hierarchy.get("levels") or []
-    tree = raw.get("tree") if isinstance(raw.get("tree"), Mapping) else {}
+    raw_tree = raw.get("tree")
+    tree: Mapping[str, Any] = raw_tree if isinstance(raw_tree, Mapping) else {}
     try:
         return resolve_hierarchy_descriptions(tree, levels)
     except (ValueError, AttributeError, TypeError) as exc:

--- a/src/osprey/interfaces/artifacts/store_watcher.py
+++ b/src/osprey/interfaces/artifacts/store_watcher.py
@@ -138,7 +138,7 @@ class _IndexFileHandler(FileSystemEventHandler):
                 self._handle(event, path=str(directory / name))
 
     def _handle(self, event: FileSystemEvent, path: str | None = None) -> None:
-        src_path = Path(path) if path is not None else Path(event.src_path)
+        src_path = Path(path) if path is not None else Path(os.fsdecode(event.src_path))
         filename = src_path.name
 
         if filename not in self._index_configs:

--- a/src/osprey/interfaces/web_terminal/file_watcher.py
+++ b/src/osprey/interfaces/web_terminal/file_watcher.py
@@ -123,6 +123,7 @@ def resolve_store_rel(store_dir: Path, workspace_dir: Path) -> PurePath | None:
     handler would drop every event and silently black out the file panel.
     There is no meaningful concealment to do in that configuration.
     """
+    store_rel: PurePath
     if store_dir.is_relative_to(workspace_dir):
         store_rel = store_dir.relative_to(workspace_dir)
     else:

--- a/src/osprey/interfaces/web_terminal/file_watcher.py
+++ b/src/osprey/interfaces/web_terminal/file_watcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 import time
 from collections.abc import Sequence
@@ -195,7 +196,7 @@ class _WorkspaceHandler(FileSystemEventHandler):
         self._listings: dict[str, dict[str, ChangeStamp]] = {}
 
     def on_any_event(self, event: FileSystemEvent) -> None:
-        src_path = Path(event.src_path)
+        src_path = Path(os.fsdecode(event.src_path))
 
         # Filter ignored paths
         if self._is_ignored(src_path):

--- a/tests/cli/test_knowledge_build_index.py
+++ b/tests/cli/test_knowledge_build_index.py
@@ -57,7 +57,7 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch, block: object) -> None:
             return block.get("ttl_path", default) if isinstance(block, dict) else default
         return default
 
-    monkeypatch.setattr("osprey.utils.config.get_config_value", _get_config_value)
+    monkeypatch.setattr("osprey.cli.knowledge_cmd.get_config_value", _get_config_value)
 
 
 def _flat(result: object) -> str:

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -1029,6 +1029,41 @@ def test_build_ttl_refuses_a_foreign_level_list_before_it_expands(
     assert not output.exists()
 
 
+def test_build_ttl_refuses_a_hierarchy_block_that_is_not_a_mapping(
+    descriptions_db: Path, tmp_path: Path
+) -> None:
+    """A ``hierarchy`` that holds a list gets the grammar sentence too.
+
+    A block of the wrong shape carries no level list at all, which is the same
+    thing to this verb as a database that names no levels: it cannot say what
+    the addresses mean. Both reduce to an empty level list and both are refused
+    with the one sentence that names the grammar build-ttl reads.
+    """
+    payload = _hierarchical_payload()
+    payload["hierarchy"] = [{"name": "ring", "type": "tree"}]
+    db_path = tmp_path / "hierarchy_is_a_list.json"
+    db_path.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "out.ttl"
+
+    result = CliRunner().invoke(
+        knowledge,
+        [
+            "build-ttl",
+            str(output),
+            "--channel-db",
+            str(db_path),
+            "--descriptions",
+            str(descriptions_db),
+        ],
+    )
+
+    assert result.exit_code != 0
+    flat = _flat(result)
+    assert "Traceback" not in result.output
+    assert "six-token grammar: RING, SYSTEM, FAMILY, DEVICE, FIELD, SUBFIELD" in flat
+    assert not output.exists()
+
+
 def test_build_ttl_points_a_yaml_ontology_at_the_compiler(
     channel_db: Path, descriptions_db: Path, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_knowledge_build_ttl.py
+++ b/tests/cli/test_knowledge_build_ttl.py
@@ -276,7 +276,7 @@ def _config_channel_db(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
             return value
         return default
 
-    monkeypatch.setattr("osprey.utils.config.get_config_value", _lookup)
+    monkeypatch.setattr("osprey.cli.knowledge_cmd.get_config_value", _lookup)
 
 
 def _config_facility_prefix(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
@@ -287,7 +287,7 @@ def _config_facility_prefix(monkeypatch: pytest.MonkeyPatch, value: object) -> N
             return value
         return default
 
-    monkeypatch.setattr("osprey.utils.config.get_config_value", _lookup)
+    monkeypatch.setattr("osprey.cli.knowledge_cmd.get_config_value", _lookup)
 
 
 def _config_graph_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -303,7 +303,7 @@ def _config_graph_mode(monkeypatch: pytest.MonkeyPatch) -> None:
             return "graph"
         return default
 
-    monkeypatch.setattr("osprey.utils.config.get_config_value", _lookup)
+    monkeypatch.setattr("osprey.cli.knowledge_cmd.get_config_value", _lookup)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_knowledge_cmd.py
+++ b/tests/cli/test_knowledge_cmd.py
@@ -139,7 +139,7 @@ def test_regen_index_no_bundle_and_no_config_errors() -> None:
         "osprey.cli.knowledge_cmd.knowledge.commands",
         wraps=knowledge.commands,
     ):
-        with mock.patch("osprey.utils.config.get_config_value", return_value=None):
+        with mock.patch("osprey.cli.knowledge_cmd.get_config_value", return_value=None):
             result = runner.invoke(knowledge, ["regen-index"])
 
     # Should exit non-zero or print an error message.
@@ -545,7 +545,7 @@ def _patch_config(monkeypatch: pytest.MonkeyPatch, block: object) -> None:
             return block.get("ttl_path", default) if isinstance(block, dict) else default
         return default
 
-    monkeypatch.setattr("osprey.utils.config.get_config_value", _get_config_value)
+    monkeypatch.setattr("osprey.cli.knowledge_cmd.get_config_value", _get_config_value)
 
 
 def _flat(result) -> str:

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -5512,3 +5512,50 @@ def test_the_type_check_declares_its_source_roots__mutation_drops_a_root(root: s
     )
     with pytest.raises(AssertionError, match=re.escape(root)):
         test_the_type_check_declares_its_source_roots(mutated)
+
+
+# ---------------------------------------------------------------------------
+# mypy target drift guard
+# ---------------------------------------------------------------------------
+
+MYPY_JOB = "lint"
+MYPY_STEP = "Run mypy (type checking)"
+
+
+def _mypy_targets_in_ci(wf: dict[str, Any]) -> list[str]:
+    """The trees the CI mypy step names, in the order it names them.
+
+    Read off the command rather than off a variable: a step that hardcodes a
+    third tree defines nothing new, so keying on anything but the arguments
+    themselves would miss exactly the drift this guard exists to catch.
+    """
+    run = _find_named_step(wf, MYPY_JOB, MYPY_STEP)["run"]
+    words = run.split()
+    after_mypy = words[words.index("mypy") + 1 :]
+    return [
+        word.rstrip("/")
+        for word in after_mypy
+        if not word.startswith("-") and word not in {"||", "true"}
+    ]
+
+
+def test_mypy_targets_match_the_declared_files(
+    workflow: dict[str, Any], pyproject: dict[str, Any]
+) -> None:
+    """CI and a bare local ``mypy`` check the same trees.
+
+    ``[tool.mypy] files`` is what a contributor's own run reads; the CI step
+    spells its trees out. With the two free to drift, a package checked in CI
+    can be invisible to everyone running the checker locally, and the first
+    report of an error is a review comment rather than the editor.
+    """
+    declared = [entry.rstrip("/") for entry in pyproject["tool"]["mypy"]["files"]]
+    assert _mypy_targets_in_ci(workflow) == declared
+
+
+def test_mypy_targets_match_the_declared_files__mutation_drops_a_tree() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    step = _find_named_step(mutated, MYPY_JOB, MYPY_STEP)
+    step["run"] = step["run"].replace(" packages/osprey-connectors/src/", "")
+    with pytest.raises(AssertionError):
+        test_mypy_targets_match_the_declared_files(mutated, _load_pyproject())

--- a/tests/interfaces/artifacts/test_store_watcher.py
+++ b/tests/interfaces/artifacts/test_store_watcher.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import json
+import os
 import shutil
 import time
 from unittest.mock import MagicMock
@@ -269,6 +270,32 @@ class TestStoreWatcher:
             # Should not crash — watcher logs warning and skips
         finally:
             watcher.stop()
+
+    def test_an_event_path_reported_as_bytes_still_announces_the_entry(self, tmp_path):
+        """watchdog types ``src_path`` as ``bytes | str`` and hands on
+        whatever the platform gave it.
+
+        A bytes path built straight into a ``Path`` raises ``TypeError``
+        inside the observer thread, and the gallery stops hearing about the
+        index for the rest of the session.
+        """
+        watcher, broadcaster, artifact_store = _make_watcher(tmp_path)
+        handler = _IndexFileHandler(watcher._index_configs, broadcaster)
+
+        artifact_store.save_file(
+            file_content=b"<html>bytes</html>",
+            filename="bytes.html",
+            artifact_type="plot_html",
+            title="Announced From A Bytes Path",
+            description="the platform reported the path as bytes",
+            mime_type="text/html",
+            tool_source="test",
+        )
+        index_file = tmp_path / "artifacts" / "artifacts.json"
+        handler._handle(FileModifiedEvent(os.fsencode(str(index_file))))
+
+        announced = [call.args[0] for call in broadcaster.broadcast.call_args_list]
+        assert [e for e in announced if e.get("title") == "Announced From A Bytes Path"]
 
 
 @pytest.mark.unit

--- a/tests/interfaces/web_terminal/test_file_watcher.py
+++ b/tests/interfaces/web_terminal/test_file_watcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 from pathlib import Path, PurePath
 from types import SimpleNamespace
@@ -245,6 +246,21 @@ class TestWorkspaceWatcher:
             assert len(git_events) == 0
         finally:
             watcher.stop()
+
+    def test_an_event_path_reported_as_bytes_still_reaches_the_panel(self):
+        """watchdog types ``src_path`` as ``bytes | str`` and hands on
+        whatever the platform gave it.
+
+        A bytes path built straight into a ``Path`` raises ``TypeError``
+        inside the observer thread, and the file panel stops hearing about
+        that tree for the rest of the session.
+        """
+        broadcaster = MagicMock()
+        handler = _handler((), broadcaster)
+
+        handler.on_any_event(FileCreatedEvent(os.fsencode(str(WORKSPACE / "notes.md"))))
+
+        assert _broadcast_paths(broadcaster) == ["notes.md"]
 
 
 WORKSPACE = Path("/tmp/osprey-test-watcher-workspace")

--- a/tests/services/test_bundle_path_resolution.py
+++ b/tests/services/test_bundle_path_resolution.py
@@ -69,14 +69,14 @@ def _mcp_server_resolution(raw: str, config_dir: Path) -> Path:
 
 def _cli_resolution(raw: str, monkeypatch) -> Path:
     """Resolve *raw* the way ``osprey knowledge <cmd>`` does with no BUNDLE arg."""
-    import osprey.utils.config as config_module
-    from osprey.cli.knowledge_cmd import _resolve_bundle
+    from osprey.cli import knowledge_cmd
 
     monkeypatch.setattr(
-        config_module,
+        knowledge_cmd,
         "get_config_value",
         lambda key, default=None: raw if key == CONFIG_KEY else default,
     )
+    _resolve_bundle = knowledge_cmd._resolve_bundle
     return _resolve_bundle(None)
 
 


### PR DESCRIPTION
Clears the remaining type errors in the two file-system watchers, the knowledge CLI and the connectors limits validator, and declares the type-check targets so a bare local `mypy` covers the same trees CI does.

- `fix(web-terminal): decode a watchdog event path before building a Path`
- `refactor(web-terminal): keep the concealment result pure on both branches`
- `refactor(cli): read the configuration accessors from the module that defines them`
- `fix(cli): narrow the hierarchy and tree lookups before reading them`
- `fix(connectors): keep the database-load failure reason off the incomplete-block name`
- `build(mypy): declare the type-check targets so a local run matches CI`

## Why

One of these is a real defect rather than an annotation. watchdog types `FileSystemEvent.src_path` as `bytes | str` and passes on whatever the platform handed it; both watchers already decode it in most places, and the two sites that did not raise `TypeError` inside the observer thread — after which the file panel and the artifact gallery stop hearing about that tree for the rest of the session. Both sites now decode, with a test each that delivers a bytes path.

The knowledge CLI's errors were a different kind. `osprey.utils.config` and `osprey.utils.workspace` replace themselves in `sys.modules` with their `osprey_connectors` counterparts at import, so no static checker can see `get_config_value` or `resolve_config_path` through them. The module now imports both from the module that defines them, the spelling ten other modules under `src/` already use, and the tests that stubbed the accessor patch it where the CLI reads it.

The last commit closes a gap a deployer runs into directly: CI has been checking `src/` and the connectors package together, while `[tool.mypy]` declared no `files` and `scripts/ci_check.sh` named only `src/`. A contributor's local check and CI disagreed about what was in scope, so the package's findings first appeared in review. Both trees are declared once, the script inherits them, and a workflow-wiring test pins the two against drift.

## Not in this PR

- The 33 errors the connectors package reports once it is in scope. Only the one assignment error this PR owns is fixed; the rest stay open.
- The contributing page's mypy command, and the whole-tree run's parse abort — both belong to the sibling typing item.
- Any other error in the 1036 `src/` reports.
