### PR TITLE
test: pin four harnesses to their own subject instead of a process-wide reach

### DIFF
--- a/changelog.d/degraded-refusal-invariant.internal.md
+++ b/changelog.d/degraded-refusal-invariant.internal.md
@@ -1,0 +1,3 @@
+The scaffold gallery's degraded-topology refusal records, beside the sentence
+itself, why naming the durable-store variable is a real way out on every
+topology that can reach it.

--- a/changelog.d/retention-sleep-name.internal.md
+++ b/changelog.d/retention-sleep-name.internal.md
@@ -1,0 +1,3 @@
+The dispatch worker's retention sweep imports `asyncio` at module scope instead
+of inside the loop function, so the name it awaits through can be replaced by
+tests without touching the process-wide one.

--- a/src/osprey/interfaces/web_terminal/scaffold_gallery_service.py
+++ b/src/osprey/interfaces/web_terminal/scaffold_gallery_service.py
@@ -362,6 +362,10 @@ class ScaffoldGalleryService:
             "  Restore the profile this project names — its manifest records the path as\n"
             "  build_args.profile_path_abs — or rebuild from the profile you want to own\n"
             "  this artifact, and try again.\n\n"
+            # Unconditional, and true on every topology that reaches here: a
+            # mounted store resolves to VOLUME, so DEGRADED means there is none
+            # — on a bare host as much as in a container. Naming the variable is
+            # therefore always a real way out, never a container-only aside.
             f"  {NO_DURABLE_STORE}"
         )
 

