### PR TITLE
fix(config-guard): enforce the manifest's union size, default placement and required-key notes

### DIFF
--- a/changelog.d/config-defaults-notes.changed.md
+++ b/changelog.d/config-defaults-notes.changed.md
@@ -1,0 +1,4 @@
+`osprey config --defaults` now prints the accepted values beside every key the
+build refuses to guess at. The five that carried no note — `approval.enabled`,
+`approval.default_policy`, `hooks.debug`, `claude_code.telemetry.enabled` and
+`facility_knowledge.bundle_path` — say what they take and what each value does.

--- a/changelog.d/config-key-guard.internal.md
+++ b/changelog.d/config-key-guard.internal.md
@@ -1,0 +1,3 @@
+The config-key guard now asserts the rendered union's size instead of noting a
+drift against it, so a stale count in the manifest fails the check with the
+number to record.

--- a/changelog.d/config-key-guard.internal.md
+++ b/changelog.d/config-key-guard.internal.md
@@ -1,3 +1,4 @@
 The config-key guard now asserts the rendered union's size instead of noting a
 drift against it, so a stale count in the manifest fails the check with the
-number to record.
+number to record. It also refuses a `default:` line stranded below a comment
+block, where an entry inserted above it would silently take the default.

--- a/scripts/check_config_keys.py
+++ b/scripts/check_config_keys.py
@@ -32,6 +32,8 @@ Failure modes
                          entry with no ``default_note``
 9. ``union-size``        the manifest's record of how many paths the render
                          matrix produces is stale, or missing
+10. ``layout``           a ``default:`` line stranded below a comment block
+                         instead of sitting inside the entry it belongs to
 
 plus the manifest's own consistency checks (covered-by chains, evidence
 vacuity, governed sets, keeps, absent paths) and a self-test
@@ -1013,6 +1015,45 @@ class ConfigKeyGuard:
 
     # ── manifest self-consistency ───────────────────────────────────────
 
