### PR TITLE
fix(web-terminal): bar items and the panel catalog read the producer, not a copy

### DIFF
--- a/changelog.d/health-check-names.fixed.md
+++ b/changelog.d/health-check-names.fixed.md
@@ -1,0 +1,3 @@
+A health check whose name contains a dot keeps its full name in the web
+terminal's health bar item. Only the prefix spelling the check's own category
+is dropped, matching the System Health dashboard.

--- a/changelog.d/panel-label-roster.internal.md
+++ b/changelog.d/panel-label-roster.internal.md
@@ -1,0 +1,4 @@
+The check-name humaniser and the built-in panel labels each have one producer:
+the design system owns the humaniser both health surfaces call, and the web
+terminal's panel catalog takes its labels from the server-rendered roster
+instead of restating them.

--- a/changelog.d/queue-bar-unknown-state.fixed.md
+++ b/changelog.d/queue-bar-unknown-state.fixed.md
@@ -1,0 +1,4 @@
+The queue bar item shows the queue as busy, and leaves Start alone, when the
+run engine reports a manager state the web terminal does not recognise. It
+used to read any unrecognised state as "at rest" and offer Start against a
+manager that was doing something.

--- a/src/osprey/interfaces/design_system/static/js/check-name.js
+++ b/src/osprey/interfaces/design_system/static/js/check-name.js
@@ -1,0 +1,30 @@
+// @ts-check
+/* OSPREY Design System — health-check name humaniser
+ *
+ * A health check is identified by a free-form name and carries the category it
+ * belongs to beside it. Every surface that lists checks — the System Health
+ * dashboard's own bundle, the web terminal's health bar item — shows the same
+ * name the same way, and each one used to carry its own copy of the rule. The
+ * design system is the only mount both pages hold, so the rule lives here and
+ * both read it.
+ */
+
+/**
+ * Humanize a check name for display: drop the row's OWN `"<category>."` prefix
+ * and title-case the remaining underscore/space separated words.
+ * `fmtName("control_system.beam_current", "control_system")` → `"Beam Current"`.
+ *
+ * A check name is free-form, so a dot in it is not a category marker by
+ * itself — only the category the row actually carries is stripped, or a name
+ * that merely spells a dot loses its leading word. Existing capitalisation
+ * survives: the regex only ever raises a lowercase letter.
+ *
+ * @param {string} name
+ * @param {string} [category]
+ * @returns {string}
+ */
+export function fmtName(name, category) {
+  const prefix = category ? `${category}.` : "";
+  const s = prefix && name.startsWith(prefix) ? name.slice(prefix.length) : name;
+  return s.replace(/_/g, " ").replace(/\b[a-z]/g, (c) => c.toUpperCase());
+}

--- a/src/osprey/interfaces/health/static/js/helpers.js
+++ b/src/osprey/interfaces/health/static/js/helpers.js
@@ -2,13 +2,20 @@
 /*
  * System Health dashboard — pure, framework-free helpers.
  *
- * No imports: every function here is self-contained and side-effect-free apart
+ * Every function defined here is self-contained and side-effect-free apart
  * from DOM node construction. Keep it that way so the module stays trivially
  * testable in isolation. Ported from an earlier integration-status dashboard,
  * with the DOM builder aligned to the okf panel's el(tag, attrs, children)
  * signature and every status mapped to a CSS class name — never an inline
  * color literal.
+ *
+ * `fmtName` is the one exception: the web terminal's health bar item shows the
+ * same check names, and this bundle is served through the panel proxy rather
+ * than to that page, so the rule lives in the design system and is re-exported
+ * here for this dashboard's own importers.
  */
