### PR TITLE
fix(presets): document every shipped connector type, drop the inert approval rows, and key the VA noise level

### DIFF
--- a/changelog.d/inert-approval-rows.internal.md
+++ b/changelog.d/inert-approval-rows.internal.md
@@ -1,0 +1,3 @@
+The `hello-world` preset no longer ships approval policies for the two ARIEL
+logbook tools, which that preset's disabled logbook server never exposes. Both
+rows were fail-closed either way, so nothing a deployment does changes.

--- a/changelog.d/preset-connector-examples.added.md
+++ b/changelog.d/preset-connector-examples.added.md
@@ -1,0 +1,5 @@
+The `control-assistant` preset now shows a starting stanza for every connector
+and archiver type OSPREY ships: `doocs` and `tango` beside the existing `mock`,
+`virtual_accelerator` and `epics` blocks, and `mongodb_archiver` and
+`doocs_archiver` beside `mock_archiver` and `epics_archiver`. Each one is a
+commented example, so no rendered configuration changes.

--- a/changelog.d/va-noise-level-key.added.md
+++ b/changelog.d/va-noise-level-key.added.md
@@ -1,0 +1,6 @@
+The Virtual Accelerator's noise level is now a configuration key,
+`control_system.connector.virtual_accelerator.noise_level`, falling through to
+`control_system.connector.mock.noise_level` when unset. It was reachable only
+as the `VA_NOISE_LEVEL` container variable, which an operator editing the
+deployment's configuration never saw; that variable still works and still wins
+when a deployment exports it.

--- a/docs/source/how-to/control-systems/use-virtual-accelerator.rst
+++ b/docs/source/how-to/control-systems/use-virtual-accelerator.rst
@@ -262,9 +262,9 @@ environment setup is needed.
 What the IOC serves, and how often
 ==================================
 
-Two numbers about the served values are set in the deployment's ``.env`` rather
-than fixed in the image, because both are properties of the machine you are
-standing in for rather than of OSPREY:
+Two numbers about the served values reach the container through the
+deployment's ``.env`` rather than being fixed in the image, because both are
+properties of the machine you are standing in for rather than of OSPREY:
 
 .. list-table::
    :header-rows: 1
@@ -279,12 +279,19 @@ standing in for rather than of OSPREY:
    * - ``VA_NOISE_LEVEL``
      - Fractional noise on the synthesised channel values, default ``0.01``.
        ``0`` serves them flat, which is what a test that compares readings
-       wants.
+       wants. Write the value as
+       ``control_system.connector.virtual_accelerator.noise_level`` in your
+       configuration --- unset, it falls through to
+       ``control_system.connector.mock.noise_level``, so one simulated machine
+       is described once --- and ``osprey build`` renders it as this variable's
+       default.
 
 Both are refused at boot if they are not a number, or out of range, rather than
 being clamped --- so a typo shows up in ``docker logs`` instead of quietly
 changing what the machine looks like. Leave either empty and the default
-applies.
+applies. A variable exported in the deployment's own ``.env`` outranks the
+rendered default, so a single run can be made noisier or quieter without
+editing the configuration.
 
 Running from a source checkout
 ==============================

--- a/src/osprey/deployment/compose_generator.py
+++ b/src/osprey/deployment/compose_generator.py
@@ -1283,6 +1283,31 @@ def _standin_perturbation(config, repo_root):
     return lattice, default_bpm_errors_for_lattice(lattice)
 
 
