### PR TITLE
feat(ariel): HNSW embedding index and a joined enhancement-module status table

### DIFF
--- a/changelog.d/ariel-hnsw-index.changed.md
+++ b/changelog.d/ariel-hnsw-index.changed.md
@@ -1,0 +1,4 @@
+ARIEL's embedding index is now an HNSW index over the pgvector column. An
+existing deployment is moved across by `osprey ariel migrate`, which drops the
+old index and builds the new one; on a large corpus that build is the cost of
+the move.

--- a/changelog.d/ariel-index-lists.added.md
+++ b/changelog.d/ariel-index-lists.added.md
@@ -1,5 +1,0 @@
-The pgvector IVFFlat `lists` count for ARIEL's embedding index is now a config
-key, `ariel.enhancement_modules.text_embedding.index_lists` (default 224, the
-previous fixed value). The rule of thumb is roughly one list per 1000 entries.
-The value is fixed when the index is created, so changing it later means
-dropping the index and recreating it.

--- a/changelog.d/ariel-index-lists.internal.md
+++ b/changelog.d/ariel-index-lists.internal.md
@@ -1,0 +1,3 @@
+The ARIEL embedding index's list-count setting was added and removed inside one
+release cycle, so no released version ever carried it and there is nothing to
+announce.

--- a/changelog.d/ariel-status-modules.changed.md
+++ b/changelog.d/ariel-status-modules.changed.md
@@ -1,0 +1,6 @@
+`osprey ariel status` reports one enhancement-module table: every registered
+module, with whether it is enabled and how many entries it has completed,
+failed and left pending. Store keys that no registered module claims are
+reported separately, under `orphaned_enhancement_modules` in the `--json`
+payload and as one line in the human output, so leftover rows are visible
+rather than counted into a module that no longer exists.

--- a/docs/source/how-to/ariel/data-ingestion.rst
+++ b/docs/source/how-to/ariel/data-ingestion.rst
@@ -141,16 +141,12 @@ The built-in enhancement modules:
              text_embedding:
                enabled: true
                provider: ollama
-               index_lists: 224
                models:
                  - name: nomic-embed-text
                    dimension: 768
 
-      ``index_lists`` (default 224) sizes the pgvector IVFFlat index. The rule of
-      thumb is roughly one list per 1000 entries, up to about a million entries.
-      It cannot be worked out for you --- ``osprey ariel migrate`` creates the
-      index before a single entry is embedded --- and the value is baked in at
-      creation, so changing it later means dropping the index and recreating it.
+      The vector index over those tables is an HNSW index. It takes no sizing
+      parameter, so there is nothing about it to author per deployment.
 
       **Requirements:** Ollama (or another embedding provider) running with the specified model.
 

--- a/src/osprey/cli/ariel.py
+++ b/src/osprey/cli/ariel.py
@@ -274,6 +274,18 @@ def status_command(output_json: bool) -> None:
                 active = " (active)" if table["active"] else ""
                 output.note(f"- {table['table']}: {table['entries']} entries{active}")
 
+            # Printed only when there is something to clean up: these are rows
+            # in the store that no registered module writes any more, and this
+            # is the surface an operator already reads.
+            orphaned = result.get("orphaned_enhancement_modules") or {}
+            if orphaned:
+                leftovers = ", ".join(
+                    f"{name} ({counts['complete']} complete, {counts['failed']} failed, "
+                    f"{counts['pending']} pending)"
+                    for name, counts in sorted(orphaned.items())
+                )
+                output.report(f"Rows from unregistered enhancement modules: {leftovers}")
+
 
 @ariel_group.command("migrate")
 def migrate_command() -> None:

--- a/src/osprey/profiles/config_key_manifest.yml
+++ b/src/osprey/profiles/config_key_manifest.yml
@@ -1865,18 +1865,6 @@ keys:
   ariel.enhancement_modules.text_embedding.enabled: {covered-by: ariel.enhancement_modules.text_embedding, default: false}
   ariel.enhancement_modules.text_embedding.provider: {covered-by: ariel.enhancement_modules.text_embedding, default: null}
   ariel.enhancement_modules.text_embedding.models: {covered-by: ariel.enhancement_modules.text_embedding, default: null}
-  ariel.enhancement_modules.text_embedding.index_lists:
-    rendered: false
-    evidence: 'module_config\.settings\.get\("index_lists"\)'
-    note: >-
-      IVFFlat `lists` for the pgvector index, fixed when the index is created.
-      Commented in the two presets that ship an `ariel:` block: the rule of
-      thumb is rows/1000, and how many entries a facility's logbook holds is
-      not something the migration can see — `osprey ariel migrate` runs against
-      an empty table. Changing it afterwards needs the index dropped and
-      recreated; a value that is not a positive integer is refused when the
-      migration is built.
-    default: 224
   # The markdown mirror the qmd sidecar indexes — one file per logbook entry,
   # written during ingestion. Paired with `ariel.search_modules.hybrid` above: the
   # export without the search mode indexes a corpus nobody queries, and the
@@ -2491,6 +2479,9 @@ deleted:
   # removed by this branch. Distinct from the dispatch-profile `facility_name`
   # field (build_profile_schema.py:166), which is a different surface and stays.
 - system.facility_name
