### PR TITLE
docs: make five shipped prose surfaces say what the code beside them does

### DIFF
--- a/changelog.d/facility-abbreviation-sweep.changed.md
+++ b/changelog.d/facility-abbreviation-sweep.changed.md
@@ -1,0 +1,5 @@
+Shipped docstrings, comments and how-to pages that named one laboratory now use
+the placeholder cast instead — *Example Research Facility* and friends — so the
+prose a deployer reads describes their own deployment rather than someone
+else's. Magnitudes measured on a real corpus stay, because they are facts about
+the software. A guard keeps the tree that way.

--- a/changelog.d/prose-matches-the-code-beside-it.internal.md
+++ b/changelog.d/prose-matches-the-code-beside-it.internal.md
@@ -1,0 +1,5 @@
+Docstrings and comments on a handful of shipped modules now describe what the
+code beside them does: the ARIEL search end-to-end module names both of its
+test groups and their prerequisites, the JLab and ORNL ingestion adapters
+describe the reference formats they read, and the pinned dispatch render states
+the invariant it protects.

--- a/docs/source/how-to/ariel/index.rst
+++ b/docs/source/how-to/ariel/index.rst
@@ -17,10 +17,10 @@ the agent invokes ARIEL's MCP tools as part of broader workflows.
 Every layer is designed to be **facility-agnostic and extensible**. Ingestion
 adapters, search modules, and enhancement stages are all registerable --- you can
 implement your own and plug them into the full pipeline without modifying ARIEL's
-source code. Out of the box, adapters are included for facilities such as ALS,
-JLab, and ORNL, and search strategies range from fast keyword lookup to
-embedding-based semantic similarity, with multi-step reasoning over results
-delegated to the Osprey agent layer.
+source code. Out of the box, adapters are included for the reference logbook
+formats listed on :doc:`data-ingestion`, and search strategies range from fast
+keyword lookup to embedding-based semantic similarity, with multi-step
+reasoning over results delegated to the Osprey agent layer.
 
 .. figure:: /_static/resources/ariel_overview.svg
    :alt: ARIEL Logbook Search Architecture

--- a/docs/source/how-to/ariel/search-modes.rst
+++ b/docs/source/how-to/ariel/search-modes.rst
@@ -204,7 +204,7 @@ Search modules are leaf-level functions that execute a single search strategy ag
 
          qmd normalises the document paths it reports: ``_`` and ``%`` both become ``-``, runs collapse, and a leading one is dropped. ARIEL rehydrates each hit from the document's title rather than the reported path, so the entries you get back are correct. But two entry IDs that differ *only* in characters qmd collapses --- ``beam_current_setpoint`` and ``beam-current-setpoint``, say --- index as one document, and one of them becomes unreachable through this mode.
 
-         Over the real 134,996-entry ALS logbook the measured collision rate is **0.0000%**: every ALS entry ID is a 4-6 digit decimal string, so no real pair can collide. This matters only for a facility whose entry IDs are not numeric.
+         Over a real 134,996-entry logbook the measured collision rate is **0.0000%**: every entry ID there is a 4-6 digit decimal string, so no real pair can collide. This matters only for a facility whose entry IDs are not numeric.
 
 **Registering a custom search module:**
 

--- a/docs/source/how-to/ariel/search-sidecar.rst
+++ b/docs/source/how-to/ariel/search-sidecar.rst
@@ -185,7 +185,7 @@ view of the same mechanism.
 Disk footprint
 --------------
 
-Measured against a real 134,996-entry ALS logbook:
+Measured against a real 134,996-entry logbook:
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/how-to/web-terminal/operate.rst
+++ b/docs/source/how-to/web-terminal/operate.rst
@@ -169,10 +169,10 @@ The first part names the machine this deployment stands on, by what it **is**:
 - **Demo** --- mock data. Nothing moves.
 
 A deployment can put its own names on its machines