+    def check_manifest_layout(self) -> None:
+        """A ``default:`` line belongs inside its entry, never below a comment.
+
+        YAML binds a line that follows a comment block to whatever entry
+        precedes the comment, so a stray ``default:`` reads correctly today and
+        is one insertion away from reading wrong: an entry added between the
+        comment and the stray line silently takes the default, and
+        ``check_defaults`` then reports the wrong key as undefaulted. The fault
+        is invisible in the parsed mapping, so this check reads the ledger as
+        text.
+
+        Any comment line counts, not only a ``# ── section`` header. The
+        fragility is the comment standing between a line and its entry, not
+        which kind of comment it is.
+        """
+        path = self.root / "src" / "osprey" / "profiles" / MANIFEST_FILENAME
+        if not path.exists():
+            self.fail(
+                "layout",
+                f"no manifest file at {path}: the guard executes that ledger, so its "
+                f"absence is a fault rather than a check with nothing to read",
+            )
+            return
+        comment: tuple[int, str] | None = None
+        for number, line in enumerate(path.read_text().splitlines(), 1):
+            if re.match(r"^\s*#", line):
+                comment = (number, line.strip())
+            elif not line.strip():
+                continue
+            else:
+                if comment is not None and re.match(r"^\s*default(_note)?:", line):
+                    self.fail(
+                        "layout",
+                        f"line {number} ({line.strip()!r}) follows the comment on line "
+                        f"{comment[0]} ({comment[1]!r}) instead of sitting inside its own "
+                        f"entry; an entry inserted between the two would steal it",
+                    )
+                comment = None
+
     def check_branch_self_test(self) -> None:
         """Each Jinja conditional branch must still be covered by the matrix.
 
@@ -1280,6 +1321,7 @@ class ConfigKeyGuard:
         self.check_parity()
         self.check_panel_port_markers()
         self.check_branch_self_test()
+        self.check_manifest_layout()
         self.check_provider_shape()
         self.check_governed_sets()
         self.check_keeps()

--- a/scripts/check_config_keys.py
+++ b/scripts/check_config_keys.py
@@ -30,6 +30,8 @@ Failure modes
                          that is not a posture-floor key (or a posture-floor
                          key without one), or a ``derived`` / ``no-fallback``
                          entry with no ``default_note``
+9. ``union-size``        the manifest's record of how many paths the render
+                         matrix produces is stale, or missing
 
 plus the manifest's own consistency checks (covered-by chains, evidence
 vacuity, governed sets, keeps, absent paths) and a self-test
@@ -1048,14 +1050,34 @@ class ConfigKeyGuard:
                 )
 
     def check_union_size(self) -> None:
+        """The manifest's record of the union's size is an assertion.
+
+        A count nothing checks is a count two branches can each re-derive
+        against a different base, leaving a merged figure that agrees with
+        neither while still reading as a fact. Recording no count at all is the
+        same silence under another name, so it fails too: the field is not an
+        opt-out.
+
+        The failure prints the derived number first, which is the whole fix —
+        one line in the manifest, nothing to re-run.
+        """
         expected = self.manifest["render_contexts"].get("expected_union_size")
         actual = len(self.union())
-        if expected is None or expected == actual:
+        if expected == actual:
             self.note(f"rendered union: {actual} paths")
             return
-        self.note(
-            f"rendered union: {actual} paths (manifest records {expected}, "
-            f"delta {actual - expected:+d}) — informational, not a failure"
+        if expected is None:
+            self.fail(
+                "union-size",
+                f"rendered union: {actual} paths, and the manifest records none — "
+                f"write {actual} into render_contexts.expected_union_size",
+            )
+            return
+        self.fail(
+            "union-size",
+            f"rendered union: {actual} paths, but the manifest records {expected} "
+            f"(delta {actual - expected:+d}) — write {actual} into "
+            f"render_contexts.expected_union_size",
         )
 
     def check_provider_shape(self) -> None:

--- a/scripts/check_config_keys.py
+++ b/scripts/check_config_keys.py
@@ -201,19 +201,17 @@ REQUIRED_DEFAULT_KEYS = POSTURE_FLOOR_KEYS | {"facility_knowledge.bundle_path"}
 #: ``no-fallback``  the reader supplies none: it raises, or the surface goes
 #:                  off, or nothing reads the key at all yet.
 #:
-#: ``derived`` and ``no-fallback`` say nothing on their own, so each one must
-#: carry a ``default_note:`` naming the derivation or the consequence. Without
-#: that rule the two would be an escape hatch from reading the code, which is
-#: the whole point of the column.
-#:
-#: ``required`` may carry one and need not: "no fallback exists" is a complete
-#: answer, but a key whose admissible values are a closed set has nowhere else
-#: to name them for a reader holding only the ledger. A literal default may
-#: not: the literal is the whole answer, so prose beside one is an excuse for
-#: it or a sign the sentinel is wrong.
+#: ``derived``, ``no-fallback`` and ``required`` say nothing on their own, so
+#: each one must carry a ``default_note:`` naming the derivation, the
+#: consequence, or the values the key accepts. Without that rule the three
+#: would be an escape hatch from reading the code, which is the whole point of
+#: the column: "you must set this" leaves a reader holding only the ledger with
+#: nowhere to learn what may be set. A literal default carries no note: the
+#: literal is the whole answer, so prose beside one is an excuse for it or a
+#: sign the sentinel is wrong. ``n/a`` carries none either — a ``covered-by``
+#: leaf is answered by its parent.
 DEFAULT_SENTINELS = frozenset({"required", "n/a", "derived", "no-fallback"})
-DEFAULT_SENTINELS_NEEDING_NOTE = frozenset({"derived", "no-fallback"})
-DEFAULT_SENTINELS_ALLOWING_NOTE = DEFAULT_SENTINELS_NEEDING_NOTE | {"required"}
+DEFAULT_SENTINELS_NEEDING_NOTE = frozenset({"derived", "no-fallback", "required"})
 
 
 def sentinel_lookalike(value: object) -> str | None:
@@ -695,10 +693,10 @@ class ConfigKeyGuard:
            refusal that no longer happens, and a floor key that loses
            ``required`` invites a fallback to be invented for something the
            build refuses to guess at;
-        3. ``derived`` and ``no-fallback`` carry a ``default_note:``,
-           ``required`` may carry one, a literal carries none, and a near-miss
-           spelling of a sentinel (``no_fallback``, ``Derived``) is refused
-           rather than waved through as the literal string it technically is.
+        3. ``derived``, ``no-fallback`` and ``required`` carry a
+           ``default_note:``, a literal carries none, and a near-miss spelling
+           of a sentinel (``no_fallback``, ``Derived``) is refused rather than
+           waved through as the literal string it technically is.
         """
         keys = self.manifest["keys"]
         for key, spec in keys.items():