+
+export { fmtName } from "/design-system/js/check-name.js";
 
 /**
  * Status severity, highest wins. `worst()` reduces a set of statuses to the
@@ -76,26 +83,6 @@ export function worst(results) {
     (w, c) => ((STATUS_PRIORITY[c.status] || 0) > (STATUS_PRIORITY[w] || 0) ? c.status : w),
     "ok",
   );
-}
-
-/**
- * Humanize a check name for display: drop the row's OWN `"<category>."` prefix
- * and title-case the remaining underscore/space separated words.
- * `fmtName("control_system.beam_current", "control_system")` → `"Beam Current"`.
- *
- * A check name is free-form, so a dot in it is not a category marker by
- * itself — only the category the row actually carries is stripped, or a name
- * that merely spells a dot loses its leading word. Existing capitalisation
- * survives: the regex only ever raises a lowercase letter.
- *
- * @param {string} name
- * @param {string} [category]
- * @returns {string}
- */
-export function fmtName(name, category) {
-  const prefix = category ? `${category}.` : "";
-  const s = prefix && name.startsWith(prefix) ? name.slice(prefix.length) : name;
-  return s.replace(/_/g, " ").replace(/\b[a-z]/g, (c) => c.toUpperCase());
 }
 
 /**

--- a/src/osprey/interfaces/health/static/js/helpers.test.mjs
+++ b/src/osprey/interfaces/health/static/js/helpers.test.mjs
@@ -16,6 +16,7 @@ import {
   msCls,
   byCategory,
 } from './helpers.js';
+import { fmtName as sharedFmtName } from '/design-system/js/check-name.js';
 
 describe('esc', () => {
   test('escapes HTML metacharacters so server data cannot inject markup', () => {
@@ -124,6 +125,14 @@ describe('fmtName', () => {
 
   test('a single word is capitalized', () => {
     expect(fmtName('latency', 'network')).toBe('Latency');
+  });
+
+  // The web terminal's health bar item lists the same check names and cannot
+  // import this bundle, so the rule lives in the design system and this module
+  // re-exports it. Asserting identity — not behaviour — is what makes a future
+  // second copy a failure here rather than a quiet divergence on two surfaces.
+  test('is the design system\'s function itself, not a copy of it', () => {
+    expect(fmtName).toBe(sharedFmtName);
   });
 });
 

--- a/src/osprey/interfaces/web_terminal/app.py
+++ b/src/osprey/interfaces/web_terminal/app.py
@@ -60,6 +60,7 @@ from osprey.interfaces.web_terminal.routes.agent_activity import ACTIVITY_RING_M
 from osprey.interfaces.web_terminal.transcript_map import load as load_transcript_map
 from osprey.port_layout import default_port
 from osprey.profiles.web_panels import (
+    BUILTIN_PANEL_LABELS,
     BUILTIN_PANELS,
     SIDECAR_PANELS,
     UNIVERSAL_PANELS,
@@ -2684,6 +2685,11 @@ def create_app(
                 "bar_header_visible": plan.header_visible,
                 "bar_status_visible": plan.status_visible,
                 "bar_context": bar_context,
+                # The registry's own labels for the built-in panels, stamped so
+                # panel-catalog.js can read them at module load. /api/panels
+                # answers for the ENABLED panels only and resolves after that
+                # module's array is built, so it cannot seed the roster.
+                "builtin_panel_labels": BUILTIN_PANEL_LABELS,
             },
         )
 
@@ -2712,6 +2718,10 @@ def create_app(
                 "storage_scope": resolve_storage_scope(
                     getattr(request.app.state, "terminal_user", "")
                 ),
+                # activity-strip.js reaches panel-manager.js for the labels it
+                # words panel actions with, so the pop-out page carries the
+                # same roster stamp the index does.
+                "builtin_panel_labels": BUILTIN_PANEL_LABELS,
             },
         )
 

--- a/src/osprey/interfaces/web_terminal/static/index.html
+++ b/src/osprey/interfaces/web_terminal/static/index.html
@@ -23,7 +23,12 @@
     stored layout read-only for the session. JSON in an attribute, exactly as
     the shells carry data-bar-options; SINGLE-quoted because Jinja's tojson
     escapes ' (and < > &) but leaves " alone. -#}
-<html lang="en" data-bar-context='{{ bar_context|tojson }}' data-theme="{{ web_theme_id }}"{% if web_theme_mode %} data-theme-mode="{{ web_theme_mode }}"{% endif %} data-ui-mode="{{ web_ui_mode }}" data-rail-position="{{ web_rail_position }}"{% if storage_scope %} data-osprey-storage-scope="{{ storage_scope }}"{% endif %}{% if not bar_header_visible %} data-header-bar="hidden"{% endif %}{% if not bar_status_visible %} data-status-bar="hidden"{% endif %}{% if terminal_user and landing_url %} data-landing-url="{{ landing_url }}"{% endif %}>
+{#- data-panel-labels is the registry's roster of built-in panel labels, which
+    panel-catalog.js reads at module load. It is stamped rather than fetched
+    because /api/panels answers for the ENABLED panels only and resolves after
+    that module's array is built, so it can never name the full roster the
+    rail's catalog list needs. Same single-quoted JSON, for the same reason. -#}
+<html lang="en" data-bar-context='{{ bar_context|tojson }}' data-panel-labels='{{ builtin_panel_labels|tojson }}' data-theme="{{ web_theme_id }}"{% if web_theme_mode %} data-theme-mode="{{ web_theme_mode }}"{% endif %} data-ui-mode="{{ web_ui_mode }}" data-rail-position="{{ web_rail_position }}"{% if storage_scope %} data-osprey-storage-scope="{{ storage_scope }}"{% endif %}{% if not bar_header_visible %} data-header-bar="hidden"{% endif %}{% if not bar_status_visible %} data-status-bar="hidden"{% endif %}{% if terminal_user and landing_url %} data-landing-url="{{ landing_url }}"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/osprey/interfaces/web_terminal/static/js/bar-item-health.js
+++ b/src/osprey/interfaces/web_terminal/static/js/bar-item-health.js
@@ -10,6 +10,8 @@
  * type has a builder before the first reconcile asks for one.
  */
 
+import { fmtName } from '/design-system/js/check-name.js';
+
 import { withPrefix } from './api.js';
 import { registerBarPopover } from './bar-host.js';
 import { defineBarItem } from './bar-items.js';