-(``control_system.target_display_names`` in ``config.yml`` --- *ALS storage
-ring* rather than *Real machine*); what the machine is stays behind the small
-ⓘ beside its name either way, and that tooltip also keeps the controls
-server's own technical label.
+(``control_system.target_display_names`` in ``config.yml`` --- *Example
+Research Facility storage ring* rather than *Real machine*); what the machine
+is stays behind the small ⓘ beside its name either way, and that tooltip
+also keeps the controls server's own technical label.
 
 The second part is the write state **on that machine**, for the whole
 deployment:

--- a/src/osprey/cli/build_profile_emit.py
+++ b/src/osprey/cli/build_profile_emit.py
@@ -370,7 +370,7 @@ _COMMENTED_TEMPLATES: dict[str, str] = {
 #   triggers: triggers/my-facility.yml
 #   worker_count: 1
 #   workspace_mode: isolated
-#   facility_name: ALS
+#   facility_name: Example Research Facility
 """,
     "bluesky": """
 # --- Bluesky bridge -----------------------------------------------------

--- a/src/osprey/cli/build_profile_load.py
+++ b/src/osprey/cli/build_profile_load.py
@@ -205,7 +205,7 @@ _KNOWN_PROFILE_KEYS = frozenset(
 
 # Keys recognized inside the ``provenance:`` block. Closed like the others: a
 # misspelled `deviation_marker:` would silently leave the default tag in force
-# and every `# ALS-DEVIATION:` comment unread.
+# and every `# SITE-DEVIATION:` comment unread.
 _KNOWN_PROVENANCE_KEYS = frozenset({"preset", "preset_hash", "providers_hash", "deviation_marker"})
 
 

--- a/src/osprey/cli/build_profile_merge.py
+++ b/src/osprey/cli/build_profile_merge.py
@@ -414,9 +414,9 @@ def _resolve_extends(
         return raw
 
     # Try a bundled preset by name first; fall through to filesystem-path
-    # resolution. Path-shaped values like ``als-base.yml`` correctly miss the
-    # preset probe (it looks up ``als-base.yml.yml``) and resolve as paths,
-    # preserving the sibling-file semantics ALS-style profiles depend on.
+    # resolution. Path-shaped values like ``site-base.yml`` correctly miss the
+    # preset probe (it looks up ``site-base.yml.yml``) and resolve as paths, so
+    # a profile that extends a sibling file keeps those semantics.
     preset_path = _preset_exists(extends_value)
     if preset_path is not None:
         base_path = preset_path

--- a/src/osprey/cli/scaffold_personas.py
+++ b/src/osprey/cli/scaffold_personas.py
@@ -77,7 +77,7 @@ def emit_persona_files(
         repo_root: The deployment repo the files land in. ``personas/`` is
             created under it, and only when there is something to write.
         repo_name: The repo's display name, which titles each emitted persona
-            (``"ALS Assistant (readonly)"``). The host profile's ``name``, not
+            (``"My Assistant (readonly)"``). The host profile's ``name``, not
             the directory.
         preset_name: The bundled preset whose ``modules.web_terminals.personas``
             catalog is the source. It need not be the repo's own preset — that

--- a/src/osprey/interfaces/okf_panel/helpers.py
+++ b/src/osprey/interfaces/okf_panel/helpers.py
@@ -4,10 +4,8 @@ Small, dependency-free helpers used by the panel backend (grouping, structure
 overview, search snippets). Functions here stay self-contained so they can be
 unit-tested without importing the rest of the package.
 
-Ported from the ALS ``mcp_servers/okf_panel`` service during its promotion to a
-native OSPREY builtin. The only intentional change from the ALS original is that
-:func:`build_structure_markdown` renders a facility-neutral title (this panel now
-serves any profile's bundle, not just ALS).
+:func:`build_structure_markdown` renders a facility-neutral title, so the panel
+serves any profile's bundle.
 """
 
 from __future__ import annotations

--- a/src/osprey/interfaces/okf_panel/validation.py
+++ b/src/osprey/interfaces/okf_panel/validation.py
@@ -6,9 +6,7 @@ OKF §9 authoring level) and dangling/malformed cross-links in document bodies
 (OKF §9 tolerates broken links, but the panel surfaces them as warnings so
 authors can fix them).
 
-Ported from the ALS ``mcp_servers/okf_panel`` service; the only change from the
-ALS original is that the OKF imports now resolve to core osprey rather than a
-vendored ``okf/`` copy.
+The OKF imports resolve to core osprey rather than a vendored ``okf/`` copy.
 
 The OKF API this builds on is intentionally narrow:
 

--- a/src/osprey/mcp_server/ariel/server.py
+++ b/src/osprey/mcp_server/ariel/server.py
@@ -79,8 +79,9 @@ def build_entry_url(entry_id: str | None, source_system: str | None = None) -> "
     - ``source_system`` marks an ARIEL-native entry not yet in the facility
       logbook (``ARIEL_NATIVE_SOURCE_SYSTEM``);
     - ``entry_id`` is empty/blank;
-    - no ``ariel.entry_url_template`` is configured (non-ALS / unconfigured
-      deployments emit no ``entry_url`` and the agent shows plain IDs);
+    - no ``ariel.entry_url_template`` is configured (a deployment that
+      configures no template emits no ``entry_url`` and the agent shows
+      plain IDs);
     - the template is malformed (fail-safe — this runs per-entry on the search
       hot path, so a one-character typo in the template must degrade to "no URL",
       never crash a read).

--- a/src/osprey/mcp_server/channel_finder_hierarchical/server_context.py
+++ b/src/osprey/mcp_server/channel_finder_hierarchical/server_context.py
@@ -116,7 +116,7 @@ class ChannelFinderHierContext:
 
     @property
     def facility_name(self) -> str:
-        """Facility name from config (e.g. 'ALS')."""
+        """Facility name from config (e.g. 'Example Research Facility')."""
         return self._facility_name
 
     @property

--- a/src/osprey/mcp_server/channel_finder_middle_layer/server_context.py
+++ b/src/osprey/mcp_server/channel_finder_middle_layer/server_context.py
@@ -118,7 +118,7 @@ class ChannelFinderMLContext:
 
     @property
     def facility_name(self) -> str:
-        """Facility name from config (e.g. 'ALS')."""
+        """Facility name from config (e.g. 'Example Research Facility')."""
         return self._facility_name
 
     @property

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1383,10 +1383,10 @@ keys:
     rendered: false
     evidence: 'epics_archiver'
     note: >-
-      Commented placeholder since the ALS-URL strip: a facility's Archiver
-      Appliance cannot be guessed, so authoring the block travels with the
-      flip to `type: epics_archiver`. The connector refuses to start without
-      a `url`, which keeps the unauthored state honest.
+      Commented placeholder: a facility's Archiver Appliance cannot be
+      guessed, so authoring the block travels with the flip to
+      `type: epics_archiver`. The connector refuses to start without a
+      `url`, which keeps the unauthored state honest.
     default: {}
   archiver.epics_archiver.url: {covered-by: archiver.epics_archiver, rendered: false, default: 'no-fallback', default_note: "the connector raises ValueError('archiver URL is required for EPICS archiver')"}
   archiver.epics_archiver.timeout: {covered-by: archiver.epics_archiver, rendered: false, default: 60}

--- a/src/osprey/services/ariel_search/config.py
+++ b/src/osprey/services/ariel_search/config.py
@@ -718,8 +718,8 @@ class ARIELConfig:
             (see ``mcp_server.ariel.server.build_entry_url``), NOT parsed by
             ``from_dict`` — the ARIEL read tools render it with the URL-encoded
             ``entry_id`` so the agent links entries verbatim. Facility-neutral by
-            default (unset -> no ``entry_url`` emitted); the facility supplies the
-            value in its own config (for ALS, ``als-base.yml``).
+            default (unset -> no ``entry_url`` emitted); a facility supplies the
+            value in its own sibling base file.
     """
 
     database: DatabaseConfig

--- a/src/osprey/services/ariel_search/database/qmd_resync_migration.py
+++ b/src/osprey/services/ariel_search/database/qmd_resync_migration.py
@@ -3,7 +3,7 @@
 ``osprey ariel qmd-resync`` finds the rows it must re-export by asking for
 every ``enhanced_entries`` row whose ``updated_at`` is at or after the stored
 watermark. Without an index that predicate is a sequential scan of the whole
-table on every ingest and every watch cycle, which at ALS scale (~135k rows)
+table on every ingest and every watch cycle, which at ~135k rows
 turns a routine pre-step into the most expensive thing in the loop.
 
 The index is purely additive: it creates no column, changes no existing one,

--- a/src/osprey/services/ariel_search/enhancement/qmd_export/writer.py
+++ b/src/osprey/services/ariel_search/enhancement/qmd_export/writer.py
@@ -16,7 +16,7 @@ body, where they are retrievable.
 **Byte-compare before write.** :func:`write_entry` reads the existing file and
 returns without touching it when the rendered bytes are identical. An exporter
 that rewrote unchanged entries would turn qmd's free "nothing changed" scan into
-a full reindex and re-embed pass on every tick — at ALS scale (~135k entries)
+a full reindex and re-embed pass on every tick — at ~135k entries
 that is tens of minutes of work per tick instead of ~12 seconds. Rendering is
 therefore fully deterministic: no wall-clock stamps, no dict-iteration order.
 

--- a/src/osprey/services/ariel_search/ingestion/adapters/jlab.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/jlab.py
@@ -1,6 +1,8 @@
-"""JLab Logbook ingestion adapter.
+"""JLab logbook reference format ingestion adapter.
 
-This module provides the adapter for Jefferson Lab electronic logbook system.
+This module provides the adapter for the JLab logbook reference format. It
+reads that format's JSON shape; a facility running such a logbook points the
+adapter at its own source URL.
 """
 
 import json
@@ -21,7 +23,7 @@ logger = get_logger("ariel")
 
 
 class JLabLogbookAdapter(FacilityAdapter):
-    """Adapter for Jefferson Lab electronic logbook system."""
+    """Adapter for the JLab logbook reference format."""
 
     def __init__(self, config: "ARIELConfig") -> None:
         """Initialize the adapter."""

--- a/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
+++ b/src/osprey/services/ariel_search/ingestion/adapters/ornl.py
@@ -1,7 +1,8 @@
-"""ORNL Logbook ingestion adapter.
+"""ORNL logbook reference format ingestion adapter.
 
-This module provides the adapter for Oak Ridge National Laboratory
-electronic logbook system.
+This module provides the adapter for the ORNL logbook reference format. It
+reads that format's JSON shape; a facility running such a logbook points the
+adapter at its own source URL.
 """
 
 import json
@@ -22,7 +23,7 @@ logger = get_logger("ariel")
 
 
 class ORNLLogbookAdapter(FacilityAdapter):
-    """Adapter for Oak Ridge National Laboratory electronic logbook system."""
+    """Adapter for the ORNL logbook reference format."""
 
     def __init__(self, config: "ARIELConfig") -> None:
         """Initialize the adapter."""

--- a/src/osprey/services/bluesky_bridge/devices/_specs_from_file.py
+++ b/src/osprey/services/bluesky_bridge/devices/_specs_from_file.py
@@ -20,8 +20,9 @@ The document has exactly two top-level keys, both optional::
 
 ``yaml.safe_load`` parses it, so a ``.json`` file is read by the same code
 path. Nothing here splits a value on any character, which is the point of the
-format: EPICS PV names may contain commas (16 of ALS's BTS quadrupoles do),
-and the env-var channel this replaced used commas as its entry separator.
+format: EPICS PV names may contain commas (16 of the bundled demo tree's BTS
+quadrupoles do), and the env-var channel this replaced used commas as its
+entry separator.
 
 Parsing is **fail-soft**. A malformed entry is skipped with a warning rather
 than raised on — one typo must not cost every other device in a 13k-entry file

--- a/src/osprey/templates/apps/control_assistant/__init__.py
+++ b/src/osprey/templates/apps/control_assistant/__init__.py
@@ -2,7 +2,6 @@
 {{ app_display_name }} - Control System Assistant
 
 A production-grade template demonstrating control system integration patterns.
-Based on the ALS control-room assistant deployment.
 
 Features:
 - Natural language channel finding (in-context or hierarchical pipelines)

--- a/src/osprey/templates/apps/control_assistant/data/simulation/machine.json
+++ b/src/osprey/templates/apps/control_assistant/data/simulation/machine.json
@@ -1,5 +1,5 @@
 {
-  "name": "ALS-style storage ring demo machine",
+  "name": "Storage ring demo machine",
   "description": "Demo machine model for the control-assistant preset: 12-sector vacuum system, DCCT beam-current monitor, and a two-cavity RF system with klystrons. Drives the mock control-system connector and mock archiver via the simulation engine.",
   "channels": {
     "SR:VAC:GAUGE:SR01:PRESSURE:RB": {

--- a/src/osprey/templates/services/qmd/docker-compose.yml.j2
+++ b/src/osprey/templates/services/qmd/docker-compose.yml.j2
@@ -129,8 +129,8 @@ services:
     volumes:
       # The index. A named volume rather than a bind: it is derived data the
       # sidecar owns end to end, it is large, and rebuilding it from scratch
-      # costs ~41 minutes at ALS scale — which is exactly why it must survive a
-      # container recreate.
+      # costs ~41 minutes — which is exactly why it must survive a container
+      # recreate.
       - qmd_index:{{ state_dir }}
       - ./build/services/qmd/index.yml:{{ index_config }}:ro
 {%- if services.qmd.models_dir %}

--- a/src/osprey/templates/services/qmd/entrypoint.sh
+++ b/src/osprey/templates/services/qmd/entrypoint.sh
@@ -394,7 +394,7 @@ decide_build_mode() {
 announce_full_build() {
     log "FULL REINDEX required: $BUILD_REASON"
     log "  Every document will be re-scanned and every embedding recomputed."
-    log "  This is slow by nature: at ALS scale (~135,000 documents) it measured"
+    log "  This is slow by nature: at ~135,000 documents it measured"
     log "  41 minutes -- 17 for the keyword index, 24 for the embeddings."
     log "  The search endpoint on port $PORT stays CLOSED until it finishes."
     log "  That is deliberate, not a hang: serving a half-built index would"

--- a/tests/cli/test_dispatch_network_injection.py
+++ b/tests/cli/test_dispatch_network_injection.py
@@ -26,17 +26,14 @@ from ruamel.yaml import YAML
 from osprey.cli.build_cmd import _inject_dispatch
 from osprey.cli.build_profile import DispatchConfig
 
-# The exact config.yml this injection renders for the profile built by
-# ``_dispatch()`` below, captured from the injector as it stood before the
-# network axis existed and re-pinned when the injector joined the shared config
-# writer, whose style indents block sequences under their key. Any byte of
-# drift in the default (bridge) render is a regression, not a refresh: the
-# axis is opt-in and unset means unchanged.
+# The exact config.yml this injection renders for the profile ``_dispatch()``
+# builds below, in the default (bridge) topology. Any byte of drift is a
+# regression, not a refresh: the axis is opt-in, and unset means unchanged.
 #
 # ``max_turns`` sits in the worker's block beside the two clock budgets and is
 # written on every deploy exactly as they are, so it belongs in the pinned
 # bytes rather than in an exception beside them.
-PRE_AXIS_CONFIG_YML = """\
+BRIDGE_RENDER_CONFIG_YML = """\
 deployed_services:
   - postgresql
   - event_dispatcher
@@ -132,16 +129,14 @@ def _dispatcher_block(project_path: Path) -> dict:
 class TestBridgeDefault:
     """With the axis unset, nothing about the build changes."""
 
-    def test_omitted_network_renders_the_pre_axis_config_byte_for_byte(
-        self, tmp_path: Path
-    ) -> None:
+    def test_omitted_network_renders_the_bridge_config_byte_for_byte(self, tmp_path: Path) -> None:
         """A profile with no ``dispatch.network`` renders the pinned bytes."""
         project_path, profile_dir = _project(tmp_path)
 
         _inject_dispatch(_dispatch(), profile_dir=profile_dir, project_path=project_path)
 
         rendered = (project_path / "config.yml").read_text(encoding="utf-8")
-        assert rendered == PRE_AXIS_CONFIG_YML
+        assert rendered == BRIDGE_RENDER_CONFIG_YML
 
     def test_spelled_bridge_renders_the_same_bytes_as_omitting_it(self, tmp_path: Path) -> None:
         """Writing the default out explicitly is the same build as leaving it out.
@@ -158,7 +153,7 @@ class TestBridgeDefault:
         )
 
         rendered = (project_path / "config.yml").read_text(encoding="utf-8")
-        assert rendered == PRE_AXIS_CONFIG_YML
+        assert rendered == BRIDGE_RENDER_CONFIG_YML
 
     def test_neither_half_carries_a_network_key(self, tmp_path: Path) -> None:
         """The default is left to the schema and the template, not written out."""

--- a/tests/docs/test_shipped_identity_literals.py
+++ b/tests/docs/test_shipped_identity_literals.py
@@ -34,7 +34,8 @@ Three kinds of surface legitimately name an institution and carry an ``allow``
 entry rather than an edit: the shipped provider adapters for named LLM
 gateways, the named ingestion adapter, and the packaging and escalation
 metadata that has to spell the upstream project's own ``owner/repo`` — the
-last of these has no pattern yet.
+last of these is out of scope here, because a project's own address is not a
+facility's.
 """
 
 from __future__ import annotations

--- a/tests/docs/test_shipped_identity_literals.py
+++ b/tests/docs/test_shipped_identity_literals.py
@@ -24,11 +24,7 @@ nothing else would notice.
 because a pattern that fires on the current tree is not a guard, it is a
 failing test. As each remaining literal is removed, its pattern joins
 :data:`DENIED` in the same change that removes it. ``lbl.gov``, ``ALS-U``,
-``BELLA`` and ``GEECS`` are in the table now. One name is still to come: the
-word-boundary facility abbreviation ``\\bALS\\b``, which still reads across
-dozens of files the wording sweep has not reached, and which cannot join until
-it does — an entry that exempted them all would be a list of files this guard
-does not cover rather than a guard.
+``\\bALS\\b``, ``BELLA`` and ``GEECS`` are in the table now.
 
 Three kinds of surface legitimately name an institution and carry an ``allow``
 entry rather than an edit: the shipped provider adapters for named LLM
@@ -151,7 +147,6 @@ DENIED: tuple[Denied, ...] = (
         # file that name the lattice those packages load.
         allow=frozenset(
             {
-                "src/osprey/profiles/config_key_manifest.yml",
                 "src/osprey/services/channel_finder/naming.py",
                 "src/osprey/services/virtual_accelerator/lattice/__init__.py",
                 "src/osprey/services/virtual_accelerator/lattice/calibration.py",
@@ -169,6 +164,56 @@ DENIED: tuple[Denied, ...] = (
                 "src/osprey/simulation/lattice/build.py",
                 "src/osprey/simulation/lattice/ring.py",
                 "src/osprey/templates/apps/control_assistant/data/channel_limits.json",
+            }
+        ),
+    ),
+    Denied(
+        # Case-sensitive on purpose: the acronym is always capitalised, while
+        # a case-insensitive read also matches the project's own ``als-apg``
+        # slug and the ``als-assistant`` example paths across the shipped tree.
+        name="facility abbreviation",
+        pattern=re.compile(r"\bALS\b"),
+        why=(
+            "one laboratory's abbreviation reads as this deployment's own "
+            "facility wherever the prose ships"
+        ),
+        sample="#   facility_name: ALS",
+        # The bundled demo ring, whose own name this is, in the simulation and
+        # virtual-accelerator packages plus the two files that name the lattice
+        # they load.
+        allow=frozenset(
+            {
+                "src/osprey/services/channel_finder/naming.py",
+                "src/osprey/services/virtual_accelerator/lattice/__init__.py",
+                "src/osprey/services/virtual_accelerator/lattice/calibration.py",
+                "src/osprey/services/virtual_accelerator/lattice/response.py",
+                "src/osprey/services/virtual_accelerator/lattice/ring.py",
+                "src/osprey/services/virtual_accelerator/lattice/strengths.py",
+                "src/osprey/services/virtual_accelerator/model/__init__.py",
+                "src/osprey/services/virtual_accelerator/model/bindings.py",
+                "src/osprey/services/virtual_accelerator/model/pyat.py",
+                "src/osprey/services/virtual_accelerator/model/variables.py",
+                "src/osprey/simulation/channel_schema.py",
+                "src/osprey/simulation/facility_spec.py",
+                "src/osprey/simulation/lattice/__init__.py",
+                "src/osprey/simulation/lattice/artifact.py",
+                "src/osprey/simulation/lattice/build.py",
+                "src/osprey/simulation/lattice/ring.py",
+                "src/osprey/templates/apps/control_assistant/data/channel_limits.json",
+                # The shipped reference ingestion format, and the places that
+                # quote the ``source_system`` values its adapter returns —
+                # rewriting those would name a value no adapter produces.
+                "docs/source/how-to/ariel/data-ingestion.rst",
+                "docs/source/reference/contracts/ariel.rst",
+                "src/osprey/registry/builtins.py",
+                "src/osprey/services/ariel_search/ingestion/adapters/als.py",
+                "src/osprey/services/ariel_search/ingestion/base.py",
+                "src/osprey/services/ariel_search/models.py",
+                # The shipped named-gateway provider adapter, and the two
+                # surfaces that name the gateway it fronts.
+                "docs/source/how-to/llm-providers/configure-providers.rst",
+                "src/osprey/models/providers/als_apg.py",
+                "src/osprey/services/channel_finder/benchmarks/evaluation.py",
             }
         ),
     ),

--- a/tests/e2e/test_ariel_search.py
+++ b/tests/e2e/test_ariel_search.py
@@ -1,7 +1,16 @@
 """ARIEL Search E2E Tests.
 
-Tests the full ARIEL pipeline: ingest -> enhance -> search.
-Requires Ollama with nomic-embed-text (skips if unavailable).
+Two groups of tests live here, with different prerequisites:
+
+Pipeline
+    The full ARIEL pipeline: ingest -> enhance -> search. Needs Ollama with
+    ``nomic-embed-text``, and skips without it.
+
+The read-only role, against a live server
+    The privileges the read-only database role actually holds. Needs a
+    reachable PostgreSQL server -- ``ARIEL_TEST_DATABASE_URL``, a running dev
+    database, or Docker for a test container -- plus ``psql`` to run the init
+    script the entrypoint runs. Skips when either is missing.
 
 Run with:
     pytest tests/e2e/test_ariel_search.py -v

--- a/tests/templates/render_axis_shapes/images-on-a-registry/qmd.yml
+++ b/tests/templates/render_axis_shapes/images-on-a-registry/qmd.yml
@@ -84,8 +84,8 @@ services:
     volumes:
       # The index. A named volume rather than a bind: it is derived data the
       # sidecar owns end to end, it is large, and rebuilding it from scratch
-      # costs ~41 minutes at ALS scale — which is exactly why it must survive a
-      # container recreate.
+      # costs ~41 minutes — which is exactly why it must survive a container
+      # recreate.
       - qmd_index:/var/lib/qmd
       - ./build/services/qmd/index.yml:/etc/qmd/index.yml:ro
     networks:

--- a/tests/templates/render_defaults/qmd.yml
+++ b/tests/templates/render_defaults/qmd.yml
@@ -84,8 +84,8 @@ services:
     volumes:
       # The index. A named volume rather than a bind: it is derived data the
       # sidecar owns end to end, it is large, and rebuilding it from scratch
-      # costs ~41 minutes at ALS scale — which is exactly why it must survive a
-      # container recreate.
+      # costs ~41 minutes — which is exactly why it must survive a container
+      # recreate.
       - qmd_index:/var/lib/qmd
       - ./build/services/qmd/index.yml:/etc/qmd/index.yml:ro
     networks:


### PR DESCRIPTION
Five shipped prose surfaces now describe the code they sit beside, and the identity guard gains the word-boundary facility abbreviation it could not carry before.

- `docs(ariel): name both test groups in the search end-to-end docstring`
- `docs(ariel): align the two reference-format adapter docstrings with the registry`
- `test(cli): state the pinned render's invariant, and name the constant for it`
- `docs(test): say the upstream project's own address is out of scope`
- `docs: sweep the remaining facility-abbreviation prose into the placeholder cast`
- `test(docs): deny the word-boundary facility abbreviation`

## Why

A deployer reads the framework's own prose — a docstring, a comment in a rendered compose file, a how-to page — as a statement about their own deployment. Twenty-two shipped files across `cli`, `interfaces`, `mcp_server`, `profiles`, `services` and `templates` still named one particular laboratory in 25 lines of that prose, so the text was wrong everywhere else and wrong in files `osprey init --force` and `profile expand` regenerate. Those lines now use the placeholder cast (*Example Research Facility*, `alice`/`carol` at `example.org`, `~/my-assistant`); magnitudes measured on a real corpus stay, because they are facts about the software rather than about whose machine produced them. With the tree clean, `\bALS\b` joins `DENIED` in `tests/docs/test_shipped_identity_literals.py`, so the next pull request cannot put one back — and the stale `config_key_manifest.yml` exemption on the ring-name row goes with it, since the only hit it explained was one of the lines this sweep rewrote.

The four other rows are the same defect at smaller scale: an end-to-end module whose docstring named only one of its two test groups (a reader hitting the PostgreSQL skip was told to install Ollama); two ingestion adapters whose docstrings described a named laboratory's logbook system while their own registry entries call them reference formats; a pinned-bytes constant whose comment and name narrated how it came to be instead of saying what it protects; and a guard docstring recording an exemption as a pattern still to be written when the upstream project's own `owner/repo` slug is the project's address, not a facility's.

No executable line changes. The two rendered qmd goldens move because the qmd compose template's comment did, and they were regenerated with the documented commands, never by hand.

## Not in this PR

- `PRE_AXIS_TRIGGERS_DISPATCHER` in the same module carries the same shape of name and the same kind of comment; only the config-render constant was in scope, and renaming its neighbour would be an unruled edit here.
- The fixture values inside that constant (`facility_name`, `channel_strip_prefix`) stay: the identity guard stops at shipped surfaces, and `tests/` keeps its fixtures.
- Prose copies of some swept lines also sit under `tests/` — outside the guard's roots, and left as they are. Only the two qmd goldens moved, because they are rendered bytes.
- `ingestion/base.py` and `models.py` are exemptions rather than sweep targets: their hits quote the `source_system` values the reference adapter actually returns, so rewriting them would name a value no adapter produces.