+def _va_noise_level(config):
+    """The noise the Virtual Accelerator's synthesised readings carry, as text.
+
+    A config key rather than a bare ``.env`` variable, because how noisy a
+    reading is belongs to the machine being simulated and is therefore the
+    facility's to state — and it falls through to
+    ``control_system.connector.mock.noise_level`` exactly as ``simulation_file``
+    beside it does, so a deployment describing one simulated machine describes
+    it once whichever connector serves it.
+
+    :param config: The config being rendered.
+    :return: The resolved level as the string the template interpolates, or
+        ``""`` when neither key is stated — which leaves the entrypoint's own
+        default in force.
+    :rtype: str
+    """
+    from osprey_connectors.types import MOCK, VIRTUAL_ACCELERATOR
+
+    connector = (config.get("control_system") or {}).get("connector") or {}
+    va_block = connector.get(VIRTUAL_ACCELERATOR) or {}
+    mock_block = connector.get(MOCK) or {}
+    level = va_block.get("noise_level", mock_block.get("noise_level"))
+    return "" if level is None else str(level)
+
+
 def _telemetry_link_host(config):
     """The host the dashboard's per-run telemetry link names, or ``None``.
 
@@ -1631,6 +1656,12 @@ def _inject_project_metadata(config):
     # (the template gates it on the stand-in branch), so this is inert for every
     # project that has not asked for a second instance.
     _, config_with_labels["standin_bpm_errors_default"] = _standin_perturbation(config, repo_root)
+
+    # The Virtual Accelerator's noise level, resolved here for the same reason:
+    # the template cannot follow the fall-through from the VA connector block to
+    # the mock one (:func:`_va_noise_level`), and a second copy of that rule is
+    # a second answer waiting to disagree with the first.
+    config_with_labels["va_noise_level"] = _va_noise_level(config)
 
     # The host the dispatcher dashboard's per-run telemetry link names, derived
     # from the one external-origin authority (:func:`_telemetry_link_host`).

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -973,6 +973,24 @@ keys:
   control_system.connector.epics.gateways.write_access.address: {rendered: false, covered-by: control_system.connector.epics.gateways.write_access, default: ''}
   control_system.connector.epics.gateways.write_access.port: {rendered: false, covered-by: control_system.connector.epics.gateways.write_access, default: 5064}
   control_system.connector.epics.gateways.write_access.use_name_server: {rendered: false, evidence: 'use_name_server', default: false}
+  # The DOOCS and TANGO connector blocks. No preset renders either one —
+  # `control-assistant` documents both as commented examples — so the parents
+  # and every leaf below them are `rendered: false` together.
+  control_system.connector.doocs: {rendered: false, covered-by: control_system.connector, default: n/a}
+  control_system.connector.tango: {rendered: false, covered-by: control_system.connector, default: n/a}
+  control_system.connector.tango.tango_host:
+    rendered: false
+    evidence: 'config\.get\("tango_host"\)'
+    note: >-
+      The TANGO device database this deployment speaks to, written `host:port`.
+      It is the ONE coordinate the TANGO connector takes; everything else in
+      its block is a leaf every connector type answers. DOOCS has no
+      counterpart at all, because doocs4py addresses the ENS its own
+      environment names.
+    default: derived
+    default_note: >-
+      unset leaves PyTango reading the TANGO_HOST already in the container's environment
+  control_system.connector.tango.timeout: {rendered: false, covered-by: control_system.connector.tango, default: 5.0}
   control_system.connector.virtual_accelerator: {covered-by: control_system.connector, default: n/a}
   control_system.connector.virtual_accelerator.timeout: {covered-by: control_system.connector.virtual_accelerator, default: 5.0}
   # The VA connector subclasses the EPICS one and hands its own block to
@@ -1051,6 +1069,23 @@ keys:
       No longer forward-declared: the switch's host manager reads it out of the
       resolved connector block, which is where the evidence anchors.
     default: ''
+  control_system.connector.doocs.probe_channel:
+    rendered: false
+    evidence: '"probe_channel": str\(block\.get\(PROBE_CHANNEL_KEY\)'
+    note: >-
+      The same key read through the doocs block: the host manager takes it out
+      of whichever connector block is active, so a DOOCS deployment names a
+      DOOCS property here. Commented in `control-assistant`, and an unnamed one
+      leaves that target un-switchable-to rather than falsely eligible.
+    default: ''
+  control_system.connector.tango.probe_channel:
+    rendered: false
+    evidence: '"probe_channel": str\(block\.get\(PROBE_CHANNEL_KEY\)'
+    note: >-
+      The same key read through the tango block, naming a device attribute
+      rather than a channel. Commented in `control-assistant` for the same
+      reason: which attribute answers is a facility fact.
+    default: ''
   control_system.connector.virtual_accelerator.writes_enabled:
     rendered: false
     evidence: 'block\[TYPE_WRITES_ENABLED_LEAF\] is True'
@@ -1081,6 +1116,25 @@ keys:
       decision that cannot ship pre-made, so no shipped preset ever sets this
       one true; `control-assistant-readonly` writes it false into an applied
       project's config.yml, which is the one way a build produces it.
+    default: derived
+    default_note: falls through to control_system.writes_enabled
+  control_system.connector.doocs.writes_enabled:
+    rendered: false
+    evidence: 'block\[TYPE_WRITES_ENABLED_LEAF\] is True'
+    note: >-
+      The same leaf reached through the doocs block — one type-keyed resolver
+      answers for every connector type, so the reader cited here is the reader
+      cited above. Commented in `control-assistant`: arming writes against a
+      DOOCS machine is a facility decision, so no shipped preset states it.
+    default: derived
+    default_note: falls through to control_system.writes_enabled
+  control_system.connector.tango.writes_enabled:
+    rendered: false
+    evidence: 'block\[TYPE_WRITES_ENABLED_LEAF\] is True'
+    note: >-
+      The same leaf reached through the tango block, with the same tri-state
+      reading and the same single reader. Commented in `control-assistant` for
+      the same reason the doocs one is.
     default: derived
     default_note: falls through to control_system.writes_enabled
   control_system.connector.virtual_accelerator.limits_checking:
@@ -1169,6 +1223,56 @@ keys:
       for the epics block. Setting it `true` is what makes a live target stop
       counting
       as strict, which the target-switch gate refuses by naming this key.
+    default: no-fallback
+    default_note: an unstated leaf is not False — the write paths fail closed
+  control_system.connector.doocs.limits_checking:
+    rendered: false
+    evidence: 'limits = block\[LIMITS_CHECKING_LEAF\]'
+    note: >-
+      The same block reached through the doocs block, overriding whole the way
+      every per-type block does. Commented in `control-assistant`: a DOOCS
+      machine's limits posture is the facility's to state.
+    default: derived
+    default_note: falls through to control_system.limits_checking
+  control_system.connector.doocs.limits_checking.enabled:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(enabled_leaf\)\)'
+    note: >-
+      The same leaf, same absent/unreadable reading and the same shared reader,
+      for the doocs block.
+    default: no-fallback
+    default_note: an unstated leaf is not False — the write paths fail closed
+  control_system.connector.doocs.limits_checking.allow_unlisted_channels:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
+    note: >-
+      The same leaf and the same shared reader for the doocs block; the write
+      paths allow only on a literal `true`.
+    default: no-fallback
+    default_note: an unstated leaf is not False — the write paths fail closed
+  control_system.connector.tango.limits_checking:
+    rendered: false
+    evidence: 'limits = block\[LIMITS_CHECKING_LEAF\]'
+    note: >-
+      The same block reached through the tango block, with the same
+      whole-block override semantics. Commented in `control-assistant` for the
+      same reason the doocs one is.
+    default: derived
+    default_note: falls through to control_system.limits_checking
+  control_system.connector.tango.limits_checking.enabled:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(enabled_leaf\)\)'
+    note: >-
+      The same leaf, same absent/unreadable reading and the same shared reader,
+      for the tango block.
+    default: no-fallback
+    default_note: an unstated leaf is not False — the write paths fail closed
+  control_system.connector.tango.limits_checking.allow_unlisted_channels:
+    rendered: false
+    evidence: '_limits_leaf\(block\.get\(allow_unlisted_leaf\)\)'
+    note: >-
+      The same leaf and the same shared reader for the tango block; the write
+      paths allow only on a literal `true`.
     default: no-fallback
     default_note: an unstated leaf is not False — the write paths fail closed
   control_system.connector.live_standin.limits_checking:
@@ -1278,6 +1382,23 @@ keys:
     default: {}
   archiver.epics_archiver.url: {covered-by: archiver.epics_archiver, rendered: false, default: 'no-fallback', default_note: "the connector raises ValueError('archiver URL is required for EPICS archiver')"}
   archiver.epics_archiver.timeout: {covered-by: archiver.epics_archiver, rendered: false, default: 60}
+  archiver.doocs_archiver:
+    rendered: false
+    evidence: 'doocs_archiver'
+    note: >-
+      DOOCS local history. Like the DOOCS connector it takes no coordinates —
+      doocs4py reaches the ENS its own environment names — so the block holds
+      only the two optional knobs below. Commented in `control-assistant`,
+      which reads the archive it records itself.
+    default: {}
+  archiver.doocs_archiver.avg_window:
+    rendered: false
+    evidence: 'config\.get\("avg_window", None\)'
+    note: >-
+      Centered moving average, in seconds, applied to the samples a read
+      returns. Unset returns the raw samples.
+    default: null
+  archiver.doocs_archiver.timeout: {rendered: false, covered-by: archiver.doocs_archiver, default: 60}
   # The stored archive's connection block, rendered by the control_assistant
   # template and written from the profile's `va_archiver:` block at build time.
   # The mongodb_archiver connection block is `rendered: false` as a set: the

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -762,21 +762,13 @@ keys:
   approval.tools.archiver_read: {evidence: 'archiver_read', default: derived, default_note: falls through to approval.default_policy}
   approval.tools.execute: {covered-by: approval.tools, default: derived, default_note: falls through to approval.default_policy}
   approval.tools.setup_patch: {evidence: 'setup_patch', default: derived, default_note: falls through to approval.default_policy}
-  approval.tools.entry_create:
-    evidence: 'entry_create'
-    note: >-
-      Inert in hello_world: that template disables the ariel server, so the
-      tool never exists. Harmless (fail-closed either way); recorded so it is
-      not mistaken for drift.
-    default: derived
-    default_note: falls through to approval.default_policy
+  approval.tools.entry_create: {evidence: 'entry_create', default: derived, default_note: falls through to approval.default_policy}
   approval.tools.entry_publish:
     evidence: 'entry_publish'
     note: >-
       The second half of the logbook write: entry_create drafts, entry_publish
       writes the entry through to the facility's logbook. Both carry the
-      approval hook, so both belong here. Inert in hello-world for the same
-      reason entry_create is.
+      approval hook, so both belong here.
     default: derived
     default_note: falls through to approval.default_policy
   # The panel-rail verbs. Spelled in exactly the three presets that ship an

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -915,6 +915,22 @@ keys:
   # noisier machine authors them itself.
   control_system.connector.mock.response_delay_ms: {rendered: false, evidence: 'response_delay_ms', default: 10}
   control_system.connector.mock.noise_level: {rendered: false, evidence: 'noise_level', default: 0.01}
+  control_system.connector.virtual_accelerator.noise_level:
+    rendered: false
+    evidence: 'va_block\.get\("noise_level", mock_block\.get\("noise_level"\)\)'
+    note: >-
+      Fractional noise on the readings the simulator synthesises — the one knob
+      deciding whether a reading looks alive or flat, so it is a config key and
+      not only a container variable. The build renders it as the default of the
+      compose file's `VA_NOISE_LEVEL` interpolation, which is why the evidence
+      anchors on the resolver in `deployment/compose_generator.py` rather than
+      on the entrypoint that consumes the variable: an exported VA_NOISE_LEVEL
+      still outranks it, so the variable is the carrier and this key is the
+      surface. Commented in `control-assistant`, so nothing renders it.
+    default: derived
+    default_note: >-
+      falls through to control_system.connector.mock.noise_level, and then to the
+      entrypoint's own 0.01
   control_system.connector.epics: {covered-by: control_system.connector, default: n/a}
   control_system.connector.epics.timeout: {covered-by: control_system.connector.epics, default: 5.0}
   control_system.connector.epics.step_read_timeout_s:

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -344,6 +344,30 @@ config:
   # control_system.connector.epics.pva_channels: ["*:IMAGE*", "*:ARRAY*"]
   # control_system.connector.epics.pva_gateway.address: your-pva-gateway.example.com
   # control_system.connector.epics.pva_gateway.use_name_server: false
+  # DOOCS connector: no coordinates of its own. doocs4py reaches the ENS the
+  # facility's own DOOCS environment already names, so the empty coordinate set
+  # is the point of this block rather than an omission — what is left is the
+  # four leaves every connector type answers.
+  # Write posture for the DOOCS machine. Same tri-state as the epics leaf
+  # above: stating it pins it, and only a literal true arms writes.
+  # control_system.connector.doocs.writes_enabled: false
+  # Limits posture for the DOOCS machine alone, both leaves required.
+  # control_system.connector.doocs.limits_checking.enabled: true
+  # control_system.connector.doocs.limits_checking.allow_unlisted_channels: false
+  # Property the target switch reads to prove this machine is reachable.
+  # control_system.connector.doocs.probe_channel: FACILITY/DEVICE/LOCATION/PROPERTY
+  # TANGO connector: one coordinate of its own, the device database, spelled
+  # `host:port`. Leave `tango_host` unset and PyTango reads the TANGO_HOST the
+  # environment already carries; write it to name a database that environment
+  # does not. The port is the database's own, not one of this deployment's.
+  # control_system.connector.tango.tango_host: your-tango-db.example.com:<db-port>
+  # Seconds a device call waits before it is given up on.
+  # control_system.connector.tango.timeout: 5.0
+  # The same four leaves as every other connector type, for the TANGO machine.
+  # control_system.connector.tango.writes_enabled: false
+  # control_system.connector.tango.limits_checking.enabled: true
+  # control_system.connector.tango.limits_checking.allow_unlisted_channels: false
+  # control_system.connector.tango.probe_channel: sys/tg_test/1/ampli
   # Target switch: how a running session moves between the connectors above.
   #
   # Seconds in-flight operations get to finish on the old target before it is
@@ -376,6 +400,23 @@ config:
   # `archiver.type: epics_archiver`.
   # archiver.epics_archiver.url: https://your-archiver.example.com:8443
   # archiver.epics_archiver.timeout: 60
+  # MongoDB archiver pointed at a store this deployment does NOT run. The
+  # coordinates above are derived from `va_archiver:`; spell them here instead
+  # to read an archive someone else keeps, and drop the `va_archiver:` block so
+  # this deployment does not record a second history beside it.
+  # archiver.mongodb_archiver.host: your-mongo.example.com
+  # archiver.mongodb_archiver.port: 27017
+  # archiver.mongodb_archiver.name: your-archive-database
+  # archiver.mongodb_archiver.collection: your-archive-collection
+  # archiver.mongodb_archiver.auth: your-auth-database
+  # archiver.mongodb_archiver.username: your-readonly-user
+  # archiver.mongodb_archiver.password_env: OSPREY_ARCHIVER_PASSWORD
+  # archiver.mongodb_archiver.timeout: 60
+  # DOOCS local history: like the DOOCS connector it takes no coordinates and
+  # reaches the ENS the environment names. Both knobs are optional — a centered
+  # moving average over this many seconds, and the read budget.
+  # archiver.doocs_archiver.avg_window: 20
+  # archiver.doocs_archiver.timeout: 60
 
   # ── Scan plans (Bluesky) ───────────────────────────────────────────────────
   # Both servers are off by default in OSPREY. Turn them on so the agent can

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -288,6 +288,11 @@ config:
   # Same machine model as the mock connector, so `osprey sim apply` stays
   # consistent whichever connector is active.
   control_system.connector.virtual_accelerator.simulation_file: data/simulation/machine.json
+  # Fractional noise on the synthesised readings. Unset falls through to
+  # `control_system.connector.mock.noise_level`, and then to the simulator's
+  # own 0.01; `0` serves the channels flat, which is what a comparison of two
+  # reads wants. It reaches the container as VA_NOISE_LEVEL.
+  # control_system.connector.virtual_accelerator.noise_level: 0.01
   # Write posture for the simulator alone. Uncomment to arm writes here while
   # the master switch keeps the live machine read-only; the shipped
   # `control-assistant-va-readwrite` persona is exactly this key.

--- a/src/osprey/profiles/presets/hello-world.yml
+++ b/src/osprey/profiles/presets/hello-world.yml
@@ -183,9 +183,6 @@ config:
   approval.tools.execute: selective
   # The agent's own config-editing tool: a config change needs approval.
   approval.tools.setup_patch: always
-  # ARIEL logbook writes. Inert here: the ariel server is off below.
-  approval.tools.entry_create: always
-  approval.tools.entry_publish: always
   # The panel rail is the operator's own view. Adding or removing a panel, and
   # registering a new one, changes what the next person sees, so each asks.
   approval.tools.add_panel_to_rail: always

--- a/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
+++ b/src/osprey/templates/services/virtual_accelerator/docker-compose.yml.j2
@@ -192,8 +192,15 @@ services:
       # noise the synthesised channels carry. Empty means the entrypoint's own
       # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
       # than clamped, so a typo shows up in `docker logs`.
+      #
+      # The noise level's surface is the config key
+      # `control_system.connector.virtual_accelerator.noise_level` (falling
+      # through to the mock connector's), rendered here as the interpolation's
+      # default by compose_generator's `_va_noise_level`; the variable is how
+      # that value reaches the container, and a deployment that exports it in
+      # its own .env still wins.
       VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
-      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
+      VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-{{ va_noise_level | default('') }}}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD
       # read these): the entrypoint module to run, the channel manifest, and
       # whether the PyAT lattice is constructed. Passthrough from the project

--- a/tests/cli/test_explicit_config_equivalence.py
+++ b/tests/cli/test_explicit_config_equivalence.py
@@ -505,7 +505,12 @@ CELL_DELTAS: dict[str, tuple[Delta, ...]] = {
     # presets already render `hooks.debug: true`, so they gain nothing.
     "hello-world/unset": (
         Delta(document="root", path="hooks.debug", fixture=ABSENT, live=False),
-        *_entry_publish_deltas("root"),
+        # hello-world dropped the two ARIEL logbook rows for a server it
+        # disables, so where the fixture carries `entry_create` the live render
+        # carries nothing, and `entry_publish` — which the fixture predates and
+        # every other ARIEL-gating preset gained — never reaches this cell at
+        # all, so no delta declares it here.
+        Delta(document="root", path="approval.tools.entry_create", fixture="always", live=ABSENT),
         *_rail_tool_deltas("root"),
     ),
     "ariel-standalone/unset": _standalone_catalog_delta()

--- a/tests/cli/test_explicit_config_partition.py
+++ b/tests/cli/test_explicit_config_partition.py
@@ -123,10 +123,25 @@ _RETIRED_SINCE_THE_FREEZE = frozenset(
     {"web.docs_url", "web.feedback.email", "web.feedback.github_repo"}
 )
 
+#: The same, for a leaf one cell alone retired, keyed by fixture directory.
+#:
+#: ``hello-world`` gates the two ARIEL logbook tools while disabling the server
+#: that serves them, so both rows were inert; dropping them leaves the frozen
+#: render carrying an ``entry_create`` the preset no longer states. The other
+#: presets that spell an ARIEL approval policy still render both rows, which is
+#: why this retirement is per cell rather than global — subtracting the leaf
+#: from every render would read as those presets stating a key that never
+#: arrives. The same difference is declared in
+#: ``test_explicit_config_equivalence.CELL_DELTAS``.
+_RETIRED_PER_CELL: Mapping[str, frozenset[str]] = {
+    "hello-world/unset": frozenset({"approval.tools.entry_create"}),
+}
+
 
 def _render(directory: str, document: str = "root") -> dict[str, Any]:
+    retired = _RETIRED_SINCE_THE_FREEZE | _RETIRED_PER_CELL.get(directory, frozenset())
     frozen = _leaves(yaml.safe_load((FIXTURE_ROOT / directory / f"{document}.yml").read_text()))
-    return {key: value for key, value in frozen if key not in _RETIRED_SINCE_THE_FREEZE}
+    return {key: value for key, value in frozen if key not in retired}
 
 
 def _preset_document(preset: str) -> dict[str, Any]:

--- a/tests/cli/test_preset_hash_pin.py
+++ b/tests/cli/test_preset_hash_pin.py
@@ -87,6 +87,13 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     # children inherit the root preset and move with it; ariel-standalone and
     # hello-world carry no channel finder and stand still. Every other key this
     # change added is shipped commented, and a comment is not resolved content.
+    # The ninth move, and hello-world alone: it dropped the two ARIEL approval
+    # rows — `approval.tools.entry_create` and `approval.tools.entry_publish` —
+    # for a server it never runs, so its resolved content is two leaves shorter.
+    # Both were fail-closed either way (the tools do not exist there), so a
+    # rebuilt project behaves identically. Every other preset stands still:
+    # control-assistant's own additions in this change are commented examples,
+    # which the hash does not see.
     "ariel-standalone": ("sha256:389fad6bd826efc4b53ea263800110585867aab31c92d9931206897c75548643"),
     "channel-finder-standalone": (
         "sha256:2dfc06f64433fcb1d8393931dccf76550e75ac76dc12f5011029010e02aa9448"
@@ -112,7 +119,7 @@ PINNED_PRESET_HASHES: dict[str, str] = {
     "control-assistant-va-readwrite": (
         "sha256:862dd6a5c5df3843c066ebdc26806c9283f75c9a658145fba1856b47d6e14ce1"
     ),
-    "hello-world": ("sha256:10ce4bc73c7a244debbf355189dfbcd13feb7d31007c79e83c93aec978831b65"),
+    "hello-world": ("sha256:3ce9623f1874a11a5500eb0a2b5a29bbfc324cf0e6ed95678ea13feadfefecb4"),
 }
 
 

--- a/tests/deployment/goldens/va_single_instance/minimal.yml
+++ b/tests/deployment/goldens/va_single_instance/minimal.yml
@@ -85,6 +85,13 @@ services:
       # noise the synthesised channels carry. Empty means the entrypoint's own
       # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
       # than clamped, so a typo shows up in `docker logs`.
+      #
+      # The noise level's surface is the config key
+      # `control_system.connector.virtual_accelerator.noise_level` (falling
+      # through to the mock connector's), rendered here as the interpolation's
+      # default by compose_generator's `_va_noise_level`; the variable is how
+      # that value reaches the container, and a deployment that exports it in
+      # its own .env still wins.
       VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
       VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD

--- a/tests/deployment/goldens/va_single_instance/overridden.yml
+++ b/tests/deployment/goldens/va_single_instance/overridden.yml
@@ -87,6 +87,13 @@ services:
       # noise the synthesised channels carry. Empty means the entrypoint's own
       # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
       # than clamped, so a typo shows up in `docker logs`.
+      #
+      # The noise level's surface is the config key
+      # `control_system.connector.virtual_accelerator.noise_level` (falling
+      # through to the mock connector's), rendered here as the interpolation's
+      # default by compose_generator's `_va_noise_level`; the variable is how
+      # that value reaches the container, and a deployment that exports it in
+      # its own .env still wins.
       VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
       VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD

--- a/tests/deployment/test_compose_generator.py
+++ b/tests/deployment/test_compose_generator.py
@@ -828,6 +828,53 @@ def test_va_state_mount_matches_what_the_engine_writes(
     assert (tmp_path / source).resolve() == resolve_state_dir(config, tmp_path).resolve()
 
 
+# ---------------------------------------------------------------------------
+# Virtual Accelerator noise level
+# ---------------------------------------------------------------------------
+# How noisy a synthesised reading is decides whether a demo looks alive and
+# whether a test comparing two reads can. It is a property of the simulated
+# machine, so it is a config key like the simulation file beside it — with the
+# same fall-through to the mock connector, so `osprey sim` scenarios behave the
+# same whichever connector serves them. The rendered value is the DEFAULT of
+# the compose interpolation: a deployment that exports VA_NOISE_LEVEL in its
+# .env still wins.
+
+
+def _va_noise_config(**levels: float) -> dict[str, Any]:
+    """A config naming ``noise_level`` on the connector types given."""
+    return {
+        "control_system": {
+            "connector": {name: {"noise_level": level} for name, level in levels.items()}
+        }
+    }
+
+
+def test_va_noise_level_comes_from_the_virtual_accelerator_key() -> None:
+    rendered = _render_va_template(_va_noise_config(virtual_accelerator=0.05))
+
+    assert 'VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-0.05}"' in rendered
+
+
+def test_va_noise_level_falls_through_to_the_mock_connector() -> None:
+    """One machine model, one noise level — the VA need not restate it."""
+    rendered = _render_va_template(_va_noise_config(mock=0.2))
+
+    assert 'VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-0.2}"' in rendered
+
+
+def test_va_noise_level_prefers_its_own_key_to_the_mock_one() -> None:
+    rendered = _render_va_template(_va_noise_config(mock=0.2, virtual_accelerator=0.05))
+
+    assert 'VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-0.05}"' in rendered
+
+
+def test_va_noise_level_is_empty_when_neither_key_is_set() -> None:
+    """An empty default leaves the entrypoint's own 0.01 in force."""
+    rendered = _render_va_template({})
+
+    assert 'VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"' in rendered
+
+
 # The worker process reads OSPREY config directly (get_facility_timezone while
 # building the agent system prompt) with CWD=/app (the image WORKDIR), so without
 # CONFIG_FILE it falls back to /app/config.yml and every dispatch errors with

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -428,6 +428,11 @@ config:
   # Same machine model as the mock connector, so `osprey sim apply` stays
   # consistent whichever connector is active.
   control_system.connector.virtual_accelerator.simulation_file: data/simulation/machine.json