@@ -246,18 +248,6 @@ function readHealth(snap) {
 }
 
 /**
- * Humanize a check name: drop the leading `category.` and title-case the
- * rest, so `epics.beam_current` reads `Beam Current`. The dashboard's rule.
- * @param {string} name
- * @returns {string}
- */
-function checkTitle(name) {
-  const dot = name.indexOf('.');
-  const bare = dot > -1 ? name.slice(dot + 1) : name;
-  return bare.replace(/_/g, ' ').replace(/\b[a-z]/g, (c) => c.toUpperCase());
-}
-
-/**
  * The checks grouped by category, first-seen order kept.
  * @param {readonly HealthCheck[]} checks
  * @returns {Map<string, HealthCheck[]>}
@@ -408,7 +398,7 @@ function buildSystemHealth(ctx) {
           rows.appendChild(
             row(
               toneOf(check.status),
-              checkTitle(String(check.name ?? '')),
+              fmtName(String(check.name ?? ''), String(check.category ?? '')),
               '',
               typeof check.value === 'string' && check.value ? check.value : String(check.message ?? '')
             )

--- a/src/osprey/interfaces/web_terminal/static/js/bar-item-queue.js
+++ b/src/osprey/interfaces/web_terminal/static/js/bar-item-queue.js
@@ -45,6 +45,23 @@ const QUEUE_ACTIVE_MANAGER_STATES = Object.freeze([
   'paused',
 ]);
 
+/**
+ * Manager states that affirmatively mean REST. Motion is derived from this
+ * list and not from the active one: the bridge owns the state vocabulary and
+ * it grows, so a state this bundle has never heard of is a state whose
+ * meaning the browser does not know — and the only safe reading of "the
+ * manager is doing something I cannot name" is that the queue is busy.
+ * @type {readonly string[]}
+ */
+const QUEUE_IDLE_MANAGER_STATES = Object.freeze(['idle']);
+
+/**
+ * Manager states already warned about, so a 1 s frame stream cannot flood the
+ * console with the same line.
+ * @type {Set<string>}
+ */
+const warnedManagerStates = new Set();
+
 /** Longest the stream waits between reconnects, ms. */
 const QUEUE_RECONNECT_MAX_MS = 30000;
 
@@ -205,7 +222,18 @@ function readQueue(snap) {
     };
   }
   const state = typeof status.manager_state === 'string' ? status.manager_state : '';
-  const active = QUEUE_ACTIVE_MANAGER_STATES.includes(state);
+  if (
+    !QUEUE_ACTIVE_MANAGER_STATES.includes(state) &&
+    !QUEUE_IDLE_MANAGER_STATES.includes(state) &&
+    !warnedManagerStates.has(state)
+  ) {
+    warnedManagerStates.add(state);
+    console.warn(
+      `[bar-item-queue] unknown manager state ${state || '(none reported)'}; ` +
+        'treating the queue as busy'
+    );
+  }
+  const active = !QUEUE_IDLE_MANAGER_STATES.includes(state);
   const stopPending = status.queue_stop_pending === true;
   const progress = running && running.progress && typeof running.progress === 'object'
     ? running.progress
@@ -230,13 +258,18 @@ function readQueue(snap) {
   } else if (state === 'starting_queue') {
     word = 'starting';
     tone = 'active';
-  } else if (active) {
+  } else if (QUEUE_ACTIVE_MANAGER_STATES.includes(state)) {
     word = 'running';
     tone = 'active';
   } else if (state && state !== 'idle') {
     // creating_environment, closing_environment, … — the manager is busy
     // with something that is not a plan.
     word = state.replace(/_/g, ' ');
+    tone = 'warn';
+  } else if (!state) {
+    // The bridge reported no state at all; the item says so rather than
+    // showing a queue at rest it has no evidence for.
+    word = 'unknown';
     tone = 'warn';
   }
   return { tone, word, plan, count, active, stopPending };

--- a/src/osprey/interfaces/web_terminal/static/js/panel-catalog.js
+++ b/src/osprey/interfaces/web_terminal/static/js/panel-catalog.js
@@ -2,10 +2,18 @@
 /* OSPREY Web Terminal — Shipped Service Panel Catalog
  *
  * The static registry of built-in service panels plus the terminal rail
- * constants — pure data, extracted from panel-manager.js to keep that module
- * under the max-lines cap. panel-manager.js filters the array in place against
+ * constants, extracted from panel-manager.js to keep that module under the
+ * max-lines cap. panel-manager.js filters the array in place against
  * /api/panels at init; panel-lifecycle.js appends runtime-registered panels;
  * panel-sse.js reads it for the close fallback.
+ *
+ * The ids, endpoints and health posture below are the browser's own — they are
+ * what it builds proxy paths and polls from. The DISPLAY LABELS are not: the
+ * backend registry owns them, and the page carries them here as a stamp on
+ * <html>. /api/panels cannot seed them, for two reasons: PANELS is module
+ * state read before that request resolves, and the route answers for the
+ * ENABLED panels only, so it could never name the full roster the rail's
+ * catalog list needs.
  */
 
 /**
@@ -29,43 +37,86 @@ export const TERMINAL_RAIL_LABEL = 'SESSION';
  *  osprey.profiles.web_panels.DEFAULT_PANEL_FALLBACK on the backend). */
 export const DEFAULT_PANEL_FALLBACK = 'artifacts';
 