+  # The embedding index is HNSW, which takes no list count, so there is no
+  # number left for a deployment to author.
+- ariel.enhancement_modules.text_embedding.index_lists
 
 # ---------------------------------------------------------------------------
 # deleted_commented_examples — the two keys above whose COMMENTED example in a

--- a/src/osprey/profiles/presets/ariel-standalone.yml
+++ b/src/osprey/profiles/presets/ariel-standalone.yml
@@ -328,11 +328,6 @@ config:
   ariel.enhancement_modules.text_embedding.models:
     - name: nomic-embed-text
       dimension: 768
-  # IVFFlat `lists` for the vector index, chosen when the index is created.
-  # Rule of thumb: rows/1000 for corpora up to a million entries. It cannot be
-  # derived — `osprey ariel migrate` runs against an empty table — and changing
-  # it later needs the index dropped and recreated.
-  # ariel.enhancement_modules.text_embedding.index_lists: 224
   # qmd export: one markdown file per entry into the mirror tree the sidecar
   # indexes. On for the same reason `hybrid` above is; an enabled export with
   # no mirror_path is refused at startup.

--- a/src/osprey/profiles/presets/control-assistant.yml
+++ b/src/osprey/profiles/presets/control-assistant.yml
@@ -619,11 +619,6 @@ config:
   ariel.enhancement_modules.text_embedding.models:
     - name: nomic-embed-text
       dimension: 768
-  # IVFFlat `lists` for the vector index, chosen when the index is created.
-  # Rule of thumb: rows/1000 for corpora up to a million entries. It cannot be
-  # derived — `osprey ariel migrate` runs against an empty table — and changing
-  # it later needs the index dropped and recreated.
-  # ariel.enhancement_modules.text_embedding.index_lists: 224
   # qmd export: one markdown file per entry into the mirror tree the sidecar
   # indexes. On for the same reason `hybrid` above is; an enabled export with
   # no mirror_path is refused at startup.

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -340,6 +340,20 @@ def vocabulary_status(config_dict: dict, config_dir: Path | None = None) -> dict
     }
 
 
+_EMPTY_MODULE_COUNTS = {"complete": 0, "failed": 0, "pending": 0}
+
+
+def _module_counts(entry: object) -> dict[str, int]:
+    """Return the ``{complete, failed, pending}`` counts carried by *entry*.
+
+    A module the store has never seen has no entry at all, and reads as zeros —
+    the count of rows it has produced, which is what "never seen" means.
+    """
+    if not isinstance(entry, dict):
+        return dict(_EMPTY_MODULE_COUNTS)
+    return {key: int(entry.get(key, 0)) for key in _EMPTY_MODULE_COUNTS}
+
+
 async def get_status(config_dict: dict, *, config_dir: Path | None = None) -> dict:
     """Return ARIEL service status as a plain dict.
 
@@ -355,6 +369,13 @@ async def get_status(config_dict: dict, *, config_dir: Path | None = None) -> di
         doing. The healthy paths also carry ``last_ingestion``: the ISO-8601
         timestamp of the newest successful ingestion run, or ``None`` when the
         store has never been ingested.
+
+        On the healthy paths ``enhancement_modules`` is one table over the
+        registered modules, each carrying ``enabled`` alongside its
+        ``complete``/``failed``/``pending`` counts, and
+        ``orphaned_enhancement_modules`` carries the same counts for store keys
+        no registered module claims — rows present with nothing left to write
+        them.
     """
     from osprey.services.ariel_search import create_ariel_service
     from osprey.services.ariel_search.config import registered_ariel_names
@@ -372,6 +393,7 @@ async def get_status(config_dict: dict, *, config_dir: Path | None = None) -> di
         async with service:
             healthy, message = await service.health_check()
             stats = await service.repository.get_enhancement_stats()
+            registered = registered_ariel_names("ariel_enhancement_modules")
             tables = await service.repository.get_embedding_tables()
             last_ingestion = await service.repository.get_last_ingestion()
 
