### PR TITLE
test: wait on the readiness signals the code exposes instead of wall-clock budgets

### DIFF
--- a/changelog.d/example-server-readiness.added.md
+++ b/changelog.d/example-server-readiness.added.md
@@ -1,0 +1,1 @@
+The hello-world preset's example MCP server now prints a startup-timing line to stderr when it is ready to serve, matching the framework's own servers, so a launcher can tell a slow start from a stuck one.

--- a/changelog.d/health-offload-closed-loop.fixed.md
+++ b/changelog.d/health-offload-closed-loop.fixed.md
@@ -1,0 +1,1 @@
+A health check that timed out no longer prints an `Event loop is closed` traceback when its abandoned worker thread finishes after the loop it started on has gone.

--- a/src/osprey/health/offload.py
+++ b/src/osprey/health/offload.py
@@ -129,13 +129,26 @@ async def run_sync(fn: Callable[..., T], *args: Any, timeout_s: float) -> T:
         if not future.done():
             future.set_exception(exc)
 
+    def _deliver(setter: Callable[[Any], None], value: Any) -> None:
+        # An abandoned thread may finish after the loop that started it has
+        # closed — a timed-out check at the end of a request, a test whose loop
+        # ends with the test. There is no awaiter left to hand anything to, and
+        # `call_soon_threadsafe` answers a closed loop with `RuntimeError`
+        # raised on this thread, where nothing can catch it: it surfaces as an
+        # unhandled thread exception attached to no failing caller. Silence is
+        # the honest outcome; the abandonment was already counted.
+        try:
+            loop.call_soon_threadsafe(setter, value)
+        except RuntimeError:
+            pass
+
     def _worker() -> None:
         try:
             result = fn(*args)
         except Exception as exc:  # noqa: BLE001 - forwarded verbatim to the awaiter
-            loop.call_soon_threadsafe(_set_exception, exc)
+            _deliver(_set_exception, exc)
         else:
-            loop.call_soon_threadsafe(_set_result, result)
+            _deliver(_set_result, result)
 
     thread = threading.Thread(target=_worker, daemon=True)
     thread.start()

--- a/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__init__.py
+++ b/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__init__.py
@@ -6,6 +6,11 @@ the first time ``osprey init`` runs with the hello-world preset. From there
 profile's ``mcp_servers:`` entry launches it as ``python -m example_server`` with
 ``build/_mcp_servers`` on ``PYTHONPATH``.
 
+Stdio is split between the two streams and the split is a contract: stdout
+carries protocol frames and nothing else, and a server announces on stderr
+once it is ready to serve. Printing anything else to stdout corrupts the
+session.
+
 It depends on nothing but ``fastmcp`` — deliberately, so that it runs standalone
 and stays readable as a starting point. Copy the directory, rename it, and
 replace :func:`example_server.server.example_status` with tools that talk to your

--- a/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__main__.py
+++ b/src/osprey/templates/apps/hello_world/mcp_servers/example_server/__main__.py
@@ -2,7 +2,22 @@
 
 from __future__ import annotations
 
-from .server import mcp
+import sys
+import time
+
+_started = time.perf_counter()
+
+from .server import mcp  # noqa: E402 — the import is the cost being measured
 
 if __name__ == "__main__":
+    # Say on stderr that the frames can start, the way every OSPREY-framework
+    # server does. Until this line a launcher cannot tell a server still
+    # importing from one that is stuck: both are silence on stdout. Stdlib
+    # only, so this package keeps depending on nothing but ``fastmcp``.
+    print(
+        f"[STARTUP-TIMING] example_server | total_startup: "
+        f"{(time.perf_counter() - _started) * 1000:.0f}ms",
+        file=sys.stderr,
+        flush=True,
+    )
     mcp.run()

--- a/tests/_container_support.py
+++ b/tests/_container_support.py
@@ -312,6 +312,61 @@ def start_or_fail(
     )
 
 