+/** Attribute carrying the registry's built-in panel labels, JSON. */
+const PANEL_LABELS_ATTR = 'data-panel-labels';
+
+/**
+ * The built-in panel labels this page was served with. An absent or unreadable
+ * stamp answers with an empty roster — every panel then wears its own id,
+ * which is wrong but readable, and says so once in the console. This is the
+ * posture bar-sync.js takes for `data-bar-context`.
+ * @returns {Record<string, string>}
+ */
+function panelLabels() {
+  const raw =
+    typeof document === 'undefined'
+      ? null
+      : document.documentElement?.getAttribute(PANEL_LABELS_ATTR);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') return parsed;
+    } catch {
+      // Falls through to the warning below.
+    }
+  }
+  console.warn(
+    `[panel-catalog] no readable ${PANEL_LABELS_ATTR} on this page; ` +
+      'panels are labelled by id'
+  );
+  return {};
+}
+
+const PANEL_LABELS = panelLabels();
+
+/**
+ * The label the server gave this panel, or its id when the stamp does not
+ * name it.
+ * @param {string} id
+ * @returns {string}
+ */
+function labelOf(id) {
+  const label = PANEL_LABELS[id];
+  return typeof label === 'string' && label ? label : id.toUpperCase();
+}
+
 /** @type {Panel[]} */
 export const PANELS = [
   {
     id: 'artifacts',
-    label: 'WORKSPACE',
+    label: labelOf('artifacts'),
     configEndpoint: '/api/artifact-server',
     healthEndpoint: null,    // embedded same-origin — skip health polling
   },
   {
     id: 'ariel',
-    label: 'ARIEL',
+    label: labelOf('ariel'),
     configEndpoint: '/api/ariel-server',
   },
   {
     id: 'channel-finder',
-    label: 'CHANNELS',
+    label: labelOf('channel-finder'),
     configEndpoint: '/api/channel-finder-server',
   },
   {
     id: 'lattice',
-    label: 'LATTICE',
+    label: labelOf('lattice'),
     configEndpoint: '/api/lattice-server',
   },
   {
     id: 'jupyter',
-    label: 'JUPYTER',
+    label: labelOf('jupyter'),
     configEndpoint: '/api/jupyter-server',
     healthEndpoint: '/api/status', // the sidecar's own status route, reached through the panel proxy
   },
   {
     id: 'okf',
-    label: 'KNOWLEDGE',
+    label: labelOf('okf'),
     configEndpoint: '/api/okf-server',
   },
   {
     id: 'system-health',
-    label: 'SYSTEM',
+    label: labelOf('system-health'),
     configEndpoint: '/api/system-health-server', // data string; fetchJSON prefixes it in initPanel()
     healthEndpoint: '/health', // EXPLICIT — omitting/null skips polling and pins the panel healthy, which would leave the rail entry enabled with the sidecar down
   },

--- a/src/osprey/interfaces/web_terminal/static/session.html
+++ b/src/osprey/interfaces/web_terminal/static/session.html
@@ -6,7 +6,12 @@
     rail-position keys, and those readers take the namespace from here rather
     than parsing the URL. Absent means single-user: keys stay unscoped. Never
     emit it empty. See resolve_storage_scope() in app.py. -#}
-<html lang="en"{% if storage_scope %} data-osprey-storage-scope="{{ storage_scope }}"{% endif %}>
+{#- data-panel-labels is the registry's roster of built-in panel labels, read
+    at module load by panel-catalog.js. activity-strip.js reaches panel-manager
+    for the labels it words panel actions with, so this page needs the same
+    stamp the index carries. SINGLE-quoted because Jinja's tojson escapes '
+    (and < > &) but leaves " alone. -#}
+<html lang="en" data-panel-labels='{{ builtin_panel_labels|tojson }}'{% if storage_scope %} data-osprey-storage-scope="{{ storage_scope }}"{% endif %}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/tests/interfaces/web_terminal/js/bar-item-health.test.js
+++ b/tests/interfaces/web_terminal/js/bar-item-health.test.js
@@ -300,6 +300,38 @@ describe('system-health item: the card', () => {
     ]);
   });
 
