### PR TITLE
test(e2e): require a run to name the provider it builds with, and gate the build-and-run lanes on that provider's credential

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,15 @@ env:
   # honest outcome — a baked-in host would instead send that fork's traffic,
   # and its API key, to somebody else's gateway.
   ALS_APG_BASE_URL: ${{ vars.ALS_APG_BASE_URL }}
+  # The provider every lane that collects tests/e2e/ builds its deployment
+  # repos with. Stated once here rather than per lane, because a run that names
+  # none is refused at collection — no constant stands behind the variable —
+  # and one name for every lane is the only way the credential a lane holds and
+  # the gateway it builds against stay the same fact. A fork driving its own
+  # gateway changes this one line. A plain name, not a vars. lookup: a fork that
+  # has not set the variable would get an empty value and refuse every e2e lane
+  # rather than run them.
+  OSPREY_E2E_PROVIDER: als-apg
 
 jobs:
   test:

--- a/changelog.d/e2e-provider-marker.internal.md
+++ b/changelog.d/e2e-provider-marker.internal.md
@@ -1,0 +1,1 @@
+An end-to-end run must name the provider it builds with — there is no default behind `OSPREY_E2E_PROVIDER` any more — and the lanes that build a deployment repo now skip on that provider's credential rather than one gateway's.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -598,6 +598,7 @@ markers = [
     "requires_google: Tests that require Google API key",
     "requires_cborg: Tests that require CBORG API key (local dev only — IP allowlist blocks GitHub Actions runners)",
     "requires_als_apg: Tests that require ALS-APG API key (the ALS-APG gateway; reachable from GitHub Actions runners)",
+    "requires_e2e_provider: Tests that build a deployment repo with the provider the run named in OSPREY_E2E_PROVIDER, and so need that provider's credential — the variable holding it comes from PROVIDER_API_KEYS, not from the test",
     "requires_ollama: Tests that require local Ollama service",
     "asyncio: Async test marker",
     "flaky: Rerun on failure to absorb nondeterminism outside the process — LLM sampling in e2e, OS event delivery in a couple of watcher tests (pytest-rerunfailures). Not for flaky unit tests; see tests/README.md",

--- a/scripts/benchmark/README.md
+++ b/scripts/benchmark/README.md
@@ -22,7 +22,8 @@ them by hand.
 
 | Env var | Effect | Read in |
 | --- | --- | --- |
-| `OSPREY_E2E_FORCE_PROVIDER` | build every project with this provider | `sdk_helpers.init_project` |
+| `OSPREY_E2E_PROVIDER` | name the provider the run builds with; required — a run naming none is refused before it runs | `e2e.provider.e2e_provider` |
+| `OSPREY_E2E_FORCE_PROVIDER` | build every project with this provider | `e2e.provider` |
 | `OSPREY_E2E_FORCE_MODEL` | collapse all tiers (haiku/sonnet/opus) → this id | `sdk_helpers._apply_e2e_overrides` |
 | `OSPREY_E2E_PROXY_UPSTREAM` | (open models) start the translation proxy + rewrite base URL | `conftest._e2e_translation_proxy` |
 | `OSPREY_E2E_PROXY_KEY` | upstream auth for the proxy (`""` for keyless local servers — honored by presence, not truthiness) | `conftest._e2e_translation_proxy` |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ This module provides shared fixtures and utilities for all Osprey tests.
 import logging
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -942,6 +943,49 @@ def _has_cborg_api_key() -> bool:
     return bool(_os.environ.get("CBORG_API_KEY"))
 
 
+def _e2e_provider_availability() -> tuple[bool, str]:
+    """Whether the credential of the provider this run builds with is present.
+
+    Two facts meet here and neither is authored: which provider the run was
+    told to build with (``tests.e2e.provider``) and which variable holds that
+    provider's key (``PROVIDER_API_KEYS``, whose own comment calls it the single
+    source of truth). Gating on one gateway's key instead is what let a run
+    naming another provider, and holding its credential, skip anyway.
+
+    A run that named no provider reads as unavailable carrying the refusal's own
+    message rather than raising: the e2e collection hook owns ending such a
+    session, and keeping this predicate out of that business leaves the two free
+    of any hook ordering.
+    """
+    import os as _os
+
+    from osprey.models.provider_registry import PROVIDER_API_KEYS
+    from tests.e2e.provider import E2E_PROVIDER_ENV, e2e_provider
+
+    try:
+        provider = e2e_provider()
+    except RuntimeError as exc:
+        return False, str(exc)
+    if provider not in PROVIDER_API_KEYS:
+        known = ", ".join(sorted(PROVIDER_API_KEYS))
+        return False, (
+            f"{E2E_PROVIDER_ENV} names {provider!r}, which is not a provider OSPREY "
+            f"registers (known: {known})"
+        )
+    key_var = PROVIDER_API_KEYS[provider]
+    if key_var is None or _os.environ.get(key_var):
+        return True, ""
+    return False, f"{key_var} not set — the provider this run builds with is {provider!r}"
+
+
+def _has_e2e_provider_key() -> bool:
+    return _e2e_provider_availability()[0]
+
+
+def _e2e_provider_reason() -> str:
+    return _e2e_provider_availability()[1]
+
+
 def _is_ollama_available() -> bool:
     """True if a local Ollama server responds at localhost:11434."""
     try:
@@ -952,7 +996,10 @@ def _is_ollama_available() -> bool:
         return False
 
 
-_RESOURCE_CHECKS: dict[str, tuple[callable, str]] = {
+# The second element is the skip reason: a fixed string, or a zero-arg callable
+# for a resource whose absence has more than one explanation to report.
+_RESOURCE_CHECKS: dict[str, tuple[Callable[[], bool], str | Callable[[], str]]] = {
+    "requires_e2e_provider": (_has_e2e_provider_key, _e2e_provider_reason),
     "requires_als_apg": (_has_als_apg_api_key, "ALS_APG_API_KEY not set"),
     "requires_anthropic": (_has_anthropic_api_key, "ANTHROPIC_API_KEY not set"),
     "requires_api": (
@@ -974,17 +1021,19 @@ def pytest_collection_modifyitems(config, items):
     missing resource adds a real `pytest.mark.skip(reason=...)`; satisfied
     markers are no-ops.
     """
-    cache: dict[str, bool] = {}
+    cache: dict[str, tuple[bool, str]] = {}
     for item in items:
         for marker_name, (predicate, reason) in _RESOURCE_CHECKS.items():
             if marker_name not in item.keywords:
                 continue
-            available = cache.get(marker_name)
-            if available is None:
+            resolved = cache.get(marker_name)
+            if resolved is None:
                 available = predicate()
-                cache[marker_name] = available
-            if not available:
-                item.add_marker(pytest.mark.skip(reason=reason))
+                text = "" if available else (reason() if callable(reason) else reason)
+                resolved = (available, text)
+                cache[marker_name] = resolved
+            if not resolved[0]:
+                item.add_marker(pytest.mark.skip(reason=resolved[1]))
 
 
 # ===================================================================

--- a/tests/deployment/test_ci_workflow_wiring.py
+++ b/tests/deployment/test_ci_workflow_wiring.py
@@ -115,6 +115,7 @@ GCHAT_SKIP_GATE_STEP = "Fail the lane on any skipped test"
 PUBSUB_FIXTURE_NAME = "pubsub_emulator"
 
 ALS_APG_BASE_URL_ENV = "ALS_APG_BASE_URL"
+E2E_PROVIDER_ENV = "OSPREY_E2E_PROVIDER"
 PROBE_BASE_VAR = "ALS_APG_PROBE_BASE"
 PROBE_KEY_ENV = "ALS_APG_API_KEY"
 PROBE_TARGET_PATH = "/v1/messages"
@@ -2106,6 +2107,63 @@ def test_workflow_exports_the_als_apg_base_url_override__mutation_adds_a_fallbac
     )
     with pytest.raises(AssertionError, match="no fallback"):
         test_workflow_exports_the_als_apg_base_url_override(mutated)
+
+
+def _e2e_provider_overrides(wf: dict[str, Any]) -> list[str]:
+    """Every job or step that redefines the end-to-end provider, as labels."""
+    found: list[str] = []
+    for job_name, job in _jobs(wf).items():
+        if E2E_PROVIDER_ENV in (job.get("env") or {}):
+            found.append(f"job {job_name}")
+        for step in job.get("steps") or []:
+            if E2E_PROVIDER_ENV in (step.get("env") or {}):
+                found.append(f"step {job_name} / {step.get('name', '<unnamed>')}")
+    return found
+
+
+def test_the_workflow_names_the_end_to_end_provider(workflow: dict[str, Any]) -> None:
+    """Every lane that collects ``tests/e2e/`` states what it builds with.
+
+    There is no constant behind the variable any more — an e2e run that names
+    no provider is refused at collection — so the name has to be stated
+    somewhere, and workflow level is the one place that covers every lane at
+    once. A fork driving its own gateway changes this line and nothing else,
+    which is also why the value is a plain name rather than an expression: a
+    ``vars.`` lookup a fork has not set would resolve to empty and refuse every
+    e2e lane in the fork.
+
+    The second half is the one that rots quietly: a job or step that sets the
+    variable itself would build against a different gateway than the one whose
+    key the lane holds, and the failure would read as a credential problem."""
+    named = (workflow.get("env") or {}).get(E2E_PROVIDER_ENV)
+    assert isinstance(named, str) and named.strip(), (
+        f"ci.yml must name {E2E_PROVIDER_ENV} in its workflow-level env block; found {named!r}"
+    )
+    assert "${{" not in named, (
+        f"{E2E_PROVIDER_ENV} must be a plain provider name, not an expression; found {named!r}"
+    )
+    overrides = _e2e_provider_overrides(workflow)
+    assert not overrides, (
+        f"no job or step may override {E2E_PROVIDER_ENV} — one provider for every e2e "
+        f"lane; found: {', '.join(overrides)}"
+    )
+
+
+def test_the_workflow_names_the_end_to_end_provider__mutation_drops_the_name() -> None:
+    mutated = copy.deepcopy(_load_workflow())
+    (mutated.get("env") or {}).pop(E2E_PROVIDER_ENV, None)
+    with pytest.raises(AssertionError, match="must name"):
+        test_the_workflow_names_the_end_to_end_provider(mutated)
+
+
+def test_the_workflow_names_the_end_to_end_provider__mutation_overrides_it_in_a_job() -> None:
+    """The dangerous half: the workflow-level name survives, so the block still
+    reads right, while one lane quietly builds somewhere else."""
+    mutated = copy.deepcopy(_load_workflow())
+    job = _jobs(mutated)[E2E_TESTS_JOB]
+    job["env"] = {**(job.get("env") or {}), E2E_PROVIDER_ENV: "somewhere-else"}
+    with pytest.raises(AssertionError, match="may override"):
+        test_the_workflow_names_the_end_to_end_provider(mutated)
 
 
 def test_every_als_apg_probe_honors_the_base_url_override(workflow: dict[str, Any]) -> None:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -267,15 +267,22 @@ export ANTHROPIC_API_KEY="your-key"
 The lanes that `osprey init` a real deployment repo and run an agent against it
 (`test_claude_code_build_integration.py`, `test_dispatch_tutorial.py`,
 `test_dispatch_allowlist_parity.py`, `test_dispatch_overlay_visibility.py`)
-build with one provider. It is named in one place — `OSPREY_E2E_PROVIDER`,
-defaulting to the gateway this project's own runners hold a key for:
+build with one provider, and you say which — `OSPREY_E2E_PROVIDER` is required:
 
 ```bash
 export OSPREY_E2E_PROVIDER="my-gateway"
 ```
 
-The `requires_*` marker on each lane still gates on the default gateway's key,
-so a facility driving its own gateway deselects by marker or supplies both.
+Nothing stands behind it. A run under `tests/e2e/` that sets neither it nor the
+benchmark override `OSPREY_E2E_FORCE_PROVIDER` stops before it runs a test, with
+a message naming both variables and the providers OSPREY registers — a gateway
+belongs to whoever runs it, so an unnamed run is refused rather than sent to
+whichever one a default happened to point at. CI names it once, at workflow
+level in `ci.yml`.
+
+Each of these lanes then skips only when the provider it was told to build with
+has no credential, and the skip reason names that provider and the environment
+variable holding its key.
 
 ### Provider × model matrix (opt-in)
 
@@ -357,7 +364,11 @@ async def test_my_workflow(e2e_project_factory):
    dry-verify both halves offline — the floor against hand-built traces, the
    judge against one passing conclusion plus one failing control per criterion —
    before you spend a live run. See `test_plan_stack_agentic.py`.
-3. **Mark appropriately** - use `@pytest.mark.e2e`, `@pytest.mark.slow`, `@pytest.mark.requires_*`
+3. **Mark appropriately** - use `@pytest.mark.e2e`, `@pytest.mark.slow`, `@pytest.mark.requires_*`.
+   Which credential marker depends on what the test builds with: `requires_e2e_provider`
+   when it builds with `e2e_provider()` and therefore follows the run, the
+   gateway-specific marker (`requires_als_apg`, `requires_cborg`, …) when the test
+   pins a provider itself.
 4. **Clean validation** - verify actual outputs (files, code content) not just LLM responses
 
 ## CI/CD Integration

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,10 +7,14 @@ See tests/e2e/README.md for details.
 import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
 from osprey.registry import reset_registry
+from tests.e2e.provider import e2e_provider, provider_refusal
+
+_E2E_ROOT = Path(__file__).resolve().parent
 
 
 def _print_failure_now(report) -> None:
@@ -108,8 +112,66 @@ def pytest_collection_finish(session):
         pass
 
 
+def _run_names_a_provider() -> bool:
+    """Whether either variable told this run which provider to build with."""
+    try:
+        e2e_provider()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _refusal_applies(config) -> bool:
+    """Whether this run has to name a provider before it goes any further.
+
+    A ``--collect-only`` run is exempt. It enumerates the suite instead of
+    building anything, so no gateway is reached and nothing needs a credential
+    — and enumerating is how the benchmark lane gate reads each test's lane
+    marker out of a real collection.
+    """
+    if config.getoption("collectonly", False):
+        return False
+    return not _run_names_a_provider()
+
+
+def pytest_collection_modifyitems(config, items):
+    """End the session when an e2e run has not said which provider to build with.
+
+    The lanes under this directory stand up a real deployment repo and drive an
+    agent through it, so the provider is not a detail one of them can shrug off
+    — it decides which gateway the run talks to and which credential it needs.
+    One rule for the whole directory rather than a per-module one: a module that
+    pins its own provider still builds inside a run whose provider decides the
+    rest, and a rule with exceptions is a rule nobody can read off the failure.
+
+    ``UsageError`` rather than a skip or a collection error: it ends the session
+    with the message and no traceback, which is what a misconfigured invocation
+    deserves. This hook is the refusal for an invocation that reaches these
+    tests without naming this directory, so ``pytest_configure`` below never
+    loads; the two are the same refusal, and whichever fires first states it.
+    The rest of ``tests/`` is untouched — the fast lane runs
+    ``pytest tests/ --ignore=tests/e2e`` and never loads this conftest.
+    """
+    if not _refusal_applies(config):
+        return
+    for item in items:
+        path = Path(str(getattr(item, "path", "") or item.fspath)).resolve()
+        if path == _E2E_ROOT or _E2E_ROOT in path.parents:
+            raise pytest.UsageError(provider_refusal())
+
+
 def pytest_configure(config):
-    """Register E2E markers and warn if tests are being run incorrectly."""
+    """Refuse a run that names no provider, register E2E markers, and warn if
+    tests are being run incorrectly."""
+    # The refusal belongs here as well as at collection because the e2e lanes
+    # run distributed (`-n 4 --dist loadfile`), and collection there happens
+    # inside a worker, where a UsageError reaches the operator as an
+    # INTERNALERROR traceback instead of as the message it carries. This
+    # conftest is loaded from the initial arguments, so this hook runs once in
+    # the controlling process before any worker is spawned.
+    if _refusal_applies(config):
+        raise pytest.UsageError(provider_refusal())
+
     # Register custom markers
     config.addinivalue_line("markers", "e2e: End-to-end workflow tests (requires API keys, slow)")
     config.addinivalue_line("markers", "e2e_smoke: Quick smoke tests for critical workflows")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,25 +12,6 @@ import pytest
 
 from osprey.registry import reset_registry
 
-#: Environment variable naming the provider the build-and-run e2e lanes drive.
-#:
-#: These lanes init a real deployment repo and run an agent against it, so they
-#: need a provider whose credential the runner actually holds. That is one fact
-#: about a CI environment, not about OSPREY: a facility running this suite on
-#: its own gateway sets this variable and the lanes follow it, instead of
-#: patching four modules that each spelled one gateway's name inline.
-E2E_PROVIDER_ENV = "OSPREY_E2E_PROVIDER"
-
-#: The provider used when :data:`E2E_PROVIDER_ENV` names none — the gateway
-#: whose key the project's own runners carry, and the one the ``requires_*``
-#: markers on these lanes gate on.
-DEFAULT_E2E_PROVIDER = "als-apg"
-
-
-def e2e_provider() -> str:
-    """The provider these lanes build their deployment repo with."""
-    return os.environ.get(E2E_PROVIDER_ENV, "").strip() or DEFAULT_E2E_PROVIDER
-
 
 def _print_failure_now(report) -> None:
     """Put a failed test's traceback in the log the moment it fails.

--- a/tests/e2e/provider.py
+++ b/tests/e2e/provider.py
@@ -1,0 +1,51 @@
+"""Which provider an end-to-end run builds with.
+
+Two environment variables decide it and this module is where they meet, so the
+precedence between them is stated once rather than rediscovered at each call
+site. It carries no pytest fixtures on purpose: the root ``tests/conftest.py``
+needs the same answer to gate the lanes on a credential, and one conftest
+importing another is not a seam worth opening.
+"""
+
+import os
+
+#: Environment variable naming the provider the build-and-run e2e lanes drive.
+#:
+#: These lanes init a real deployment repo and run an agent against it, so they
+#: need a provider whose credential the runner actually holds. That is one fact
+#: about a CI environment, not about OSPREY: a facility running this suite on
+#: its own gateway sets this variable and the lanes follow it, instead of
+#: patching four modules that each spelled one gateway's name inline.
+E2E_PROVIDER_ENV = "OSPREY_E2E_PROVIDER"
+
+#: The provider used when :data:`E2E_PROVIDER_ENV` names none — the gateway
+#: whose key the project's own runners carry, and the one the ``requires_*``
+#: markers on these lanes gate on.
+DEFAULT_E2E_PROVIDER = "als-apg"
+
+#: Environment variable overriding the provider of *every* project a run builds,
+#: whatever each call site pinned. The benchmark matrix sets it per cell.
+FORCE_PROVIDER_ENV = "OSPREY_E2E_FORCE_PROVIDER"
+
+
+def e2e_provider() -> str:
+    """The provider these lanes build their deployment repo with."""
+    return os.environ.get(E2E_PROVIDER_ENV, "").strip() or DEFAULT_E2E_PROVIDER
+
+
+def build_provider(pinned: str) -> str:
+    """The provider to build a project with, given what the call site pinned.
+
+    Suite-wide override (CBORG model-matrix, issue #259): when
+    :data:`FORCE_PROVIDER_ENV` names a provider it replaces the per-call-site
+    ``pinned`` value so the *entire* ``tests/e2e/`` suite can be pointed at one
+    provider without editing each fixture. Paired with ``OSPREY_E2E_FORCE_MODEL``
+    (honored in ``sdk_helpers._resolve_project_spec``), which collapses all
+    tiers onto a single model id.
+
+    The override is read the way :func:`e2e_provider` reads it — stripped, and
+    empty means unset — so the two functions of this module agree on what the
+    same shell said.
+    """
+    forced = os.environ.get(FORCE_PROVIDER_ENV, "").strip()
+    return forced or pinned

--- a/tests/e2e/provider.py
+++ b/tests/e2e/provider.py
@@ -18,19 +18,45 @@ import os
 #: patching four modules that each spelled one gateway's name inline.
 E2E_PROVIDER_ENV = "OSPREY_E2E_PROVIDER"
 
-#: The provider used when :data:`E2E_PROVIDER_ENV` names none — the gateway
-#: whose key the project's own runners carry, and the one the ``requires_*``
-#: markers on these lanes gate on.
-DEFAULT_E2E_PROVIDER = "als-apg"
-
 #: Environment variable overriding the provider of *every* project a run builds,
 #: whatever each call site pinned. The benchmark matrix sets it per cell.
 FORCE_PROVIDER_ENV = "OSPREY_E2E_FORCE_PROVIDER"
 
 
+def provider_refusal() -> str:
+    """What to tell a run that has not said which provider it builds with.
+
+    The providers are read from the registry's own key table rather than listed
+    here, so the refusal cannot name a set OSPREY does not have.
+    """
+    from osprey.models.provider_registry import PROVIDER_API_KEYS
+
+    known = ", ".join(sorted(PROVIDER_API_KEYS))
+    return (
+        f"This end-to-end run names no provider. Set {E2E_PROVIDER_ENV} to the provider "
+        f"whose credential this environment holds, or {FORCE_PROVIDER_ENV} to point the "
+        f"whole suite at one provider. Known providers: {known}."
+    )
+
+
 def e2e_provider() -> str:
-    """The provider these lanes build their deployment repo with."""
-    return os.environ.get(E2E_PROVIDER_ENV, "").strip() or DEFAULT_E2E_PROVIDER
+    """The provider these lanes build their deployment repo with.
+
+    No constant stands behind the two variables. A gateway is whoever runs it,
+    so a run that named none is refused by name instead of being sent somewhere
+    a default happened to point. The override is honored first: the benchmark
+    runner requires it and sets nothing else.
+
+    Raises:
+        RuntimeError: when neither variable names a provider.
+    """
+    forced = os.environ.get(FORCE_PROVIDER_ENV, "").strip()
+    if forced:
+        return forced
+    selected = os.environ.get(E2E_PROVIDER_ENV, "").strip()
+    if selected:
+        return selected
+    raise RuntimeError(provider_refusal())
 
 
 def build_provider(pinned: str) -> str:

--- a/tests/e2e/sdk_helpers.py
+++ b/tests/e2e/sdk_helpers.py
@@ -37,6 +37,7 @@ import yaml
 from osprey.port_layout import BLOCK_SIZE
 from tests import ci_diagnostics
 from tests.e2e.profile_edits import set_pairs
+from tests.e2e.provider import build_provider
 
 # SDK imports — skip entire module if not installed
 try:
@@ -355,16 +356,12 @@ def init_project(
     setup. ``CliRunner`` is also a unit-test harness; an e2e fixture
     should exercise the same entry point real users invoke.
 
-    Suite-wide override (CBORG model-matrix, issue #259): when
-    ``OSPREY_E2E_FORCE_PROVIDER`` is set it replaces the per-callsite
-    ``provider`` so the *entire* tests/e2e/ suite can be pointed at one
-    provider without editing each fixture. Paired with
-    ``OSPREY_E2E_FORCE_MODEL`` (honored in ``_resolve_project_spec``), which
-    collapses all tiers onto a single model id.
+    The suite-wide override of that pinned choice is resolved by
+    :func:`tests.e2e.provider.build_provider`, which states the precedence.
     """
     from osprey.build.build_tiers import default_tier_for_mode, tier_mode_conflict
 
-    provider = os.environ.get("OSPREY_E2E_FORCE_PROVIDER", provider)
+    provider = build_provider(provider)
     if channel_finder_mode is None and _preset_channel_finder_mode(template) == "graph":
         channel_finder_mode = "hierarchical"
     effective_tier = tier

--- a/tests/e2e/test_claude_code_build_integration.py
+++ b/tests/e2e/test_claude_code_build_integration.py
@@ -36,8 +36,8 @@ from click.testing import CliRunner
 
 from osprey.cli.build_cmd import build
 from osprey.cli.init_cmd import init
-from tests.e2e.conftest import e2e_provider
 from tests.e2e.profile_edits import set_pairs
+from tests.e2e.provider import e2e_provider
 from tests.e2e.sdk_helpers import (
     agent_data_dir,
     e2e_port_base,

--- a/tests/e2e/test_claude_code_build_integration.py
+++ b/tests/e2e/test_claude_code_build_integration.py
@@ -471,7 +471,8 @@ class TestClaudeExecutesArchiverAndPlots:
     @pytest.mark.flaky(reruns=2, reruns_delay=5)
     @pytest.mark.slow
     @pytest.mark.requires_api
-    @pytest.mark.requires_als_apg
+    # Builds with the provider the run named, so the gate follows that name.
+    @pytest.mark.requires_e2e_provider
     def test_claude_executes_archiver_and_plots(self, tmp_path):
         repo = init_project(tmp_path, "archiver-plot-test", provider=e2e_provider())
         disable_approval(repo)
@@ -580,7 +581,8 @@ class TestClaudeFullBpmAnalysisPipeline:
     @pytest.mark.flaky(reruns=2, reruns_delay=5)
     @pytest.mark.slow
     @pytest.mark.requires_api
-    @pytest.mark.requires_als_apg
+    # Builds with the provider the run named, so the gate follows that name.
+    @pytest.mark.requires_e2e_provider
     def test_claude_full_bpm_analysis_pipeline(self, tmp_path):
         repo = init_project(tmp_path, "bpm-pipeline-test", provider=e2e_provider())
         disable_approval(repo)

--- a/tests/e2e/test_dispatch_allowlist_parity.py
+++ b/tests/e2e/test_dispatch_allowlist_parity.py
@@ -66,7 +66,8 @@ RUN_TIMEOUT_SEC = 320.0  # worker's own DISPATCH_TIMEOUT (300s) + polling slack
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.requires_als_apg,
+    # Gates on the credential of whichever provider the run builds with.
+    pytest.mark.requires_e2e_provider,
     pytest.mark.flaky(reruns=2, reruns_delay=5),  # agentic-e2e convention
 ]
 

--- a/tests/e2e/test_dispatch_allowlist_parity.py
+++ b/tests/e2e/test_dispatch_allowlist_parity.py
@@ -52,7 +52,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.e2e.conftest import e2e_provider
+from tests.e2e.provider import e2e_provider
 from tests.e2e.test_dispatch_tutorial import (
     HEALTH_TIMEOUT_SEC,
     _find_osprey_console_script,

--- a/tests/e2e/test_dispatch_overlay_visibility.py
+++ b/tests/e2e/test_dispatch_overlay_visibility.py
@@ -64,8 +64,8 @@ import yaml
 from osprey.deployment.compose_generator import resolve_project_name
 from osprey.port_layout import default_port
 from tests.e2e._volumes import remove_project_volumes
-from tests.e2e.conftest import e2e_provider
 from tests.e2e.profile_edits import set_pairs
+from tests.e2e.provider import e2e_provider
 
 #: This deploy's own thousand-port block — same convention as
 #: test_dispatch_deploy.py (20700) and test_web_bind.py (21000): a real

--- a/tests/e2e/test_dispatch_overlay_visibility.py
+++ b/tests/e2e/test_dispatch_overlay_visibility.py
@@ -108,7 +108,8 @@ SURFACE_TOKEN = "SURFACE=e2e-generic-webhook"  # emitted only if surface_prompt 
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.requires_als_apg,
+    # Gates on the credential of whichever provider the run builds with.
+    pytest.mark.requires_e2e_provider,
     pytest.mark.slow,
     # dockerbuild: full dispatcher/worker image build + deploy -- runs in the
     # dedicated dispatch-overlay-e2e CI job, never the shared e2e-tests lane

--- a/tests/e2e/test_dispatch_tutorial.py
+++ b/tests/e2e/test_dispatch_tutorial.py
@@ -1,9 +1,9 @@
 """Real-token subprocess sweep over the shipped tutorial triggers (L1).
 
 Proves the bundled ``tutorial_triggers.yml`` triggers actually work end to end
-ACROSS PROCESSES with a real Claude Agent SDK run, using the provider named by
-``OSPREY_E2E_PROVIDER`` (defaulting to the ALS-APG gateway, reachable from
-GitHub Actions runners). For each token trigger this:
+ACROSS PROCESSES with a real Claude Agent SDK run, using the provider the run
+named in ``OSPREY_E2E_PROVIDER``; the lane skips when that provider's
+credential is absent. For each token trigger this:
 
   1. Builds a real control-assistant deployment repo once (module-scoped fixture).
   2. Loads the REAL shipped ``tutorial_triggers.yml`` and overrides ONLY
@@ -57,7 +57,9 @@ HEALTH_TIMEOUT_SEC = 45.0
 
 pytestmark = [
     pytest.mark.e2e,
-    pytest.mark.requires_als_apg,
+    # The provider comes from the run, so the credential gate has to follow it
+    # rather than name one gateway: see tests/e2e/provider.py.
+    pytest.mark.requires_e2e_provider,
     pytest.mark.skipif(not HAS_SDK, reason="claude_agent_sdk not installed"),
     pytest.mark.flaky(reruns=2, reruns_delay=5),
 ]

--- a/tests/e2e/test_dispatch_tutorial.py
+++ b/tests/e2e/test_dispatch_tutorial.py
@@ -46,7 +46,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tests.e2e.conftest import e2e_provider
+from tests.e2e.provider import e2e_provider
 from tests.e2e.sdk_helpers import HAS_SDK
 
 TOKEN = "tutorial-e2e-token"  # shared dispatcher<->worker bearer for the test

--- a/tests/infrastructure/test_resource_marker_checks.py
+++ b/tests/infrastructure/test_resource_marker_checks.py
@@ -45,7 +45,10 @@ def test_every_resource_check_is_a_declared_marker() -> None:
 
 
 def test_resource_checks_are_predicate_reason_pairs() -> None:
+    """A reason may be computed rather than fixed — a resource whose absence has
+    more than one explanation says which one — but it must be one of the two: a
+    bare ``None`` or an empty string would skip the test with nothing to read."""
     for name, entry in _RESOURCE_CHECKS.items():
         predicate, reason = entry
         assert callable(predicate), name
-        assert isinstance(reason, str) and reason, name
+        assert callable(reason) or (isinstance(reason, str) and reason), name

--- a/tests/test_api_marker_placement.py
+++ b/tests/test_api_marker_placement.py
@@ -8,7 +8,8 @@ exported*.
 The ``requires_<resource>`` skip-gates in ``tests/conftest.py`` are
 one-directional: each skips when its resource is *absent*, but silently
 exercises the real resource when it is *present*. For a credentialed marker
-(``requires_api`` / ``requires_als_apg`` / ``requires_anthropic``) that means a
+(``requires_api`` / ``requires_als_apg`` / ``requires_anthropic`` /
+``requires_e2e_provider``) that means a
 live LLM call — which passes on a clean machine yet fails on a blocked or
 expired key for anyone who has a key in their shell. That non-determinism is
 what this guard prevents.

--- a/tests/test_e2e_provider_gate.py
+++ b/tests/test_e2e_provider_gate.py
@@ -1,0 +1,64 @@
+"""The provider an end-to-end run builds with, and the credential gate behind it.
+
+Two environment variables and one registry table decide three things: which
+provider a run builds its deployment repos with, whether a run that named none
+is refused, and whether the lanes that build one can reach that provider at
+all. The resolution lives in ``tests/e2e/provider.py`` and the gate in
+``tests/conftest.py``; both are exercised here, in the fast lane, because
+neither needs a credential to be wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.e2e.provider import E2E_PROVIDER_ENV, FORCE_PROVIDER_ENV, build_provider, e2e_provider
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every case from a shell that names no provider.
+
+    A developer running the fast lane with either variable exported would
+    otherwise see cases pass or fail on their environment rather than on what
+    each case sets.
+    """
+    monkeypatch.delenv(E2E_PROVIDER_ENV, raising=False)
+    monkeypatch.delenv(FORCE_PROVIDER_ENV, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# build_provider: what a call site pinned, and what overrides it
+# ---------------------------------------------------------------------------
+
+
+def test_build_provider_keeps_what_the_call_site_pinned() -> None:
+    assert build_provider("cborg") == "cborg"
+
+
+def test_build_provider_takes_the_suite_wide_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The benchmark matrix points the whole suite at one provider per cell
+    without editing a fixture; the pinned value is what it overrides."""
+    monkeypatch.setenv(FORCE_PROVIDER_ENV, "anthropic")
+    assert build_provider("cborg") == "anthropic"
+
+
+def test_an_empty_override_is_unset_for_both_readers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A shell that exports the override empty has named no provider with it.
+    Both functions of this module read the same variable, so they have to read
+    it the same way — otherwise one call site builds with "" and the other with
+    what it pinned."""
+    monkeypatch.setenv(FORCE_PROVIDER_ENV, "   ")
+    monkeypatch.setenv(E2E_PROVIDER_ENV, "cborg")
+    assert build_provider("ds4") == "ds4"
+    assert e2e_provider() == "cborg"
+
+
+# ---------------------------------------------------------------------------
+# e2e_provider: which provider the build-and-run lanes were told to use
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_provider_reads_the_selection_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(E2E_PROVIDER_ENV, "cborg")
+    assert e2e_provider() == "cborg"

--- a/tests/test_e2e_provider_gate.py
+++ b/tests/test_e2e_provider_gate.py
@@ -10,12 +10,34 @@ neither needs a credential to be wrong.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from osprey.models.provider_registry import PROVIDER_API_KEYS
+from tests.conftest import _e2e_provider_availability
 from tests.e2e import conftest as e2e_conftest
 from tests.e2e.provider import E2E_PROVIDER_ENV, FORCE_PROVIDER_ENV, build_provider, e2e_provider
+
+#: The lanes that build a deployment repo and run an agent against it. They gate
+#: on the provider the run named; every other e2e module pins a provider in its
+#: own render and keeps the gateway-specific marker.
+BUILD_AND_RUN_MODULES = (
+    "e2e/test_claude_code_build_integration.py",
+    "e2e/test_dispatch_tutorial.py",
+    "e2e/test_dispatch_allowlist_parity.py",
+    "e2e/test_dispatch_overlay_visibility.py",
+)
+
+#: A module that pins its own provider, so the gateway-specific marker is the
+#: truth for it and the swap below must not have reached it.
+PINNED_PROVIDER_MODULE = "e2e/test_preset_agentic.py"
+
+PROVIDER_MARKER = "requires_e2e_provider"
+GATEWAY_MARKER = "requires_als_apg"
+
+_TESTS_ROOT = Path(__file__).resolve().parent
 
 
 @pytest.fixture(autouse=True)
@@ -83,8 +105,6 @@ def test_the_override_wins_over_the_selection(monkeypatch: pytest.MonkeyPatch) -
 def test_a_run_that_names_no_provider_is_refused() -> None:
     """No constant stands behind the variables: a run that named nothing is
     told what to set rather than sent to whichever gateway was compiled in."""
-    from osprey.models.provider_registry import PROVIDER_API_KEYS
-
     with pytest.raises(RuntimeError) as excinfo:
         e2e_provider()
     message = str(excinfo.value)
@@ -140,3 +160,87 @@ def test_a_named_provider_lets_configure_register_its_markers(
     config = _StubConfig()
     e2e_conftest.pytest_configure(config)
     assert any(line.startswith("e2e:") for line in config.markers)
+
+
+# ---------------------------------------------------------------------------
+# The credential gate: can the lanes reach the provider they were told to use?
+# ---------------------------------------------------------------------------
+
+
+def _a_provider_needing(key: bool) -> tuple[str, str | None]:
+    """A provider from the registry's table that does (or does not) need a key."""
+    for name, key_var in sorted(PROVIDER_API_KEYS.items()):
+        if (key_var is not None) == key:
+            return name, key_var
+    raise AssertionError("PROVIDER_API_KEYS has no provider of that shape")
+
+
+def test_a_provider_whose_key_is_exported_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, key_var = _a_provider_needing(key=True)
+    monkeypatch.setenv(E2E_PROVIDER_ENV, provider)
+    monkeypatch.setenv(key_var, "test-key")
+    assert _e2e_provider_availability() == (True, "")
+
+
+def test_a_provider_that_needs_no_key_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A local server authenticates differently or not at all; the table says
+    so with ``None``, and a gate that demanded a variable would skip a lane
+    that would have run."""
+    provider, _ = _a_provider_needing(key=False)
+    monkeypatch.setenv(E2E_PROVIDER_ENV, provider)
+    assert _e2e_provider_availability() == (True, "")
+
+
+def test_a_missing_key_names_the_provider_and_its_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider, key_var = _a_provider_needing(key=True)
+    monkeypatch.setenv(E2E_PROVIDER_ENV, provider)
+    monkeypatch.delenv(key_var, raising=False)
+    available, reason = _e2e_provider_availability()
+    assert not available
+    assert provider in reason
+    assert key_var in reason
+
+
+def test_an_unknown_provider_is_a_reason_not_a_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(E2E_PROVIDER_ENV, "not-a-provider")
+    available, reason = _e2e_provider_availability()
+    assert not available
+    assert "not-a-provider" in reason
+
+
+def test_a_run_naming_no_provider_reads_as_unavailable() -> None:
+    """The collection hook owns the refusal. The gate must not raise it a
+    second time from inside a collection hook of its own — whichever hook runs
+    first would then decide what the operator reads."""
+    available, reason = _e2e_provider_availability()
+    assert not available
+    assert E2E_PROVIDER_ENV in reason
+
+
+# ---------------------------------------------------------------------------
+# Which modules carry which marker
+# ---------------------------------------------------------------------------
+
+
+def test_the_build_and_run_lanes_gate_on_the_named_provider() -> None:
+    """The four lanes that build with whatever the run named must gate on that
+    provider's credential. Gating them on one gateway's key is how a run that
+    named another provider, and held its key, skipped anyway."""
+    for relative in BUILD_AND_RUN_MODULES:
+        source = (_TESTS_ROOT / relative).read_text(encoding="utf-8")
+        assert PROVIDER_MARKER in source, f"tests/{relative} must gate on {PROVIDER_MARKER}"
+        assert GATEWAY_MARKER not in source, (
+            f"tests/{relative} builds with the provider the run named, so "
+            f"{GATEWAY_MARKER} would gate it on a gateway it may never contact"
+        )
+
+
+def test_a_module_pinning_its_own_provider_keeps_the_gateway_marker() -> None:
+    """The swap is scoped, not a retirement: for a module that passes one
+    provider to every ``init_project`` call, the gateway-specific marker names
+    exactly the credential it needs, and a neutral marker would make the gate
+    lie."""
+    source = (_TESTS_ROOT / PINNED_PROVIDER_MODULE).read_text(encoding="utf-8")
+    assert GATEWAY_MARKER in source

--- a/tests/test_e2e_provider_gate.py
+++ b/tests/test_e2e_provider_gate.py
@@ -10,8 +10,11 @@ neither needs a credential to be wrong.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
+from tests.e2e import conftest as e2e_conftest
 from tests.e2e.provider import E2E_PROVIDER_ENV, FORCE_PROVIDER_ENV, build_provider, e2e_provider
 
 
@@ -62,3 +65,78 @@ def test_an_empty_override_is_unset_for_both_readers(monkeypatch: pytest.MonkeyP
 def test_e2e_provider_reads_the_selection_variable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(E2E_PROVIDER_ENV, "cborg")
     assert e2e_provider() == "cborg"
+
+
+def test_e2e_provider_accepts_the_override_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The benchmark runner requires the override and sets nothing else, so the
+    override has to satisfy the selection on its own."""
+    monkeypatch.setenv(FORCE_PROVIDER_ENV, "ds4")
+    assert e2e_provider() == "ds4"
+
+
+def test_the_override_wins_over_the_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(E2E_PROVIDER_ENV, "cborg")
+    monkeypatch.setenv(FORCE_PROVIDER_ENV, "ds4")
+    assert e2e_provider() == "ds4"
+
+
+def test_a_run_that_names_no_provider_is_refused() -> None:
+    """No constant stands behind the variables: a run that named nothing is
+    told what to set rather than sent to whichever gateway was compiled in."""
+    from osprey.models.provider_registry import PROVIDER_API_KEYS
+
+    with pytest.raises(RuntimeError) as excinfo:
+        e2e_provider()
+    message = str(excinfo.value)
+    assert E2E_PROVIDER_ENV in message
+    assert FORCE_PROVIDER_ENV in message
+    assert any(name in message for name in PROVIDER_API_KEYS), (
+        f"the refusal must list the providers it would accept: {message}"
+    )
+
+
+class _StubConfig:
+    """Just enough pytest config for ``pytest_configure`` to register markers."""
+
+    def __init__(self, *, collect_only: bool = False) -> None:
+        self.markers: list[str] = []
+        self.option = SimpleNamespace(markexpr="")
+        self._collect_only = collect_only
+
+    def getoption(self, name: str, default: object = None) -> object:
+        return self._collect_only if name == "collectonly" else default
+
+    def addinivalue_line(self, name: str, line: str) -> None:
+        self.markers.append(line)
+
+
+def test_the_e2e_session_is_refused_before_its_workers_spawn() -> None:
+    """The refusal has to reach the operator when the lanes run distributed.
+    Collection then happens inside an xdist worker, where a ``UsageError`` is
+    reported as an internal error with a traceback; raised from
+    ``pytest_configure`` of an initial-argument conftest it is raised once, in
+    the controlling process, before a worker exists."""
+    with pytest.raises(pytest.UsageError) as excinfo:
+        e2e_conftest.pytest_configure(_StubConfig())
+    assert E2E_PROVIDER_ENV in str(excinfo.value)
+
+
+def test_enumerating_the_suite_needs_no_provider() -> None:
+    """``--collect-only`` builds nothing and reaches no gateway, so it is not
+    refused: the benchmark lane gate reads every test's lane marker out of a
+    real collection of ``tests/e2e/`` and would have no manifest otherwise."""
+    config = _StubConfig(collect_only=True)
+    e2e_conftest.pytest_configure(config)
+    e2e_conftest.pytest_collection_modifyitems(config, [])
+    assert any(line.startswith("e2e:") for line in config.markers)
+
+
+def test_a_named_provider_lets_configure_register_its_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal is the only thing added to that hook: a run that named a
+    provider still gets the markers the e2e lanes select on."""
+    monkeypatch.setenv(E2E_PROVIDER_ENV, "cborg")
+    config = _StubConfig()
+    e2e_conftest.pytest_configure(config)
+    assert any(line.startswith("e2e:") for line in config.markers)


### PR DESCRIPTION
An end-to-end run must name the provider it builds with, and the four lanes that build a deployment repo now gate on that provider's credential instead of one fixed gateway's.

- `test(e2e): resolve the provider in one module instead of at two call sites`
- `test(e2e): refuse an end-to-end run that names no provider`
- `ci: state the provider the end-to-end lanes build with`
- `test(e2e): gate the build-and-run lanes on the credential of the provider they name`
- `docs(e2e): say which provider a run must name and which credential its lanes need`

## Why

Four e2e modules stand up a real deployment repo and drive an agent through it, and they already read which provider to build with from `OSPREY_E2E_PROVIDER`. Two things did not follow that variable. Their skip gate read one fixed gateway's key, so a run naming another provider and holding its credential skipped anyway, while a run holding the fixed gateway's key passed a check for a gateway it never contacted. And the selector had a constant behind it, so a run that named nothing built with one project's gateway by default.

Both are gone. Provider selection is resolved in one module, `tests/e2e/provider.py`, which states the precedence between the selection variable and the benchmark override once. A run under `tests/e2e/` that sets neither is refused before it runs anything, by name, listing the providers the registry knows — raised in the controlling process, so the operator reads the message rather than a worker's traceback when the lanes run distributed — a gateway belongs to whoever runs it, so an unnamed run stops rather than being sent somewhere a constant pointed. The credential gate follows the same answer: it looks the named provider up in `PROVIDER_API_KEYS`, the registry's own single source of truth, and skips only when that provider's variable is absent, with a reason naming both.

A deployer can now point the whole build-and-run suite at their own gateway by setting one variable, and get lanes that actually run against it — where before they had to either deselect by marker or export a second project's key to satisfy a check that measured nothing. In CI the name is stated once at workflow level, so a fork retargets every e2e lane by editing one line.

Every runner in the repository keeps working: CI lanes inherit the workflow-level name, and the benchmark runner already requires its own override, which satisfies the same check.

## Not in this PR

- Retiring the gateway-specific marker. 34 other e2e modules pin a provider in their own render, so for them that marker names exactly the credential they need; retiring it waits on a later change making those modules read the selected provider instead.
- Auto-switching to whichever provider happens to hold a key — declined by the same no-default rule that removed the constant.
- The base-URL half of the gate. Only two of the eight providers declaring `requires_base_url` also declare a `base_url_env_var`; for the rest the endpoint comes from the rendered config, so gating on a variable would skip runs that would have worked.
- Reconciling `PROVIDER_API_KEYS`, which maps one provider to `None`, with that provider's own `requires_api_key = True` (it authenticates another way). The gate follows the table; the mismatch is a follow-up.
- The single-gateway branch in `tests/e2e/judge.py`, which builds a self-contained judge config for one provider and returns `None` for every other — generalising it needs the base-URL table this PR cut.