@@ -718,22 +716,21 @@ class ConfigKeyGuard:
                 )
                 continue
             needs_note = isinstance(value, str) and value in DEFAULT_SENTINELS_NEEDING_NOTE
-            may_note = isinstance(value, str) and value in DEFAULT_SENTINELS_ALLOWING_NOTE
             has_note = bool(str(spec.get("default_note") or "").strip())
             if needs_note and not has_note:
                 self.fail(
                     "default",
                     f"{key} is {value!r} but carries no default_note naming the "
-                    f"derivation or the consequence",
+                    f"derivation, the consequence, or the values it accepts",
                 )
-            elif has_note and not may_note:
+            elif has_note and not needs_note:
                 # A note on a literal reads as an excuse for it. The literal is
                 # the whole answer, or it is the wrong sentinel.
                 self.fail(
                     "default",
                     f"{key} carries a default_note but its default is the literal "
                     f"{value!r}; a note belongs only on "
-                    f"{sorted(DEFAULT_SENTINELS_ALLOWING_NOTE)}",
+                    f"{sorted(DEFAULT_SENTINELS_NEEDING_NOTE)}",
                 )
 
         declared = {

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -2584,16 +2584,15 @@ render_contexts:
     panel_presets_set: web.presets
   expected_union_size: 355
   note_union_size: >-
-    Informational, not an assertion — it moves whenever the framework template
-    or a preset gains or loses a key, and the guard reports a diff against it
-    rather than failing on it. Because it cannot fail, it is a signal only while
-    it is re-derived whenever a source's key set changes: a counter left behind
-    reads as an agreement it has not earned.
+    An assertion: the guard derives the union on every run and fails when this
+    figure disagrees with it, or when it is missing. It moves whenever the
+    framework template or a preset gains or loses a key, so the commit that
+    moves it records the new number here.
 
-    Re-derive it by running the guard and recording the number it reports, never
-    by adding an expected delta to the number already written here. The union is
-    taken over the rendered sources, so a change in what those sources are moves
-    it by an amount arithmetic on the previous figure cannot predict.
+    The failure prints the number to write down. Record that number, never a
+    delta added to the figure already written here: the union is taken over the
+    rendered sources, so a change in what those sources are moves it by an
+    amount arithmetic on the previous figure cannot predict.
 
 # ---------------------------------------------------------------------------
 # governed_sets — ADDENDUM 2. Two safety stanzas make EXHAUSTIVE claims that no

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -268,6 +268,7 @@ keys:
     default: ''
   services:
     evidence: 'get_config_value\("services\.postgresql", \{\}\)'
+    default: {}
   # The bluesky bridge's plan-lane blocks are INJECTOR-written, not template-
   # rendered: `_inject_bluesky` writes `services.bluesky` (and, on a two-lane
   # deploy, its `bluesky_va`/`bluesky_live` sibling) into an already-rendered
@@ -277,7 +278,6 @@ keys:
   # on every lane of every bluesky deploy — its disappearance is therefore a
   # real signal, where the omit-when-unset neighbours (`plan_dir`,
   # `excluded_plans`) would go silent for a configuration reason.
-    default: {}
   services.bluesky.devices_file:
     rendered: false
     evidence: '\{"devices_file": bluesky\.devices_file\}'
@@ -367,6 +367,7 @@ keys:
       missing or lacks a model under its exact `hf_<org>_<basename>` cache
       name — the one operator error that would otherwise surface only as an
       unhealthy container an hour later.
+    default: null
   # `services.qmd.bind_address` is deliberately absent: the sidecar publishes on
   # the project-wide `deployment.bind_address` like every other service. See
   # deployment/qmd_service.py for why a per-service key would be a hazard.
@@ -382,7 +383,6 @@ keys:
   # The query bounds are the one pair the deploy path never sees: they shape a
   # single agent query, so the graph MCP server reads them at query time and
   # their evidence anchors there instead.
-    default: null
   services.graphdb:
     evidence: '_graphdb_block\(config\)'
     default: null
@@ -482,10 +482,10 @@ keys:
       complete one. Bounds what a question costs the AGENT's context window
       rather than what it costs the store, which is why it is a query-time key
       and not a container one.
+    default: 200
   # `services.graphdb.bind_address` is deliberately absent for the same reason
   # qmd's is — every service publishes on the project-wide
   # `deployment.bind_address`, and graphdb reuses that one reading.
-    default: 200
   services.graphdb.database:
     rendered: false
     evidence: '_text\(section\.get\("database"\), DEFAULT_DATABASE, "services\.graphdb\.database"\)'
@@ -634,6 +634,8 @@ keys:
       fragment, so the evidence anchors on that alias rather than on the dotted
       path — the alias is what a rename would have to touch. Same shape as
       `services.bluesky.image`.
+    default: derived
+    default_note: osprey_images.va
   # The live stand-in is a SECOND INSTANCE of the virtual accelerator, not a
   # service of its own. `_inject_va` writes `services.live_standin` beside
   # `services.virtual_accelerator` — same `path`, same template directory, same
@@ -653,8 +655,6 @@ keys:
   # that one key, so its disappearance is a real signal in a way the baseline
   # VA's port — read only by the generic compose machinery, and recorded here
   # no more than `services.virtual_accelerator.port` is — would not be.
-    default: derived
-    default_note: osprey_images.va
   services.live_standin:
     rendered: false
     evidence: '_LIVE_STANDIN_SERVICE_KEY = LIVE_STANDIN_PORT_KEY\.split\("\."\)\[1\]'
@@ -708,10 +708,10 @@ keys:
     rendered: false
     evidence: 'OSPREY_QMD_IMAGE:-\{\{ services\.qmd\.image'
     note: OSPREY-built image, same layering as `services.event_dispatcher.image`.
-
-  # ── Safety / approval ───────────────────────────────────────────────
     default: derived
     default_note: osprey_images.qmd
+
+  # ── Safety / approval ───────────────────────────────────────────────
   approval:
     all-templates: true
     evidence: 'config\.get\("approval", \{\}\)'
@@ -797,9 +797,9 @@ keys:
       live false in hello-world. It is a posture-floor key, so every preset has
       to state it either way — which is what makes it parity-required now,
       where under the templates it was a per-template divergence.
+    default: required
 
   # ── Control system ──────────────────────────────────────────────────
-    default: required
   control_system: {evidence: 'get_config_value\("control_system", \{\}\)', default: {}}
   control_system.type:
     evidence: 'get_config_value\("control_system\.type", "mock"\)'
@@ -1191,10 +1191,10 @@ keys:
       the same shared reader; the shipped `control-assistant` preset writes no
       live_standin block, so a stand-in target there answers the
       deployment-wide posture and stays strict where the deployment is.
-
-  # ── Control-system target switch ────────────────────────────────────
     default: no-fallback
     default_note: an unstated leaf is not False — the write paths fail closed
+
+  # ── Control-system target switch ────────────────────────────────────
   control_system.target_switch:
     evidence: 'section\.get\("target_switch"\)'
     note: >-
@@ -1236,11 +1236,11 @@ keys:
       the eligibility gate reads it, and the evidence anchors on that gate's
       own spelling of the key rather than on the leaf the CLI writes it
       through, because the gate is what a rename would have to keep in step.
-
-  # ── Archiver ────────────────────────────────────────────────────────
     default: derived
     default_note: >-
       absent or empty means unacknowledged; presence alone is the acknowledgement, never a value comparison
+
+  # ── Archiver ────────────────────────────────────────────────────────
   archiver: {evidence: 'get_config_value\("archiver", \{\}\)', default: {}}
   # Evidenced by the factory's own diagnostic for an unset type, not by the name
   # of whichever connector happens to be the default. The literal 'mock_archiver'
@@ -1361,11 +1361,11 @@ keys:
       the key's own name, api_calls_dir, as a directory under agent_data.base_dir
   file_paths.registry_exports_dir:
     evidence: 'get_agent_dir\("registry_exports_dir"\)'
-
-  # ── API providers ───────────────────────────────────────────────────
     default: derived
     default_note: >-
       the key's own name, registry_exports_dir, as a directory under agent_data.base_dir
+
+  # ── API providers ───────────────────────────────────────────────────
   api:
     evidence: 'api_providers'
     default: {}
@@ -1386,9 +1386,9 @@ keys:
       build/claude_code_resolver.py, which is the quoted evidence. The guard
       stays stricter than the runtime on purpose — a shipped template should
       map every tier rather than lean on that fallback.
+    default: {}
 
   # ── Claude Code ─────────────────────────────────────────────────────
-    default: {}
   claude_code:
     all-templates: true
     evidence: 'get_config_value\("claude_code", \{\}\)'
@@ -1817,6 +1817,7 @@ keys:
     default: 200
   artifact_server.example_artifact:
     evidence: 'get_config_value\("artifact_server\.example_artifact"'
+    default: false
 
   # ── Health suite ────────────────────────────────────────────────────
   # The `health:` section is unset in all five templates — the built-in checks
@@ -1825,7 +1826,6 @@ keys:
   # reference names as dotted paths are carried here; the scalar suite settings
   # (`suite_timeout_s`, `on_demand_timeout_s`, `interval_s`) are documented as
   # bare leaf names and read straight off the same mapping.
-    default: false
   health.categories:
     rendered: false
     evidence: 'categories_raw = health\.get\("categories"\) or \{\}'
@@ -1859,11 +1859,11 @@ keys:
       re-declare its MCP servers as probes. Only `auto.mcp.enabled` and
       `auto.mcp.url_key` are read; anything else under it is ignored by design,
       which is why the leaves carry no entries of their own.
-
-  # ── Web UI / CLI ────────────────────────────────────────────────────
     default: derived
     default_note: >-
       the default AutoMcpSettings: mcp.enabled true, url_key host_url, not explicit
+
+  # ── Web UI / CLI ────────────────────────────────────────────────────
   web: {evidence: 'config\.get\("web", \{\}\)', default: {}}
   web.theme:
     evidence: 'get_config_value\("web\.theme", DEFAULT_WEB_THEME\)'

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -720,10 +720,18 @@ keys:
     all-templates: true
     covered-by: approval
     default: required
+    default_note: >-
+      true or false. true applies the approval hook, so every hook-wired tool
+      call follows the policies below; false applies none of them and leaves
+      those tools to the rendered settings.json permissions alone.
   approval.default_policy:
     all-templates: true
     evidence: 'default_policy'
     default: required
+    default_note: >-
+      always, skip or selective, applied to any hook-wired tool with no policy
+      of its own. selective is content-aware for `execute` and reads as always
+      everywhere else.
   approval.tools:
     covered-by: approval
     note: >-
@@ -798,6 +806,10 @@ keys:
       to state it either way — which is what makes it parity-required now,
       where under the templates it was a per-template divergence.
     default: required
+    default_note: >-
+      true or false. true logs one line per hook call to stderr and appends to
+      .claude/hooks/hook_debug.jsonl, which is what the web terminal's Safety
+      panel hook feed reads; false writes neither.
 
   # ── Control system ──────────────────────────────────────────────────
   control_system: {evidence: 'get_config_value\("control_system", \{\}\)', default: {}}
@@ -1443,6 +1455,9 @@ keys:
     all-templates: true
     covered-by: claude_code.telemetry
     default: required
+    default_note: >-
+      true or false. true emits the agent's OTLP logs and metrics to the
+      backend named below; false emits none and the rest of the block is inert.
   claude_code.telemetry.backend:
     evidence: 'telemetry_cfg\.get\("backend"\) == "openobserve"'
     default: null
@@ -1784,6 +1799,10 @@ keys:
   facility_knowledge.bundle_path:
     evidence: 'get_config_value\("facility_knowledge\.bundle_path", None\)'
     default: required
+    default_note: >-
+      A path to the bundle, absolute or resolved against the project directory.
+      None is derived: a facility_knowledge section naming no bundle has
+      nothing to serve, so the knowledge commands refuse rather than guess.
   artifact_server: {all-templates: true, evidence: 'config\.get\("artifact_server"\) or \{\}', default: {}}
   artifact_server.host: {all-templates: true, covered-by: artifact_server, default: 127.0.0.1}
   artifact_server.port: {covered-by: artifact_server, default: derived, default_note: the layout's artifact slot at this deployment's port base}

--- a/tests/scripts/test_config_key_guard.py
+++ b/tests/scripts/test_config_key_guard.py
@@ -775,6 +775,22 @@ def test_near_miss_sentinel_goes_red(misspelling):
     assert "cli.theme" in details(guard)
 
 
+def test_required_default_without_a_note_goes_red():
+    """`required` names no fallback, so it has to name the accepted values.
+
+    A reader holding only the ledger otherwise sees "you must set this" with
+    nowhere to learn what may be set.
+    """
+
+    def strip_the_note(manifest):
+        manifest["keys"]["control_system.type"].pop("default_note", None)
+
+    guard = make_guard(strip_the_note)
+    guard.check_defaults()
+    assert "default" in modes(guard)
+    assert "control_system.type" in details(guard)
+
+
 def test_note_on_a_required_default_stays_green():
     """`required` says no fallback exists; the note says which values are legal.
 

--- a/tests/scripts/test_config_key_guard.py
+++ b/tests/scripts/test_config_key_guard.py
@@ -891,6 +891,78 @@ def test_a_self_test_key_a_preset_also_spells_goes_red():
     assert "must come from the framework template" in details(guard)
 
 
+def _write_manifest(root: Path, body: str) -> Path:
+    """Put *body* where the guard looks for the ledger under *root*."""
+    path = root / "src" / "osprey" / "profiles" / "config_key_manifest.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+@pytest.mark.parametrize(
+    "comment",
+    ["  # an ordinary paragraph about the block below", "  # \u2500\u2500 A section \u2500\u2500"],
+)
+def test_a_default_line_after_a_comment_goes_red(tmp_path, comment):
+    """A stranded `default:` is bound to whatever precedes the comment.
+
+    It reads correctly until someone inserts an entry between the comment and
+    the stray line, at which point the new entry silently takes the default and
+    the defaults check reports the wrong key. Both comment shapes are pinned:
+    the fragility is the comment standing in the way, not whether it happens to
+    be a section header.
+    """
+    _write_manifest(
+        tmp_path,
+        "keys:\n"
+        "  alpha:\n"
+        "    evidence: 'alpha'\n"
+        f"{comment}\n"
+        "    default: {}\n"
+        "  beta:\n"
+        "    evidence: 'beta'\n"
+        "    default: {}\n",
+    )
+
+    guard = make_guard(root=tmp_path)
+    guard.check_manifest_layout()
+    assert "layout" in modes(guard)
+    assert "line 5" in details(guard)
+
+
+def test_a_default_line_inside_its_entry_stays_green(tmp_path):
+    """The same two entries, with the default where it belongs."""
+    _write_manifest(
+        tmp_path,
+        "keys:\n"
+        "  alpha:\n"
+        "    evidence: 'alpha'\n"
+        "    default: {}\n"
+        "  # an ordinary paragraph about the block below\n"
+        "  beta:\n"
+        "    evidence: 'beta'\n"
+        "    default: {}\n",
+    )
+
+    guard = make_guard(root=tmp_path)
+    guard.check_manifest_layout()
+    assert modes(guard) == []
+
+
+def test_a_missing_manifest_file_goes_red(tmp_path):
+    """The guard executes that ledger, so its absence is a fault, not a skip."""
+    guard = make_guard(root=tmp_path)
+    guard.check_manifest_layout()
+    assert "layout" in modes(guard)
+
+
+def test_every_default_line_sits_inside_its_entry():
+    """The live ledger carries no stranded default line."""
+    guard = make_guard()
+    guard.check_manifest_layout()
+    assert guard.result.ok, details(guard)
+
+
 def test_a_stale_union_size_goes_red():
     """The recorded union size is an assertion, so a wrong one has to fail.
 

--- a/tests/scripts/test_config_key_guard.py
+++ b/tests/scripts/test_config_key_guard.py
@@ -891,6 +891,36 @@ def test_a_self_test_key_a_preset_also_spells_goes_red():
     assert "must come from the framework template" in details(guard)
 
 
+def test_a_stale_union_size_goes_red():
+    """The recorded union size is an assertion, so a wrong one has to fail.
+
+    While it was a note, two branches could each re-derive the count against a
+    different base and the merged figure agreed with neither — a number a
+    reader takes for a fact and nothing checks.
+    """
+
+    def leave_the_counter_behind(manifest):
+        actual = len(make_guard().union())
+        manifest["render_contexts"]["expected_union_size"] = actual + 1
+
+    guard = make_guard(leave_the_counter_behind)
+    guard.check_union_size()
+    assert "union-size" in modes(guard)
+    assert str(len(guard.union())) in details(guard), "the failure must print what to record"
+
+
+def test_a_missing_union_size_goes_red():
+    """An assertion with an opt-out is the informational note under a new name."""
+
+    def drop_the_counter(manifest):
+        manifest["render_contexts"].pop("expected_union_size", None)
+
+    guard = make_guard(drop_the_counter)
+    guard.check_union_size()
+    assert "union-size" in modes(guard)
+    assert str(len(guard.union())) in details(guard)
+
+
 def test_incomplete_provider_tier_map_goes_red():
     def demand_a_tier_no_provider_maps(manifest):
         manifest["keys"]["api.providers"]["key-shape"]["models-tiers"] = ["fable"]


### PR DESCRIPTION
Three columns the config-key manifest wrote down and nothing verified become checks in the guard that executes it.

- `fix(config-guard): fail on a stale manifest union size instead of noting it`
- `fix(config-guard): keep every default line inside its own manifest entry`
- `feat(config-guard): require a default note on every key the build refuses to guess`

## Why

The manifest is the ledger a deployer reads to answer "what happens if I leave this key out". Three of its columns were prose nothing re-derived, so each could drift while still reading as a fact. The rendered union's size was a note the guard printed and never failed on — two branches could each re-record it against a different base and the merged figure agreed with neither; it is now an assertion whose failure prints the number to write down. Twelve `default:` lines sat below a comment block instead of inside their entry, where YAML binds them to whatever precedes the comment: correct today, and one inserted entry away from silently handing the default to the wrong key. And `default: required` could carry a note or not, so five of the seven keys that state it named no accepted values at all.

A deployer reading `osprey config --defaults` now sees, beside every key the build refuses to guess at, what that key takes and what each value does — `approval.enabled`, `approval.default_policy`, `hooks.debug`, `claude_code.telemetry.enabled` and `facility_knowledge.bundle_path`. The guard's failure-mode list goes from eight to ten, each new mode with its own negative control beside the existing ones.

## Not in this PR

- No docs changes: the manifest's own prose is the documentation, and both prose edits ship here.
- The `expected_union_size` field is kept, not removed — it is now the assertion rather than a tally. It stays 355; nothing here moves the rendered union.
- `n/a` is untouched: a note on a `covered-by` leaf is still refused, because the parent's default is the answer.