@@ -398,8 +420,16 @@ async def get_status(config_dict: dict, *, config_dir: Path | None = None) -> di
                     for t in tables
                 ],
                 "enhancement_modules": {
-                    name: config.is_enhancement_module_enabled(name)
-                    for name in registered_ariel_names("ariel_enhancement_modules")
+                    name: {
+                        "enabled": config.is_enhancement_module_enabled(name),
+                        **_module_counts(stats.get(name)),
+                    }
+                    for name in registered
+                },
+                "orphaned_enhancement_modules": {
+                    key: _module_counts(counts)
+                    for key, counts in stats.items()
+                    if key != "total_entries" and key not in registered
                 },
                 "search_modules": {
                     name: config.is_search_module_enabled(name)

--- a/src/osprey/services/ariel_search/cli_operations.py
+++ b/src/osprey/services/ariel_search/cli_operations.py
@@ -1494,13 +1494,7 @@ async def run_reembed(
         if not table_exists:
             if progress:
                 progress(f"Creating embedding table: {table_name}")
-            embedding_config = config.enhancement_modules.get("text_embedding")
-            migration = TextEmbeddingMigration(
-                [(model, dimension)],
-                index_lists=(
-                    embedding_config.settings.get("index_lists") if embedding_config else None
-                ),
-            )
+            migration = TextEmbeddingMigration([(model, dimension)])
             async with service.pool.connection() as conn:
                 await migration.up(conn)
             if progress:

--- a/src/osprey/services/ariel_search/database/migrations.py
+++ b/src/osprey/services/ariel_search/database/migrations.py
@@ -165,6 +165,11 @@ def model_to_table_name(model_name: str) -> str:
 # Migration runner
 # ---------------------------------------------------------------------------
 
+# Migrations constructed with the configured (model, dimension) pairs rather
+# than bare. Each writes per-model objects, so a name missing here would work
+# the hardcoded default table instead of the ones the deployment configured.
+MIGRATIONS_TAKING_EMBEDDING_MODELS = frozenset({"text_embedding", "text_embedding_hnsw_index"})
+
 # Format: (name, module_path, class_name, requires_module)
 # requires_module is None for core_schema (always runs), otherwise module name
 KNOWN_MIGRATIONS: list[tuple[str, str, str, str | None]] = [
@@ -196,6 +201,12 @@ KNOWN_MIGRATIONS: list[tuple[str, str, str, str | None]] = [
         "text_embedding",
         "osprey.services.ariel_search.enhancement.text_embedding.migration",
         "TextEmbeddingMigration",
+        "text_embedding",
+    ),
+    (
+        "text_embedding_hnsw_index",
+        "osprey.services.ariel_search.enhancement.text_embedding.hnsw_migration",
+        "TextEmbeddingHnswIndexMigration",
         "text_embedding",
     ),
     (
@@ -248,10 +259,10 @@ class MigrationRunner:
                 try:
                     module = importlib.import_module(module_path)
                     migration_class = getattr(module, class_name)
-                    # The text_embedding migration needs the configured
-                    # (model, dimension) pairs so `osprey ariel migrate` creates a
-                    # table per configured model, not just the hardcoded default.
-                    if name == "text_embedding":
+                    # These migrations need the configured (model, dimension)
+                    # pairs so `osprey ariel migrate` works a table per
+                    # configured model, not just the hardcoded default.
+                    if name in MIGRATIONS_TAKING_EMBEDDING_MODELS:
                         models = self._configured_embedding_models()
                         migration = migration_class(models)
                     else:

--- a/src/osprey/services/ariel_search/database/migrations.py
+++ b/src/osprey/services/ariel_search/database/migrations.py
@@ -253,9 +253,7 @@ class MigrationRunner:
                     # table per configured model, not just the hardcoded default.
                     if name == "text_embedding":
                         models = self._configured_embedding_models()
-                        migration = migration_class(
-                            models, index_lists=self._configured_index_lists()
-                        )
+                        migration = migration_class(models)
                     else:
                         migration = migration_class()
                     migrations.append(migration)
@@ -275,17 +273,6 @@ class MigrationRunner:
         if module_config and module_config.models:
             return [(m.name, m.dimension) for m in module_config.models]
         return None
-
-    def _configured_index_lists(self) -> int | None:
-        """Read ``text_embedding.index_lists``, or None to take the default.
-
-        Cannot be derived here: `osprey ariel migrate` creates the index before
-        any entry is embedded, so there is no row count to size it from.
-        """
-        module_config = self.config.enhancement_modules.get("text_embedding")
-        if module_config is None:
-            return None
-        return module_config.settings.get("index_lists")
 
     def _topological_sort(self, migrations: list[BaseMigration]) -> list[BaseMigration]:
         """Sort migrations by dependencies using topological sort.

--- a/src/osprey/services/ariel_search/enhancement/text_embedding/__init__.py
+++ b/src/osprey/services/ariel_search/enhancement/text_embedding/__init__.py
@@ -6,6 +6,9 @@ This module provides text embedding generation for logbook entries.
 from osprey.services.ariel_search.enhancement.text_embedding.embedder import (
     TextEmbeddingModule,
 )
+from osprey.services.ariel_search.enhancement.text_embedding.hnsw_migration import (
+    TextEmbeddingHnswIndexMigration,
+)
 from osprey.services.ariel_search.enhancement.text_embedding.migration import (
     TextEmbeddingMigration,
     create_vector_index_sql,
@@ -14,6 +17,7 @@ from osprey.services.ariel_search.enhancement.text_embedding.migration import (
 )
 
 __all__ = [
+    "TextEmbeddingHnswIndexMigration",
     "TextEmbeddingMigration",
     "TextEmbeddingModule",
     "create_vector_index_sql",

--- a/src/osprey/services/ariel_search/enhancement/text_embedding/__init__.py
+++ b/src/osprey/services/ariel_search/enhancement/text_embedding/__init__.py
@@ -8,6 +8,15 @@ from osprey.services.ariel_search.enhancement.text_embedding.embedder import (
 )
 from osprey.services.ariel_search.enhancement.text_embedding.migration import (
     TextEmbeddingMigration,
+    create_vector_index_sql,
+    legacy_vector_index_name,
+    vector_index_name,
 )
 
-__all__ = ["TextEmbeddingMigration", "TextEmbeddingModule"]
+__all__ = [
+    "TextEmbeddingMigration",
+    "TextEmbeddingModule",
+    "create_vector_index_sql",
+    "legacy_vector_index_name",
+    "vector_index_name",
+]

--- a/src/osprey/services/ariel_search/enhancement/text_embedding/hnsw_migration.py
+++ b/src/osprey/services/ariel_search/enhancement/text_embedding/hnsw_migration.py
@@ -1,0 +1,87 @@
+"""Reconcile an existing embedding index onto HNSW.
+
+A deployment that already ran ``text_embedding`` carries its record in
+``ariel_migrations`` and never re-runs it, so the index it created stays as it
+was made. This additive migration moves that index across without mutating the
+historical migration record.
+"""
+
+from typing import TYPE_CHECKING
+
+from osprey.services.ariel_search.database.migrations import (
+    BaseMigration,
+    MigrationSkippedError,
+    model_to_table_name,
+)
+from osprey.services.ariel_search.enhancement.text_embedding.migration import (
+    create_vector_index_sql,
+    legacy_vector_index_name,
+    pgvector_available,
+    vector_index_name,
+)
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+
+class TextEmbeddingHnswIndexMigration(BaseMigration):
+    """Rebuilds each per-model embedding index as an HNSW index.
+
+    The index is rebuilt once per model table. On a large corpus that build is
+    the cost of the move.
+    """
+
+    def __init__(self, models: list[tuple[str, int]] | None = None) -> None:
+        """Initialize the migration.
+
+        Args:
+            models: The (model_name, dimension) pairs the creating migration
+                was given. If None, uses the same default it does.
+        """
+        super().__init__()
+        self._models = models
+
+    @property
+    def name(self) -> str:
+        """Return migration identifier."""
+        return "text_embedding_hnsw_index"
+
+    @property
+    def depends_on(self) -> list[str]:
+        """Depends on the per-model tables the creating migration makes."""
+        return ["text_embedding"]
+
+    def _get_models(self) -> list[tuple[str, int]]:
+        """Get the list of models whose index is reconciled.
+
+        Returns:
+            List of (model_name, dimension) tuples
+        """
+        if self._models:
+            return self._models
+        return [("nomic-embed-text", 768)]
+
+    async def up(self, conn: "AsyncConnection") -> None:
+        """Apply the HNSW index reconciliation."""
+        if not await pgvector_available(conn):
+            raise MigrationSkippedError(
+                "pgvector extension is not available in this PostgreSQL installation. "
+                "Install pgvector to enable semantic search. "
+                "ARIEL will fall back to keyword-only search."
+            )
+
+        for model_name, _dimension in self._get_models():
+            table_name = model_to_table_name(model_name)
+            result = await conn.execute("SELECT to_regclass(%s) IS NOT NULL", (table_name,))
+            row = await result.fetchone()
+            if not (row and row[0]):
+                continue
+
+            await conn.execute(f"DROP INDEX IF EXISTS {legacy_vector_index_name(table_name)}")
+            await conn.execute(create_vector_index_sql(table_name))
+
+    async def down(self, conn: "AsyncConnection") -> None:
+        """Rollback the HNSW index reconciliation."""
+        for model_name, _dimension in self._get_models():
+            table_name = model_to_table_name(model_name)
+            await conn.execute(f"DROP INDEX IF EXISTS {vector_index_name(table_name)}")

--- a/src/osprey/services/ariel_search/enhancement/text_embedding/migration.py
+++ b/src/osprey/services/ariel_search/enhancement/text_embedding/migration.py
@@ -38,6 +38,19 @@ def create_vector_index_sql(table_name: str) -> str:
     )
 
 
+async def pgvector_available(conn: "AsyncConnection") -> bool:
+    """Report whether the pgvector extension can be installed on this server.
+
+    Returns:
+        True if pgvector is available for installation
+    """
+    result = await conn.execute(
+        "SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector')"
+    )
+    row = await result.fetchone()
+    return bool(row and row[0])
+
+
 class TextEmbeddingMigration(BaseMigration):
     """Text embedding enhancement migration.
 
@@ -78,21 +91,9 @@ class TextEmbeddingMigration(BaseMigration):
         # Default: nomic-embed-text (most common)
         return [("nomic-embed-text", 768)]
 
-    async def _is_pgvector_available(self, conn: "AsyncConnection") -> bool:
-        """Check if the pgvector extension is available in PostgreSQL.
-
-        Returns:
-            True if pgvector is available for installation
-        """
-        result = await conn.execute(
-            "SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector')"
-        )
-        row = await result.fetchone()
-        return bool(row and row[0])
-
     async def up(self, conn: "AsyncConnection") -> None:
         """Apply the text embedding migration."""
-        if not await self._is_pgvector_available(conn):
+        if not await pgvector_available(conn):
             raise MigrationSkippedError(
                 "pgvector extension is not available in this PostgreSQL installation. "
                 "Install pgvector to enable semantic search. "

--- a/src/osprey/services/ariel_search/enhancement/text_embedding/migration.py
+++ b/src/osprey/services/ariel_search/enhancement/text_embedding/migration.py
@@ -16,12 +16,26 @@ if TYPE_CHECKING:
     from psycopg import AsyncConnection
 
 
-#: Used when ``ariel.enhancement_modules.text_embedding.index_lists`` is unset.
-#: The IVFFlat rule of thumb is rows/1000 for corpora up to a million entries;
-#: this suits a few hundred thousand entries and is a workable index for far
-#: fewer. It cannot be derived at migration time — ``osprey ariel migrate``
-#: runs against an empty table.
-DEFAULT_INDEX_LISTS = 224
+def vector_index_name(table_name: str) -> str:
+    """Return the name of the HNSW embedding index on ``table_name``."""
+    return f"idx_{table_name}_hnsw"
+
+
+def legacy_vector_index_name(table_name: str) -> str:
+    """Return the name the superseded IVFFlat index was created under."""
+    return f"idx_{table_name}_vector"
+
+
+def create_vector_index_sql(table_name: str) -> str:
+    """Return the DDL creating the embedding index on ``table_name``.
+
+    The single producer of that statement: the creating migration and the
+    reconcile migration must write the same index, so neither spells it out.
+    """
+    return (
+        f"CREATE INDEX IF NOT EXISTS {vector_index_name(table_name)} "
+        f"ON {table_name} USING hnsw (embedding vector_cosine_ops)"
+    )
 
 
 class TextEmbeddingMigration(BaseMigration):
@@ -30,36 +44,18 @@ class TextEmbeddingMigration(BaseMigration):
     Creates:
     - pgvector extension
     - text_embeddings_<model_name> table for each configured model
-    - IVFFlat vector indexes
+    - HNSW vector indexes
     """
 
-    def __init__(
-        self,
-        models: list[tuple[str, int]] | None = None,
-        index_lists: int | None = None,
-    ) -> None:
+    def __init__(self, models: list[tuple[str, int]] | None = None) -> None:
         """Initialize the migration.
 
         Args:
             models: List of (model_name, dimension) tuples to create tables for.
                    If None, uses a default for testing.
-            index_lists: IVFFlat ``lists`` for the vector index, from
-                ``ariel.enhancement_modules.text_embedding.index_lists``. None
-                uses :data:`DEFAULT_INDEX_LISTS`.
-
-        Raises:
-            ValueError: If ``index_lists`` is not a positive integer.
         """
         super().__init__()
         self._models = models
-        if index_lists is not None and (
-            not isinstance(index_lists, int) or isinstance(index_lists, bool) or index_lists < 1
-        ):
-            raise ValueError(
-                "ariel.enhancement_modules.text_embedding.index_lists must be an "
-                f"integer >= 1 (got {index_lists!r})"
-            )
-        self._index_lists = DEFAULT_INDEX_LISTS if index_lists is None else index_lists
 
     @property
     def name(self) -> str:
@@ -121,17 +117,7 @@ class TextEmbeddingMigration(BaseMigration):
                 """  # noqa: S608
             )
 
-            index_name = f"idx_{table_name}_vector"
-            # `lists` is baked into the index at creation, so changing the key
-            # later needs the index dropped and recreated — it is not re-read.
-            await conn.execute(
-                f"""
-                CREATE INDEX IF NOT EXISTS {index_name}
-                ON {table_name}
-                USING ivfflat (embedding vector_cosine_ops)
-                WITH (lists = {self._index_lists})
-                """  # noqa: S608
-            )
+            await conn.execute(create_vector_index_sql(table_name))
 
     async def down(self, conn: "AsyncConnection") -> None:
         """Rollback the text embedding migration."""

--- a/tests/cli/data/json_keysets/ariel_status.json
+++ b/tests/cli/data/json_keysets/ariel_status.json
@@ -14,6 +14,7 @@
   "entries",
   "last_ingestion",
   "message",
+  "orphaned_enhancement_modules",
   "search_modules",
   "search_modules.hybrid",
   "search_modules.keyword",

--- a/tests/cli/test_json_keyset_capture.py
+++ b/tests/cli/test_json_keyset_capture.py
@@ -26,7 +26,10 @@ so equality is a real contract rather than a fixture artifact:
   ``enhancement_modules``, ``search_modules``. ``database`` is a literal dict
   in ``get_status``; the two module maps are keyed by what the registry
   carries, so this golden also records which modules the framework registers,
-  and a module added or renamed lands here.
+  and a module added or renamed lands here. ``enhancement_modules`` is the
+  joined table: each registered module's ``enabled`` flag alongside its store
+  counts. Its sibling ``orphaned_enhancement_modules`` is deliberately not
+  nested — those keys are store contents rather than a schema.
 * ``ariel search`` → ``entries[]`` (``_entry_summary``'s fixed projection).
 
 Deliberately **not** nested: ``health``'s ``results[]`` rows, whose ``value`` /
@@ -400,7 +403,13 @@ def test_ariel_status_json_keyset(
 ) -> None:
     """``ariel status --json`` emits the recorded ``get_status`` shape."""
     repository = MagicMock()
-    repository.get_enhancement_stats = AsyncMock(return_value={"total_entries": 7})
+    repository.get_enhancement_stats = AsyncMock(
+        return_value={
+            "total_entries": 7,
+            "text_embedding": {"complete": 7, "failed": 0, "pending": 0},
+            "retired_tagger": {"complete": 2, "failed": 0, "pending": 5},
+        }
+    )
     repository.get_embedding_tables = AsyncMock(
         return_value=[
             SimpleNamespace(

--- a/tests/fixtures/lifecycle_repo.py
+++ b/tests/fixtures/lifecycle_repo.py
@@ -759,11 +759,6 @@ config:
   ariel.enhancement_modules.text_embedding.models:
     - name: nomic-embed-text
       dimension: 768
-  # IVFFlat `lists` for the vector index, chosen when the index is created.
-  # Rule of thumb: rows/1000 for corpora up to a million entries. It cannot be
-  # derived — `osprey ariel migrate` runs against an empty table — and changing
-  # it later needs the index dropped and recreated.
-  # ariel.enhancement_modules.text_embedding.index_lists: 224
   # qmd export: one markdown file per entry into the mirror tree the sidecar
   # indexes. On for the same reason `hybrid` above is; an enabled export with
   # no mirror_path is refused at startup.

--- a/tests/services/ariel_search/test_cli_operations.py
+++ b/tests/services/ariel_search/test_cli_operations.py
@@ -290,6 +290,50 @@ class TestGetStatus:
         assert out["status"] == "error"
         assert "boom-ingestion" in out["message"]
 
+    async def test_registered_module_with_no_rows_reports_zeros(self, monkeypatch):
+        """One table over every registered module, whether the store knows it or not."""
+        repo = _status_repo(stats={"total_entries": 3})
+        _patch_service(monkeypatch, _StubService(repository=repo))
+
+        out = await ops.get_status(dict(_DB))
+
+        assert out["enhancement_modules"]["text_embedding"] == {
+            "enabled": False,
+            "complete": 0,
+            "failed": 0,
+            "pending": 0,
+        }
+
+    async def test_store_key_with_no_registered_module_is_reported_as_orphaned(self, monkeypatch):
+        """Rows nothing writes any more are named, not silently folded in."""
+        repo = _status_repo(
+            stats={
+                "total_entries": 3,
+                "text_embedding": {"complete": 3, "failed": 0, "pending": 0},
+                "retired_tagger": {"complete": 1, "failed": 2, "pending": 0},
+            }
+        )
+        _patch_service(monkeypatch, _StubService(repository=repo))
+
+        out = await ops.get_status(dict(_DB))
+
+        assert out["orphaned_enhancement_modules"] == {
+            "retired_tagger": {"complete": 1, "failed": 2, "pending": 0}
+        }
+        assert "retired_tagger" not in out["enhancement_modules"]
+        assert out["enhancement_modules"]["text_embedding"]["complete"] == 3
+
+    async def test_total_entries_is_not_a_module_in_either_table(self, monkeypatch):
+        """It is the store's own count, and it already has its own key."""
+        repo = _status_repo(stats={"total_entries": 3})
+        _patch_service(monkeypatch, _StubService(repository=repo))
+
+        out = await ops.get_status(dict(_DB))
+
+        assert "total_entries" not in out["enhancement_modules"]
+        assert "total_entries" not in out["orphaned_enhancement_modules"]
+        assert out["entries"] == 3
+
 
 class TestGetStatusVocabulary:
     """The ``vocabulary`` block rides on every path out of ``get_status``."""

--- a/tests/services/ariel_search/test_database.py
+++ b/tests/services/ariel_search/test_database.py
@@ -26,9 +26,14 @@ from osprey.services.ariel_search.enhancement.semantic_processor.migration impor
 from osprey.services.ariel_search.enhancement.semantic_processor.search_migration import (
     SemanticProcessorSearchMigration,
 )
+from osprey.services.ariel_search.enhancement.text_embedding.hnsw_migration import (
+    TextEmbeddingHnswIndexMigration,
+)
 from osprey.services.ariel_search.enhancement.text_embedding.migration import (
     TextEmbeddingMigration,
     create_vector_index_sql,
+    legacy_vector_index_name,
+    vector_index_name,
 )
 
 
@@ -863,6 +868,26 @@ class TestGetEnabledMigrations:
         )
         assert text_embedding._get_models() == [("nomic-embed-text", 768)]
 
+    def test_hnsw_reconcile_migration_gets_the_configured_models(self) -> None:
+        """It has to rebuild the index on the same tables the creating one made."""
+        config = ARIELConfig.from_dict(
+            {
+                "database": {"uri": "postgresql://localhost:5432/test"},
+                "enhancement_modules": {
+                    "text_embedding": {
+                        "enabled": True,
+                        "models": [{"name": "mxbai-embed-large", "dimension": 1024}],
+                    },
+                },
+            }
+        )
+        runner = make_runner(config=config)
+
+        reconcile = next(
+            m for m in runner._get_enabled_migrations() if m.name == "text_embedding_hnsw_index"
+        )
+        assert reconcile._get_models() == [("mxbai-embed-large", 1024)]
+
 
 class TestMigrationRunnerRun:
     """Tests for MigrationRunner.run."""
@@ -1205,3 +1230,56 @@ class TestTextEmbeddingMigrationDDL:
 
         assert spelled_in == ["enhancement/text_embedding/migration.py"]
         assert "USING hnsw (embedding vector_cosine_ops)" in create_vector_index_sql("some_table")
+
+
+class TestTextEmbeddingHnswIndexMigrationDDL:
+    """Tests for TextEmbeddingHnswIndexMigration."""
+
+    def test_properties(self) -> None:
+        """It reconciles the index the creating migration made, so it follows it."""
+        migration = TextEmbeddingHnswIndexMigration()
+        assert migration.name == "text_embedding_hnsw_index"
+        assert migration.depends_on == ["text_embedding"]
+
+    async def test_up_skips_when_pgvector_is_unavailable(self, ddl_conn) -> None:
+        """A keyword-only deployment retries later instead of failing the run."""
+        with pytest.raises(MigrationSkippedError, match="pgvector"):
+            await TextEmbeddingHnswIndexMigration().up(ddl_conn)
+
+        assert len(ddl_conn.sql) == 1
+        assert "pg_available_extensions" in ddl_conn.sql[0]
+
+    async def test_up_drops_the_legacy_index_before_creating_the_hnsw_one(self, ddl_conn) -> None:
+        """Leaving the old index in place would keep both on the same column."""
+        ddl_conn.recorder.rows_for = {
+            "pg_available_extensions": [(True,)],
+            "to_regclass": [(True,)],
+        }
+
+        await TextEmbeddingHnswIndexMigration(models=[("model-a", 512)]).up(ddl_conn)
+
+        legacy = sql_index(
+            ddl_conn, f"DROP INDEX IF EXISTS {legacy_vector_index_name('text_embeddings_model_a')}"
+        )
+        created = sql_index(ddl_conn, create_vector_index_sql("text_embeddings_model_a"))
+        assert legacy < created
+
+    async def test_up_skips_a_model_whose_table_is_absent(self, ddl_conn) -> None:
+        """A model configured but never migrated has no index to reconcile."""
+        ddl_conn.recorder.rows_for = {
+            "pg_available_extensions": [(True,)],
+            "to_regclass": [(False,)],
+        }
+
+        await TextEmbeddingHnswIndexMigration(models=[("model-a", 512)]).up(ddl_conn)
+
+        assert ddl_conn.recorder.matching("DROP INDEX") == []
+        assert ddl_conn.recorder.matching("CREATE INDEX") == []
+
+    async def test_down_drops_the_hnsw_index(self, ddl_conn) -> None:
+        """Rollback removes the index this migration created, not the table."""
+        await TextEmbeddingHnswIndexMigration(models=[("model-a", 512)]).down(ddl_conn)
+
+        assert ddl_conn.sql == [
+            f"DROP INDEX IF EXISTS {vector_index_name('text_embeddings_model_a')}"
+        ]

--- a/tests/services/ariel_search/test_database.py
+++ b/tests/services/ariel_search/test_database.py
@@ -5,6 +5,7 @@ migration logic and configuration parts that don't require database access.
 """
 
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,7 @@ from osprey.services.ariel_search.enhancement.semantic_processor.search_migratio
 )
 from osprey.services.ariel_search.enhancement.text_embedding.migration import (
     TextEmbeddingMigration,
+    create_vector_index_sql,
 )
 
 
@@ -192,24 +194,6 @@ class TestBaseMigration:
         models = [("custom-model", 512), ("another-model", 1024)]
         migration = TextEmbeddingMigration(models=models)
         assert migration._get_models() == models
-
-    def test_text_embedding_index_lists_defaults(self) -> None:
-        """With no key the migration keeps the number it has always written."""
-        from osprey.services.ariel_search.enhancement.text_embedding.migration import (
-            DEFAULT_INDEX_LISTS,
-        )
-
-        assert TextEmbeddingMigration()._index_lists == DEFAULT_INDEX_LISTS
-
-    def test_text_embedding_index_lists_is_read(self) -> None:
-        """A facility sizes the IVFFlat index for the corpus it expects."""
-        assert TextEmbeddingMigration(index_lists=40)._index_lists == 40
-
-    @pytest.mark.parametrize("bad", [0, -1, True, "224", 2.5])
-    def test_text_embedding_index_lists_refuses_a_non_positive_int(self, bad) -> None:
-        """Refused where the operator can still see the line, naming the key."""
-        with pytest.raises(ValueError, match="index_lists"):
-            TextEmbeddingMigration(index_lists=bad)
 
 
 class TestMigrationTopologicalSort:
@@ -530,41 +514,6 @@ class TestMigrationRunnerLogic:
 
         text_emb = next(m for m in migrations if m.name == "text_embedding")
         assert text_emb._get_models() == [("mxbai-embed-large", 1024)]
-
-    def test_get_enabled_migrations_defaults_the_index_lists(self) -> None:
-        """An unstated `index_lists` leaves the migration's own default in force."""
-        from osprey.services.ariel_search.database.migrations import MigrationRunner
-        from osprey.services.ariel_search.enhancement.text_embedding.migration import (
-            DEFAULT_INDEX_LISTS,
-        )
-
-        config = ARIELConfig.from_dict(
-            {
-                "database": {"uri": "postgresql://localhost:5432/test"},
-                "enhancement_modules": {"text_embedding": {"enabled": True}},
-            }
-        )
-
-        runner = MigrationRunner(pool=None, config=config)  # type: ignore[arg-type]
-        text_emb = next(m for m in runner._get_enabled_migrations() if m.name == "text_embedding")
-
-        assert text_emb._index_lists == DEFAULT_INDEX_LISTS
-
-    def test_get_enabled_migrations_passes_the_configured_index_lists(self) -> None:
-        """A facility sizing the index for its own corpus reaches the CREATE INDEX."""
-        from osprey.services.ariel_search.database.migrations import MigrationRunner
-
-        config = ARIELConfig.from_dict(
-            {
-                "database": {"uri": "postgresql://localhost:5432/test"},
-                "enhancement_modules": {"text_embedding": {"enabled": True, "index_lists": 40}},
-            }
-        )
-
-        runner = MigrationRunner(pool=None, config=config)  # type: ignore[arg-type]
-        text_emb = next(m for m in runner._get_enabled_migrations() if m.name == "text_embedding")
-
-        assert text_emb._index_lists == 40
 
 
 class TestRepositoryInitialization:
@@ -1213,13 +1162,9 @@ class TestTextEmbeddingMigrationDDL:
             ddl_conn.sql[table_a].split()
         )
 
-        index_a = sql_index(
-            ddl_conn, "CREATE INDEX IF NOT EXISTS idx_text_embeddings_model_a_vector"
-        )
+        index_a = sql_index(ddl_conn, "CREATE INDEX IF NOT EXISTS idx_text_embeddings_model_a_hnsw")
         assert table_a < index_a
-        assert "USING ivfflat (embedding vector_cosine_ops)" in " ".join(
-            ddl_conn.sql[index_a].split()
-        )
+        assert "USING hnsw (embedding vector_cosine_ops)" in " ".join(ddl_conn.sql[index_a].split())
 
         table_b = sql_index(ddl_conn, "CREATE TABLE IF NOT EXISTS text_embeddings_model_b")
         assert "embedding vector(1024)" in " ".join(ddl_conn.sql[table_b].split())
@@ -1242,3 +1187,21 @@ class TestTextEmbeddingMigrationDDL:
             "DROP TABLE IF EXISTS text_embeddings_model_b CASCADE",
         ]
         assert ddl_conn.recorder.matching("DROP EXTENSION") == []
+
+    def test_the_index_ddl_has_exactly_one_producer(self) -> None:
+        """Both migrations write the same index because only one spells it out.
+
+        A second spelling anywhere in the package would let the created index
+        and the reconciled one drift apart without a test noticing.
+        """
+        import osprey.services.ariel_search as ariel_pkg
+
+        package_root = Path(ariel_pkg.__file__).parent
+        spelled_in = sorted(
+            path.relative_to(package_root).as_posix()
+            for path in package_root.rglob("*.py")
+            if "USING hnsw" in path.read_text()
+        )
+
+        assert spelled_in == ["enhancement/text_embedding/migration.py"]
+        assert "USING hnsw (embedding vector_cosine_ops)" in create_vector_index_sql("some_table")


### PR DESCRIPTION
ARIEL's embedding index sizes itself, and `osprey ariel status` answers with one
enhancement-module table.

Commits:

- `feat(ariel): size the embedding index by HNSW instead of an authored list count`
- `feat(ariel): reconcile an existing embedding index onto HNSW`
- `fix(ariel): status reports one enhancement-module table and names store-only keys`

## Why

`osprey ariel migrate` creates the embedding index against an empty table, so the
IVFFlat `lists` count could not be derived there and had to be authored as
`ariel.enhancement_modules.text_embedding.index_lists` — a guess about a corpus
size the migration cannot see, baked into the index at creation and changeable
only by dropping and recreating it by hand. HNSW takes no such parameter, so the
key is gone and one producer, `create_vector_index_sql`, now writes the index DDL
for everything that creates it. A deployment that already ran the creating
migration carries its record in `ariel_migrations` and never re-runs it, so an
additive `text_embedding_hnsw_index` migration moves it across — the same shape
`keyword_search_fts_index` and `semantic_processor_search_index` already use.
A deployer runs `osprey ariel migrate` and has nothing left to author about the
index.

`get_status` built `enhancement_modules` from the registry while the store's own
counts came from `get_enhancement_stats()`, so one payload could name two
different module sets. They are joined: `enhancement_modules` carries every
registered module with its `enabled` flag and its complete/failed/pending counts,
zero-filled where the store has never seen it, and `orphaned_enhancement_modules`
carries the counts for store keys no registered module claims. The human `status`
renderer names those leftovers on one line, so an operator who has to clean up
sees them where they already look.

## Not in this PR

- Deleting the legacy `OSPREY_E2E_MCP_READY_TIMEOUT` fallback. No release carries
  the new `OSPREY_MCP_READY_TIMEOUT` spelling yet, so removing the fallback now
  breaks every released host; it goes after the first release that carries it.
  The removal notice in the environment-variables reference stays as it is.