+  # Fractional noise on the synthesised readings. Unset falls through to
+  # `control_system.connector.mock.noise_level`, and then to the simulator's
+  # own 0.01; `0` serves the channels flat, which is what a comparison of two
+  # reads wants. It reaches the container as VA_NOISE_LEVEL.
+  # control_system.connector.virtual_accelerator.noise_level: 0.01
   # Write posture for the simulator alone. Uncomment to arm writes here while
   # the master switch keeps the live machine read-only; the shipped
   # `control-assistant-va-readwrite` persona is exactly this key.

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -484,6 +484,30 @@ config:
   # control_system.connector.epics.pva_channels: ["*:IMAGE*", "*:ARRAY*"]
   # control_system.connector.epics.pva_gateway.address: your-pva-gateway.example.com
   # control_system.connector.epics.pva_gateway.use_name_server: false
+  # DOOCS connector: no coordinates of its own. doocs4py reaches the ENS the
+  # facility's own DOOCS environment already names, so the empty coordinate set
+  # is the point of this block rather than an omission — what is left is the
+  # four leaves every connector type answers.
+  # Write posture for the DOOCS machine. Same tri-state as the epics leaf
+  # above: stating it pins it, and only a literal true arms writes.
+  # control_system.connector.doocs.writes_enabled: false
+  # Limits posture for the DOOCS machine alone, both leaves required.
+  # control_system.connector.doocs.limits_checking.enabled: true
+  # control_system.connector.doocs.limits_checking.allow_unlisted_channels: false
+  # Property the target switch reads to prove this machine is reachable.
+  # control_system.connector.doocs.probe_channel: FACILITY/DEVICE/LOCATION/PROPERTY
+  # TANGO connector: one coordinate of its own, the device database, spelled
+  # `host:port`. Leave `tango_host` unset and PyTango reads the TANGO_HOST the
+  # environment already carries; write it to name a database that environment
+  # does not. The port is the database's own, not one of this deployment's.
+  # control_system.connector.tango.tango_host: your-tango-db.example.com:<db-port>
+  # Seconds a device call waits before it is given up on.
+  # control_system.connector.tango.timeout: 5.0
+  # The same four leaves as every other connector type, for the TANGO machine.
+  # control_system.connector.tango.writes_enabled: false
+  # control_system.connector.tango.limits_checking.enabled: true
+  # control_system.connector.tango.limits_checking.allow_unlisted_channels: false
+  # control_system.connector.tango.probe_channel: sys/tg_test/1/ampli
   # Target switch: how a running session moves between the connectors above.
   #
   # Seconds in-flight operations get to finish on the old target before it is
