### PR TITLE
fix(va,roster): derive nominal currents and readback pairing from the manifest

### DIFF
--- a/changelog.d/roster-vocabulary.internal.md
+++ b/changelog.d/roster-vocabulary.internal.md
@@ -1,0 +1,4 @@
+The channel roster's reserved address tokens are declared once, by the record
+module both readers import, instead of twice. The module docstrings that
+presented one demo namespace's six-token colon addresses as the framework's
+now say whose spelling they are describing.

--- a/changelog.d/va-nominal-current-selection.fixed.md
+++ b/changelog.d/va-nominal-current-selection.fixed.md
@@ -1,0 +1,4 @@
+The virtual accelerator picks the magnets it holds a nominal current for from
+the channel manifest's lattice-backed partition instead of from an address
+ending in `:CURRENT:SP`, so a facility that spells its magnet current setpoints
+any other way gets its baseline and its writes reach the lattice.

--- a/src/osprey/channel_roster/database.py
+++ b/src/osprey/channel_roster/database.py
@@ -48,6 +48,8 @@ from osprey_connectors.control_system.limits_validator import (
 )
 
 from .records import (
+    ADDRESS_SEPARATOR,
+    WRITE_SUBFIELD,
     ChannelDirection,
     ChannelRecord,
     RosterAbsence,
@@ -57,13 +59,6 @@ from .records import (
 )
 
 logger = get_logger("channel_roster.database")
-
-
-#: Final address token the grammar fallback reads as a setpoint.
-WRITE_SUBFIELD = "SP"
-
-#: What separates an address into its tokens.
-ADDRESS_SEPARATOR = ":"
 
 
 def resolve_limits_path(config: Mapping[str, Any]) -> Path | None:

--- a/src/osprey/channel_roster/pairing.py
+++ b/src/osprey/channel_roster/pairing.py
@@ -5,21 +5,25 @@ took, not the value it was asked to take. Where the facility publishes a
 readback beside the setpoint, that is the channel to read; where it does not,
 the worker reads the setpoint back and reports what it can.
 
-The rule is one line of address grammar -- the final colon-separated token
-``SP`` becomes ``RB`` -- and one membership test: the candidate is adopted only
-when the roster already holds that address *with read direction*. The grammar
-alone would be a guess; the roster is the authority on what exists, so a
-setpoint whose sibling nobody enumerated stays unpaired rather than pointing a
-plan at an address that is not there. That test also declines a ``:RB`` sibling
-the source called settable, which is a corpus that has drifted rather than a
-readback.
+The rule is one naming convention plus one membership test. The convention is
+the bundled demo tree's, and nobody else's: a final token of
+:data:`~osprey.channel_roster.records.WRITE_SUBFIELD` becomes
+:data:`~osprey.channel_roster.records.READBACK_SUBFIELD`. The membership test
+is the authority: the candidate is adopted only when the roster already holds
+that address *with read direction*. A facility that names its readbacks some
+other way is not paired by the convention and loses nothing it had -- the
+convention alone would be a guess anywhere, so a setpoint whose sibling nobody
+enumerated stays unpaired rather than pointing a plan at an address that is not
+there. That test also declines a readback sibling the source called settable,
+which is a corpus that has drifted rather than a readback.
 
-Address grammar lives in exactly two places in this package: here, and
+The tokens the convention is spelled in have one producer,
+:mod:`osprey.channel_roster.records`, shared with
 :mod:`osprey.channel_roster.database`'s direction fallback. Membership never
-comes from grammar anywhere -- the readers enumerate it, and this module only
-consults what they returned. Hence the input is a plain sequence of records:
-pairing is one heuristic applied identically to both sources, and importing
-either reader here would tie it to one of them.
+comes from a naming convention anywhere -- the readers enumerate it, and this
+module only consults what they returned. Hence the input is a plain sequence of
+records: pairing is one heuristic applied identically to both sources, and
+importing either reader here would tie it to one of them.
 """
 
 from __future__ import annotations

--- a/src/osprey/channel_roster/pairing.py
+++ b/src/osprey/channel_roster/pairing.py
@@ -26,17 +26,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from .records import ChannelRecord
-
-#: Final address token that marks a setpoint -- the same token
-#: :mod:`osprey.channel_roster.database` derives direction from.
-WRITE_SUBFIELD = "SP"
-
-#: Final address token that marks the readback of a setpoint.
-READBACK_SUBFIELD = "RB"
-
-#: What separates an address into its tokens.
-ADDRESS_SEPARATOR = ":"
+from .records import ADDRESS_SEPARATOR, READBACK_SUBFIELD, WRITE_SUBFIELD, ChannelRecord
 
 
 def assign_readbacks(records: Sequence[ChannelRecord]) -> tuple[ChannelRecord, ...]:

--- a/src/osprey/channel_roster/records.py
+++ b/src/osprey/channel_roster/records.py
@@ -13,6 +13,11 @@ selection, no parsing. The readers (:mod:`osprey.channel_roster.graph`,
 plan-device derivation, the channel snapshot, the build's fact lines, the
 channel-finder web routes -- read them.
 
+The package's reserved address tokens are declared here for the same reason:
+the database reader derives direction from one of them and the pairing
+heuristic builds a sibling address from both, and neither may import the other
+-- pairing is applied identically to whichever reader ran.
+
 **Absence is data, not a missing return.** A roster that cannot be built is
 reported as a :class:`RosterAbsence` carrying its reason and the subjects it
 has to name (a path, the config keys that would have declared one), and every
@@ -43,6 +48,22 @@ from typing import Literal
 ChannelDirection = Literal["read", "write"]
 
 _DIRECTIONS: frozenset[str] = frozenset({"read", "write"})
+
+# The roster's setpoint/readback vocabulary, and the one place it is spelled.
+# A channel's ADDRESS text is free -- any facility's namespace enumerates
+# through the same readers -- but these two tokens are reserved: ``SP`` marks
+# the settable channel and ``RB`` marks its readback, and an address whose
+# final token is neither is read as neither. Deliberately not
+# facility-configurable: a typo in a per-facility spelling would silently
+# unsettle every channel on the machine rather than fail loudly.
+#: Final address token that marks a setpoint.
+WRITE_SUBFIELD = "SP"
+
+#: Final address token that marks the readback of a setpoint.
+READBACK_SUBFIELD = "RB"
+
+#: What separates an address into its tokens.
+ADDRESS_SEPARATOR = ":"
 
 
 class RosterSourceKind(Enum):

--- a/src/osprey/services/virtual_accelerator/lattice/strengths.py
+++ b/src/osprey/services/virtual_accelerator/lattice/strengths.py
@@ -1,7 +1,8 @@
 """Ring-facing current<->strength mapping for the ALS-U AR virtual accelerator.
 
-Owns the per-device nominal-current baseline (read from the scenario-seed
-``machine.json``, no hardcoded currents) and the current->strength formulas
+Owns the per-device nominal-current baseline -- the manifest's pyat-coupled
+setpoints, valued from the scenario-seed ``machine.json``, no hardcoded
+currents -- and the current->strength formulas
 for every magnet and corrector family in the real ring. This module is
 deliberately decoupled from the serving layer -- it never imports anything
 from :mod:`osprey.services.virtual_accelerator.ioc` or
@@ -43,6 +44,10 @@ import re
 import at
 from lume_pyat.simulator import ElementState, restore_element, snapshot_element
 
+from osprey.services.virtual_accelerator.manifest import (
+    build_manifest,
+    pyat_coupled_setpoint_addresses,
+)
 from osprey.services.virtual_accelerator.manifest.loaders import (
     load_machine_json_channels,
 )
@@ -115,11 +120,21 @@ class StrengthMap:
     write a current and update the matching element in place.
     """
 
-    def __init__(self, ring: at.Lattice) -> None:
+    def __init__(self, ring: at.Lattice, channels: list[dict] | None = None) -> None:
+        """Snapshot the baked strengths of ``ring`` and the nominal-current baseline.
+
+        Args:
+            ring: The lattice to snapshot baked strengths from.
+            channels: the manifest's ``channels`` list; ``None`` builds the
+                manifest. A caller that already has one should pass it.
+        """
+        if channels is None:
+            channels = build_manifest()["channels"]
+        machine_channels = load_machine_json_channels()
         self._i_nom_by_address: dict[str, float] = {
-            address: float(entry["value"])
-            for address, entry in load_machine_json_channels().items()
-            if address.endswith(":CURRENT:SP")
+            address: float(machine_channels[address]["value"])
+            for address in pyat_coupled_setpoint_addresses(channels)
+            if address in machine_channels
         }
         self._baked: dict[str, float] = {}
         for element in ring:

--- a/src/osprey/services/virtual_accelerator/lattice/strengths.py
+++ b/src/osprey/services/virtual_accelerator/lattice/strengths.py
@@ -61,7 +61,6 @@ __all__ = [
     "SEXTUPOLE_FAMILIES",
     "ElementState",
     "StrengthMap",
-    "current_address",
     "restore_element",
     "snapshot_element",
     "split_fam_name",
@@ -99,17 +98,6 @@ def split_fam_name(fam_name: str) -> tuple[str, str]:
     return match.group(1), match.group(2)
 
 
-def current_address(family: str, device_id: str) -> str:
-    """Return the SR machine.json ``CURRENT:SP`` address for a device.
-
-    e.g. ``current_address("QF", "01") == "SR:MAG:QF:01:CURRENT:SP"``. The
-    ``SR:MAG:`` prefix is fixed -- machine.json is a namespace shared with
-    other rings (``BR``, ``BTS``), and this map only ever addresses the
-    storage ring this service simulates.
-    """
-    return f"SR:MAG:{family}:{device_id}:CURRENT:SP"
-
-
 class StrengthMap:
     """Current<->strength mapping for every magnet/corrector in the AR ring.
 
@@ -131,10 +119,17 @@ class StrengthMap:
         if channels is None:
             channels = build_manifest()["channels"]
         machine_channels = load_machine_json_channels()
+        coupled_setpoints = pyat_coupled_setpoint_addresses(channels)
         self._i_nom_by_address: dict[str, float] = {
             address: float(machine_channels[address]["value"])
-            for address in pyat_coupled_setpoint_addresses(channels)
+            for address in coupled_setpoints
             if address in machine_channels
+        }
+        self._i_nom_by_device: dict[tuple[str, str], float] = {
+            (channel["family"], channel["device"]): self._i_nom_by_address[channel["address"]]
+            for channel in channels
+            if channel["address"] in self._i_nom_by_address
+            and channel["address"] in coupled_setpoints
         }
         self._baked: dict[str, float] = {}
         for element in ring:
@@ -155,6 +150,27 @@ class StrengthMap:
     def i_nom(self, address: str) -> float:
         """Return the machine.json nominal (baseline) current for ``address``."""
         return self._i_nom_by_address[address]
+
+    def i_nom_for(self, family: str, device_id: str) -> float:
+        """Return the nominal current of the ``family``+``device_id`` device.
+
+        The device-keyed half of :meth:`i_nom`, for the callers that hold an
+        element's family and id rather than a channel address. The pair is
+        resolved through the manifest rows the baseline itself is built from,
+        so a facility's address spelling is never reconstructed here.
+
+        Raises:
+            ValueError: the manifest declares no lattice-backed current
+                setpoint for that pair -- a device outside the partition, or
+                one the scenario seed carries no nominal current for.
+        """
+        try:
+            return self._i_nom_by_device[(family, device_id)]
+        except KeyError:
+            raise ValueError(
+                f"no nominal current for family {family!r} device {device_id!r}: the "
+                "manifest declares no lattice-backed current setpoint for that device"
+            ) from None
 
     def baked(self, fam_name: str) -> float:
         """Return the strength snapshotted at construction for ``fam_name``.
@@ -199,7 +215,7 @@ class StrengthMap:
             element.KickAngle = kick_angle
             return
 
-        i_nom = self._i_nom_by_address[current_address(family, device_id)]
+        i_nom = self.i_nom_for(family, device_id)
         fraction = current / i_nom
 
         if family in QUADRUPOLE_FAMILIES:

--- a/src/osprey/services/virtual_accelerator/lattice/strengths.py
+++ b/src/osprey/services/virtual_accelerator/lattice/strengths.py
@@ -9,6 +9,13 @@ from :mod:`osprey.services.virtual_accelerator.ioc` or
 :mod:`osprey.services.virtual_accelerator.serving` -- so any physics server
 can consume it identically.
 
+Scoped to one ring, and it says so. The families below, their formulas and the
+calibration constants are the AR ring's physics, not a framework contract. The
+channels they apply to are not stated here at all: which addresses carry a
+magnet current, and which device each belongs to, come from the manifest's
+pyat-coupled partition, so no address spelling -- the bundled demo tree's six
+colon-separated tokens included -- is assumed or reconstructed in this module.
+
 Apply-current semantics (per family):
 
 - ``HCM``/``VCM`` correctors: ``KickAngle[plane] = I / AMPS_PER_RADIAN_KICK``

--- a/src/osprey/services/virtual_accelerator/manifest/__init__.py
+++ b/src/osprey/services/virtual_accelerator/manifest/__init__.py
@@ -3,10 +3,20 @@
 The Control Assistant Tutorial's channel-finder databases already define the
 channel namespace the virtual accelerator must serve: the tutorial ships
 three interchangeable file "paradigm" formats (in_context, hierarchical,
-middle_layer) that describe the same set of PV addresses under the grammar
-``{ring}:{system}:{family}:{device}:{field}:{subfield}``. The ``graph``
+middle_layer) that describe the same set of PV addresses. The ``graph``
 paradigm is deliberately not among them -- it answers from a seeded store
 rather than a tier file, so it contributes no manifest source.
+
+What this package fixes, and what it does not. A channel's ADDRESS text is
+free: it is carried through verbatim from whatever source declared it, and the
+bundled demo tree's six colon-separated tokens
+(``{ring}:{system}:{family}:{device}:{field}:{subfield}``) are that tree's
+spelling rather than a shape anything here requires -- a facility whose
+addresses are three parts, or slashed, loads through the same call (see
+``loaders.load_manifest_file``). What IS reserved is the ``subfield`` VALUE:
+``SETPOINT_SUBFIELD`` marks the writable channel and ``READBACK_SUBFIELD``
+marks its readback, and a channel carrying any other token is neither written
+nor paired with one.
 
 This package expands all three file formats at their build-resolved tier,
 verifies they agree, unions in the scenario-seed ``machine.json`` channels,

--- a/src/osprey/services/virtual_accelerator/manifest/__init__.py
+++ b/src/osprey/services/virtual_accelerator/manifest/__init__.py
@@ -32,6 +32,7 @@ from .classify import (
     SETPOINT_SUBFIELD,
     classify_partition,
     derive_record_type,
+    pyat_coupled_setpoint_addresses,
     setpoint_addresses,
 )
 from .loaders import MANIFEST_CHANNEL_KEYS, ManifestFileError, load_manifest_file
@@ -53,5 +54,6 @@ __all__ = [
     "RECORD_TYPE_MBB",
     "RECORD_TYPE_STRING",
     "SETPOINT_SUBFIELD",
+    "pyat_coupled_setpoint_addresses",
     "setpoint_addresses",
 ]

--- a/src/osprey/services/virtual_accelerator/manifest/classify.py
+++ b/src/osprey/services/virtual_accelerator/manifest/classify.py
@@ -66,6 +66,24 @@ def setpoint_addresses(channels: Iterable[Mapping[str, Any]]) -> frozenset[str]:
     )
 
 
+def pyat_coupled_setpoint_addresses(channels: Iterable[Mapping[str, Any]]) -> frozenset[str]:
+    """The addresses a manifest declares writable AND backed by the lattice model.
+
+    The setpoint half of the pyat-coupled partition -- the magnet currents a
+    write actually steers the beam with, as opposed to the sp-echo setpoints
+    that only echo onto their readback. Read off the manifest's own
+    ``partition`` and ``subfield``, because that is where the answer is: the
+    address text is a facility's own spelling and says nothing about whether a
+    lattice element is behind it.
+    """
+    return frozenset(
+        channel["address"]
+        for channel in channels
+        if channel["partition"] == PARTITION_PYAT_COUPLED
+        and channel["subfield"] == SETPOINT_SUBFIELD
+    )
+
+
 # SR RF/VAC fields that carry a real writable-setpoint + readback pair.
 # Pure telemetry fields in the same systems (POWER, TEMPERATURE, PRESSURE,
 # ION-PUMP CURRENT) have no setpoint counterpart and stay static-noisy.

--- a/src/osprey/services/virtual_accelerator/model/catalog.py
+++ b/src/osprey/services/virtual_accelerator/model/catalog.py
@@ -1,15 +1,17 @@
 """The LUME variable catalog for the pyat-coupled channel partition.
 
-Every variable is keyed and named by its full six-level channel address
-(``{ring}:{system}:{family}:{device}:{field}:{subfield}``) so there is no
-address translation anywhere between the manifest, the IOC and the model.
-The catalog is derived -- from the manifest, ``machine.json`` and
-``channel_limits.json`` -- never hand-listed: the databases fix the model,
-not vice versa.
+Every variable is keyed and named by its channel address exactly as the
+manifest carries it, so there is no address translation anywhere between the
+manifest, the IOC and the model -- whatever a facility's addresses look like
+(the bundled demo tree spells them as six colon-separated tokens,
+``{ring}:{system}:{family}:{device}:{field}:{subfield}``). The catalog is
+derived -- from the manifest, ``machine.json`` and ``channel_limits.json`` --
+never hand-listed: the databases fix the model, not vice versa.
 
-The ``:RB`` setpoint echo is deliberately excluded. It is a serving-layer
-concern (the IOC mirrors each ``:SP`` write back onto its ``:RB`` record),
-not model state, so it is not a model variable.
+The setpoint echo is deliberately excluded, selected by the manifest's
+reserved ``READBACK_SUBFIELD`` rather than by anything in the address text. It
+is a serving-layer concern (the IOC mirrors each setpoint write back onto its
+readback record), not model state, so it is not a model variable.
 
 **Declared ranges are metadata, not enforcement.** Inputs carry
 ``default_validation_config='none'``, so ``LUMEModel.set()`` neither

--- a/src/osprey/services/virtual_accelerator/model/variables.py
+++ b/src/osprey/services/virtual_accelerator/model/variables.py
@@ -55,7 +55,6 @@ from osprey.services.virtual_accelerator.lattice.strengths import (
     QUADRUPOLE_FAMILIES,
     SEXTUPOLE_FAMILIES,
     StrengthMap,
-    current_address,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -209,7 +208,7 @@ class CurrentSetpointVariable(PyATWritableScalarVariable):
             fraction = field_error * float(element.Length) / float(element.BendingAngle) + 1.0
         else:
             fraction = float(element.PolynomB[2]) / self._strength_map.baked(self.element_name)
-        i_nom = self._strength_map.i_nom(current_address(self.family, self.device_id))
+        i_nom = self._strength_map.i_nom_for(self.family, self.device_id)
         return i_nom * fraction
 
 

--- a/tests/channel_roster/test_records.py
+++ b/tests/channel_roster/test_records.py
@@ -352,3 +352,40 @@ class TestNoIO:
         source = Path(records_module.__file__ or "").read_text(encoding="utf-8")
         for forbidden in ("open(", "read_text", "rdflib", "json.load", "requests"):
             assert forbidden not in source
+
+
+class TestAddressTokenVocabularyHasOneProducer:
+    """``SP``/``RB``/``:`` are declared once, by ``records``, and read everywhere else.
+
+    The two readers disagree on almost everything, but they agree on what an
+    address token means: the database reader derives direction from ``SP``
+    when it has no limits file, and pairing builds the ``RB`` sibling it then
+    asks the roster to vouch for. A second spelling in either module is a
+    second source of truth that is free to drift from the one the other reader
+    is enumerating against.
+    """
+
+    def test_every_consumer_reads_the_same_constants(self) -> None:
+        from osprey.channel_roster import database, pairing, records
+
+        assert records.WRITE_SUBFIELD == "SP"
+        assert records.READBACK_SUBFIELD == "RB"
+        assert records.ADDRESS_SEPARATOR == ":"
+        for module in (pairing, database):
+            assert module.WRITE_SUBFIELD is records.WRITE_SUBFIELD
+            assert module.ADDRESS_SEPARATOR is records.ADDRESS_SEPARATOR
+        assert pairing.READBACK_SUBFIELD is records.READBACK_SUBFIELD
+
+    def test_no_reader_declares_a_vocabulary_of_its_own(self) -> None:
+        import inspect
+
+        from osprey.channel_roster import database, pairing, records
+
+        for module in (pairing, database):
+            source = inspect.getsource(module)
+            for name in ("WRITE_SUBFIELD", "READBACK_SUBFIELD", "ADDRESS_SEPARATOR"):
+                assert f"{name} = " not in source, f"{module.__name__} declares {name}"
+        producer = inspect.getsource(records)
+        assert 'WRITE_SUBFIELD = "SP"' in producer
+        assert 'READBACK_SUBFIELD = "RB"' in producer
+        assert 'ADDRESS_SEPARATOR = ":"' in producer

--- a/tests/va/test_strength_map.py
+++ b/tests/va/test_strength_map.py
@@ -28,6 +28,7 @@ from osprey.services.virtual_accelerator.manifest import (
     READBACK_SUBFIELD,
     RECORD_TYPE_ANALOG,
     SETPOINT_SUBFIELD,
+    pyat_coupled_setpoint_addresses,
 )
 
 #: A magnet current setpoint spelled the way no six-token colon grammar reads:
@@ -95,3 +96,51 @@ class TestTheNominalCurrentBaselineComesFromTheManifest:
     def test_a_readback_is_not_in_the_map(self, foreign_map: StrengthMap) -> None:
         with pytest.raises(KeyError):
             foreign_map.i_nom(_RING_READBACK)
+
+
+class TestADeviceResolvesThroughTheManifestRoster:
+    """``i_nom_for`` answers "what is this device's baseline" without an address.
+
+    ``apply`` and the model's current readback hold a family and a device id,
+    never an address. Formatting one from them would put a second spelling of
+    the demo tree's grammar in the module every write goes through; the
+    manifest already carries the family and device of each channel, so the
+    device -> setpoint map is derived from the same rows the baseline is.
+    """
+
+    def test_a_device_resolves_when_no_address_grammar_names_it(
+        self, foreign_map: StrengthMap
+    ) -> None:
+        assert foreign_map.i_nom_for("QF", "01") == 137.5
+
+    def test_it_agrees_with_the_address_accessor_across_the_bundled_manifest(self) -> None:
+        from osprey.services.virtual_accelerator.manifest import build_manifest
+
+        channels = build_manifest()["channels"]
+        strength_map = StrengthMap(cast(Any, []), channels=channels)
+        coupled_setpoints = pyat_coupled_setpoint_addresses(channels)
+        by_address = {channel["address"]: channel for channel in channels}
+
+        assert coupled_setpoints
+        for address in sorted(coupled_setpoints):
+            channel = by_address[address]
+            assert strength_map.i_nom_for(channel["family"], channel["device"]) == (
+                strength_map.i_nom(address)
+            )
+
+    def test_an_unknown_pair_raises_naming_both_tokens(self, foreign_map: StrengthMap) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            foreign_map.i_nom_for("ZZ", "99")
+        assert "ZZ" in str(excinfo.value)
+        assert "99" in str(excinfo.value)
+
+    def test_a_device_outside_the_pyat_coupled_partition_does_not_resolve(
+        self, foreign_map: StrengthMap
+    ) -> None:
+        # ``_ECHO_SETPOINT`` carries the same family and device tokens as the
+        # ring's magnet; only the partition tells them apart.
+        with pytest.raises(ValueError):
+            StrengthMap(
+                cast(Any, []),
+                channels=[_channel(_ECHO_SETPOINT, SETPOINT_SUBFIELD, PARTITION_SP_ECHO)],
+            ).i_nom_for("QF", "01")

--- a/tests/va/test_strength_map.py
+++ b/tests/va/test_strength_map.py
@@ -1,0 +1,97 @@
+"""Unit tests for the virtual accelerator's nominal-current baseline.
+
+:class:`~osprey.services.virtual_accelerator.lattice.strengths.StrengthMap`
+scales every magnet strength by ``I / I_nom``, so the set of channels it holds
+a nominal current for decides which writes reach the lattice at all. That set
+comes from the manifest -- the pyat-coupled partition's setpoint half -- and
+not from the address text, which is a facility's own spelling and carries no
+promise that a magnet current is written ``:CURRENT:SP``.
+
+Two facts are pinned here: a setpoint the demo tree's grammar does not name is
+still in the map, and a channel the manifest puts outside the pyat-coupled
+partition is not -- the sp-echo transport-line magnets share family and device
+tokens with the ring's, so a looser filter would hand a ring device the wrong
+baseline.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from osprey.services.virtual_accelerator.lattice import strengths
+from osprey.services.virtual_accelerator.lattice.strengths import StrengthMap
+from osprey.services.virtual_accelerator.manifest import (
+    PARTITION_PYAT_COUPLED,
+    PARTITION_SP_ECHO,
+    READBACK_SUBFIELD,
+    RECORD_TYPE_ANALOG,
+    SETPOINT_SUBFIELD,
+)
+
+#: A magnet current setpoint spelled the way no six-token colon grammar reads:
+#: the facility uses slashes and a dotted subfield, so nothing about the text
+#: ends in ``:CURRENT:SP``.
+_RING_SETPOINT = "ZZSM/MAG/QF01/CURRENT.SETPOINT"
+_RING_READBACK = "ZZSM/MAG/QF01/CURRENT.READBACK"
+#: Same family and device tokens, one partition away: a transport-line magnet
+#: that no lattice element backs.
+_ECHO_SETPOINT = "ZZTL/MAG/QF01/CURRENT.SETPOINT"
+
+
+def _channel(address: str, subfield: str, partition: str) -> dict[str, Any]:
+    """One manifest channel for the ``QF`` device ``01`` of a made-up facility."""
+    return {
+        "address": address,
+        "ring": "ZZSM",
+        "system": "MAG",
+        "family": "QF",
+        "device": "01",
+        "field": "CURRENT",
+        "subfield": subfield,
+        "partition": partition,
+        "record_type": RECORD_TYPE_ANALOG,
+        "noise": False,
+    }
+
+
+_CHANNELS = [
+    _channel(_RING_SETPOINT, SETPOINT_SUBFIELD, PARTITION_PYAT_COUPLED),
+    _channel(_RING_READBACK, READBACK_SUBFIELD, PARTITION_PYAT_COUPLED),
+    _channel(_ECHO_SETPOINT, SETPOINT_SUBFIELD, PARTITION_SP_ECHO),
+]
+
+_MACHINE_JSON = {
+    _RING_SETPOINT: {"value": 137.5, "units": "A"},
+    _RING_READBACK: {"value": 137.5, "units": "A"},
+    _ECHO_SETPOINT: {"value": 42.0, "units": "A"},
+}
+
+
+@pytest.fixture
+def foreign_map(monkeypatch: pytest.MonkeyPatch) -> StrengthMap:
+    """A map built from a facility whose addresses carry no colon grammar."""
+    monkeypatch.setattr(
+        strengths, "load_machine_json_channels", lambda: dict(_MACHINE_JSON), raising=True
+    )
+    # No ring: every assertion below is about the nominal-current baseline, and
+    # baked strengths are snapshotted from whatever elements the ring holds.
+    return StrengthMap(cast(Any, []), channels=_CHANNELS)
+
+
+class TestTheNominalCurrentBaselineComesFromTheManifest:
+    def test_a_setpoint_no_address_grammar_names_still_has_its_nominal(
+        self, foreign_map: StrengthMap
+    ) -> None:
+        assert foreign_map.i_nom(_RING_SETPOINT) == 137.5
+
+    def test_a_channel_outside_the_pyat_coupled_partition_is_not_in_the_map(
+        self, foreign_map: StrengthMap
+    ) -> None:
+        with pytest.raises(KeyError):
+            foreign_map.i_nom(_ECHO_SETPOINT)
+
+    def test_a_readback_is_not_in_the_map(self, foreign_map: StrengthMap) -> None:
+        with pytest.raises(KeyError):
+            foreign_map.i_nom(_RING_READBACK)


### PR DESCRIPTION
The virtual accelerator's nominal-current baseline and the channel roster's readback pairing stop taking facts off address text.

- `refactor(roster): one producer for the roster's setpoint and readback vocabulary`
- `fix(va): select the nominal-current channels from the manifest, not from an address suffix`
- `fix(va): resolve a device's current setpoint through the manifest roster`
- `docs(va,roster): scope the six-token colon grammar to the bundled tree`

## Why

Two pieces of generic code still derived meaning from how an address happens to be spelled. `StrengthMap` kept every `machine.json` channel whose address ended `":CURRENT:SP"`, so a facility that spells its magnet setpoints any other way got an empty baseline and a `KeyError` on the first write; and `current_address()` formatted a setpoint address from a fixed `SR:MAG:` prefix and a `:CURRENT:SP` tail in the module both the IOC and the model reach through. The manifest already answers both questions structurally — the pyat-coupled partition is the lattice-backed channels, its setpoint half is the magnet current setpoints, and every channel carries its own `family` and `device`. `StrengthMap` now selects from `pyat_coupled_setpoint_addresses(channels)` and resolves a device through `i_nom_for(family, device_id)`; `current_address` is gone, with both callers converted in this diff. A deployer whose namespace is slashed, three-part, or otherwise not the demo tree's six colon-separated tokens now gets its nominal currents, and its writes reach the lattice.

On the roster side, `pairing.py` and `database.py` each declared their own copies of the `SP`/`RB`/`:` tokens. They move to `records.py` — the package's declarative, stdlib-only module both readers already import, and the only home that does not make pairing depend on one of the two readers it must stay neutral between. A test asserts the three modules reference the same constant objects and that neither reader declares a vocabulary of its own.

Four module docstrings presented one facility's spelling as the framework's. They now say whose it is: the address text is free and carried through verbatim, the `subfield` *value* is the reserved vocabulary, and the six-token colon form is what the bundled demo tree happens to use.

Behaviour on the bundled tree is unchanged for the ring: the manifest selection is the old address-suffix set minus the BR/BTS transport-line magnets, which are `sp-echo` and were never addressable through the old `SR:MAG:`-prefixed formatter anyway. Dropping them also removes a latent `(family, device)` collision between a transport-line magnet and a ring magnet of the same name.

New tests: `tests/va/test_strength_map.py` (a setpoint no address grammar names still has its nominal; a channel outside the pyat-coupled partition is not in the map; `i_nom_for` agrees with `i_nom` across the bundled manifest and raises naming both tokens for an unknown pair) and a vocabulary-producer class in `tests/channel_roster/test_records.py`.

## Not in this PR

- `ttl_generator/direction.py`'s `WRITE_SUBFIELD`, which is the facility-knowledge package's own single producer for the corpus it mints and belongs to a different package's vocabulary.
- The N-level address grammar itself.