+def wait_until_ready(
+    probe: Callable[[], object],
+    label: str,
+    *,
+    timeout: float = 60.0,
+    interval: float = 0.5,
+) -> None:
+    """Call *probe* until it stops raising, or fail after *timeout* seconds.
+
+    A started container is not yet a reachable one. testcontainers' own
+    readiness check runs *inside* the container, so it reports ready while the
+    host side of the published port is still being wired up; the first
+    connection from the host is then refused or reset. Waiting for the store to
+    answer a request the test itself makes is the signal the code exposes, and
+    it replaces sleeping for however long the forwarder happened to take on the
+    machine the number was measured on.
+
+    Fail-hard for the reason :func:`start_or_fail` gives: past a successful
+    ``start()`` the daemon is present, so a port that never answers is a defect
+    and a skip here would be a vacuous green.
+
+    Args:
+        probe: Zero-argument callable that raises while the subject is not
+            ready and returns anything at all once it is. Keep it short —
+            it is called repeatedly, so a client built inside it wants a
+            selection or connect timeout well under *interval*.
+        label: Human-readable name for the subject, used in the failure.
+        timeout: Seconds to keep probing before giving up.
+        interval: Seconds between attempts.
+
+    Raises:
+        AssertionError: If no call succeeded before the deadline.
+    """
+    deadline = time.monotonic() + timeout
+    started = time.monotonic()
+    last: BaseException | None = None
+    while True:
+        try:
+            probe()
+        except Exception as exc:  # noqa: BLE001 — any failure means "not ready yet"
+            last = exc
+        else:
+            return
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(interval)
+
+    elapsed = time.monotonic() - started
+    raise AssertionError(
+        f"{label}: started, but never answered in {elapsed:.1f}s — the daemon is reachable "
+        f"and the container is up, so this is a real failure, not a missing dependency.\n"
+        f"last attempt: {type(last).__name__}: {last}"
+    )
+
+
 def _skip_message(label: str, exc: BaseException, attempt: int) -> str:
     """Build a skip message naming the container, attempt count, and cause.
 

--- a/tests/cli/test_example_server_launch.py
+++ b/tests/cli/test_example_server_launch.py
@@ -18,8 +18,12 @@ from __future__ import annotations
 
 import importlib.resources
 import json
+import os
 import subprocess
+import threading
+import time
 from pathlib import Path
+from queue import Empty, Queue
 
 import pytest
 from click.testing import CliRunner
@@ -27,7 +31,15 @@ from click.testing import CliRunner
 from osprey.cli.build_cmd import build
 from osprey.cli.build_profile_emit import _MCP_SERVERS_APPENDIX
 from osprey.cli.init_cmd import init
-from tests.integration._mcp_handshake import list_mcp_tools
+from tests.integration._mcp_handshake import _STARTUP_TIMING, list_mcp_tools
+
+#: How long the spawned entry gets to say it is serving. It is a bound on a
+#: failure, not a wait: the read returns the moment the line arrives. The
+#: stream is drained on its own thread because a server that announces nothing
+#: never closes stderr either -- a blocking read would hang the test instead of
+#: failing it.
+_ANNOUNCE_TIMEOUT = 60.0
+_ANNOUNCE_POLL = 0.1
 
 PACKAGE_DIR = Path("src/osprey/templates/apps/hello_world/mcp_servers/example_server")
 PACKAGED_FILES = ("__init__.py", "server.py", "__main__.py")
@@ -192,4 +204,63 @@ def test_rendered_entry_spawns_the_seeded_server(runner: CliRunner, tmp_path: Pa
     assert "mcp__example_server__.*" in matchers, (
         "build did not wire the example_server guidance hook into PostToolUse; "
         f"matchers present: {matchers}"
+    )
+
+
+def test_the_rendered_entry_announces_when_it_is_ready(runner: CliRunner, tmp_path: Path) -> None:
+    """The seeded server says on stderr that it is serving, as the framework's do.
+
+    A launcher cannot otherwise tell a server that is still importing from one
+    that is stuck: both are silence on stdout. Every framework server announces
+    through ``run_mcp_server``, and the worked example a facility author copies
+    has to teach the same contract -- so the marker is asserted here against the
+    very pattern the boot smoke's handshake reads.
+    """
+    target = tmp_path / "my-facility"
+    init_result = runner.invoke(init, [str(target), "--preset", "hello-world", "--no-git"])
+    assert init_result.exit_code == 0, init_result.output
+
+    build_result = runner.invoke(build, ["--repo", str(target), "--skip-deps", "--skip-lifecycle"])
+    assert build_result.exit_code == 0, build_result.output
+
+    entry = json.loads((target / "build" / ".mcp.json").read_text(encoding="utf-8"))["mcpServers"][
+        "example_server"
+    ]
+    env = dict(os.environ)
+    env.update(entry.get("env") or {})
+
+    proc = subprocess.Popen(  # noqa: S603 - command comes from the generated .mcp.json
+        [entry["command"], *entry["args"]],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+    phases: list[str] = []
+    lines: Queue[str] = Queue()
+
+    def drain() -> None:
+        for line in iter(proc.stderr.readline, ""):
+            lines.put(line)
+
+    threading.Thread(target=drain, daemon=True).start()
+    try:
+        deadline = time.monotonic() + _ANNOUNCE_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                line = lines.get(timeout=_ANNOUNCE_POLL)
+            except Empty:
+                continue
+            match = _STARTUP_TIMING.search(line)
+            if match:
+                phases.append(match.group(1))
+                break
+    finally:
+        proc.terminate()
+        proc.wait(timeout=_ANNOUNCE_TIMEOUT)
+
+    assert "total_startup" in phases, (
+        f"the seeded example server never announced total_startup on stderr; phases seen: {phases}"
     )

--- a/tests/connectors/conftest.py
+++ b/tests/connectors/conftest.py
@@ -12,7 +12,12 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from tests._container_support import is_docker_available, start_or_skip, stop_quietly
+from tests._container_support import (
+    is_docker_available,
+    start_or_skip,
+    stop_quietly,
+    wait_until_ready,
+)
 
 
 @pytest.fixture(scope="session")
@@ -21,6 +26,10 @@ def mongodb_container():
 
     Yields a dict with connection parameters. Skips the entire chain
     of dependent tests if Docker isn't available.
+
+    The store is waited for rather than assumed: testcontainers' readiness
+    check runs inside the container, so the first connection from the host on
+    the freshly published port can be reset while the port forwarder settles.
     """
     if not is_docker_available():
         pytest.skip(
@@ -46,6 +55,30 @@ def mongodb_container():
 
     host = container.get_container_host_ip()
     port = int(container.get_exposed_port(27017))
+
+    def answers() -> None:
+        """Ask the store for a pong, raising while it is not yet answering.
+
+        The one-second selection window is what makes this a poll rather than
+        one long wait: a client left on its own default would spend the whole
+        retry budget inside a single attempt.
+        """
+        from pymongo import MongoClient
+
+        client = MongoClient(
+            host,
+            port,
+            username=username,
+            password=password,
+            authSource=auth_db,
+            serverSelectionTimeoutMS=1000,
+        )
+        try:
+            client.admin.command("ping")
+        finally:
+            client.close()
+
+    wait_until_ready(answers, "mongodb")
 
     try:
         yield {

--- a/tests/connectors/test_archiver_world_contracts.py
+++ b/tests/connectors/test_archiver_world_contracts.py
@@ -82,7 +82,12 @@ from osprey.simulation.archiver_seed import (
 )
 from osprey.simulation.procedural import DEFAULT_NOISE_LEVEL
 from osprey.simulation.series import epoch_seconds_array
-from tests._container_support import is_docker_available, start_or_skip, stop_quietly
+from tests._container_support import (
+    is_docker_available,
+    start_or_skip,
+    stop_quietly,
+    wait_until_ready,
+)
 
 # ---------------------------------------------------------------------------
 # The world under test
@@ -272,6 +277,10 @@ def mongo():
     off by default and on only where a test asks for it. The one-second sleep is
     what makes that sweep quick when it is enabled — the shipped default is 60s,
     which is a timer, not a contract.
+
+    The store is waited for rather than assumed: testcontainers' readiness
+    check runs inside the container, so the first connection from the host on
+    the freshly published port can be reset while the port forwarder settles.
     """
     if not is_docker_available():
         pytest.skip("Docker not available — needed to seed and read a real store.")
@@ -295,10 +304,37 @@ def mongo():
         ),
         label="mongodb-world-contracts",
     )
+    host = container.get_container_host_ip()
+    port = int(container.get_exposed_port(27017))
+
+    def answers() -> None:
+        """Ask the store for a pong, raising while it is not yet answering.
+
+        The one-second selection window is what makes this a poll rather than
+        one long wait: a client left on its own default would spend the whole
+        retry budget inside a single attempt.
+        """
+        from pymongo import MongoClient
+
+        client = MongoClient(
+            host,
+            port,
+            username=username,
+            password=password,
+            authSource="admin",
+            serverSelectionTimeoutMS=1000,
+        )
+        try:
+            client.admin.command("ping")
+        finally:
+            client.close()
+
+    wait_until_ready(answers, "mongodb-world-contracts")
+
     try:
         yield {
-            "host": container.get_container_host_ip(),
-            "port": int(container.get_exposed_port(27017)),
+            "host": host,
+            "port": port,
             "username": username,
             "password": password,
             "auth_db": "admin",

--- a/tests/health/test_offload.py
+++ b/tests/health/test_offload.py
@@ -178,3 +178,54 @@ async def test_event_loop_not_blocked_during_offload() -> None:
 
     assert result == "ok"
     assert ticks == 5
+
+
+def test_an_abandoned_thread_finishing_after_the_loop_closed_says_nothing() -> None:
+    """A timed-out check's thread outliving its loop is silent, not an exception.
+
+    Abandoning the thread is the design: it keeps running, and it may well
+    outlive the loop that started it — a health check timing out at the end of
+    a request, or a test whose loop closes when the test ends. Handing a result
+    to a closed loop raises ``RuntimeError('Event loop is closed')`` on the
+    worker thread, where nothing can catch it: it surfaces as an unhandled
+    thread exception with no failing test attached to it, and under a parallel
+    runner it is noise on a worker that did nothing wrong. There is no awaiter
+    left to deliver to, so there is nothing to report.
+    """
+    release = threading.Event()
+    finished = threading.Event()
+    thread_errors: list[BaseException] = []
+
+    def hook(args) -> None:
+        thread_errors.append(args.exc_value)
+
+    def blocks() -> str:
+        release.wait(5.0)
+        return "late"
+
+    async def abandon() -> None:
+        with pytest.raises(TimeoutError):
+            await offload.run_sync(blocks, timeout_s=0.05)
+
+    previous = threading.excepthook
+    threading.excepthook = hook
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(abandon())
+        finally:
+            loop.close()
+
+        # The loop is gone; now let the abandoned thread finish into it.
+        release.set()
+        for _ in range(500):
+            if not any(
+                t.name.startswith("Thread-") and t.is_alive() for t in threading.enumerate()
+            ):
+                break
+            time.sleep(0.01)
+        finished.wait(0.2)
+    finally:
+        threading.excepthook = previous
+
+    assert thread_errors == [], thread_errors

--- a/tests/integration/test_build_boot.py
+++ b/tests/integration/test_build_boot.py
@@ -14,7 +14,11 @@ Each preset becomes a parametrized test ID. CI matrices invoke the right
 preset via ``pytest -k <preset>``.
 
 Wall-clock budget: ~2 min/preset with a warm uv cache; cold cache may take
-5-6 min on the first run after ``uv.lock`` changes.
+5-6 min on the first run after ``uv.lock`` changes. That cost is what the
+module-wide ``slow`` marker is for: a contended local run deselects it with
+``-m "not slow"``, the selector ``scripts/quick_check.sh`` already passes, while
+CI still runs it — the boot-smoke job names the file by path and the unit lane
+selects only ``-m "not pty"``, so neither loses it.
 """
 
 from __future__ import annotations
@@ -33,6 +37,8 @@ from tests.integration._mcp_handshake import (
     assert_tools_superset,
     list_mcp_tools,
 )
+
+pytestmark = pytest.mark.slow
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/integration/test_build_boot.py
+++ b/tests/integration/test_build_boot.py
@@ -287,15 +287,18 @@ def test_mcp_servers_register_expected_tools(build_outputs: dict[str, Path], pre
         if "url" in entry:
             continue  # http/sse — out of scope for stdio handshake
         try:
-            # A liveness bound, not a speed one: fast failure on a broken
-            # command is the previous test's contract. This one only has to
-            # outwait a server's imports on the slowest shared runner, where
-            # the control-system server alone has taken twenty seconds to load.
+            # Time to answer, not time to exist. The clock starts when the
+            # server says it is serving, so this bounds a stuck server rather
+            # than a slow import — every stdio server reachable from here
+            # announces, the framework's through run_mcp_server and the
+            # hello-world example through its own entry. A server that
+            # announces nothing spends this budget on both, which is why it is
+            # generous rather than tight.
             tool_names = list_mcp_tools(
                 command=entry["command"],
                 args=list(entry.get("args") or []),
                 env=entry.get("env"),
-                timeout=120.0,
+                timeout=60.0,
             )
         except MCPHandshakeError as exc:
             failures.append(f"{name}: handshake failed: {exc}")

--- a/tests/services/bluesky_bridge/test_document_plane.py
+++ b/tests/services/bluesky_bridge/test_document_plane.py
@@ -28,6 +28,7 @@ fail; it does.
 
 from __future__ import annotations
 
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -119,8 +120,45 @@ def plane(certificates: dict[str, Path]):
         started.stop()
 
 
-def _publisher(plane: DocumentPlane, certificates: dict[str, Path] | None = None):
-    """A ``Publisher`` aimed at *plane*, authenticated only if given certificates."""
+@pytest.fixture
+def publishers(plane):
+    """Every publisher a test opens, closed before the plane goes down.
+
+    ``Publisher`` owns a 0MQ context and a PUB socket and releases neither
+    until ``close()`` is called. Left to the garbage collector that teardown
+    runs at a time and on a thread nobody chose — and for a forged publisher it
+    runs against a CURVE handshake that never completed, while the proxy's own
+    context may be terminating on another thread. libzmq answers a context torn
+    down in that state by aborting the process, which arrives as a crashed test
+    worker rather than as a failing test. Depending on ``plane`` is what orders
+    this teardown ahead of the proxy's.
+
+    Publishers close in reverse order of opening, and each close is attempted
+    even if an earlier one raised, so one bad socket cannot strand the rest.
+    """
+    opened: list[Any] = []
+    try:
+        yield opened
+    finally:
+        _close_all(opened)
+
+
+def _close_all(opened: list[Any]) -> None:
+    """Close *opened* newest first, attempting every one."""
+    for publisher in reversed(opened):
+        try:
+            publisher.close()
+        except Exception:  # noqa: BLE001 — teardown reports, it does not fail
+            logging.getLogger(__name__).warning("publisher close failed", exc_info=True)
+
+
+def _publisher(
+    opened: list[Any], plane: DocumentPlane, certificates: dict[str, Path] | None = None
+):
+    """A ``Publisher`` aimed at *plane*, authenticated only if given certificates.
+
+    Registered with *opened* so the ``publishers`` fixture closes it.
+    """
     from bluesky.callbacks.zmq import ClientCurve, Publisher
 
     curve = None
@@ -129,7 +167,9 @@ def _publisher(plane: DocumentPlane, certificates: dict[str, Path] | None = None
             secret_path=certificates["client_secret"],
             server_public_key=certificates["server_public"],
         )
-    return Publisher(plane.publish_address, curve_config=curve)
+    publisher = Publisher(plane.publish_address, curve_config=curve)
+    opened.append(publisher)
+    return publisher
 
 
 def _wait_until(predicate, timeout: float = _DELIVERY_TIMEOUT) -> bool:
@@ -193,9 +233,9 @@ def _establish_link(publisher, plane: DocumentPlane) -> None:
     live_rows._clear()
 
 
-def test_rows_land_under_the_osprey_run_id(plane, certificates):
+def test_rows_land_under_the_osprey_run_id(plane, certificates, publishers):
     """A worker's documents become live rows keyed by the enqueued run id."""
-    publisher = _publisher(plane, certificates)
+    publisher = _publisher(publishers, plane, certificates)
     _establish_link(publisher, plane)
 
     run_uid = "run-engine-uid-1"
@@ -260,15 +300,15 @@ def _assert_refused(forged, authorized, label: str) -> None:
     assert document_plane.progress(run_id) is None
 
 
-def test_documents_without_the_client_key_are_rejected(plane, certificates):
+def test_documents_without_the_client_key_are_rejected(plane, certificates, publishers):
     """CurveZMQ, not network placement, is what protects the in-side socket."""
-    authorized = _publisher(plane, certificates)
+    authorized = _publisher(publishers, plane, certificates)
     _establish_link(authorized, plane)
 
-    _assert_refused(_publisher(plane, certificates=None), authorized, "unkeyed")
+    _assert_refused(_publisher(publishers, plane, certificates=None), authorized, "unkeyed")
 
 
-def test_documents_from_an_unpinned_keypair_are_rejected(plane, certificates):
+def test_documents_from_an_unpinned_keypair_are_rejected(plane, certificates, publishers):
     """A well-formed key the accepted-client directory doesn't list is still a stranger.
 
     This is the difference the pinned directory buys over ``CURVE_ALLOW_ANY``:
@@ -284,10 +324,11 @@ def test_documents_from_an_unpinned_keypair_are_rejected(plane, certificates):
     directory in the fixture — i.e. before startup — must make this test fail;
     it does.
     """
-    authorized = _publisher(plane, certificates)
+    authorized = _publisher(publishers, plane, certificates)
     _establish_link(authorized, plane)
 
     intruder = _publisher(
+        publishers,
         plane,
         {
             "client_secret": certificates["intruder_secret"],
@@ -297,9 +338,9 @@ def test_documents_from_an_unpinned_keypair_are_rejected(plane, certificates):
     _assert_refused(intruder, authorized, "unpinned")
 
 
-def test_a_run_without_an_osprey_run_id_falls_back_to_its_run_uid(plane, certificates):
+def test_a_run_without_an_osprey_run_id_falls_back_to_its_run_uid(plane, certificates, publishers):
     """A worker driven outside the queue is still recorded — under its only identity."""
-    publisher = _publisher(plane, certificates)
+    publisher = _publisher(publishers, plane, certificates)
     _establish_link(publisher, plane)
 
     run_uid = "unmanaged-run-uid"
@@ -313,9 +354,9 @@ def test_a_run_without_an_osprey_run_id_falls_back_to_its_run_uid(plane, certifi
     assert buffer["rows"] == [[0.5]]
 
 
-def test_a_run_that_declares_its_point_count_gets_a_denominator(plane, certificates):
+def test_a_run_that_declares_its_point_count_gets_a_denominator(plane, certificates, publishers):
     """A run's own declaration of its extent is what progress divides by."""
-    publisher = _publisher(plane, certificates)
+    publisher = _publisher(publishers, plane, certificates)
     _establish_link(publisher, plane)
 
     run_uid = "declared-run-uid"
@@ -334,7 +375,9 @@ def test_a_run_that_declares_its_point_count_gets_a_denominator(plane, certifica
     }
 
 
-def test_the_worker_publisher_and_this_proxy_speak_the_same_configuration(plane, certificates):
+def test_the_worker_publisher_and_this_proxy_speak_the_same_configuration(
+    plane, certificates, publishers
+):
     """The two halves are built by different modules from the same env contract.
 
     Every other test in this file builds its publisher by hand, which proves
@@ -354,6 +397,7 @@ def test_the_worker_publisher_and_this_proxy_speak_the_same_configuration(plane,
         }
     )
     assert publisher is not None
+    publishers.append(publisher)
     _establish_link(publisher, plane)
 
     run_uid = "worker-built-run-uid"
@@ -570,3 +614,29 @@ def test_router_never_raises_on_a_malformed_document():
     router("event", {"seq_num": 1})  # no descriptor
     router("stop", {})  # no run_start
     assert live_rows.get("") is None
+
+
+def test_every_publisher_is_closed_even_when_one_refuses() -> None:
+    """The teardown closes all of them, newest first, whatever one of them does.
+
+    The order matters because a later publisher may have been built against
+    state an earlier one owns, and the completeness matters because a single
+    context left to the garbage collector is the whole defect: one refusing
+    socket must not strand the rest.
+    """
+
+    closed: list[str] = []
+
+    class Fake:
+        def __init__(self, name: str, refuses: bool = False) -> None:
+            self.name = name
+            self.refuses = refuses
+
+        def close(self) -> None:
+            closed.append(self.name)
+            if self.refuses:
+                raise RuntimeError("this socket will not close")
+
+    _close_all([Fake("first"), Fake("second", refuses=True), Fake("third")])
+
+    assert closed == ["third", "second", "first"]

--- a/tests/services/channel_finder/graph_index/test_scale.py
+++ b/tests/services/channel_finder/graph_index/test_scale.py
@@ -61,6 +61,7 @@ from osprey.services.channel_finder.graph_index.builder import (
     parse_corpus,
 )
 from osprey.services.channel_finder.graph_index.reader import (
+    SEARCH_FACETS,
     GraphIndex,
     GraphIndexAbsence,
     open_graph_index,
@@ -115,6 +116,15 @@ DEMO_PARSE_SECONDS = 3.0
 #: The finder redraws its page on every filter click, so this is the number the
 #: interaction is made of.
 SCALE_SEARCH_P50_SECONDS = 0.150
+
+#: How many statements one :meth:`GraphIndex.search` issues, whatever the
+#: corpus: the totals, the page, and one per facet. Derived from
+#: ``SEARCH_FACETS`` rather than restated as seven, so a facet added to the
+#: rail moves both sides together. This is the countable form of what the
+#: latency budgets only approximate -- a search that became a per-row walk
+#: would issue a different number of statements on a loaded host and an idle
+#: one alike.
+STATEMENTS_PER_SEARCH = len(SEARCH_FACETS) + 2
 
 #: The first search after opening the *demo* index -- cold caches, nothing
 #: mapped yet.
@@ -479,6 +489,43 @@ def _time_shapes(index: GraphIndex, shapes: list[dict[str, Any]]) -> list[float]
     return timings
 
 
+class _CountingCursor:
+    """A cursor that records every statement and otherwise gets out of the way.
+
+    Delegation is by ``__getattr__`` and every call returns the inner cursor's
+    own result, so ``execute(...).fetchone()`` and ``execute(...).fetchall()``
+    keep chaining exactly as the reader writes them.
+    """
+
+    def __init__(self, inner: Any, statements: list[str]) -> None:
+        self._inner = inner
+        self._statements = statements
+
+    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+        self._statements.append(sql)
+        return self._inner.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def _count_statements(index: GraphIndex) -> list[str]:
+    """Record the SQL every later search on *index* issues.
+
+    Wraps the opened index's own ``cursor`` factory, which is the single place
+    a search reaches for a connection, so nothing about the search itself has
+    to be parameterised for the count.
+    """
+    statements: list[str] = []
+    opener = index.cursor
+
+    def counting() -> Any:
+        return _CountingCursor(opener(), statements)
+
+    index.cursor = counting  # type: ignore[method-assign]
+    return statements
+
+
 def _report(label: str, timings: list[float]) -> tuple[float, float, float]:
     """Print and log ``p50``/``p95``/``max`` for *timings*, and return them."""
     ordered = sorted(timings)
@@ -558,6 +605,22 @@ class TestHundredThousandBindings:
         assert len(payload["rows"]) == 10
         assert {entry["value"] for entry in payload["facets"]["system"]} == set(SYSTEM_CODES)
         assert {entry["value"] for entry in payload["facets"]["dir"]} == {"R", "W", "RW", "none"}
+
+    def test_a_search_over_the_synthetic_index_issues_a_fixed_number_of_statements(self, built):
+        """The count is the regression guard a wall clock only approximates.
+
+        What the latency budgets exist to catch is a search that stops being a
+        fixed number of scans and becomes a per-row walk, and that is countable
+        rather than timeable: the totals, the page, and one statement per
+        facet. A host under load changes the milliseconds and not this number.
+        """
+        index_path, _, _ = built
+
+        with _open(index_path) as index:
+            statements = _count_statements(index)
+            index.search()
+
+        assert len(statements) == STATEMENTS_PER_SEARCH, statements
 
     def test_a_search_over_a_hundred_thousand_rows_stays_interactive(self, built):
         index_path, _, _ = built
@@ -661,6 +724,21 @@ class TestDemoCorpusOverTheParityMatrix:
         assert empty == DEMO_EMPTY_SHAPES, (
             f"the shapes matching nothing on the demo corpus are not the expected ones: {empty}"
         )
+
+    def test_a_search_over_the_demo_index_issues_the_same_number_of_statements(
+        self, demo_index_path: Path
+    ):
+        """And the count does not grow with the corpus.
+
+        The same expression bounds both corpora, which is the claim: a corpus
+        thirty times larger costs the same number of statements. Restating the
+        seven here instead would let the two sides drift apart in silence.
+        """
+        with _open(demo_index_path) as index:
+            statements = _count_statements(index)
+            index.search()
+
+        assert len(statements) == STATEMENTS_PER_SEARCH, statements
 
     def test_the_first_search_after_opening_answers_at_once(self, demo_index_path: Path):
         index = _open(demo_index_path)

--- a/tests/services/channel_finder/graph_index/test_scale.py
+++ b/tests/services/channel_finder/graph_index/test_scale.py
@@ -12,18 +12,20 @@ it asserts anything. What the printed lines are for is the *trend* -- a build
 that goes from forty seconds to ninety has regressed even though it never
 failed, and the run history is where that is visible.
 
-The latency budgets are held to a workstation's numbers rather than widened
-until a loaded runner fits inside them, which is why this module does not run
-in the parallel lane. Measured: a search over the hundred-thousand-row index
-takes 42 ms here and 298 ms in the shared lane, and the whole parity matrix
-over the demo corpus 5.5 ms here and 34 ms there -- the same ~7x on a corpus of
-a hundred thousand rows and on one of three thousand. A factor that does not
-move with the data is the box, not the code: four xdist workers on a four-vCPU
-runner, with DuckDB asking for cores none of them can spare. Coverage
-instrumentation was measured too and is not the cause (+6%). Budgets widened to
-survive that contention would sit twelve times above the real number and could
-no longer see a threefold regression, so the tests are taken out of the lane
-instead and the budgets left where the measurement puts them.
+The two search guards are ratios, not wall clocks. What moves between hosts is
+the whole scale and not the shape of it: a search over the hundred-thousand-row
+index takes 42 ms on a workstation and 298 ms in the shared lane, and the whole
+parity matrix over the demo corpus 5.5 ms here and 34 ms there -- the same ~7x
+on a corpus of a hundred thousand rows and on one of three thousand. A factor
+that does not move with the data is the box, not the code: four xdist workers
+on a four-vCPU runner, with DuckDB asking for cores none of them can spare
+(coverage instrumentation was measured too, and is not the cause, at +6%). So
+each search guard measures its own baseline in the same process seconds before
+the number it bounds -- the big index against the demo matrix, and the median
+matrix shape against the unfiltered scan the matrix opens with -- and host load
+divides out. The build budgets and the cold-search budget stay absolute: they
+are coarse enough that contention does not reach them, and there is no cheaper
+thing in the same process to measure them against.
 
 The whole module is therefore marked ``channel_finder_benchmark`` as well as
 ``slow``: it is deselected from CI's unit lane and runs on demand, in the
@@ -112,11 +114,6 @@ DEMO_BUILD_SECONDS = 5.0
 #: is a strict part of it.
 DEMO_PARSE_SECONDS = 3.0
 
-#: The median of twenty varied searches over the hundred-thousand-row index.
-#: The finder redraws its page on every filter click, so this is the number the
-#: interaction is made of.
-SCALE_SEARCH_P50_SECONDS = 0.150
-
 #: How many statements one :meth:`GraphIndex.search` issues, whatever the
 #: corpus: the totals, the page, and one per facet. Derived from
 #: ``SEARCH_FACETS`` rather than restated as seven, so a facet added to the
@@ -130,10 +127,22 @@ STATEMENTS_PER_SEARCH = len(SEARCH_FACETS) + 2
 #: mapped yet.
 DEMO_FIRST_SEARCH_SECONDS = 0.100
 
-#: The median of the whole parity matrix over the demo index, once warm. The
-#: measured number is around five milliseconds, so this is a generous bound
-#: whose job is to catch a change of order, not a slow afternoon.
-DEMO_WARM_P50_SECONDS = 0.030
+#: How much slower the median search over the hundred-thousand-row index may be
+#: than the median shape over the demo one, measured in the same process
+#: seconds apart. The ratio is the stable quantity: 42 ms against 5.5 ms on a
+#: workstation and 298 ms against 34 ms in the shared lane is the same factor
+#: on both, so a ceiling twice above the loaded measurement still sees a
+#: threefold regression while a contended box cancels out. Measured 6.1x-7.0x
+#: over four runs on a workstation.
+SCALE_OVER_DEMO_CEILING = 20.0
+
+#: How much slower the median shape in the parity matrix may be than the
+#: unfiltered full scan the matrix opens with. Every filter narrows the same
+#: scan, so the median shape costing more than a bounded multiple of the widest
+#: one is a filter that stopped being a predicate. Measured 0.85x-0.98x over
+#: four runs -- the median shape is a touch cheaper than the widest one, which
+#: is what a working predicate looks like.
+MATRIX_OVER_BARE_SEARCH_CEILING = 2.0
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +555,51 @@ def _report(label: str, timings: list[float]) -> tuple[float, float, float]:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# The demo corpus, built once for the module
+# ---------------------------------------------------------------------------
+
+# Module-scoped rather than class-scoped: the scale class measures itself
+# against the demo corpus, so both classes have to reach the same build.
+
+
+@pytest.fixture(scope="module")
+def demo_build(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, float]:
+    """The demo index, built once for the module, and how long the build took."""
+    resource = (
+        files("osprey.templates")
+        .joinpath("apps")
+        .joinpath("control_assistant")
+        .joinpath("data")
+        .joinpath("demo_machine.ttl")
+    )
+    index_path = tmp_path_factory.mktemp("demo") / "graph.duckdb"
+    with as_file(resource) as path:
+        started = time.perf_counter()
+        build_graph_index(path, index_path)
+        elapsed = time.perf_counter() - started
+    return index_path, elapsed
+
+
+@pytest.fixture(scope="module")
+def demo_index_path(demo_build: tuple[Path, float]) -> Path:
+    return demo_build[0]
+
+
+@pytest.fixture(scope="module")
+def demo_matrix_timings(demo_index_path: Path) -> list[float]:
+    """The warm parity matrix over the demo index, timed once for the module.
+
+    This is the baseline both ratio guards are measured against, and measuring
+    it here is the whole point: it is taken on the same box, in the same
+    process, within seconds of the number compared to it, so whatever the host
+    is doing to one it is doing to the other.
+    """
+    with _open(demo_index_path) as index:
+        index.search()  # Warm the page cache; the cold call is timed on its own.
+        return _time_shapes(index, PARITY_MATRIX)
+
+
 class TestHundredThousandBindings:
     """A machine two orders of magnitude past the demo, built and searched."""
 
@@ -622,7 +676,16 @@ class TestHundredThousandBindings:
 
         assert len(statements) == STATEMENTS_PER_SEARCH, statements
 
-    def test_a_search_over_a_hundred_thousand_rows_stays_interactive(self, built):
+    def test_a_search_over_a_hundred_thousand_rows_stays_interactive(
+        self, built, demo_matrix_timings: list[float]
+    ):
+        """A search over the big corpus is a bounded multiple of one over the demo.
+
+        The finder redraws its page on every filter click, so this is the number
+        the interaction is made of -- but it is a number the box owns, not the
+        code. Held against a demo-corpus median measured moments earlier in the
+        same process, host load divides out of both sides.
+        """
         index_path, _, _ = built
 
         with _open(index_path) as index:
@@ -630,9 +693,17 @@ class TestHundredThousandBindings:
             timings = _time_shapes(index, SCALE_SHAPES)
 
         p50, _, _ = _report("search over the 100k synthetic index", timings)
-        assert p50 < SCALE_SEARCH_P50_SECONDS, (
-            f"the median of {len(timings)} searches was {p50 * 1000:.1f} ms, "
-            f"budget {SCALE_SEARCH_P50_SECONDS * 1000:.0f} ms"
+        baseline = median(demo_matrix_timings)
+        ratio = p50 / baseline
+        line = (
+            f"the 100k index over the demo corpus: {ratio:.1f}x "
+            f"({p50 * 1000:.1f} ms against {baseline * 1000:.1f} ms)"
+        )
+        print(line)
+        logger.info(line)
+        assert ratio < SCALE_OVER_DEMO_CEILING, (
+            f"the median of {len(timings)} searches was {ratio:.1f}x the demo median, "
+            f"ceiling {SCALE_OVER_DEMO_CEILING:.0f}x"
         )
 
 
@@ -643,27 +714,6 @@ class TestHundredThousandBindings:
 
 class TestDemoCorpusOverTheParityMatrix:
     """The corpus a deployment actually ships, over every shape parity replays."""
-
-    @pytest.fixture(scope="class")
-    def demo_build(self, tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, float]:
-        """The demo index, built once for the class, and how long the build took."""
-        resource = (
-            files("osprey.templates")
-            .joinpath("apps")
-            .joinpath("control_assistant")
-            .joinpath("data")
-            .joinpath("demo_machine.ttl")
-        )
-        index_path = tmp_path_factory.mktemp("demo") / "graph.duckdb"
-        with as_file(resource) as path:
-            started = time.perf_counter()
-            build_graph_index(path, index_path)
-            elapsed = time.perf_counter() - started
-        return index_path, elapsed
-
-    @pytest.fixture(scope="class")
-    def demo_index_path(self, demo_build: tuple[Path, float]) -> Path:
-        return demo_build[0]
 
     @pytest.fixture(scope="class")
     def demo_text(self) -> str:
@@ -758,13 +808,27 @@ class TestDemoCorpusOverTheParityMatrix:
             f"budget {DEMO_FIRST_SEARCH_SECONDS * 1000:.0f} ms"
         )
 
-    def test_the_whole_parity_matrix_stays_inside_the_warm_budget(self, demo_index_path: Path):
-        with _open(demo_index_path) as index:
-            index.search()  # Warm the page cache; the cold call is timed above.
-            timings = _time_shapes(index, PARITY_MATRIX)
+    def test_the_whole_parity_matrix_stays_inside_the_warm_budget(
+        self, demo_matrix_timings: list[float]
+    ):
+        """The median filtered shape is a bounded multiple of an unfiltered scan.
 
-        p50, _, _ = _report("the parity matrix over the demo index", timings)
-        assert p50 < DEMO_WARM_P50_SECONDS, (
-            f"the warm median over {len(timings)} shapes was {p50 * 1000:.1f} ms, "
-            f"budget {DEMO_WARM_P50_SECONDS * 1000:.0f} ms"
+        Entry 0 of the matrix is the unfiltered shape -- pinned by
+        ``test_the_parity_matrix_covers_every_filter_the_rail_offers`` -- so it
+        is the widest scan there is, measured in the same sweep as everything
+        compared to it. A filter that costs more than a small multiple of
+        scanning everything has stopped narrowing and started walking.
+        """
+        p50, _, _ = _report("the parity matrix over the demo index", demo_matrix_timings)
+        bare = demo_matrix_timings[0]
+        ratio = p50 / bare
+        line = (
+            f"the median matrix shape over the unfiltered one: {ratio:.2f}x "
+            f"({p50 * 1000:.1f} ms against {bare * 1000:.1f} ms)"
+        )
+        print(line)
+        logger.info(line)
+        assert ratio < MATRIX_OVER_BARE_SEARCH_CEILING, (
+            f"the warm median over {len(demo_matrix_timings)} shapes was {ratio:.2f}x the "
+            f"unfiltered search, ceiling {MATRIX_OVER_BARE_SEARCH_CEILING:.1f}x"
         )

--- a/tests/simulation/test_archiver_seed.py
+++ b/tests/simulation/test_archiver_seed.py
@@ -49,7 +49,12 @@ from osprey.simulation.archiver_seed import (
 )
 from osprey.simulation.procedural import baseline_value, generate_series
 from osprey.simulation.series import epoch_seconds_array
-from tests._container_support import is_docker_available, start_or_skip, stop_quietly
+from tests._container_support import (
+    is_docker_available,
+    start_or_skip,
+    stop_quietly,
+    wait_until_ready,
+)
 
 # A fixed anchor: every expectation below is a function of it, and a failure
 # should be reproducible tomorrow.
@@ -76,7 +81,12 @@ ADDRESSES = [channel["address"] for channel in CHANNELS]
 
 @pytest.fixture(scope="module")
 def mongo_store():
-    """A MongoDB container for this module, yielding connection parameters."""
+    """A MongoDB container for this module, yielding connection parameters.
+
+    The store is waited for rather than assumed: testcontainers' readiness
+    check runs inside the container, so the first connection from the host on
+    the freshly published port can be reset while the port forwarder settles.
+    """
     if not is_docker_available():
         pytest.skip("Docker not available — needed to seed a real store.")
     try:
@@ -89,10 +99,37 @@ def mongo_store():
         lambda: MongoDbContainer("mongo:7", username=username, password=password),
         label="mongodb-seed",
     )
+    host = container.get_container_host_ip()
+    port = int(container.get_exposed_port(27017))
+
+    def answers() -> None:
+        """Ask the store for a pong, raising while it is not yet answering.
+
+        The one-second selection window is what makes this a poll rather than
+        one long wait: a client left on its own default would spend the whole
+        retry budget inside a single attempt.
+        """
+        from pymongo import MongoClient
+
+        client = MongoClient(
+            host,
+            port,
+            username=username,
+            password=password,
+            authSource="admin",
+            serverSelectionTimeoutMS=1000,
+        )
+        try:
+            client.admin.command("ping")
+        finally:
+            client.close()
+
+    wait_until_ready(answers, "mongodb-seed")
+
     try:
         yield {
-            "host": container.get_container_host_ip(),
-            "port": int(container.get_exposed_port(27017)),
+            "host": host,
+            "port": port,
             "username": username,
             "password": password,
             "auth_db": "admin",

--- a/tests/test_container_support.py
+++ b/tests/test_container_support.py
@@ -14,7 +14,11 @@ import pytest
 import requests
 
 from tests import _container_support
-from tests._container_support import docker_cli_unavailable_reason, start_or_skip
+from tests._container_support import (
+    docker_cli_unavailable_reason,
+    start_or_skip,
+    wait_until_ready,
+)
 
 # ``docker`` is a ``dev``-extra dependency. Importing it at module scope would
 # make this file ERROR at collection wherever the extra is absent — the very
@@ -258,3 +262,60 @@ def test_docker_probe_is_silent_when_the_cli_works(monkeypatch):
     monkeypatch.setattr(_container_support.subprocess, "run", lambda argv, **kwargs: _completed(0))
 
     assert docker_cli_unavailable_reason() is None
+
+
+# ---------------------------------------------------------------------------
+# wait_until_ready
+# ---------------------------------------------------------------------------
+
+
+class CountingProbe:
+    """A probe that raises *failures* times before it starts succeeding.
+
+    ``failures=None`` never succeeds, which is the case the deadline is for.
+    Spelling it as ``None`` rather than a large count matters: a counted probe
+    with no pause between attempts exhausts any plausible count long before a
+    short deadline expires, and the test would then be asserting the success
+    path under a name that promises the failure one.
+    """
+
+    def __init__(self, failures: int | None, error: BaseException | None = None):
+        self.remaining = failures
+        self.error = error or ConnectionResetError("connection reset by peer")
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+        if self.remaining is None:
+            raise self.error
+        if self.remaining > 0:
+            self.remaining -= 1
+            raise self.error
+
+
+def test_a_probe_that_answers_at_once_is_called_once():
+    probe = CountingProbe(failures=0)
+
+    wait_until_ready(probe, "mongodb", interval=0.0)
+
+    assert probe.calls == 1
+
+
+def test_a_probe_that_answers_on_the_third_try_returns_after_three_calls():
+    probe = CountingProbe(failures=2)
+
+    wait_until_ready(probe, "mongodb", interval=0.0)
+
+    assert probe.calls == 3
+
+
+def test_a_probe_that_never_answers_fails_with_the_label_and_the_last_cause():
+    probe = CountingProbe(failures=None, error=ConnectionRefusedError("port not published"))
+
+    with pytest.raises(AssertionError) as caught:
+        wait_until_ready(probe, "mongodb-seed", timeout=0.05, interval=0.0)
+
+    message = str(caught.value)
+    assert "mongodb-seed" in message
+    assert "ConnectionRefusedError" in message
+    assert "port not published" in message


### PR DESCRIPTION
Three load-sensitive test guards — a container's startup window, a stdio server's import time, a search's median latency — now wait on a signal the code actually exposes instead of a number measured on an unloaded workstation.

Commits, in order:

- `test(containers): wait for a started container to answer before yielding it`
- `test(integration): mark the build-boot module slow`
- `feat(templates): announce readiness on stderr from the seeded example server`
- `test(integration): hold the boot handshake to an answer budget`
- `test(channel-finder): count a search's statements instead of pinning its wall clock`
- `test(channel-finder): express the search guards as ratios measured in the same process`
- `test(bluesky-bridge): close the document-plane publishers instead of leaking their contexts`
- `fix(health): stay silent when an abandoned check thread outlives its event loop`

## Why

Each of these guards held a real subject to a wall-clock budget, so a second suite running on the same box turned a healthy run red. The thing being waited for already had a deterministic signal, or could cheaply be given one, so the budgets are replaced by those signals rather than widened.

A new `wait_until_ready(probe, label)` helper in the shared container support polls a started container until it answers a `ping` and fails hard, naming the label and the last exception, if it never does — testcontainers' own readiness check runs inside the container, so the first connection from the host on a freshly published port can be reset while the port forwarder settles. The three MongoDB fixtures now use it between the port read and the yield.

The hello-world preset's worked example was the one stdio server in the boot smoke that printed no startup line, while every framework server announces through `run_mcp_server`. It now prints the same `[STARTUP-TIMING]` line to stderr with stdlib only, keeping the package's "depends on nothing but fastmcp" promise, and its `__init__` documents the convention for a facility author copying it. With every server in the smoke announcing, the handshake's caller timeout is once again what its docstring says — time to answer, not time to exist — so it drops from 120s to 60s.

The two channel-finder latency budgets become claims that survive a loaded host: a search issues a fixed number of statements whatever the corpus size, counted directly against the seven-statement contract in the reader, and the remaining timing guards are ratios against a baseline measured microseconds away in the same process, so host load cancels. The build and cold-search budgets are coarse and are untouched.

A deployer can now run these suites on a contended machine — or alongside another suite — without a green build turning red on a number that only described someone else's idle workstation, and a launcher can tell a slow stdio server from a stuck one.

## Not in this PR

- No workflow file is edited: the build-boot module is marked `slow` so a contended local run can deselect it, while CI runs the file by path and the unit lane's selection is unaffected.
- `pyproject.toml` is untouched; the benchmark marker text stays true because the build budgets still measure wall clock.
- The coarse build budgets and the cold-search budget keep their absolute values.
- The document-plane forwarder's own shutdown — sockets closed from another thread under a blocked `zmq.device` in `DocumentPlane.stop()` — is a separate fix and is not in this PR.