@@ -516,6 +540,23 @@ config:
   # `archiver.type: epics_archiver`.
   # archiver.epics_archiver.url: https://your-archiver.example.com:8443
   # archiver.epics_archiver.timeout: 60
+  # MongoDB archiver pointed at a store this deployment does NOT run. The
+  # coordinates above are derived from `va_archiver:`; spell them here instead
+  # to read an archive someone else keeps, and drop the `va_archiver:` block so
+  # this deployment does not record a second history beside it.
+  # archiver.mongodb_archiver.host: your-mongo.example.com
+  # archiver.mongodb_archiver.port: 27017
+  # archiver.mongodb_archiver.name: your-archive-database
+  # archiver.mongodb_archiver.collection: your-archive-collection
+  # archiver.mongodb_archiver.auth: your-auth-database
+  # archiver.mongodb_archiver.username: your-readonly-user
+  # archiver.mongodb_archiver.password_env: OSPREY_ARCHIVER_PASSWORD
+  # archiver.mongodb_archiver.timeout: 60
+  # DOOCS local history: like the DOOCS connector it takes no coordinates and
+  # reaches the ENS the environment names. Both knobs are optional — a centered
+  # moving average over this many seconds, and the read budget.
+  # archiver.doocs_archiver.avg_window: 20
+  # archiver.doocs_archiver.timeout: 60
 
   # ── Scan plans (Bluesky) ───────────────────────────────────────────────────
   # Both servers are off by default in OSPREY. Turn them on so the agent can