+  // A check name is free-form and a dot in it is not a category marker: only
+  // the prefix the row's OWN category spells is dropped. Cutting at the first
+  // dot instead renames every check whose name carries one.
+  test('a dotted check name keeps everything past its own category prefix', async () => {
+    answer = () =>
+      envelope([
+        {
+          name: 'control_system.beam.current',
+          category: 'control_system',
+          status: 'ok',
+          value: '498 mA',
+        },
+      ]);
+    seedDom('', shellMarkup({ detail: 'checks' }));
+    host.hydrate();
+    await settle();
+
+    chip().click();
+    expect(rows().map((r) => r.name)).toEqual(['Beam.Current']);
+  });
+
+  test('a name that does not start with its category keeps its leading word', async () => {
+    answer = () =>
+      envelope([{ name: 'epics.gateway', category: 'services', status: 'ok', message: 'up' }]);
+    seedDom('', shellMarkup({ detail: 'checks' }));
+    host.hydrate();
+    await settle();
+
+    chip().click();
+    expect(rows().map((r) => r.name)).toEqual(['Epics.Gateway']);
+  });
+
   test('the card closes on Escape, on a click elsewhere, and on the chip again', async () => {
     seedDom('', shellMarkup());
     host.hydrate();

--- a/tests/interfaces/web_terminal/js/bar-item-queue.test.js
+++ b/tests/interfaces/web_terminal/js/bar-item-queue.test.js
@@ -1,0 +1,184 @@
+/**
+ * The Bluesky-queue bar item, happy-dom environment (configured globally):
+ *   npx vitest run tests/interfaces/web_terminal/js/bar-item-queue.test.js
+ *
+ * What is pinned here is the item's posture towards a manager state the
+ * bundle has never heard of. The bridge's state vocabulary is the bridge's,
+ * and it grows: a browser that decides "not one of my four active states,
+ * therefore at rest" shows a quiet chip and offers Start against a manager
+ * that is doing something. The item derives REST from the one state that
+ * affirmatively means rest, so every other state — invented, renamed, or
+ * missing — reads as busy and withholds Start.
+ *
+ * These run against the REAL bar-host.js and bar-items.js, with `EventSource`
+ * stubbed as a class so the item's own stream path is exercised.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+const HOST_PATH = '../../../../src/osprey/interfaces/web_terminal/static/js/bar-host.js';
+const ITEMS_PATH = '../../../../src/osprey/interfaces/web_terminal/static/js/bar-items.js';
+const QUEUE_PATH = '../../../../src/osprey/interfaces/web_terminal/static/js/bar-item-queue.js';
+
+/** @type {typeof import('../../../../src/osprey/interfaces/web_terminal/static/js/bar-host.js')} */
+let host;
+/** @type {typeof import('../../../../src/osprey/interfaces/web_terminal/static/js/bar-items.js')} */
+let items;
+/** Every warning the item logged this test. @type {string[]} */
+let warnings;
+
+/**
+ * happy-dom ships no EventSource and the item opens its own; a class stub
+ * keeps the module's stream path intact and hands the test the socket.
+ */
+class FakeEventSource {
+  /** @type {FakeEventSource[]} */
+  static opened = [];
+  /** @param {string} url */
+  constructor(url) {
+    this.url = url;
+    this.readyState = 1;
+    /** @type {((event: {data: string}) => void) | null} */
+    this.onmessage = null;
+    /** @type {(() => void) | null} */
+    this.onopen = null;
+    /** @type {(() => void) | null} */
+    this.onerror = null;
+    FakeEventSource.opened.push(this);
+  }
+  close() {
+    this.readyState = 2;
+  }
+}
+
+/** Push one queue frame down every open socket. @param {unknown} frame */
+function emit(frame) {
+  for (const source of FakeEventSource.opened) {
+    source.onmessage?.({ data: JSON.stringify(frame) });
+  }
+}
+
+/**
+ * One frame in the shape the bridge relays: a bounded `status`, the pending
+ * plans and the one in motion.
+ * @param {string} managerState
+ * @param {Array<Record<string, unknown>>} [pending]
+ */
+function frame(managerState, pending = [{ name: 'count_plan' }]) {
+  return {
+    status: { available: true, manager_state: managerState, items_in_queue: pending.length },
+    items: pending,
+    running_item: null,
+  };
+}
+
+beforeEach(async () => {
+  warnings = [];
+  FakeEventSource.opened = [];
+  vi.stubGlobal('EventSource', FakeEventSource);
+  vi.spyOn(console, 'warn').mockImplementation((/** @type {unknown[]} */ ...args) => {
+    warnings.push(args.map(String).join(' '));
+  });
+  vi.resetModules();
+  host = await import(HOST_PATH);
+  items = await import(ITEMS_PATH);
+  await import(QUEUE_PATH);
+});
+
+afterEach(() => {
+  items.disposeBarItems();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+/** The page as the bar hosts lay it out, with the queue item in the status bar. */
+function seedDom() {
+  document.body.innerHTML = `
+    <header class="header">
+      <div class="header-actions" data-bar-host="header"></div>
+    </header>
+    <footer class="status-bar" data-bar-host="status">
+      <div class="bar-item" data-bar-item="bluesky-queue"
+           data-bar-options='${JSON.stringify({ controls: 'full' })}'></div>
+    </footer>
+    <div id="bar-item-pool" hidden></div>
+  `;
+}
+
+/** @param {string} selector */
+function el(selector) {
+  const node = document.querySelector(selector);
+  if (!(node instanceof HTMLElement)) throw new Error(`no element matched ${selector}`);
+  return node;
+}
+
+const chip = () => el('[data-bar-item="bluesky-queue"] .bar-queue');
+const dotTone = () => chip().querySelector('.bar-queue-dot')?.getAttribute('data-tone');
+const chipWord = () => chip().querySelector('.bar-queue-text')?.textContent;
+const pop = () => el('[data-bar-item="bluesky-queue"] .bar-queue-pop');
+const startButton = () =>
+  /** @type {HTMLButtonElement | undefined} */ (
+    Array.from(pop().querySelectorAll('button')).find((b) => b.textContent === 'Start')
+  );
+
+const unknownWarnings = () => warnings.filter((line) => line.includes('unknown manager state'));
+
+describe('plan-queue item: a manager state the bundle cannot read', () => {
+  test('an invented state paints the busy posture, withholds Start and warns once', () => {
+    seedDom();
+    host.hydrate();
+    emit(frame('defragmenting_queue'));
+
+    expect(dotTone()).toBe('warn');
+    expect(chipWord()).toBe('defragmenting queue');
+
+    chip().click();
+    expect(startButton()?.disabled).toBe(true);
+    expect(unknownWarnings()).toHaveLength(1);
+    expect(unknownWarnings()[0]).toContain('defragmenting_queue');
+  });
+
+  test('a second frame carrying the same state does not warn again', () => {
+    seedDom();
+    host.hydrate();
+    emit(frame('defragmenting_queue'));
+    emit(frame('defragmenting_queue'));
+    emit(frame('defragmenting_queue'));
+
+    expect(unknownWarnings()).toHaveLength(1);
+  });
+
+  test('a missing manager state is busy too, worded `unknown`', () => {
+    seedDom();
+    host.hydrate();
+    emit(frame(''));
+
+    expect(dotTone()).toBe('warn');
+    expect(chipWord()).toBe('unknown');
+    chip().click();
+    expect(startButton()?.disabled).toBe(true);
+  });
+
+  test('`idle` is at rest, offers Start and never warns', () => {
+    seedDom();
+    host.hydrate();
+    emit(frame('idle'));
+
+    expect(dotTone()).toBe('idle');
+    expect(chipWord()).toBe('idle');
+    chip().click();
+    expect(startButton()?.disabled).toBe(false);
+    expect(unknownWarnings()).toEqual([]);
+  });
+
+  test('a known active state still reads `running`', () => {
+    seedDom();
+    host.hydrate();
+    emit(frame('executing_queue'));
+
+    expect(dotTone()).toBe('active');
+    expect(chipWord()).toBe('running');
+    expect(unknownWarnings()).toEqual([]);
+  });
+});

--- a/tests/interfaces/web_terminal/panel-catalog.test.mjs
+++ b/tests/interfaces/web_terminal/panel-catalog.test.mjs
@@ -1,0 +1,111 @@
+// @ts-check
+/**
+ * The shipped panel catalog (panel-catalog.js):
+ *   npx vitest run tests/interfaces/web_terminal/panel-catalog.test.mjs
+ *
+ * The catalog is the browser's descriptor list for the built-in panels — the
+ * id every rail entry and proxy path is built from, the config endpoint, and
+ * whether the panel is health-polled. The DISPLAY LABEL is not its to decide:
+ * `osprey.profiles.web_panels` owns the roster, and `/api/panels` answers for
+ * the ENABLED panels only, too late and too narrow to seed a module-level
+ * array. So the page stamps the whole roster on `<html>` and the catalog reads
+ * it at load.
+ *
+ * The two things that can go wrong are both silent in a browser: a stamp that
+ * never arrives (the rail fills with ids, no error anywhere) and a second copy
+ * of the labels drifting from the registry's. The first is pinned here; the
+ * second is pinned by `test_panel_catalog_roster.py`, which reads this module
+ * as source.
+ */
+
+import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
+
+import { BUILTIN_PANEL_LABELS, stampPanelLabels } from './panel-labels-fixture.mjs';
+
+/** Every warning logged while the catalog loaded. @type {string[]} */
+let warnings;
+
+/**
+ * Load a fresh copy of the catalog against whatever `<html>` currently says.
+ * @returns {Promise<typeof import('../../../src/osprey/interfaces/web_terminal/static/js/panel-catalog.js')>}
+ */
+async function freshCatalog() {
+  vi.resetModules();
+  return import('../../../src/osprey/interfaces/web_terminal/static/js/panel-catalog.js');
+}
+
+beforeEach(() => {
+  warnings = [];
+  vi.spyOn(console, 'warn').mockImplementation((...args) => {
+    warnings.push(args.map(String).join(' '));
+  });
+  document.documentElement.removeAttribute('data-panel-labels');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.removeAttribute('data-panel-labels');
+});
+
+describe('the built-in panel labels come from the page', () => {
+  test('with the stamp, every panel wears the label the server sent', async () => {
+    stampPanelLabels(document);
+    const { PANELS } = await freshCatalog();
+
+    expect(Object.fromEntries(PANELS.map((p) => [p.id, p.label]))).toEqual(BUILTIN_PANEL_LABELS);
+    expect(warnings).toEqual([]);
+  });
+
+  test('a label the stamp renames follows the stamp, not a copy in the bundle', async () => {
+    document.documentElement.setAttribute(
+      'data-panel-labels',
+      JSON.stringify({ ...BUILTIN_PANEL_LABELS, artifacts: 'FILES' })
+    );
+    const { PANELS } = await freshCatalog();
+
+    expect(PANELS.find((p) => p.id === 'artifacts')?.label).toBe('FILES');
+  });
+
+  test('without the stamp every panel wears its id, and one warning is logged', async () => {
+    const { PANELS } = await freshCatalog();
+
+    expect(PANELS.map((p) => p.label)).toEqual(PANELS.map((p) => p.id.toUpperCase()));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('data-panel-labels');
+  });
+
+  test('an unreadable stamp is treated as an absent one', async () => {
+    document.documentElement.setAttribute('data-panel-labels', '{not json');
+    const { PANELS } = await freshCatalog();
+
+    expect(PANELS.find((p) => p.id === 'artifacts')?.label).toBe('ARTIFACTS');
+    expect(warnings).toHaveLength(1);
+  });
+
+  test('a panel the stamp does not name falls back to its id', async () => {
+    document.documentElement.setAttribute(
+      'data-panel-labels',
+      JSON.stringify({ artifacts: 'WORKSPACE' })
+    );
+    const { PANELS } = await freshCatalog();
+
+    expect(PANELS.find((p) => p.id === 'artifacts')?.label).toBe('WORKSPACE');
+    expect(PANELS.find((p) => p.id === 'okf')?.label).toBe('OKF');
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('the descriptors the browser builds paths from', () => {
+  test('the endpoints and health posture are the bundle’s own, stamp or no stamp', async () => {
+    const { PANELS } = await freshCatalog();
+    const byId = Object.fromEntries(PANELS.map((p) => [p.id, p]));
+
+    expect(byId['artifacts'].configEndpoint).toBe('/api/artifact-server');
+    // Explicit null: an embedded same-origin panel is not health-polled.
+    expect(byId['artifacts'].healthEndpoint).toBeNull();
+    // Explicit '/health': omitting it skips polling and pins the panel healthy,
+    // which leaves the rail entry enabled with the sidecar down.
+    expect(byId['system-health'].healthEndpoint).toBe('/health');
+    expect(byId['jupyter'].healthEndpoint).toBe('/api/status');
+  });
+});

--- a/tests/interfaces/web_terminal/panel-labels-fixture.mjs
+++ b/tests/interfaces/web_terminal/panel-labels-fixture.mjs
@@ -1,0 +1,30 @@
+// @ts-check
+/**
+ * The built-in panel labels, as the server stamps them on `<html>`.
+ *
+ * `panel-catalog.js` reads `data-panel-labels` at MODULE LOAD, so a suite that
+ * asserts a panel's display label has to stamp the roster before it imports
+ * anything that reaches the catalog — otherwise every panel wears its id.
+ * These pairs are pinned to `osprey.profiles.web_panels.BUILTIN_PANEL_LABELS`
+ * by `test_panel_catalog_roster.py`, so a renamed label cannot leave this
+ * fixture behind.
+ */
+
+/** @type {Readonly<Record<string, string>>} */
+export const BUILTIN_PANEL_LABELS = Object.freeze({
+  'artifacts': 'WORKSPACE',
+  'ariel': 'ARIEL',
+  'channel-finder': 'CHANNELS',
+  'lattice': 'LATTICE',
+  'jupyter': 'JUPYTER',
+  'okf': 'KNOWLEDGE',
+  'system-health': 'SYSTEM',
+});
+
+/**
+ * Stamp the roster on a document's `<html>`, exactly as `root()` renders it.
+ * @param {Document} [doc]
+ */
+export function stampPanelLabels(doc = document) {
+  doc.documentElement.setAttribute('data-panel-labels', JSON.stringify(BUILTIN_PANEL_LABELS));
+}

--- a/tests/interfaces/web_terminal/panel-manager.test.mjs
+++ b/tests/interfaces/web_terminal/panel-manager.test.mjs
@@ -35,6 +35,11 @@
 
 import { test, expect, describe, beforeEach, afterEach, vi } from 'vitest';
 
+// panel-catalog.js reads the built-in panel labels off <html> at module
+// load, so the roster has to be stamped before freshImport() reaches it —
+// otherwise every panel here is labelled by its id.
+import { stampPanelLabels } from './panel-labels-fixture.mjs';
+
 // dock-workspace.js is stubbed at the module boundary so a test can publish a
 // hand-built DockviewApi (see makeDockApi) and exercise the real placement
 // engine in dock-iframe.js / dock-sync.js. `dockState.api` stays null by
@@ -192,6 +197,7 @@ async function freshImport() {
 
 beforeEach(() => {
   delete window.__OSPREY_PREFIX__;
+  stampPanelLabels(document);
   vi.clearAllMocks();
   getDockApi.mockImplementation(() => dockState.api);
   dockState.api = null;
@@ -199,6 +205,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  document.documentElement.removeAttribute('data-panel-labels');
   document.body.innerHTML = '';
 });
 

--- a/tests/interfaces/web_terminal/test_bar_items_ssr.py
+++ b/tests/interfaces/web_terminal/test_bar_items_ssr.py
@@ -46,6 +46,7 @@ from osprey.interfaces.web_terminal.app import (
     bar_render_plan,
     create_app,
 )
+from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
 
 #: Ids the terminal renders on every deployment, whatever the layout says.
 _UNIVERSAL_IDS = (
@@ -752,6 +753,19 @@ def _context(body: str) -> dict:
     match = re.search(r"data-bar-context='([^']*)'", _html_tag(body))
     assert match, "the deployment context is not stamped on <html>"
     return json.loads(match.group(1))
+
+
+def test_the_builtin_panel_roster_is_stamped_on_html(plain_app):
+    """``panel-catalog.js`` reads its labels off ``<html>`` at module load.
+
+    The registry owns the built-in panel labels; ``/api/panels`` answers for
+    the ENABLED panels only, so it cannot seed the full roster the catalog
+    needs before its first render. A page rendered without this stamp shows
+    panel ids in the rail.
+    """
+    match = re.search(r"data-panel-labels='([^']*)'", _html_tag(_body(plain_app[1])))
+    assert match, "the built-in panel roster is not stamped on <html>"
+    assert json.loads(match.group(1)) == BUILTIN_PANEL_LABELS
 
 
 class TestDeploymentContextIsServerSupplied:

--- a/tests/interfaces/web_terminal/test_panel_catalog_roster.py
+++ b/tests/interfaces/web_terminal/test_panel_catalog_roster.py
@@ -1,0 +1,50 @@
+"""Registry ↔ catalog parity: the browser's panel roster is the registry's.
+
+``panel-catalog.js`` declares one descriptor per built-in panel — the id, the
+config endpoint, and whether the panel is health-polled. The DISPLAY LABEL is
+not the browser's to decide: ``osprey.profiles.web_panels`` owns it, the page
+stamps it on ``<html>``, and the catalog reads it from there. What can still
+drift is the ROSTER — a panel added to the registry and not to the catalog is
+a panel with no descriptor, and one removed from the registry but left here is
+a rail entry for a panel that no longer exists. This reads the JS source so
+either direction fails immediately.
+
+The vitest fixture that stamps the roster for the suites that assert a label is
+pinned to the same dict, so a renamed label cannot leave the fixture behind.
+"""
+
+import re
+from pathlib import Path
+
+from osprey.profiles.web_panels import BUILTIN_PANEL_LABELS
+
+_ROOT = Path(__file__).parents[3]
+_CATALOG = (
+    _ROOT / "src" / "osprey" / "interfaces" / "web_terminal" / "static" / "js" / "panel-catalog.js"
+)
+_FIXTURE = Path(__file__).parent / "panel-labels-fixture.mjs"
+
+
+def _catalog_ids() -> set[str]:
+    """Every panel id the shipped ``PANELS`` array declares."""
+    return set(re.findall(r"\bid: '([\w-]+)'", _CATALOG.read_text()))
+
+
+def test_the_catalog_declares_exactly_the_builtin_panels() -> None:
+    ids = _catalog_ids()
+    assert ids == set(BUILTIN_PANEL_LABELS), (
+        "panel-catalog.js and BUILTIN_PANEL_LABELS disagree about the built-in "
+        f"roster: only in the catalog {sorted(ids - set(BUILTIN_PANEL_LABELS))}, "
+        f"only in the registry {sorted(set(BUILTIN_PANEL_LABELS) - ids)}"
+    )
+
+
+def test_the_catalog_states_no_label_of_its_own() -> None:
+    """The labels come from the page's stamp, never from a literal here."""
+    literals = set(re.findall(r"\blabel: '([^']*)'", _CATALOG.read_text()))
+    assert literals == set(), f"panel-catalog.js restates panel labels: {sorted(literals)}"
+
+
+def test_the_vitest_label_fixture_matches_the_registry() -> None:
+    pairs = dict(re.findall(r"'([\w-]+)': '([A-Z-]+)'", _FIXTURE.read_text()))
+    assert pairs == BUILTIN_PANEL_LABELS

--- a/tests/interfaces/web_terminal/test_system_health_wiring.py
+++ b/tests/interfaces/web_terminal/test_system_health_wiring.py
@@ -82,7 +82,6 @@ def test_panel_catalog_registers_system_health_tab_with_explicit_health_endpoint
         js = fh.read()
     assert "id: 'system-health'" in js
     assert "/api/system-health-server" in js
-    assert "'SYSTEM'" in js
     assert "healthEndpoint: '/health'" in js
 
 

--- a/tests/registry/test_okf_panel_registration.py
+++ b/tests/registry/test_okf_panel_registration.py
@@ -149,7 +149,6 @@ def test_frontend_panel_manager_registers_okf_tab():
         js = fh.read()
     assert "id: 'okf'" in js
     assert "/api/okf-server" in js
-    assert "KNOWLEDGE" in js
 
 
 def test_build_chain_reads_builtins_dynamically_no_hardcoded_okf():

--- a/tests/registry/test_system_health_panel_registration.py
+++ b/tests/registry/test_system_health_panel_registration.py
@@ -178,7 +178,6 @@ def test_frontend_panel_manager_registers_system_health_tab():
         js = fh.read()
     assert "id: 'system-health'" in js
     assert "/api/system-health-server" in js
-    assert "SYSTEM" in js
     # healthEndpoint MUST be the explicit '/health': an omitted/null value skips
     # polling and pins the tab healthy (panel-lifecycle.js initPanel).
     assert "healthEndpoint: '/health'" in js


### PR DESCRIPTION
Three surfaces in the web terminal's chrome stop deciding from a private copy of a fact another producer already owns.

- `fix(web-terminal): a manager state the queue bar item cannot read keeps it busy`
- `refactor(design-system): one producer for the check-name humaniser`
- `fix(web-terminal): the health bar item strips only the check's own category prefix`
- `fix(web-terminal): the panel catalog takes its built-in labels from the page's roster stamp`

## Why

The queue bar item derived motion from a list of the manager states that mean motion, so any state the bundle had never heard of read as "at rest": the chip went quiet and Start was offered against a manager that was doing something. Motion is now derived from the one state that affirmatively means rest, so an unrecognised or missing state is busy, withholds Start, and says so once in the console. The run engine owns that vocabulary and is free to grow it without the browser going quiet.

The health bar item carried its own check-name humaniser that cut at the first dot, so a check named `control_system.beam.current` lost its leading word wherever a name contained a dot. The dashboard's rule — strip only the prefix spelling the row's own category — now lives in the design system, the only mount both pages hold, and both surfaces call it. A test asserts the dashboard's export IS that function, so a future divergence fails rather than becoming a second copy.

The panel catalog restated the seven built-in panel labels that `osprey.profiles.web_panels` defines. The page now stamps the registry's roster on `<html>` and the catalog reads it at load; `/api/panels` cannot seed it, because it resolves after the module's array is built and answers for the enabled panels only. A deployer who renames a built-in panel's label renames it in one place, and a Python test pins the catalog's roster — and the vitest fixture that stamps it — to the registry dict in both directions.

## Not in this PR

- `bar-item-health.js`'s `STATUS_RANK` copy of the dashboard's `STATUS_PRIORITY`, which the same shared module would host — a second move.
- `queueControls`' own unknown-state posture in `bluesky_web/panels/bluesky/queue-client.js`; this change is scoped to the bar item.
