### PR TITLE
fix(registry): anchor a relative registry_path on project_root (#965)

### DIFF
--- a/changelog.d/965.fixed.md
+++ b/changelog.d/965.fixed.md
@@ -1,0 +1,1 @@
+A relative `registry_path` now anchors on the deployment's `project_root` rather than the working directory, so a project's own registry — and the ARIEL adapters, search modules and enhancement modules it registers — loads from anywhere a deployment verb runs, not only from the repo root.

--- a/src/osprey/registry/manager.py
+++ b/src/osprey/registry/manager.py
@@ -7,6 +7,7 @@ Provides :class:`RegistryManager` plus the global singleton helpers
 """
 
 import logging
+import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -344,20 +345,35 @@ def resolve_registry_path(
     3. ``application.registry_path`` — an accepted alias.
 
     ``${VAR}`` in the value is expanded against the environment, and a relative
-    path is resolved against *base_path* when one is given.
+    path is resolved against *base_path*, defaulting to the config's own
+    ``project_root``.
+
+    A relative spelling is the documented one, and the anchor it means is the
+    deployment — the same anchor ``data/``, ``plans/`` and ``health.plugins``
+    use. Falling back to ``project_root`` is what makes that true for a caller
+    with no ``base_path`` to offer: every runtime reader reaches the registry
+    through ``get_registry()`` with no config path, and anchoring on the
+    working directory instead loaded a deployment's own registry from the repo
+    root and nowhere else.
+
+    ``project_root`` is used only when it names a directory that exists here. A
+    rendered config carries the ``project_root`` of the environment it was
+    rendered for, so one read on another machine — a service's config
+    bind-mounted into a container, say — names a path that is not this one's,
+    and anchoring on it would be confidently wrong rather than merely
+    unanchored.
 
     Args:
         config: Config mapping to read. ``None`` reads through the global
             config singleton, which is what the registry factory has when it
             was handed only a config path.
-        base_path: Directory relative paths resolve against; ``None`` leaves a
-            relative path relative.
+        base_path: Directory relative paths resolve against. ``None`` falls
+            back to the config's ``project_root``, and leaves the path relative
+            when there is none.
 
     Returns:
         The resolved path, or ``None`` when no spelling names one.
     """
-    import os
-
     raw: Any = os.environ.get(REGISTRY_PATH_ENV)
     if not raw:
         if config is None:
@@ -377,9 +393,29 @@ def resolve_registry_path(
         return None
 
     expanded: str = os.path.expandvars(str(raw))
+    if base_path is None:
+        base_path = _project_root_anchor(config)
     if base_path is not None and not Path(expanded).is_absolute():
         return str((Path(base_path) / expanded).resolve())
     return expanded
+
+
+def _project_root_anchor(config: Mapping[str, Any] | None) -> Path | None:
+    """Return the config's ``project_root``, when it names a directory here.
+
+    Args:
+        config: Config mapping to read, or ``None`` to read through the global
+            config singleton.
+
+    Returns:
+        The project root as a path, or ``None`` when the config names none or
+        names one that does not exist on this machine.
+    """
+    root = get_config_value("project_root", None) if config is None else config.get("project_root")
+    if not root or not isinstance(root, (str, Path)):
+        return None
+    path = Path(os.path.expandvars(str(root)))
+    return path if path.is_dir() else None
 
 
 def _create_registry_from_config(config_path: str | None = None) -> RegistryManager:

--- a/tests/registry/test_registry_validation.py
+++ b/tests/registry/test_registry_validation.py
@@ -335,6 +335,58 @@ class TestResolveRegistryPath:
         resolved = resolve_registry_path({"registry_path": "${APP_DIR}/registry.py"})
         assert resolved == "myapp/registry.py"
 
+    def test_project_root_anchors_a_relative_path_with_no_base_path(self, tmp_path):
+        """The anchor a relative spelling means, for a caller that has none.
+
+        Every runtime reader reaches the registry through ``get_registry()``
+        with no config path, so it offers no ``base_path``; anchoring on the
+        working directory instead found the file only from the repo root.
+        """
+        (tmp_path / "project").mkdir()
+        config = {"project_root": str(tmp_path), "registry_path": "project/registry.py"}
+
+        resolved = resolve_registry_path(config)
+
+        assert resolved == str(tmp_path / "project" / "registry.py")
+
+    def test_an_explicit_base_path_still_wins_over_project_root(self, tmp_path):
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        config = {"project_root": str(tmp_path), "registry_path": "registry.py"}
+
+        resolved = resolve_registry_path(config, base_path=elsewhere)
+
+        assert resolved == str(elsewhere / "registry.py")
+
+    def test_a_project_root_that_is_not_here_leaves_the_path_relative(self, tmp_path):
+        """A rendered config read on another machine must not anchor.
+
+        A service's config bind-mounted into a container carries the
+        ``project_root`` of the machine that rendered it. Anchoring on a path
+        that does not exist here would be confidently wrong.
+        """
+        config = {
+            "project_root": str(tmp_path / "not-on-this-machine"),
+            "registry_path": "project/registry.py",
+        }
+
+        assert resolve_registry_path(config) == "project/registry.py"
+
+    def test_project_root_does_not_touch_an_absolute_path(self, tmp_path):
+        absolute = str(tmp_path / "registry.py")
+        config = {"project_root": str(tmp_path), "registry_path": absolute}
+
+        assert resolve_registry_path(config) == absolute
+
+    def test_env_vars_in_project_root_are_expanded(self, tmp_path, monkeypatch):
+        (tmp_path / "project").mkdir()
+        monkeypatch.setenv("DEPLOY_ROOT", str(tmp_path))
+        config = {"project_root": "${DEPLOY_ROOT}", "registry_path": "project/registry.py"}
+
+        resolved = resolve_registry_path(config)
+
+        assert resolved == str(tmp_path / "project" / "registry.py")
+
 
 class TestConfigurationErrorMessages:
     """Test configuration-related error messages."""


### PR DESCRIPTION
## Summary

- A relative `registry_path` is the documented spelling, but it only worked
  when the process happened to start from the project root: the resolver
  anchors a relative path on `base_path`, and `_create_registry_from_config`
  computed that anchor only when it had been handed a config path. Every
  runtime reader calls `get_registry()` with no argument, so the anchor was
  `None` and the path fell back to the working directory.
- `project_root` was in the same config the whole time — the anchor `data/`,
  `plans/` and `health.plugins` already use, rendered per environment so it is
  right on a host and inside a container. It just was not consulted.
- Fixes #965.

## Changes

`resolve_registry_path` falls back to the config's `project_root` when the
caller gives no `base_path`. The loader is untouched: in the failing case it
already passes `None`, and the resolver now fills the anchor in. Keeping it in
the one resolver means the health row's reader gets the same answer for the
same config rather than a second copy of the rule.

`project_root` is used only when it names a directory that exists on this
machine. A rendered config carries the `project_root` of the environment it
was rendered for, so a service config bind-mounted into a container names a
path that is not the container's; anchoring on that would be confidently wrong
rather than merely unanchored, so it falls through to today's behaviour.

An explicit `base_path` still wins, so the health row's `--project-path`
threading is unchanged.

## Test plan

Found in a running deployment, not in the abstract: an ARIEL facility adapter
registered by a project loaded when a verb was run from the repo root and was
reported unknown from anywhere else.

- [x] The issue's reproduction, before and after. Loading from `<root>/build/`
      failed with "Registry file not found: project/registry.py"; it now
      resolves to `<root>/project/registry.py`. From the project root it
      resolves to the same absolute path instead of an accidentally-relative
      one.
- [x] Five cases added to `TestResolveRegistryPath`: `project_root` anchors a
      relative path when no `base_path` is given; an explicit `base_path` still
      wins; a `project_root` that is not a directory here leaves the path
      relative; an absolute `registry_path` is untouched; `${VAR}` in
      `project_root` is expanded. The existing resolver tests are unchanged and
      still pass — a config with no `project_root` still resolves relative.
- [x] `./scripts/quick_check.sh` — 41,838 passed, 288 skipped.
- [x] `./scripts/premerge_check.sh origin/main` — every gate passes except its
      test step, which fails only in
      `tests/services/channel_finder/graph_index/test_scale.py` (6 latency
      budgets, e.g. "the median of 20 searches was 466.5 ms, budget 150 ms").
      That module is excluded by path from `ci_check.sh` and its own docstring
      says the budgets are "held to a workstation's numbers ... which is why
      this module does not run in the parallel lane"; `premerge_check.sh` runs
      it anyway, under `-n auto`. Unrelated to this change, which touches no
      channel-finder code. The rest of the slow lane: 265 passed.
- [x] `mypy src/osprey/registry/manager.py` before and after: the same nine
      pre-existing errors, identical messages. No new ones.
- [x] `ruff check` and `ruff format --check` clean; changelog gate accepts the
      fragment.

Not run locally: the documentation, JavaScript and coverage lanes of
`ci_check.sh`, none of which this change can reach.

## Related issues

- Closes #965.
- #966 is a separate defect in the same area, not addressed here: the ARIEL
  panel replaces the registry singleton with a framework-only one, so a
  deployment's registered components are missing from that process regardless
  of how the path resolves.
- The `registry_file` health row anchors on `cwd` rather than `project_root`
  (`health/core/file_system.py:178`), so it can still name a different file
  than the loader used when run from elsewhere. Left alone here because the
  explicit `base_path` is also how `--project-path` is threaded; noted in #965
  if you want it changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d4jCsiSSMy4jaBqWyX3VY