--- a/tests/profiles/test_approval_tools_parity.py
+++ b/tests/profiles/test_approval_tools_parity.py
@@ -34,19 +34,6 @@ GUARD_PATH = REPO_ROOT / "scripts" / "check_config_keys.py"
 #: control-assistant and carry deltas, not blocks of their own.
 ROOT_PRESETS = ("control-assistant", "hello-world", "ariel-standalone", "channel-finder-standalone")
 
-#: Rows that name a tool their preset's servers do not gate, and the reason.
-#: Quoted from the manifest's own entry for these keys: "Inert in hello_world:
-#: that template disables the ariel server, so the tool never exists. Harmless
-#: (fail-closed either way); recorded so it is not mistaken for drift." The
-#: manifest is pinned to this set below, so the two cannot part company.
-_INERT_ROWS = {("hello-world", "entry_create"), ("hello-world", "entry_publish")}
-
-#: The manifest phrase that records the exemption above. Matched on the shape
-#: rather than the exact spelling: the manifest writes the preset's name both
-#: ways ("hello_world" beside "hello-world"), and which separator a note happens
-#: to use is not the fact being pinned.
-_INERT_NOTE_RE = re.compile(r"inert in hello[-_]world", re.IGNORECASE)
-
 _ROW_RE = re.compile(r"^\s*approval\.tools\.([a-z_]+):", re.MULTILINE)
 
 pytestmark = pytest.mark.unit