--- a/src/osprey/mcp_server/dispatch_worker/retention.py
+++ b/src/osprey/mcp_server/dispatch_worker/retention.py
@@ -29,6 +29,7 @@ functions are pure (they take the log dir, an ``ArtifactStore``, and an injected
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -275,8 +276,6 @@ async def retention_loop(
     A failing sweep is logged and the loop continues — retention must never take
     the worker down. Returns only on cancellation.
     """
-    import asyncio
-
     logger.info(
         "Retention sweep enabled: deleting records older than %d day(s), every %.0fs",
         retention_days,

--- a/tests/dispatch_worker/test_retention.py
+++ b/tests/dispatch_worker/test_retention.py
@@ -302,24 +302,25 @@ def test_retention_loop_runs_one_iteration(tmp_path, monkeypatch):
     store = ArtifactStore(workspace_root=tmp_path)
 
     calls: list[float] = []
-    real_sleep = asyncio.sleep
 
     async def fake_sleep(interval):
-        # This patch replaces the PROCESS-global asyncio.sleep, and daemon
-        # threads left running by earlier tests in the same worker (uvicorn
-        # servers tick sleep(0.1), the epics-ca test loop, …) call it too.
-        # Intercept only this loop's own interval and pass everything else
-        # through, so a foreign thread's tick can neither pollute `calls`
-        # nor swallow the cancellation meant for the retention loop.
-        if interval != 123.0:
-            await real_sleep(interval)
-            return
         # Let the first sleep return so one sweep runs, then cancel the loop.
         calls.append(interval)
         if len(calls) >= 2:
             raise asyncio.CancelledError
 
-    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    # ``retention_loop`` awaits ``asyncio.sleep(...)`` through its own module-level
+    # ``asyncio`` name. Patch THAT name, never ``asyncio.sleep`` itself: the
+    # function is shared with every other event loop alive in the process, and a
+    # daemon thread left by an earlier test in the same worker would tick through
+    # the fake.
+    class _AsyncioForRetention:
+        sleep = staticmethod(fake_sleep)
+
+        def __getattr__(self, name):
+            return getattr(asyncio, name)
+
+    monkeypatch.setattr(retention, "asyncio", _AsyncioForRetention())
 
     async def drive():
         with pytest.raises(asyncio.CancelledError):
@@ -365,19 +366,21 @@ def test_retention_loop_re_resolves_a_callable_log_dir(tmp_path, monkeypatch):
         return answer
 
     calls: list[float] = []
-    real_sleep = asyncio.sleep
 
     async def fake_sleep(interval):
-        # Same passthrough as the test above: only this loop's own interval is
-        # intercepted, so a foreign thread's tick cannot drive the loop.
-        if interval != 123.0:
-            await real_sleep(interval)
-            return
         calls.append(interval)
         if len(calls) >= 3:
             raise asyncio.CancelledError
 
-    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    # Same scoped patch as the test above: the name replaced is the retention
+    # module's own, so no other event loop in the process sees the fake.
+    class _AsyncioForRetention:
+        sleep = staticmethod(fake_sleep)
+
+        def __getattr__(self, name):
+            return getattr(asyncio, name)
+
+    monkeypatch.setattr(retention, "asyncio", _AsyncioForRetention())
 
     async def drive():
         with pytest.raises(asyncio.CancelledError):

--- a/tests/interfaces/_browser.py
+++ b/tests/interfaces/_browser.py
@@ -7,6 +7,10 @@ same-origin script/stylesheet subresource came back 4xx/5xx (the classic
 intentionally narrow by default — see the module-breakage rationale below —
 with an opt-in ``console.error`` arm and an ``allowlist`` escape hatch for
 known-benign noise.
+
+``wait_for_dock_settled`` is the other shared wait: it blocks until the dock has
+finished arranging the shell, for any suite that drives or photographs the
+web-terminal hub.
 """
 
 from __future__ import annotations
@@ -129,3 +133,63 @@ def assert_page_loads_clean(
     if surviving:
         lines = "\n".join(f"  - [{kind}] {detail}" for kind, detail in surviving)
         raise AssertionError(f"Page did not load clean at {url}:\n{lines}")
+
+
+#: Resolves once the dock has finished arranging the shell: the boot layout is
+#: announced final AND the console has held its place for a frame after it. The
+#: announcement lands in the same frame as the last re-parent, so the flag alone
+#: is the boundary rather than the far side of it.
+DOCK_SETTLED_JS = """
+async (budgetMs) => {
+  const dock = await import('/static/js/dock-workspace.js');
+  const place = () => {
+    let out = '';
+    for (let n = document.querySelector('#operator-container'); n; n = n.parentElement) {
+      out += '>' + (n.id || n.className || n.tagName);
+    }
+    return out;
+  };
+  const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  const deadline = Date.now() + budgetMs;
+  let previous = null;
+  while (Date.now() < deadline) {
+    await frame();
+    const current = place();
+    if (dock.bootLayoutSettled() && current === previous) return true;
+    previous = current;
+  }
+  return false;
+}
+"""
+
+
+def wait_for_dock_settled(page: Page, *, budget_ms: int = 10_000) -> None:
+    """Block until the dock has finished arranging the shell.
+
+    The terminal card carrying both ``#terminal-container`` and
+    ``#operator-container`` is server-rendered into ``#dock-panel-sources`` and
+    re-parented twice on the way to its tile: once when the dock adopts the
+    subtree, and again when the boot layout is applied over the default
+    arrangement. The console mounts independently of either, so its textarea is
+    on screen and actionable before the shell is still.
+
+    Typing into it there is lost rather than delayed. Playwright checks
+    actionability and then writes, and a re-parent between those two steps takes
+    focus off the element, so the text is never inserted: the box reads empty,
+    ``submit`` finds no prompt and returns, and the turn never starts. The
+    equivalent hazard for a keystroke is the event landing on whatever the
+    detached node left behind.
+
+    Both moves are boot-only, so waiting for them here puts every re-parent
+    ahead of every interaction rather than between two of them.
+
+    Call this AFTER the page's own mount check, never before. The wait reads the
+    dock's state by importing its module, and a caller that has not yet waited
+    for anything makes that a cold fetch of a module graph still being loaded --
+    which fails outright rather than waiting, and reports a fetch error in place
+    of whatever the test was doing.
+    """
+    assert page.evaluate(DOCK_SETTLED_JS, budget_ms), (
+        "the dock never settled: the boot layout was not announced final, or the "
+        "console was still being re-parented when the wait ran out"
+    )

--- a/tests/interfaces/design_system/test_visual.py
+++ b/tests/interfaces/design_system/test_visual.py
@@ -48,6 +48,7 @@ from fastapi.staticfiles import StaticFiles
 from PIL import Image
 
 import osprey.interfaces.design_system as design_system_pkg
+from tests.interfaces._browser import wait_for_dock_settled
 from tests.interfaces._panel_launch import publish_artifact_url
 from tests.interfaces.conftest import (
     _apply_all,
@@ -252,8 +253,9 @@ class VisualTarget:
     # The web-terminal hub now boots a dockview workspace (dock-workspace.js)
     # whose default artifacts panel docks as an overlay iframe (dock-iframe.js).
     # Unlike the pre-dock split, the grid and its overlay settle a beat after the
-    # rail renders, so ``dock_shell`` targets wait for the dockview grid AND the
-    # auto-docked artifacts overlay iframe to be on screen before the screenshot —
+    # rail renders, so ``dock_shell`` targets wait for the dock's own settled
+    # signal — ``bootLayoutSettled()``, latched once the boot layout is final —
+    # AND the auto-docked artifacts overlay iframe, before the screenshot;
     # otherwise the baseline can capture a half-built (empty) grid.
     dock_shell: bool = False
     # UI-mode axis. Mode-aware surfaces capture the full theme x mode matrix
@@ -537,10 +539,11 @@ def test_visual_snapshot(tmp_path, chromium_browser, target: VisualTarget, pytes
                     if target.wait_selector:
                         expect(page.locator(target.wait_selector)).to_be_attached(timeout=10_000)
                     if target.dock_shell:
-                        # The dockview grid settles a beat after the rail renders;
-                        # wait for it so the baseline captures the built layout,
-                        # not a half-constructed (empty) grid.
-                        expect(page.locator(".dv-groupview").first).to_be_visible(timeout=10_000)
+                        # The dock latches ``bootLayoutSettled()`` once the boot
+                        # layout is the final arrangement, so the baseline
+                        # captures the built layout rather than a mid-restore
+                        # grid the restore may still replace.
+                        wait_for_dock_settled(page)
                         # The auto-docked service overlay is expert-only. Simple
                         # mode over an empty agent workspace boots chat-only by
                         # design (panel-manager.js's `workspaceSuppressed`: simple
@@ -561,8 +564,9 @@ def test_visual_snapshot(tmp_path, chromium_browser, target: VisualTarget, pytes
                         # grid. A capture before it lands would pin the wrong
                         # state and flake against a frame that includes it.
                         expect(page.locator(".op-messages .op-empty")).to_be_visible(timeout=10_000)
-                    # Let async init (panel health polling, SSE-driven layout,
-                    # font swaps) settle before the screenshot.
+                    # The layout is known by here; this is the paint budget
+                    # on top of it — font swaps, panel health polling and the
+                    # first render of whatever they change.
                     page.wait_for_timeout(600)
 
                     applied_theme = page.evaluate(

--- a/tests/interfaces/web_terminal/test_chat_browser.py
+++ b/tests/interfaces/web_terminal/test_chat_browser.py
@@ -66,6 +66,7 @@ import requests
 from fastapi import Request
 
 from osprey.agent_runner.project_paths import claude_project_dir
+from tests.interfaces._browser import wait_for_dock_settled
 from tests.interfaces._panel_launch import publish_artifact_url
 from tests.interfaces.conftest import _apply_all, _run_app_server
 
@@ -506,66 +507,6 @@ _PROBE_INIT_SCRIPT = """
 _DISMISS_TOUR = "try { localStorage.setItem('osprey-tour-dismissed-v1', '1') } catch (e) {}"
 
 
-#: Resolves once the dock has finished arranging the shell: the boot layout is
-#: announced final AND the console has held its place for a frame after it. The
-#: announcement lands in the same frame as the last re-parent, so the flag alone
-#: is the boundary rather than the far side of it.
-_DOCK_SETTLED_JS = """
-async (budgetMs) => {
-  const dock = await import('/static/js/dock-workspace.js');
-  const place = () => {
-    let out = '';
-    for (let n = document.querySelector('#operator-container'); n; n = n.parentElement) {
-      out += '>' + (n.id || n.className || n.tagName);
-    }
-    return out;
-  };
-  const frame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
-  const deadline = Date.now() + budgetMs;
-  let previous = null;
-  while (Date.now() < deadline) {
-    await frame();
-    const current = place();
-    if (dock.bootLayoutSettled() && current === previous) return true;
-    previous = current;
-  }
-  return false;
-}
-"""
-
-
-def _wait_for_dock_settled(page: Page) -> None:
-    """Block until the dock has finished arranging the shell.
-
-    The terminal card carrying both ``#terminal-container`` and
-    ``#operator-container`` is server-rendered into ``#dock-panel-sources`` and
-    re-parented twice on the way to its tile: once when the dock adopts the
-    subtree, and again when the boot layout is applied over the default
-    arrangement. The console mounts independently of either, so its textarea is
-    on screen and actionable before the shell is still.
-
-    Typing into it there is lost rather than delayed. Playwright checks
-    actionability and then writes, and a re-parent between those two steps takes
-    focus off the element, so the text is never inserted: the box reads empty,
-    ``submit`` finds no prompt and returns, and the turn never starts. The
-    equivalent hazard for a keystroke is the event landing on whatever the
-    detached node left behind.
-
-    Both moves are boot-only, so waiting for them here puts every re-parent
-    ahead of every interaction rather than between two of them.
-
-    Call this AFTER the page's own mount check, never before. The wait reads the
-    dock's state by importing its module, and a caller that has not yet waited
-    for anything makes that a cold fetch of a module graph still being loaded --
-    which fails outright rather than waiting, and reports a fetch error in place
-    of whatever the test was doing.
-    """
-    assert page.evaluate(_DOCK_SETTLED_JS, 10_000), (
-        "the dock never settled: the boot layout was not announced final, or the "
-        "console was still being re-parented when the wait ran out"
-    )
-
-
 def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
     """Open a fresh page (on a browser or a context) and wait for the console."""
     page: Page = opener.new_page()
@@ -575,7 +516,7 @@ def _open_chat_page(opener, base_url: str, query: str = "") -> Page:
     # initChat builds the console on DOMContentLoaded; the input row is the
     # last thing appended, so its presence means the console is mounted.
     expect(page.locator(f"{_OP} .op-input-area textarea")).to_be_visible(timeout=10_000)
-    _wait_for_dock_settled(page)
+    wait_for_dock_settled(page)
     return page
 
 
@@ -586,7 +527,7 @@ def _open_expert_page(opener, base_url: str, query: str = "") -> Page:
     page.add_init_script(_PROBE_INIT_SCRIPT)
     page.goto(f"{base_url}{query}", wait_until="domcontentloaded")
     expect(page.locator("#terminal-container .xterm")).to_be_visible(timeout=10_000)
-    _wait_for_dock_settled(page)
+    wait_for_dock_settled(page)
     return page
 
 

--- a/tests/interfaces/web_terminal/test_scaffold_gallery_service.py
+++ b/tests/interfaces/web_terminal/test_scaffold_gallery_service.py
@@ -1797,6 +1797,27 @@ class TestDegradedTopology:
         with pytest.raises(ScaffoldClaimError):
             svc.unoverride(owned[0])
 
+    def test_the_refusal_names_the_store_variable_on_a_bare_host(self, degraded_project_dir):
+        """The way out is named where the refusal is read, container or not.
+
+        ``degraded_project_dir`` is a bare host: no volume, and no
+        ``CLAUDE_CONFIG_DIR`` in the environment. The no-durable-store sentence
+        has to carry the variable's name there too, because that is the only
+        place the operator is told what to set.
+        """
+        from osprey.cli.scaffold_cmd import ScaffoldClaimError
+        from osprey.interfaces.web_terminal.ownership import (
+            CLAUDE_CONFIG_ENV,
+            NO_DURABLE_STORE,
+        )
+
+        svc = ScaffoldGalleryService(degraded_project_dir)
+        with pytest.raises(ScaffoldClaimError) as excinfo:
+            svc.create_artifact("agents", "nowhere-to-put-this")
+
+        assert NO_DURABLE_STORE in str(excinfo.value)
+        assert CLAUDE_CONFIG_ENV in str(excinfo.value)
+
     def test_the_gallery_still_opens(self, degraded_project_dir):
         """Reads must keep working — a refused write is not a broken page."""
         svc = ScaffoldGalleryService(degraded_project_dir)

--- a/tests/mcp_server/test_control_target_roster.py
+++ b/tests/mcp_server/test_control_target_roster.py
@@ -53,6 +53,7 @@ started_on = switch_suite.started_on
 # test_control_target_set.py for why they are rebound rather than imported.
 child_environment = switch_suite.child_environment
 fixture_dir = switch_suite.fixture_dir
+live_type = switch_suite.live_type
 make_manager = switch_suite.make_manager
 state_root = switch_suite.state_root
 # The agent-data root the endpoint cases narrow under, stamped and cleared the way

--- a/tests/mcp_server/test_control_target_set.py
+++ b/tests/mcp_server/test_control_target_set.py
@@ -67,6 +67,7 @@ raw_config = switch_suite.raw_config
 # parameter does not read as a shadowed import.
 child_environment = switch_suite.child_environment
 fixture_dir = switch_suite.fixture_dir
+live_type = switch_suite.live_type
 make_manager = switch_suite.make_manager
 state_root = switch_suite.state_root
 

--- a/tests/mcp_server/test_switch_lifecycle.py
+++ b/tests/mcp_server/test_switch_lifecycle.py
@@ -72,15 +72,20 @@ from osprey_connectors import control_context, posture_store
 from osprey_connectors.control_system.base import ChannelValue
 from osprey_connectors.factory import ConnectorFactory, isolated_connector_registries
 from osprey_connectors.ipc.proxy import ConnectorHostProxy
-from osprey_connectors.types import VIRTUAL_ACCELERATOR
+from osprey_connectors.types import EPICS, VIRTUAL_ACCELERATOR
 from tests._control_context_fixtures import write_control_context
 from tests.fixtures.control_context import context_for
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPO_PATHS = (str(REPO_ROOT / "src"), str(REPO_ROOT / "packages" / "osprey-connectors" / "src"))
 
-#: The mock connector by dotted path, so ``live`` resolves to something real.
-LIVE_TYPE = "osprey_connectors.control_system.mock_connector.MockConnector"
+#: The mock connector by dotted path: what lets a test *serve* ``live`` from a
+#: real child on a machine with no Channel Access, which is what nearly every
+#: test here does — hence this module's default.
+SERVED_LIVE_TYPE = "osprey_connectors.control_system.mock_connector.MockConnector"
+#: A Channel Access type, for the tests that need ``live`` to read as a real
+#: machine rather than be served by one. Nothing is spawned from it.
+CA_LIVE_TYPE = EPICS
 LIVE_PROBE = "SR:BEAM:CURRENT"
 VA_PROBE = "VA:BEAM:CURRENT"
 REFUSE_CHANNEL = "FIXTURE:REFUSE"
@@ -211,7 +216,7 @@ def raw_config(
     live_probe=LIVE_PROBE,
     va_probe=VA_PROBE,
     drain_timeout_s=None,
-    live_type=LIVE_TYPE,
+    live_type=SERVED_LIVE_TYPE,
 ):
     """A config with a servable block for each target."""
     live_block = {"response_delay_ms": 1, "noise_level": 0.0}
@@ -318,7 +323,24 @@ def state_root(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-async def make_manager(state_root):
+def live_type(request):
+    """The connector type the deployment under test names as its ``live`` target.
+
+    Defaults to :data:`SERVED_LIVE_TYPE`, because nearly every test here wants a
+    ``live`` target a real child can actually serve. Eligibility reads the
+    connector type, so a test that needs ``live`` to read as a real machine —
+    an away-switch, a Channel Access rung — must name a Channel Access type
+    instead. Ask for one by parametrising this fixture::
+
+        @pytest.mark.parametrize("live_type", [CA_LIVE_TYPE], indirect=True)
+
+    rather than by adding a second config helper beside ``raw_config``.
+    """
+    return getattr(request, "param", SERVED_LIVE_TYPE)
+
+
+@pytest.fixture
+async def make_manager(state_root, live_type):
     """Managers whose children are all reaped when the test ends."""
     created = []
 
@@ -331,7 +353,10 @@ async def make_manager(state_root):
         }
         options.update(overrides)
         manager = ConnectorHostManager(
-            MCPServerConfig(raw=raw if raw is not None else raw_config(), config_path=config_path),
+            MCPServerConfig(
+                raw=raw if raw is not None else raw_config(live_type=live_type),
+                config_path=config_path,
+            ),
             **options,
         )
         manager.spawned = []
@@ -2061,6 +2086,24 @@ class TestSwitchCapability:
         assert switch_capable({}) is False
 
 
+class TestTheLiveTypeIsAParameter:
+    """The served ``live`` type is this module's default, not its only answer."""
+
+    async def test_the_default_is_the_served_type_and_reaches_the_manager(
+        self, live_type, make_manager
+    ):
+        assert live_type == SERVED_LIVE_TYPE
+        assert make_manager()._config.raw["control_system"]["type"] == SERVED_LIVE_TYPE
+
+    @pytest.mark.parametrize("live_type", [CA_LIVE_TYPE], indirect=True)
+    async def test_a_parametrised_type_reaches_the_manager(self, live_type, make_manager):
+        assert live_type == CA_LIVE_TYPE
+        assert make_manager()._config.raw["control_system"]["type"] == CA_LIVE_TYPE
+
+    def test_a_channel_access_live_type_is_still_switch_capable(self):
+        assert switch_capable(raw_config(live_type=CA_LIVE_TYPE)) is True
+
+
 class TestServingFromTheChild:
     async def test_the_first_tool_call_brings_the_baseline_child_up(self, make_manager):
         manager = make_manager()
@@ -2099,7 +2142,7 @@ class TestServingFromTheChild:
         context = context_for(manager)
 
         with isolated_connector_registries():
-            ConnectorFactory.register_control_system(LIVE_TYPE, _NeverBuilt)
+            ConnectorFactory.register_control_system(SERVED_LIVE_TYPE, _NeverBuilt)
             ConnectorFactory.register_control_system("virtual_accelerator", _NeverBuilt)
 
             before = await context.control_system()
@@ -2143,7 +2186,7 @@ class TestServingFromTheChild:
         context = context_for(manager)
 
         with isolated_connector_registries():
-            ConnectorFactory.register_control_system(LIVE_TYPE, _NeverBuilt)
+            ConnectorFactory.register_control_system(SERVED_LIVE_TYPE, _NeverBuilt)
             ConnectorFactory.register_archiver("mongodb_archiver", _FakeArchiver)
 
             archiver = await context.archiver()


### PR DESCRIPTION
Four unrelated test harnesses stop reaching past their own subject: a visual capture waits on the dock's own settled flag instead of a child element plus a sleep, two retention tests patch the retention module's `asyncio` name instead of the process-global one, the switch harness's `live` connector type becomes a fixture instead of a hard-coded constant, and the gallery's degraded refusal gains a test that reads the store variable back on a bare host.

Commits:

- `test(web-terminal): wait on the dock's own settled signal before a visual capture`
- `test(dispatch): patch the retention module's own asyncio name`
- `test(controls): make the switch harness's live connector type a fixture`
- `test(web-terminal): pin the bare-host degraded refusal to the store variable`

## Why

Each of the four harnesses was coupled to something wider than the thing it tested, and each coupling cost a deployer something concrete.

The visual suite waited for `.dv-groupview` to become visible and then slept — but that element becoming visible is a mid-construction state the boot restore may still replace, so the baseline could pin a layout that was not the final one. The dock already latches `bootLayoutSettled()` once the boot layout is decided, and the sibling browser suite already read it; the wait now rests on that flag, and the remaining 600 ms is the paint budget it always was rather than the thing the layout was resting on. The helper that reads the flag moves into `tests/interfaces/_browser.py`, where the shared browser assertions live, so any suite that drives or photographs the web-terminal hub can reach it.

The two retention tests replaced `asyncio.sleep` process-wide, which every other event loop alive in the worker also calls — so they carried a passthrough arm to keep a foreign daemon thread from polluting their call list or swallowing their cancellation. `retention_loop` imported `asyncio` inside the function body, so there was no module-level name to patch instead; hoisting that import to module scope (its one caller already imports the module at package import time) lets each test scope the patch to the retention module, and the passthrough arm the process-wide reach forced has nothing left to guard.

The switch harness hard-coded the mock connector's dotted path as the deployment's `live` type. Eligibility reads the connector type, so any future test that wants `live` to read as a real machine — an away-switch, a Channel Access rung — was judged unswitchable before it started, with no way through short of a second config helper. The constant is now named for what it is (`SERVED_LIVE_TYPE`, the type a real child can serve on a machine with no Channel Access) beside a `CA_LIVE_TYPE`, and a `live_type` fixture carries either one through `make_manager` via indirect parametrisation. Every existing call site and every existing test keeps the config it has today.

The gallery's degraded refusal appends the no-durable-store sentence unconditionally, but the only place that sentence was read back was a container render — so on a bare host it was believed rather than known. One test on the existing bare-host fixture now asserts the refusal names both the sentence and the `CLAUDE_CONFIG_DIR` variable, and a comment beside the append records the invariant that makes it true on every topology: a mounted store resolves to `VOLUME`, so reaching `DEGRADED` means there is none.

## Not in this PR

- The switch harness's default `live` type does not move. Commit 3 is a rename, a fixture and one line inside `make_manager`; no existing test is added to, removed or renamed, and none of the eleven existing `raw_config(...)` call sites changes.
- No timeout is widened, no assertion weakened, and no test deleted.
- The refusal's wording is unchanged — only a comment is added beside it.