@@ -82,22 +69,12 @@ def _preset_rows(preset: str) -> set[str]:
 def test_no_row_names_a_tool_the_preset_does_not_gate(preset: str, guard) -> None:
     """A policy for an ungated tool is posture the deployment does not have."""
     governed = guard.governed_tools(preset)
-    unexplained = {
-        tool for tool in _preset_rows(preset) - governed if (preset, tool) not in _INERT_ROWS
-    }
+    unexplained = _preset_rows(preset) - governed
 
     assert not unexplained, (
         f"{preset}: approval.tools names {sorted(unexplained)}, which its resolved "
         f"servers do not attach the approval hook to"
     )
-
-
-def test_the_inert_rows_are_still_recorded_in_the_manifest(manifest) -> None:
-    """The exemption above is the manifest's, not this test's."""
-    keys = manifest["keys"]
-    for _preset, tool in _INERT_ROWS:
-        note = keys[f"approval.tools.{tool}"].get("note", "")
-        assert _INERT_NOTE_RE.search(note), tool
 
 
 def test_the_manifest_rows_are_the_union_of_what_the_presets_ship(manifest) -> None:

--- a/tests/profiles/test_preset_connector_prose.py
+++ b/tests/profiles/test_preset_connector_prose.py
@@ -11,7 +11,8 @@ introduces the key and lists its alternatives. Inside that block every
 double-quoted lower_snake token is a type name; elsewhere in the file a quoted
 token is as likely to be an approval policy or a persona id.
 
-Three rules, and the third is what keeps a partial list honest:
+Four rules. The third keeps a partial list honest; the fourth keeps the
+complete one from being a list of names with nothing behind them:
 
 1. every type name the block mentions is a type the framework actually ships —
    a renamed or deleted connector cannot be left behind in the copy;
@@ -20,7 +21,11 @@ Three rules, and the third is what keeps a partial list honest:
 3. a block that mentions only some of them points the reader at
    ``osprey config --defaults``, so a short list never reads as a complete one,
    and that ledger really does name every type — a pointer at a surface that
-   enumerates nothing is worse than the short list it excuses.
+   enumerates nothing is worse than the short list it excuses;
+4. every type the reference document names, it also SHOWS: at least one
+   ``control_system.connector.<type>.`` (or ``archiver.<type>.``) line, live or
+   commented, so a reader who picks a type off the list finds a stanza to start
+   from rather than a name and nowhere to write it.
 """
 
 from __future__ import annotations
@@ -62,6 +67,14 @@ ADVERTISED = {
     "archiver.type": frozenset(CLI_ARCHIVER_TYPES),
 }
 
+#: Where a type's own stanza is written, per key. A stanza is recognised by its
+#: dotted prefix rather than by any particular leaf: which leaves a connector
+#: takes is the connector's business, and only the presence of a block is.
+STANZA_PREFIX = {
+    "control_system.type": "control_system.connector.{name}.",
+    "archiver.type": "archiver.{name}.",
+}
+
 _QUOTED_TOKEN_RE = re.compile(r'"([a-z][a-z0-9_]*)"')
 #: The ledger writes prose, and prose quotes a name in backticks.
 _BACKTICK_TOKEN_RE = re.compile(r"`([a-z][a-z0-9_]*)`")
@@ -91,7 +104,21 @@ def _type_block(preset: str, key: str) -> tuple[set[str], str] | None:
     return None
 
 
+def _stanza_lines(preset: str, prefix: str) -> list[str]:
+    """The lines of *preset* that WRITE a *prefix*-rooted key, live or commented.
+
+    A key is written only at the head of a line, so prose that names a block in
+    passing ("its coordinates, ``archiver.mongodb_archiver.*``, are derived")
+    does not count as showing one.
+    """
+    lines = (PRESET_DIR / f"{preset}.yml").read_text().splitlines()
+    return [line for line in lines if line.strip().lstrip("#").strip().startswith(prefix)]
+
+
 _CASES = [(preset, key) for preset in ROOT_PRESETS for key in SHIPPED]
+
+#: One case per advertised type, read from the registry rather than listed here.
+_STANZA_CASES = sorted((key, name) for key in ADVERTISED for name in ADVERTISED[key])
 
 
 @pytest.mark.parametrize(("preset", "key"), _CASES)
@@ -109,6 +136,23 @@ def test_the_reference_preset_names_every_shipped_type(key: str) -> None:
     block = _type_block(REFERENCE_PRESET, key)
     assert block is not None
     assert ADVERTISED[key] <= block[0]
+
+
+@pytest.mark.parametrize(("key", "name"), _STANZA_CASES)
+def test_every_advertised_type_has_an_example_stanza(key: str, name: str) -> None:
+    """A type the reference document advertises carries a block to copy.
+
+    Naming a connector in the "the alternatives are ..." comment and then
+    showing nothing for it leaves the reader to invent the block's spelling
+    from the docs. A commented stanza counts: it is the starting point, not a
+    rendered value. A newly registered type with no stanza reds here.
+    """
+    prefix = STANZA_PREFIX[key].format(name=name)
+
+    assert _stanza_lines(REFERENCE_PRESET, prefix), (
+        f"{REFERENCE_PRESET} advertises {name!r} for {key} but shows no "
+        f"{prefix}* line to start from"
+    )
 
 
 @pytest.mark.parametrize(("preset", "key"), _CASES)

--- a/tests/templates/render_axis_shapes/images-on-a-registry/virtual_accelerator.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/virtual_accelerator.yml
@@ -85,6 +85,13 @@ services:
       # noise the synthesised channels carry. Empty means the entrypoint's own
       # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
       # than clamped, so a typo shows up in `docker logs`.
+      #
+      # The noise level's surface is the config key
+      # `control_system.connector.virtual_accelerator.noise_level` (falling
+      # through to the mock connector's), rendered here as the interpolation's
+      # default by compose_generator's `_va_noise_level`; the variable is how
+      # that value reaches the container, and a deployment that exports it in
+      # its own .env still wins.
       VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
       VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD

--- a/tests/templates/render_axis_shapes/service-env-passthrough/virtual_accelerator.yml
+++ b/tests/templates/render_axis_shapes/service-env-passthrough/virtual_accelerator.yml
@@ -85,6 +85,13 @@ services:
       # noise the synthesised channels carry. Empty means the entrypoint's own
       # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
       # than clamped, so a typo shows up in `docker logs`.
+      #
+      # The noise level's surface is the config key
+      # `control_system.connector.virtual_accelerator.noise_level` (falling
+      # through to the mock connector's), rendered here as the interpolation's
+      # default by compose_generator's `_va_noise_level`; the variable is how
+      # that value reaches the container, and a deployment that exports it in
+      # its own .env still wins.
       VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
       VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD

--- a/tests/templates/render_defaults/virtual_accelerator.yml
+++ b/tests/templates/render_defaults/virtual_accelerator.yml
@@ -85,6 +85,13 @@ services:
       # noise the synthesised channels carry. Empty means the entrypoint's own
       # defaults (1.0 s, 0.01); a value out of range is refused at boot rather
       # than clamped, so a typo shows up in `docker logs`.
+      #
+      # The noise level's surface is the config key
+      # `control_system.connector.virtual_accelerator.noise_level` (falling
+      # through to the mock connector's), rendered here as the interpolation's
+      # default by compose_generator's `_va_noise_level`; the variable is how
+      # that value reaches the container, and a deployment that exports it in
+      # its own .env still wins.
       VA_POLL_INTERVAL_S: "${VA_POLL_INTERVAL_S:-}"
       VA_NOISE_LEVEL: "${VA_NOISE_LEVEL:-}"
       # Facility-neutral source configuration (entrypoint.py + Dockerfile CMD


### PR DESCRIPTION
The reference preset now shows an example stanza for every connector and archiver type OSPREY ships, `hello-world` drops two approval rows for a server it disables, and the Virtual Accelerator's noise level becomes a configuration key.

- `docs(presets): show an example stanza for every connector and archiver type the framework ships`
- `fix(presets): drop the approval rows for a server hello-world disables`
- `feat(va): give the virtual accelerator's noise level a config key`

## Why

The reference preset named five control-system types and four archiver types while showing a block for only three and two of them, so an operator who picked `doocs` or `tango` off the list had a name and nowhere to write it. `control-assistant` now carries a commented stanza for `doocs`, `tango`, `mongodb_archiver` and `doocs_archiver`, each with its own manifest entries, and a fourth rule in the preset-prose suite reds when a newly registered type has no stanza.

`hello-world` shipped `approval.tools.entry_create` and `approval.tools.entry_publish` for an ARIEL server the same preset switches off. Both rows governed nothing and survived only because the parity test exempted them by name and pinned that exemption to a matching manifest note. The rows, the exemption and the note go together, so the parity test now holds with no carve-out.

`VA_NOISE_LEVEL` was a pure `.env` passthrough, so the one knob deciding whether a simulated reading is flat or noisy had no line in the document an operator edits. It is now `control_system.connector.virtual_accelerator.noise_level`, falling through to `control_system.connector.mock.noise_level` the way `simulation_file` beside it does, resolved once in the compose generator and rendered as the interpolation's default — a deployment that already exports the variable still wins.

## Not in this PR

- No rendered value moves: every new preset stanza is commented, the two deleted rows are still rendered by three other presets, and the new key is a commented example. The rendered union stays at 355 paths.
- Nothing is added to the `epics` or `virtual_accelerator` stanzas, and no connector gains a coordinate it does not already read.
